### PR TITLE
make sure liquid and haskell types have equal number of tyvars before rename

### DIFF
--- a/Language/Haskell/Liquid/Bare.hs
+++ b/Language/Haskell/Liquid/Bare.hs
@@ -121,8 +121,13 @@ isSimpleType t = null tvs && isNothing (splitFunTy_maybe tb)
 
 
 -- renameTyVars :: (Var, SpecType) -> (Var, SpecType)
-renameTyVars (x, Loc l t) = (x, Loc l $ mkUnivs as' [] t')
+renameTyVars (x, Loc l t) = if length as == length as'
+                              then (x, Loc l $ mkUnivs as' [] t')
+                              else errorstar $ render err
   where 
+    err                   = vcat [ text "Specified Liquid Type Does Not Match Haskell Type"
+                                 , text "Haskell:" <+> pprint x <+> dcolon <+> pprint (varType x)
+                                 , text "Liquid :" <+> pprint x <+> dcolon <+> pprint t           ]
     t'                    = subts su (mkUnivs [] ps bt)
     su                    = zip as as'
     as'                   = rTyVar <$> (fst $ splitForAllTys $ varType x)


### PR DESCRIPTION
We were previously using GHC's list of tyvars to reconstruct the type in `renameTyVars`, even when GHC had a different number of tyvars. This caused weird types in our error messages, like `forall a a. Int -> Int`.

fixes #60
