### PR TITLE
use parsec's error messages

### DIFF
--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -100,12 +100,12 @@ parseWithError parser f s
 ---------------------------------------------------------------------------
 parseErrorError     :: SourceName -> ParseError -> Error
 ---------------------------------------------------------------------------
-parseErrorError f e = ErrParse sp msg lpe
+parseErrorError f e = ErrParse sp msg e
   where 
     pos             = errorPos e
     sp              = sourcePosSrcSpan pos 
     msg             = text $ "Error Parsing Specification from: " ++ f
-    lpe             = LPE pos (eMsgs e)
+    -- lpe             = LPE pos (eMsgs e)
     eMsgs           = fmap messageString . errorMessages 
 
 ---------------------------------------------------------------------------

--- a/src/Language/Haskell/Liquid/PrettyPrint.hs
+++ b/src/Language/Haskell/Liquid/PrettyPrint.hs
@@ -38,7 +38,7 @@ import Language.Haskell.Liquid.Types hiding (sort)
 import Language.Fixpoint.Names (dropModuleNames, propConName, hpropConName)
 import TypeRep          hiding (maybeParen, pprArrowChain)  
 import Text.Parsec.Pos              (SourcePos, newPos, sourceName, sourceLine, sourceColumn) 
-import Text.Parsec.Error (ParseError)
+import Text.Parsec.Error (ParseError, errorMessages, showErrorMessages)
 import Var              (Var)
 import Control.Applicative ((<*>), (<$>))
 import Data.Maybe   (fromMaybe)
@@ -63,11 +63,15 @@ instance PPrint ErrMsg where
 instance PPrint SourceError where
   pprint = text . show
 
--- instance PPrint ParseError where 
---   pprint = text . show 
+instance PPrint ParseError where 
+  pprint e = vcat $ tail $ map text ls
+    where
+      ls = lines $ showErrorMessages "or" "unknown parse error"
+                                     "expecting" "unexpected" "end of input"
+                                     (errorMessages e)
 
-instance PPrint LParseError where
-  pprint (LPE _ msgs) = text "Parse Error: " <> vcat (map pprint msgs)
+-- instance PPrint LParseError where
+--   pprint (LPE _ msgs) = text "Parse Error: " <> vcat (map pprint msgs)
 
 instance PPrint Var where
   pprint = pprDoc 

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -149,7 +149,7 @@ module Language.Haskell.Liquid.Types (
   , Error
   , TError (..)
   , EMsg (..)
-  , LParseError (..)
+  -- , LParseError (..)
   , ErrorResult
   , errSpan
   , errOther
@@ -1326,7 +1326,7 @@ data TError t =
 
   | ErrParse    { pos :: !SrcSpan
                 , msg :: !Doc
-                , err :: !LParseError
+                , err :: !ParseError
                 } -- ^ specification parse error
 
   | ErrTySpec   { pos :: !SrcSpan
@@ -1398,8 +1398,8 @@ data TError t =
                 } -- ^ Unexpected PANIC 
   deriving (Typeable, Functor)
 
-data LParseError = LPE !SourcePos [String] 
-                   deriving (Data, Typeable, Generic)
+-- data LParseError = LPE !SourcePos [String] 
+--                    deriving (Data, Typeable, Generic)
 
 
 instance Eq Error where


### PR DESCRIPTION
Instead of dumping all of the `Message`s that parsec creates (many of which seem redundant), use it's own error output function, with a little post-processing to properly indent it.
