### PR TITLE
Uncommented GHC.Num.negate spec

### DIFF
--- a/include/GHC/Num.spec
+++ b/include/GHC/Num.spec
@@ -4,6 +4,6 @@ GHC.Num.fromInteger :: (GHC.Num.Num a)
                     => x:GHC.Integer.Type.Integer
                     -> {v:a | v = x }
 
--- GHC.Num.negate :: (GHC.Num.Num a)
---                => x:a
---                -> {v:a | v = (0-x)}
+GHC.Num.negate :: (GHC.Num.Num a)
+               => x:a
+               -> {v:a | v = -x}


### PR DESCRIPTION
I don't know why this was commented out but it fixes the issue of having to write `(0-1)` everywhere in code instead of `-1`.

This is faster than fixing it at the CoreToLogic level. Were there some kind of problems with the spec?