### PR TITLE
Use Travis's standard copy of GHC 7.8 instead of installing our own

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-# NB: don't set `language: haskell` here
+language: haskell
+
 env:
  - SMT=z3 TESTS=Unit/pos
  - SMT=z3 TESTS=Unit/neg
@@ -15,13 +16,12 @@ env:
  # ugh... Classify.hs is too slow and makes travis think the build is stalled
  # - TESTS=hscolour
 
-# Note: the distinction between `before_install` and `install` is not important.
+ghc: 7.8
+
 before_install:
- - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
  - travis_retry sudo apt-get update
- - travis_retry sudo apt-get install cabal-install-1.18 ghc-7.8.3 ocaml camlidl
- - export PATH="$HOME/.cabal/bin:/opt/ghc/7.8.3/bin:/opt/cabal/1.18/bin:$PATH"
- - cabal update
+ - travis_retry sudo apt-get install ocaml camlidl
+ - travis_retry cabal update
  - git clone git://github.com/ucsd-progsys/liquid-fixpoint.git /tmp/fixpoint
  - pushd /tmp/fixpoint && cabal install -fbuild-external && popd
  - curl "http://goto.ucsd.edu/~gridaphobe/$SMT" -o "$HOME/.cabal/bin/$SMT"
@@ -42,7 +42,7 @@ script:
  - cabal sdist   # tests that a source-distribution can be generated
 
 # The following scriptlet checks that the resulting source distribution can be built & installed
- - export SRC_TGZ=$(cabal-1.18 info . | awk '{print $2 ".tar.gz";exit}') ;
+ - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;
    cd dist/;
    if [ -f "$SRC_TGZ" ]; then
       cabal install "$SRC_TGZ";


### PR DESCRIPTION
I've been communicating with Travis-CI support, trying to work out the issue we're having with `cabal install` randomly erroring out during builds. They're not sure what the problem is, but they recommend using the standard Travis's standard copies of GHC and Cabal instead of installing our own, to eliminate that as a possible source.

It looks like we're currently using a modified version of [hvr/multi-ghc-travis](https://github.com/hvr/multi-ghc-travis), but it doesn't look like we need to anymore. We're not currently testing against multiple versions of GHC, and [Travis supports that natively now](http://docs.travis-ci.com/user/languages/haskell/) anyway.