### PR TITLE
add "no-expand-flag"

### DIFF
--- a/src/Language/Haskell/Liquid/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/CmdLine.hs
@@ -86,6 +86,10 @@ config = Config {
     = def &= help "Disable Termination Check"
           &= name "no-termination-check"
 
+ , nocaseexpand
+    = def &= help "Disable Termination Check"
+          &= name "no-case-expand"
+
 , strata
     = def &= help "Enable Strata Analysis"
 
@@ -168,13 +172,14 @@ parsePragma s = withArgs [val s] $ cmdArgs config
 ---------------------------------------------------------------------------------------
 
 instance Monoid Config where
-  mempty        = Config def def def def def def def def def def 2 def def def
+  mempty        = Config def def def def def def def def def def def 2 def def def
   mappend c1 c2 = Config (sortNub $ files c1   ++     files          c2)
                          (sortNub $ idirs c1   ++     idirs          c2)
                          (diffcheck c1         ||     diffcheck      c2) 
                          (sortNub $ binders c1 ++     binders        c2) 
                          (noCheckUnknown c1    ||     noCheckUnknown c2) 
                          (notermination  c1    ||     notermination  c2) 
+                         (nocaseexpand   c1    ||     nocaseexpand   c2) 
                          (strata         c1    ||     strata         c2) 
                          (notruetypes    c1    ||     notruetypes    c2) 
                          (totality       c1    ||     totality       c2) 

--- a/src/Language/Haskell/Liquid/GhcInterface.hs
+++ b/src/Language/Haskell/Liquid/GhcInterface.hs
@@ -110,7 +110,7 @@ getGhcInfo' cfg0 target
       load LoadAllTargets
       modguts            <- getGhcModGuts1 target
       hscEnv             <- getSession
-      coreBinds          <- liftIO $ anormalize hscEnv modguts
+      coreBinds          <- liftIO $ anormalize (not $ nocaseexpand cfg) hscEnv modguts
       let impVs           = importVars  coreBinds 
       let defVs           = definedVars coreBinds 
       let useVs           = readVars    coreBinds

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -168,6 +168,7 @@ data Config = Config {
   , binders        :: [String]   -- ^ set of binders to check
   , noCheckUnknown :: Bool       -- ^ whether to complain about specifications for unexported and unused values
   , notermination  :: Bool       -- ^ disable termination check
+  , nocaseexpand   :: Bool       -- ^ disable case expand
   , strata         :: Bool       -- ^ enable strata analysis
   , notruetypes    :: Bool       -- ^ disable truing top level types
   , totality       :: Bool       -- ^ check totality in definitions

--- a/tests/pos/NoCaseExpand.hs
+++ b/tests/pos/NoCaseExpand.hs
@@ -1,0 +1,18 @@
+module NoCaseExpand where
+
+-- time 3.6s w/ "--no-case-expand" flag VS  8.5 s w/o
+
+{- LIQUID "--no-case-expand" @-}
+
+data TokenType =
+  Space | Keyword | Keyglyph | Layout | Comment | Conid | Varid |
+  Conop | Varop   | String   | Char   | Number  | Cpp   | Error |
+  Definition
+
+
+context ::  [(TokenType, String)] -> [(TokenType, String)]
+context stream@((Keyglyph,"="):_) = stream
+context stream@((Keyglyph,"=>"):_) = stream
+context stream@((Keyglyph,"⇒"):_) = stream
+context (_:stream) = context stream
+context [] = []


### PR DESCRIPTION
"no-expand-flag" is an option that disables expansion of the `DEFAULT` alternative to all possible data-constructors in case expressions.

See [tests/pos/NoCaseExpand.hs](https://github.com/ucsd-progsys/liquidhaskell/blob/no-expand-flag/tests/pos/NoCaseExpand.hs) why this is needed. 
This test case-splits on 15 DataCons and using the above flag its verification time reduces from 8.5 to 3.6s.
The above test is just a function from [hscolour/Language/Haskell/HsColour/Anchors.hs](https://github.com/nikivazou/hscolour/blob/master/Language/Haskell/HsColour/Anchors.hs) which makes `fixpoint.native` run out of memory w/o the flag.

TODO? 
- add documentation
- disable expansion only when the `DEFAULT` expands to (>=7) DataCons
