### PR TITLE
Remove Travis branch whitelist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,4 @@
 # NB: don't set `language: haskell` here
-branches:
- only:
-  - master
-  - parser
-
 env:
  - SMT=z3 TESTS=Unit/pos
  - SMT=z3 TESTS=Unit/neg


### PR DESCRIPTION
It's a hassle to have to make a temporary commit to have Travis build each new development branch. Why not get rid of this whitelist entirely and build all branches on push?