### PR TITLE
Strengthened the AVL insert function to remove unnecessary guards

### DIFF
--- a/tests/pos/AVLRJ.hs
+++ b/tests/pos/AVLRJ.hs
@@ -26,7 +26,6 @@ bFac (Tree _ l r) = ht l - ht r
 htDiff :: Tree a -> Tree a -> Int
 htDiff l r = ht l - ht r
 
-
 -- | Empty 
 {-@ empty :: {v: AVLTree a | ht v == 0} @-}
 empty = Nil
@@ -36,7 +35,10 @@ empty = Nil
 singleton a = Tree a Nil Nil
 
 -- | Insert 
-{-@ insert :: a -> s: AVLTree a -> {t: AVLTree a | EqHt t s || HtDiff t s 1 } @-}
+
+{-@ predicate PostInsert S T = ((bFac T == 0) => (EqHt T S || ht T == 1)) && (EqHt T S || HtDiff T S 1) @-}
+
+{-@ insert :: a -> s: AVLTree a -> {t: AVLTree a | PostInsert s t } @-}
 insert :: (Ord a) => a -> Tree a -> Tree a
 insert a Nil = singleton a
 insert a t@(Tree v _ _) = case compare a v of
@@ -44,42 +46,32 @@ insert a t@(Tree v _ _) = case compare a v of
     GT -> insR a t
     EQ -> t
 
-{-@ insL :: x:a -> s:{AVLTree a | x < key s && ht s > 0} -> {t: AVLTree a | EqHt t s || HtDiff t s 1 } @-}
+{-@ insL :: x:a -> s:{AVLTree a | x < key s && ht s > 0} -> {t: AVLTree a | PostInsert s t } @-}
 insL a (Tree v l r)
-  | siblDiff > 1 && bl' > 0  = rebalanceLL v l' r
-  | siblDiff > 1 && bl' < 0  = rebalanceLR v l' r
-  | siblDiff > 1             = rebalanceL0 v l' r
+  | siblDiff == 2 && bl' == 1  = rebalanceLL v l' r
+  | siblDiff == 2 && bl' == (0-1)  = rebalanceLR v l' r
   | siblDiff <= 1            = Tree v l' r
   where
     l'                       = insert a l
     siblDiff                 = htDiff l' r
     bl'                      = bFac l'
    
-{-@ insR :: x:a -> s:{AVLTree a | key s < x && ht s > 0} -> {t: AVLTree a | EqHt t s || HtDiff t s 1 } @-}
+{-@ insR :: x:a -> s:{AVLTree a | key s < x && ht s > 0} -> {t: AVLTree a | PostInsert s t } @-}
 insR a (Tree v l r)
-  | siblDiff > 1 && br' > 0  = rebalanceRL v l r'
-  | siblDiff > 1 && br' < 0  = rebalanceRR v l r'
-  | siblDiff > 1             = rebalanceR0 v l r'
+  | siblDiff == 2 && br' == 1  = rebalanceRL v l r'
+  | siblDiff == 2 && br' == (0-1)  = rebalanceRR v l r'
   | siblDiff <= 1            = Tree v l r'
   where
     siblDiff                 = htDiff r' l
     r'                       = insert a r
     br'                      = bFac r'
 
-{-@ rebalanceL0 :: x:a -> l:{AVLL a x | NoHeavy l} -> r:{AVLR a x | HtDiff l r 2} -> {t:AVLTree a | ht t = ht l + 1 } @-}
-rebalanceL0 v (Tree lv ll lr) r                 = Tree lv ll (Tree v lr r)
 
 {-@ rebalanceLL :: x:a -> l:{AVLL a x | LeftHeavy l } -> r:{AVLR a x | HtDiff l r 2} -> {t:AVLTree a | EqHt t l} @-}
 rebalanceLL v (Tree lv ll lr) r                 = Tree lv ll (Tree v lr r)
 
-
 {-@ rebalanceLR :: x:a -> l:{AVLL a x | RightHeavy l } -> r:{AVLR a x | HtDiff l r 2} -> {t: AVLTree a | EqHt t l } @-}
 rebalanceLR v (Tree lv ll (Tree lrv lrl lrr)) r = Tree lrv (Tree lv ll lrl) (Tree v lrr r)
-
-
-{-@ rebalanceR0 :: x:a -> l: AVLL a x -> r: {AVLR a x | NoHeavy r && HtDiff r l 2 } -> {t: AVLTree a | ht t = ht r + 1} @-}
-rebalanceR0 v l (Tree rv rl rr)                 = Tree rv (Tree v l rl) rr
-
 
 {-@ rebalanceRR :: x:a -> l: AVLL a x -> r:{AVLR a x | RightHeavy r && HtDiff r l 2 } -> {t: AVLTree a | EqHt t r } @-}
 rebalanceRR v l (Tree rv rl rr)                 = Tree rv (Tree v l rl) rr
@@ -100,7 +92,6 @@ main = do
 
 {-@ predicate HtDiff S T D = ht S - ht T == D @-}
 {-@ predicate EqHt S T     = HtDiff S T 0     @-}
-{-@ predicate NoHeavy    T = bFac T == 0      @-}
 {-@ predicate LeftHeavy  T = bFac T == 1      @-}
 {-@ predicate RightHeavy T = bFac T == -1     @-}
 


### PR DESCRIPTION
I added a predicate that strengthens the postconditions on `insert` so, to satisfy the totality checker, we don't need the case checks I removed.

I feel like the type on line 21 shouldn't be required somehow, since by the definition of `balanced`, the absolute value of `bFac` for an `AVLTree` must be 0 or 1.

Probably related to that, the following type checks:

    force :: Tree a -> Tree a
    {-@ force :: forall <p :: Tree a -> Prop>. t:AVLTree a<p> -> {v:AVLTree a<p> | bFac v <= 1 && bFac v >= -1} @-}
    force t@(Nil) = t
    force t@(Tree v l r) = t

while this does not:

    force :: Tree a -> Tree a
    {-@ force :: forall <p :: Tree a -> Prop>. t:AVLTree a<p> -> {v:AVLTree a<p> | bFac v <= 1 && bFac v >= -1} @-}
    force t = t

I guess this is because on the constructors Branch and Nil, `balanced` is expanded to the whole definition, while on a general `Tree a`, we only know `balanced`. Could it be possible to try to automatically expand `t` to both constructors and then deduce it that way?
