### PR TITLE
Added ENeg type

### DIFF
--- a/src/Language/Haskell/Liquid/Bare/Expand.hs
+++ b/src/Language/Haskell/Liquid/Bare/Expand.hs
@@ -104,6 +104,8 @@ expandExpr (EApp f@(Loc l f') es)
          Nothing ->
            EApp f <$> mapM expandExpr es
 
+expandExpr (ENeg e)
+  = ENeg <$> expandExpr e
 expandExpr (EBin op e1 e2)
   = EBin op <$> expandExpr e1 <*> expandExpr e2
 expandExpr (EIte p e1 e2)

--- a/src/Language/Haskell/Liquid/Bare/RTEnv.hs
+++ b/src/Language/Haskell/Liquid/Bare/RTEnv.hs
@@ -222,6 +222,8 @@ buildExprEdges table
         go (EApp (Loc _ f) es)
           = go_alias f ++ concatMap go es
 
+        go (ENeg e)
+          = go e
         go (EBin _ e1 e2)
           = go e1 ++ go e2
         go (EIte _ e1 e2)

--- a/src/Language/Haskell/Liquid/Bare/RefToLogic.hs
+++ b/src/Language/Haskell/Liquid/Bare/RefToLogic.hs
@@ -87,6 +87,7 @@ instance Transformable Expr where
 	tx _ _ (ESym c)       = ESym c
 	tx _ _ (ECon c)       = ECon c
 	tx _ _ (ELit l s')    = ELit l s'
+	tx s m (ENeg e)       = ENeg (tx s m e)
 	tx s m (EBin o e1 e2) = EBin o (tx s m e1) (tx s m e2)
 	tx s m (EIte p e1 e2) = EIte (tx s m p) (tx s m e1) (tx s m e2)
 	tx s m (ECst e s')    = ECst (tx s m e) s'
@@ -136,4 +137,4 @@ txPApp (s, (Right (TI xs (Left e)))) f es
 txPApp (s, m) f es = PBexp $ txEApp (s, m) f es
 
 cmpSymbol s1 {- symbol in Core -} s2 {- logical Symbol-}
-  = (dropModuleNames s1) == s2  
+  = (dropModuleNames s1) == s2

--- a/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -47,6 +47,7 @@ instance Resolvable Pred where
 instance Resolvable Expr where
   resolve l (EVar s)       = EVar   <$> resolve l s
   resolve l (EApp s es)    = EApp   <$> resolve l s  <*> resolve l es
+  resolve l (ENeg e)       = ENeg   <$> resolve l e
   resolve l (EBin o e1 e2) = EBin o <$> resolve l e1 <*> resolve l e2
   resolve l (EIte p e1 e2) = EIte   <$> resolve l p  <*> resolve l e1 <*> resolve l e2
   resolve l (ECst x s)     = ECst   <$> resolve l x  <*> resolve l s

--- a/src/Language/Haskell/Liquid/CoreToLogic.hs
+++ b/src/Language/Haskell/Liquid/CoreToLogic.hs
@@ -243,6 +243,9 @@ toLogicApp e
         (\x -> makeApp def lmap x args) <$> tosymbol' f
 
 makeApp :: Expr -> LogicMap -> Located Symbol-> [Expr] -> Expr
+makeApp _ _ f [e] | val f == symbol ("GHC.Num.negate" :: String)
+  = ENeg e
+
 makeApp _ _ f [e1, e2] | Just op <- M.lookup (val f) bops
   = EBin op e1 e2
 

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -1336,6 +1336,7 @@ instance PPrint Expr where
   pprint (ECon c)        = pprint c 
   pprint (EVar s)        = pprint s
   pprint (ELit s _)      = pprint s
+  pprint (ENeg e)        = text "-" <> parens (pprint e)
   pprint (EBin o e1 e2)  = {- parens $ -} pprint e1 <+> pprint o <+> pprint e2
   pprint (EIte p e1 e2)  = {- parens $ -} text "if" <+> parens (pprint p) <+> text "then" <+> pprint e1 <+> text "else" <+> pprint e2 
   pprint (ECst e so)     = parens $ pprint e <+> text " : " <+> pprint so 

--- a/tests/pos/AVLRJ.hs
+++ b/tests/pos/AVLRJ.hs
@@ -49,7 +49,7 @@ insert a t@(Tree v _ _) = case compare a v of
 {-@ insL :: x:a -> s:{AVLTree a | x < key s && ht s > 0} -> {t: AVLTree a | PostInsert s t } @-}
 insL a (Tree v l r)
   | siblDiff == 2 && bl' == 1  = rebalanceLL v l' r
-  | siblDiff == 2 && bl' == (0-1)  = rebalanceLR v l' r
+  | siblDiff == 2 && bl' == -1  = rebalanceLR v l' r
   | siblDiff <= 1            = Tree v l' r
   where
     l'                       = insert a l
@@ -59,7 +59,7 @@ insL a (Tree v l r)
 {-@ insR :: x:a -> s:{AVLTree a | key s < x && ht s > 0} -> {t: AVLTree a | PostInsert s t } @-}
 insR a (Tree v l r)
   | siblDiff == 2 && br' == 1  = rebalanceRL v l r'
-  | siblDiff == 2 && br' == (0-1)  = rebalanceRR v l r'
+  | siblDiff == 2 && br' == -1  = rebalanceRR v l r'
   | siblDiff <= 1            = Tree v l r'
   where
     siblDiff                 = htDiff r' l
@@ -98,7 +98,7 @@ main = do
 {-@ measure balanced @-}
 balanced              :: Tree a -> Bool 
 balanced (Nil)        = True 
-balanced (Tree v l r) = ht l <= ht r + 1 && ht r <= ht l + 1 && balanced l && balanced r
+balanced (Tree v l r) = ht l - ht r <= 1 && ht l - ht r >= -1 && balanced l && balanced r
 
 {-@ type AVLTree a   = {v: Tree a | balanced v} @-}
 {-@ type AVLL a X    = AVLTree {v:a | v < X}    @-}


### PR DESCRIPTION
LH wasn't able to lift functions with expressions containing `(-1)` into measures (see `tests/pos/AVLRJ.hs` for an example), so I added a type constructor `ENeg` to represent this to `Liquid.Fixpoint.Types.Expr`. See ucsd-progsys/liquid-fixpoint#50