### PR TITLE
Disable GHC's codegen

### DIFF
--- a/Language/Haskell/Liquid/Desugar/Desugar.lhs
+++ b/Language/Haskell/Liquid/Desugar/Desugar.lhs
@@ -107,9 +107,9 @@ deSugarWithLoc hsc_env
         ; let hpcInfo = emptyHpcInfo other_hpc_info
 	; (msgs, mb_res)
               <- case target of
-	           HscNothing ->
-                       return (emptyMessages,
-                               Just ([], nilOL, [], [], NoStubs, hpcInfo, emptyModBreaks))
+	           -- HscNothing ->
+               --         return (emptyMessages,
+               --                 Just ([], nilOL, [], [], NoStubs, hpcInfo, emptyModBreaks))
                    _        -> do
 
                      let want_ticks = opt_Hpc

--- a/Language/Haskell/Liquid/GhcInterface.hs
+++ b/Language/Haskell/Liquid/GhcInterface.hs
@@ -67,7 +67,7 @@ getGhcInfo cfg target
   = runGhc (Just libdir) $ do
       df                 <- getSessionDynFlags
       setSessionDynFlags  $ updateDynFlags df (idirs cfg) 
-      -- peepGHCSimple target 
+      -- peepGHCSimple target
       modguts            <- getGhcModGuts1 target
       hscEnv             <- getSession
       -- modguts     <- liftIO $ hscSimplify hscEnv modguts
@@ -85,8 +85,8 @@ updateDynFlags df ps
   = df { importPaths  = ps ++ importPaths df  } 
        { libraryPaths = ps ++ libraryPaths df }
        { profAuto     = ProfAutoCalls         }
-       { ghcLink      = LinkInMemory          }
-       { hscTarget    = HscInterpreted        }
+       { ghcLink      = NoLink                }
+       { hscTarget    = HscNothing            }
 
 printVars s vs 
   = do putStrLn s 


### PR DESCRIPTION
Having GHC run through the codegen phase (as I understand it this occurs during the `load` call) caused errors with code that uses unboxed tuples or the FFI.
