### PR TITLE
Improve error for refined class/instances conflict

### DIFF
--- a/src/Language/Haskell/Liquid/Errors.hs
+++ b/src/Language/Haskell/Liquid/Errors.hs
@@ -240,8 +240,16 @@ ppError' _ dSp (ErrSaved _ s)
 ppError' _ dSp (ErrTermin xs _ s)
   = dSp <+> text "Termination Error on" <+> (hsep $ intersperse comma $ map pprint xs) $+$ s
 
-ppError' _ dSp (ErrRClass xs _)
-  = dSp <+> text "You cannot refine instances of refined classes" <+> (pprint xs)
+ppError' _ dSp (ErrRClass pos cls insts)
+  = dSp <+> text "Refined classes cannot have refined instances"
+    $+$ (nest 4 $ sepVcat blankLine $ describeCls : map describeInst insts)
+  where
+    describeCls
+      = text "Refined class definition for:" <+> cls
+        $+$ text "Defined at:" <+> pprint pos
+    describeInst (pos, t)
+      = text "Refined instance for:" <+> t
+        $+$ text "Defined at:" <+> pprint pos
 
 ppError' _ _ (ErrOther _ s)
   = text "Panic!" <+> nest 4 (pprint s)

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -1519,9 +1519,10 @@ data TError t =
                 , msg  :: !Doc
                 } -- ^ Termination Error 
 
-  | ErrRClass   { cls  :: !LocSymbol
-                , pos  :: !SrcSpan
-                } -- ^ Refined Class Error 
+  | ErrRClass   { pos   :: !SrcSpan
+                , cls   :: !Doc
+                , insts :: ![(SrcSpan, Doc)]
+                } -- ^ Refined Class/Interfaces Conflict
 
   | ErrOther    { pos :: !SrcSpan
                 , msg :: !Doc

--- a/tests/crash/RClass.hs
+++ b/tests/crash/RClass.hs
@@ -7,8 +7,13 @@ class Foo a where
   foo :: a -> a       
 
 
-
 instance Foo Int where
-	{-@ instance Foo Int where
-		   foo :: x:Int -> {v:Int | v = x + 1} @-}
-	foo x = x + 1
+  {-@ instance Foo Int where
+       foo :: x:Int -> {v:Int | v = x + 1} @-}
+  foo x = x + 1
+
+instance Foo Integer where
+  {-@ instance Foo Integer where
+       foo :: x:Integer -> {v:Integer | v = x + 1} @-}
+  foo x = x + 1
+


### PR DESCRIPTION
```haskell
module Crash where

class Foo a where
{-@ class Foo where
      foo :: x:a -> {v:a | v = x}
  @-}
  foo :: a -> a       


instance Foo Int where
  {-@ instance Foo Int where
       foo :: x:Int -> {v:Int | v = x + 1} @-}
  foo x = x + 1

instance Foo Integer where
  {-@ instance Foo Integer where
       foo :: x:Integer -> {v:Integer | v = x + 1} @-}
  foo x = x + 1
```

```
 tests/crash/RClass.hs:4:11: Error: Refined classes cannot have refined instances
     Refined class definition for: Foo
     Defined at: tests/crash/RClass.hs:4:11
      
     Refined instance for: Int
     Defined at: tests/crash/RClass.hs:11:16
      
     Refined instance for: Integer
     Defined at: tests/crash/RClass.hs:16:16
```
vs

```
 tests/crash/RClass.hs:4:11: Error: You cannot refine instances of refined classes Foo
```