### PR TITLE
Resolve Exprs in RExprArgs

### DIFF
--- a/src/Language/Haskell/Liquid/Bare/Env.hs
+++ b/src/Language/Haskell/Liquid/Bare/Env.hs
@@ -82,7 +82,7 @@ withVArgs l vs act = do
   return res
 
 mkExprAlias l v
-  = setRTAlias v (RTA v [] [] (RExprArg (EVar $ symbol v)) l)
+  = setRTAlias v (RTA v [] [] (RExprArg (Loc l $ EVar $ symbol v)) l)
 
 setRTAlias s a =
   modify $ \b -> b { rtEnv = mapRT (M.insert s a) $ rtEnv b }

--- a/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -25,7 +25,7 @@ import Language.Haskell.Liquid.Bare.Env
 import Language.Haskell.Liquid.Bare.Lookup
 
 class Resolvable a where
-  resolve     :: SourcePos -> a -> BareM a
+  resolve :: SourcePos -> a -> BareM a
 
 instance Resolvable a => Resolvable [a] where
   resolve = mapM . resolve

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -221,8 +221,8 @@ maybeP p = liftM Just p <|> return Nothing
 
 bareTyArgP
   =  -- try (RExprArg . expr <$> binderP) <|>
-     try (RExprArg . expr <$> integer)
- <|> try (braces $ RExprArg <$> exprP)
+     try (RExprArg . fmap expr <$> locParserP integer)
+ <|> try (braces $ RExprArg <$> locParserP exprP)
  <|> try bareAtomNoAppP
  <|> try (parens bareTypeP)
 

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -631,7 +631,7 @@ data RType c tv r
     , rt_ty     :: !(RType c tv r) 
     }
 
-  | RExprArg Expr                               -- ^ For expression arguments to type aliases
+  | RExprArg (Located Expr)                     -- ^ For expression arguments to type aliases
                                                 --   see tests/pos/vector2.hs
   | RAppTy{
       rt_arg   :: !(RType c tv r)


### PR DESCRIPTION
We do name resolution on `Expr`s inside `UReft`s, but not in `RExprArg`s in the `RType`s.