### PR TITLE
add --no-check-unknown flag to suppress "specification for unknown variable" errors

### DIFF
--- a/Language/Haskell/Liquid/CmdLine.hs
+++ b/Language/Haskell/Liquid/CmdLine.hs
@@ -21,9 +21,12 @@ config = Config {
  , idirs = def &= typDir 
                &= help "Paths to Spec Include Directory " 
  
- , binds = def &= help "Top-level binders to verify (DEFAULT = all)" 
+ , binds = def &= help "Top-level binders to verify (DEFAULT = all)"
  
- } &= verbosity 
+ , noCheckUnknown = def &= explicit
+                        &= name "no-check-unknown"
+                        &= help "Don't complain about specifications for unexported and unused values "
+ } &= verbosity
    &= program "liquid" 
    &= help    "Refinement Types for Haskell" 
    &= summary "LiquidHaskell © Copyright 2009-13 Regents of the University of California." 

--- a/Language/Haskell/Liquid/Types.hs
+++ b/Language/Haskell/Liquid/Types.hs
@@ -73,6 +73,7 @@ data Config = Config {
     files :: [FilePath] -- ^ source files to check
   , idirs :: [FilePath] -- ^ path to directory for including specs
   , binds :: ![String]  -- ^ top-level binders to check (empty means check ALL) 
+  , noCheckUnknown :: Bool -- ^ whether to complain about specifications for unexported and unused values
   } deriving (Data, Typeable, Show, Eq)
 
 


### PR DESCRIPTION
The default behavior is to throw the error. I tested the change by modifying `tests/pos/GhcListSort.hs` to only export `sort1` and running liquid with and without the flag. Worked as expected.

fixes #50 
