### PR TITLE
Remove a couple of things from BareM's shared state

### DIFF
--- a/src/Language/Haskell/Liquid/Bare/Env.hs
+++ b/src/Language/Haskell/Liquid/Bare/Env.hs
@@ -47,7 +47,6 @@ data BareEnv = BE { modName  :: !ModName
                   , rtEnv    :: !RTEnv
                   , varEnv   :: ![(Symbol,Var)]
                   , hscEnv   :: HscEnv 
-                  , logicEnv :: LogicMap
                   }
 
 setModule m b = b { modName = m }

--- a/src/Language/Haskell/Liquid/Bare/Env.hs
+++ b/src/Language/Haskell/Liquid/Bare/Env.hs
@@ -43,7 +43,6 @@ type Warn  = String
 type TCEnv = M.HashMap TyCon RTyCon
 
 data BareEnv = BE { modName  :: !ModName
-                  , tcEnv    :: !TCEnv
                   , rtEnv    :: !RTEnv
                   , varEnv   :: ![(Symbol,Var)]
                   , hscEnv   :: HscEnv 

--- a/src/Language/Haskell/Liquid/Bare/GhcSpec.hs
+++ b/src/Language/Haskell/Liquid/Bare/GhcSpec.hs
@@ -65,7 +65,7 @@ makeGhcSpec cfg name cbs vars defVars exports env lmap specs
   where
     act       = makeGhcSpec' cfg cbs vars defVars lmap' exports specs
     throwLeft = either Ex.throw return
-    initEnv   = BE name mempty mempty mempty env
+    initEnv   = BE name mempty mempty env
     lmap'     = case lmap of {Left e -> Ex.throw e; Right x -> x}
     
 postProcess :: [CoreBind] -> SEnv SortedReft -> GhcSpec -> GhcSpec
@@ -95,19 +95,18 @@ makeGhcSpec' cfg cbs vars defVars lmap exports specs
   = do name                                    <- gets modName
        makeRTEnv specs
        (tycons, datacons, dcSs, tyi, embs)     <- makeGhcSpecCHOP1 specs
-       modify                                   $ \be -> be { tcEnv = tyi }
        (cls, mts)                              <- second mconcat . unzip . mconcat <$> mapM (makeClasses cfg vars) specs
-       (invs, ialias, sigs, asms)              <- makeGhcSpecCHOP2 cfg vars defVars specs name mts embs
-       (measures, cms', ms', cs', xs')         <- makeGhcSpecCHOP3 cbs lmap specs dcSs datacons cls embs
+       (invs, ialias, sigs, asms)              <- makeGhcSpecCHOP2 cfg vars defVars specs tyi name mts embs
+       (measures, cms', ms', cs', xs')         <- makeGhcSpecCHOP3 cbs lmap specs tyi dcSs datacons cls embs
        syms                                    <- makeSymbols (vars ++ map fst cs') xs' (sigs ++ asms ++ cs') ms' (invs ++ (snd <$> ialias))
        let su  = mkSubst [ (x, mkVarExpr v) | (x, v) <- syms]
        return (emptySpec cfg)
          >>= makeGhcSpec0 cfg defVars exports name
          >>= makeGhcSpec1 vars embs tyi exports name sigs asms cs' ms' cms' su 
          >>= makeGhcSpec2 invs ialias measures su                     
-         >>= makeGhcSpec3 datacons tycons embs syms             
+         >>= makeGhcSpec3 datacons tycons tyi embs syms
          >>= makeGhcSpec4 defVars specs name su 
-         >>= makeSpecDictionaries embs vars specs
+         >>= makeSpecDictionaries embs tyi vars specs
 
 emptySpec     :: Config -> GhcSpec
 emptySpec cfg = SP [] [] [] [] [] [] [] [] [] mempty [] [] [] [] mempty mempty cfg mempty [] mempty mempty
@@ -136,13 +135,12 @@ makeGhcSpec2 invs ialias measures su sp
                 , ialiases   = subst su ialias 
                 , measures   = subst su <$> M.elems $ Ms.measMap measures }
 
-makeGhcSpec3 datacons tycons embs syms sp
-  = do tcEnv   <- gets tcEnv
-       return  $ sp { tyconEnv   = tcEnv
-                    , dconsP     = datacons
-                    , tconsP     = tycons
-                    , tcEmbeds   = embs 
-                    , freeSyms   = [(symbol v, v) | (_, v) <- syms] }
+makeGhcSpec3 datacons tycons tyi embs syms sp
+  = return $ sp { tyconEnv   = tyi
+                , dconsP     = datacons
+                , tconsP     = tycons
+                , tcEmbeds   = embs
+                , freeSyms   = [(symbol v, v) | (_, v) <- syms] }
 
 makeGhcSpec4 defVars specs name su sp
   = do decr'   <- mconcat <$> mapM (makeHints defVars . snd) specs
@@ -170,20 +168,18 @@ makeGhcSpecCHOP1 specs
        let dcSelectors  = concat $ map makeMeasureSelectors datacons
        return           $ (tycons, second val <$> datacons, dcSelectors, tyi, embs) 
 
-makeGhcSpecCHOP2 cfg vars defVars specs name mts embs
+makeGhcSpecCHOP2 cfg vars defVars specs tyi name mts embs
   = do sigs'   <- mconcat <$> mapM (makeAssertSpec name cfg vars defVars) specs
        asms'   <- mconcat <$> mapM (makeAssumeSpec name cfg vars defVars) specs
        invs    <- mconcat <$> mapM makeInvariants specs
        ialias  <- mconcat <$> mapM makeIAliases   specs
        let dms  = makeDefaultMethods vars mts
-       tyi     <- gets tcEnv
        let sigs = [ (x, txRefSort tyi embs . txExpToBind <$> t) | (_, x, t) <- sigs' ++ mts ++ dms ]
        let asms = [ (x, txRefSort tyi embs . txExpToBind <$> t) | (_, x, t) <- asms' ]
        return     (invs, ialias, sigs, asms)
 
-makeGhcSpecCHOP3 cbs lmap specs dcSelectors datacons cls embs
+makeGhcSpecCHOP3 cbs lmap specs tyi dcSelectors datacons cls embs
   = do measures'       <- mconcat <$> mapM makeMeasureSpec specs
-       tyi             <- gets tcEnv
        name            <- gets modName 
        hmeans          <- mapM (makeHaskellMeasures cbs lmap name) specs
        let measures     = mconcat (measures':Ms.mkMSpec' dcSelectors:hmeans)

--- a/src/Language/Haskell/Liquid/Bare/GhcSpec.hs
+++ b/src/Language/Haskell/Liquid/Bare/GhcSpec.hs
@@ -63,9 +63,9 @@ makeGhcSpec cfg name cbs vars defVars exports env lmap specs
        let env = ghcSpecEnv sp
        throwLeft $ checkGhcSpec specs env $ postProcess cbs env sp
   where
-    act       = makeGhcSpec' cfg cbs vars defVars exports specs
+    act       = makeGhcSpec' cfg cbs vars defVars lmap' exports specs
     throwLeft = either Ex.throw return
-    initEnv   = BE name mempty mempty mempty env lmap'
+    initEnv   = BE name mempty mempty mempty env
     lmap'     = case lmap of {Left e -> Ex.throw e; Right x -> x}
     
 postProcess :: [CoreBind] -> SEnv SortedReft -> GhcSpec -> GhcSpec
@@ -89,16 +89,16 @@ ghcSpecEnv sp        = fromListSEnv binds
     varRSort         = ofType . varType
 
 ------------------------------------------------------------------------------------------------
-makeGhcSpec' :: Config -> [CoreBind] -> [Var] -> [Var] -> NameSet -> [(ModName, Ms.BareSpec)] -> BareM GhcSpec
+makeGhcSpec' :: Config -> [CoreBind] -> [Var] -> [Var] -> LogicMap -> NameSet -> [(ModName, Ms.BareSpec)] -> BareM GhcSpec
 ------------------------------------------------------------------------------------------------
-makeGhcSpec' cfg cbs vars defVars exports specs
+makeGhcSpec' cfg cbs vars defVars lmap exports specs
   = do name                                    <- gets modName
        makeRTEnv specs
        (tycons, datacons, dcSs, tyi, embs)     <- makeGhcSpecCHOP1 specs
        modify                                   $ \be -> be { tcEnv = tyi }
        (cls, mts)                              <- second mconcat . unzip . mconcat <$> mapM (makeClasses cfg vars) specs
        (invs, ialias, sigs, asms)              <- makeGhcSpecCHOP2 cfg vars defVars specs name mts embs
-       (measures, cms', ms', cs', xs')         <- makeGhcSpecCHOP3 cbs specs dcSs datacons cls embs
+       (measures, cms', ms', cs', xs')         <- makeGhcSpecCHOP3 cbs lmap specs dcSs datacons cls embs
        syms                                    <- makeSymbols (vars ++ map fst cs') xs' (sigs ++ asms ++ cs') ms' (invs ++ (snd <$> ialias))
        let su  = mkSubst [ (x, mkVarExpr v) | (x, v) <- syms]
        return (emptySpec cfg)
@@ -181,11 +181,11 @@ makeGhcSpecCHOP2 cfg vars defVars specs name mts embs
        let asms = [ (x, txRefSort tyi embs . txExpToBind <$> t) | (_, x, t) <- asms' ]
        return     (invs, ialias, sigs, asms)
 
-makeGhcSpecCHOP3 cbs specs dcSelectors datacons cls embs
+makeGhcSpecCHOP3 cbs lmap specs dcSelectors datacons cls embs
   = do measures'       <- mconcat <$> mapM makeMeasureSpec specs
        tyi             <- gets tcEnv
        name            <- gets modName 
-       hmeans          <- mapM (makeHaskellMeasures cbs name) specs
+       hmeans          <- mapM (makeHaskellMeasures cbs lmap name) specs
        let measures     = mconcat (measures':Ms.mkMSpec' dcSelectors:hmeans)
        let (cs, ms)     = makeMeasureSpec' measures
        let cms          = makeClassMeasureSpec measures

--- a/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -25,7 +25,6 @@ import Var
 import Control.Applicative ((<$>), (<*>))
 import Control.Monad hiding (forM)
 import Control.Monad.Error hiding (Error, forM)
-import Control.Monad.State hiding (forM)
 import Data.Bifunctor
 import Data.Maybe
 import Data.Monoid
@@ -53,12 +52,11 @@ import Language.Haskell.Liquid.Bare.Lookup
 import Language.Haskell.Liquid.Bare.OfType
 import Language.Haskell.Liquid.Bare.Resolve
 
-makeHaskellMeasures :: [CoreBind] -> ModName -> (ModName, Ms.BareSpec) -> BareM (Ms.MSpec SpecType DataCon)
-makeHaskellMeasures _   name' (name, _   ) | name /= name' 
+makeHaskellMeasures :: [CoreBind] -> LogicMap -> ModName -> (ModName, Ms.BareSpec) -> BareM (Ms.MSpec SpecType DataCon)
+makeHaskellMeasures _   _    name' (name, _   ) | name /= name'
   = return mempty
-makeHaskellMeasures cbs _     (_   , spec) 
-  = do lmap <- gets logicEnv
-       Ms.mkMSpec' <$> mapM (makeMeasureDefinition lmap cbs') (S.toList $ Ms.hmeas spec)
+makeHaskellMeasures cbs lmap _     (_   , spec)
+  = Ms.mkMSpec' <$> mapM (makeMeasureDefinition lmap cbs') (S.toList $ Ms.hmeas spec)
   where 
     cbs'                  = concatMap unrec cbs
     unrec cb@(NonRec _ _) = [cb]

--- a/src/Language/Haskell/Liquid/Bare/Spec.hs
+++ b/src/Language/Haskell/Liquid/Bare/Spec.hs
@@ -205,16 +205,15 @@ makeInvariants' ts = mapM mkI ts
     mkI (Loc l t)  = (Loc l) . generalize <$> mkSpecType l t
 
 
-makeSpecDictionaries embs vars specs sp
-  = do ds <- (dfromList . concat)  <$>  mapM (makeSpecDictionary embs vars) specs
+makeSpecDictionaries embs tyi vars specs sp
+  = do ds <- (dfromList . concat)  <$>  mapM (makeSpecDictionary embs tyi vars) specs
        return $ sp {dicts = ds}
 
-makeSpecDictionary embs vars (_, spec)  
-  = mapM (makeSpecDictionaryOne embs vars) (Ms.rinstance spec)
+makeSpecDictionary embs tyi vars (_, spec)
+  = mapM (makeSpecDictionaryOne embs tyi vars) (Ms.rinstance spec)
 
-makeSpecDictionaryOne embs vars (RI x t xts) 
+makeSpecDictionaryOne embs tyi vars (RI x t xts)
   = do t'  <-  mkTy t
-       tyi <- gets tcEnv
        ts' <- (map (txRefSort tyi embs . txExpToBind)) <$> mapM mkTy' ts
        let (d, dts) = makeDictionary $ RI x t' $ zip xs ts'
        let v = lookupName d   


### PR DESCRIPTION
`logicEnv` was only used in one place. `tcEnv` was either passed in as an argument (`tyi`) or read from the state depending on the function, but was never updated. Neither of these need to be passed around between every function in Bare.