### PR TITLE
Temporarily enable verbose logging for Cabal commands on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,12 @@ before_install:
  - travis_retry sudo apt-get install ocaml camlidl
  - travis_retry cabal update
  - git clone git://github.com/ucsd-progsys/liquid-fixpoint.git /tmp/fixpoint
- - pushd /tmp/fixpoint && cabal install -fbuild-external && popd
+ - pushd /tmp/fixpoint && cabal install -v3 -fbuild-external && popd
  - curl "http://goto.ucsd.edu/~gridaphobe/$SMT" -o "$HOME/.cabal/bin/$SMT"
  - chmod a+x "$HOME/.cabal/bin/$SMT"
 
 install:
- - cabal install --only-dependencies --enable-tests
+ - cabal install -v3 --only-dependencies --enable-tests
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
 script:


### PR DESCRIPTION
I believe the cause of our random build failures is an interuption of network connectivity while we're downloading packages from Hackage. Unfortunately, Cabal doesn't print out a nice error message for this by default, and I can't reproduce the issue outside of Travis. Thus, to confirm that this is the case, we'd need to temporarily enable verbose logging for our Cabal commands in Travis builds.

If this *is* the cause of the issue, it can be worked around by adding `travis_retry` before our Cabal commands. First, though, I'd like to be able to provide Travis support with verbose log data from an errored-out build.