### PR TITLE
add failing test for interaction between Read and liquidAssertB

### DIFF
--- a/tests/neg/read.hs
+++ b/tests/neg/read.hs
@@ -1,0 +1,8 @@
+module Read where
+
+import Language.Haskell.Liquid.Prelude
+
+data Foo = Foo deriving Read
+
+bad  = liquidAssertB (0 == 1)
+bad' = liquidAssert  (0 == 1) True


### PR DESCRIPTION
defining a Read instance appears to cause invocations of `liquidAssert` and `liquidAssertB` to refine to `false`.

other typeclasses do not appear to trigger this issue, nor is `liquidError` affected. unsafe type annotations are still detected, e.g.

```
{-@ bad :: {v:Integer | v = 5} @-}
bad = 4
```
