### PR TITLE
List element via partition

### DIFF
--- a/tests/todo/ListMem.hs
+++ b/tests/todo/ListMem.hs
@@ -12,7 +12,7 @@ import Data.Set hiding (partition)
 member' :: Eq a => a -> [a] -> ([a], [a])
 member' x ls = partition (cmp x) ls 
 
-{- member :: Eq a 
+{-@ member :: Eq a 
            => x:a 
            -> xs:[a] 
            -> {v:Bool|((Prop v) <=> (ListElt x xs))}


### PR DESCRIPTION
Adding the example that we discussed today for list elements.
It is **_not**_ safe.

For `x:a`, `xs : [a]`, if I partition `xs` so that

```
ls :: [{v:a|v=x}]
rs :: [{v:a|v!=x}]
ls cup rs = xs
```

`ls` being empty is not enough to prove that `x` is not an element of `xs` 
