### PR TITLE
Update Parse.hs

### DIFF
--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -84,9 +84,9 @@ parseWithError :: Parser a -> SourceName -> String -> Either Error a
 ---------------------------------------------------------------------------
 parseWithError parser f s
   = case runParser (remainderP (whiteSpace >> parser)) 0 f s of
-      Left e         -> Left  $ parseErrorError f e
-      Right (r, "")  -> Right $ r
-      Right (_, rem) -> Left  $ parseErrorError f $ remParseError f s rem 
+      Left e            -> Left  $ parseErrorError f e
+      Right (r, "", _)  -> Right $ r
+      Right (_, rem, _) -> Left  $ parseErrorError f $ remParseError f s rem 
 
 ---------------------------------------------------------------------------
 parseErrorError     :: SourceName -> ParseError -> Error


### PR DESCRIPTION
Apparently a change in runParser causes it to return a three-tuple instead of a two-tuple.

I can't claim to have any real knowledge of this project, but I just tried compiling after a git pull and had an error during compile here.  This fix seemed simple enough.
