### PR TITLE
fix predicates on monomorphic tycon

### DIFF
--- a/Language/Haskell/Liquid/Constraint.hs
+++ b/Language/Haskell/Liquid/Constraint.hs
@@ -201,6 +201,7 @@ isGeneric α t =  all (\(c, α') -> (α'/=α) || isOrd c || isEq c ) (classConst
         isEq           = (eqClassName ==) . className
 
 -- isBase :: RType a -> Bool
+isBase (RAllP _ t)      = isBase t
 isBase (RVar _ _)       = True
 isBase (RApp _ ts _ _)  = all isBase ts
 isBase (RFun _ t1 t2 _) = isBase t1 && isBase t2

--- a/tests/pos/fixme.hs
+++ b/tests/pos/fixme.hs
@@ -1,13 +1,7 @@
-module ListSort where
+module Foo where
 
+data F = F { foo :: Int}
 
-data P a = P a Int
+{-@ data F <p :: Int -> Prop> = F (i :: Int<p>)@-}
 
-{-@ data P a <p :: a -> Int -> Prop>
-     = P (i :: a) (v :: Int<p i>)
-  @-}
-{-@ type OP  = P <{\p v ->  p > v}> Int @-}
-
-foo :: P Int
-{-@ foo :: OP @-}
-foo = P 3 2
+{-@ foo  :: F -> {v:Int| v = 0} @-}


### PR DESCRIPTION
Fixpoint used to crash when we defined an abstract refinement for monomorphic type constructors. 

See test/pos/fixme.hs
