### PR TITLE
Fixed imports in Liquid.hs

### DIFF
--- a/Liquid.hs
+++ b/Liquid.hs
@@ -13,7 +13,7 @@ import Language.Fixpoint.Interface
 import Language.Haskell.Liquid.CmdLine
 import Language.Haskell.Liquid.GhcInterface 
 import Language.Haskell.Liquid.Constraint       
-import Language.Fixpoint.Types (Fixpoint(..), sinfo, colorResult, FixResult (..))
+import Language.Fixpoint.Types (Fixpoint(..), sinfo, colorResult, FixResult (..),showFix)
 import Language.Haskell.Liquid.TransformRec   
 import Language.Haskell.Liquid.Annotate (annotate)
 import Control.DeepSeq


### PR DESCRIPTION
Hi, It seems that `showFix` was left out from the imports in `Liquidhaskell.hs`. This leads to the compile error

```
Liquid.hs:53:33: Not in scope: `showFix'
```

The commit adds showFix to the imports from `Language.Fixpoint.Types` to fix this issue.
