### PR TITLE
Work around Travis issues with travis_retry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ script:
  - cabal build
  - cabal copy
  - cabal register
- - ./dist/build/test/test --pattern "$TESTS/" --smtsolver "$SMT" -j2 +RTS -N2 -RTS
+ # travis_wait to prevent Travis from timing out tests that take > 10 minutes
+ - travis_wait ./dist/build/test/test --pattern "$TESTS/" --smtsolver "$SMT" -j2 +RTS -N2 -RTS
  # Removing cabal check, as it fails if the -Werror flag is on. We want -Werror flag!
  # - cabal check
  - cabal sdist   # tests that a source-distribution can be generated

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,15 @@ before_install:
  - travis_retry sudo apt-get install ocaml camlidl
  - travis_retry cabal update
  - git clone git://github.com/ucsd-progsys/liquid-fixpoint.git /tmp/fixpoint
- - pushd /tmp/fixpoint && cabal install -fbuild-external && popd
+ - pushd /tmp/fixpoint
+     && travis_retry cabal install --only-dependencies
+     && cabal install -fbuild-external
+     && popd
  - curl "http://goto.ucsd.edu/~gridaphobe/$SMT" -o "$HOME/.cabal/bin/$SMT"
  - chmod a+x "$HOME/.cabal/bin/$SMT"
 
 install:
- - cabal install --only-dependencies --enable-tests
+ - travis_retry cabal install --only-dependencies --enable-tests
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,38 +19,16 @@ env:
 ghc: 7.8
 
 before_install:
- - travis_retry sudo apt-get update
- - travis_retry sudo apt-get install ocaml camlidl
- - travis_retry cabal update
- - git clone git://github.com/ucsd-progsys/liquid-fixpoint.git /tmp/fixpoint
- - pushd /tmp/fixpoint
-     && travis_retry cabal install --only-dependencies
-     && cabal install -fbuild-external
-     && popd
- - curl "http://goto.ucsd.edu/~gridaphobe/$SMT" -o "$HOME/.cabal/bin/$SMT"
- - chmod a+x "$HOME/.cabal/bin/$SMT"
+ - scripts/travis install_ocaml
+ - scripts/travis setup_cabal
+ - scripts/travis install_fixpoint
+ - scripts/travis install_smt "$SMT"
 
 install:
- - travis_retry cabal install --only-dependencies --enable-tests
+ - scripts/travis install_cabal_deps
 
-# Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
 script:
- - cabal configure -fdevel -O2 --enable-tests -v2  # -v2 provides useful information for debugging
- - cabal build
- - cabal copy
- - cabal register
- # travis_wait to prevent Travis from timing out tests that take > 10 minutes
- - travis_wait ./dist/build/test/test --pattern "$TESTS/" --smtsolver "$SMT" -j2 +RTS -N2 -RTS
- # Removing cabal check, as it fails if the -Werror flag is on. We want -Werror flag!
- # - cabal check
- - cabal sdist   # tests that a source-distribution can be generated
+ - scripts/travis do_build
+ - scripts/travis do_test "$TESTS" "$SMT"
+ - scripts/travis test_source_pkg
 
-# The following scriptlet checks that the resulting source distribution can be built & installed
- - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;
-   cd dist/;
-   if [ -f "$SRC_TGZ" ]; then
-      cabal install "$SRC_TGZ";
-   else
-      echo "expected '$SRC_TGZ' not found";
-      exit 1;
-   fi

--- a/scripts/travis
+++ b/scripts/travis
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+set -e
+
+## Helper Functions
+
+function prevent_timeout {
+  local cmd="$@"
+
+  $cmd &
+  local cmd_pid=$!
+
+  poke_stdout &
+  local poke_pid=$!
+
+  wait $cmd_pid
+  exit_code=$?
+  kill $poke_pid
+
+  return $exit_code
+}
+
+function poke_stdout {
+  # Print an invisible character every minute
+  while true; do
+    echo -ne "\xE2\x80\x8B"
+    sleep 60
+  done
+}
+
+## Testing Stages
+
+function install_ocaml {
+  travis_retry sudo apt-get update
+  travis_retry sudo apt-get install ocaml camlidl
+}
+
+function setup_cabal {
+  travis_retry cabal update
+}
+
+function install_fixpoint {
+  git clone git://github.com/ucsd-progsys/liquid-fixpoint.git /tmp/fixpoint
+  pushd /tmp/fixpoint
+  travis_retry cabal install --only-dependencies
+  cabal install -fbuild-external
+  popd
+}
+
+function install_smt {
+ local smt="$1"
+
+ curl "http://goto.ucsd.edu/~gridaphobe/$smt" -o "$HOME/.cabal/bin/$smt"
+ chmod a+x "$HOME/.cabal/bin/$smt"
+}
+
+function install_cabal_deps {
+  travis_retry cabal install --only-dependencies --enable-tests
+}
+
+function do_build {
+  cabal configure -fdevel -O2 --enable-tests -v2
+  cabal build
+  cabal copy
+  cabal register
+}
+
+function do_test {
+  local tests="$1"
+  local smt="$2"
+
+  prevent_timeout ./dist/build/test/test --pattern "$tests/" --smtsolver "$smt" -j2 +RTS -N2 -RTS
+}
+
+function test_source_pkg {
+  cabal sdist
+  local src_tgz="$(cabal info . | awk '{print $2 ".tar.gz";exit}')"
+
+  if [ -f "$src_tgz" ]; then
+    cabal install "$src_tgz"
+  else
+    echo "expected '$src_tgz' not found"
+    return 1
+  fi
+}
+
+## Run Test Stage
+
+stage="$1"
+shift
+
+set -x
+$stage "$@"
+

--- a/scripts/travis
+++ b/scripts/travis
@@ -4,6 +4,11 @@ set -e
 
 ## Helper Functions
 
+function loud {
+  echo "$ $@"
+  $@
+}
+
 # Source: https://github.com/travis-ci/travis-build/blob/fc4ae8a2ffa1f2b3a2f62533bbc4f8a9be19a8ae/lib/travis/build/script/templates/header.sh
 function travis_retry {
   local result=0
@@ -53,55 +58,55 @@ function poke_stdout {
 ## Testing Stages
 
 function install_ocaml {
-  travis_retry sudo apt-get update
-  travis_retry sudo apt-get install ocaml camlidl
+  loud travis_retry sudo apt-get update
+  loud travis_retry sudo apt-get install ocaml camlidl
 }
 
 function setup_cabal {
-  travis_retry cabal update
+  loud travis_retry cabal update
 }
 
 function install_fixpoint {
-  git clone git://github.com/ucsd-progsys/liquid-fixpoint.git /tmp/fixpoint
-  pushd /tmp/fixpoint
-  travis_retry cabal install --only-dependencies
-  cabal install -fbuild-external
-  popd
+  loud git clone git://github.com/ucsd-progsys/liquid-fixpoint.git /tmp/fixpoint
+  loud pushd /tmp/fixpoint
+  loud travis_retry cabal install --only-dependencies
+  loud cabal install -fbuild-external
+  loud popd
 }
 
 function install_smt {
  local smt="$1"
 
- curl "http://goto.ucsd.edu/~gridaphobe/$smt" -o "$HOME/.cabal/bin/$smt"
- chmod a+x "$HOME/.cabal/bin/$smt"
+ loud curl "http://goto.ucsd.edu/~gridaphobe/$smt" -o "$HOME/.cabal/bin/$smt"
+ loud chmod a+x "$HOME/.cabal/bin/$smt"
 }
 
 function install_cabal_deps {
-  travis_retry cabal install --only-dependencies --enable-tests
+  loud travis_retry cabal install --only-dependencies --enable-tests
 }
 
 function do_build {
-  cabal configure -fdevel -O2 --enable-tests -v2
-  cabal build
-  cabal copy
-  cabal register
+  loud cabal configure -fdevel -O2 --enable-tests -v2
+  loud cabal build
+  loud cabal copy
+  loud cabal register
 }
 
 function do_test {
   local tests="$1"
   local smt="$2"
 
-  prevent_timeout ./dist/build/test/test --pattern "$tests/" --smtsolver "$smt" -j2 +RTS -N2 -RTS
+  loud prevent_timeout ./dist/build/test/test --pattern "$tests/" --smtsolver "$smt" -j2 +RTS -N2 -RTS
 }
 
 function test_source_pkg {
-  cabal sdist
+  loud cabal sdist
 
   local src_tgz="$(cabal info . | awk '{print $2 ".tar.gz";exit}')"
 
   pushd dist
   if [ -f "$src_tgz" ]; then
-    cabal install "$src_tgz"
+    loud cabal install "$src_tgz"
   else
     echo "expected '$src_tgz' not found"
     return 1
@@ -114,6 +119,5 @@ function test_source_pkg {
 stage="$1"
 shift
 
-set -x
 $stage "$@"
 

--- a/scripts/travis
+++ b/scripts/travis
@@ -4,6 +4,28 @@ set -e
 
 ## Helper Functions
 
+# Source: https://github.com/travis-ci/travis-build/blob/fc4ae8a2ffa1f2b3a2f62533bbc4f8a9be19a8ae/lib/travis/build/script/templates/header.sh
+function travis_retry {
+  local result=0
+  local count=1
+  while [ $count -le 3 ]; do
+    [ $result -ne 0 ] && {
+      echo -e "\n${RED}The command \"$@\" failed. Retrying, $count of 3.${RESET}\n" >&2
+    }
+    "$@"
+    result=$?
+    [ $result -eq 0 ] && break
+    count=$(($count + 1))
+    sleep 1
+  done
+
+  [ $count -eq 3 ] && {
+    echo "\n${RED}The command \"$@\" failed 3 times.${RESET}\n" >&2
+  }
+
+  return $result
+}
+
 function prevent_timeout {
   local cmd="$@"
 

--- a/scripts/travis
+++ b/scripts/travis
@@ -96,14 +96,17 @@ function do_test {
 
 function test_source_pkg {
   cabal sdist
+
   local src_tgz="$(cabal info . | awk '{print $2 ".tar.gz";exit}')"
 
+  pushd dist
   if [ -f "$src_tgz" ]; then
     cabal install "$src_tgz"
   else
     echo "expected '$src_tgz' not found"
     return 1
   fi
+  popd dist
 }
 
 ## Run Test Stage


### PR DESCRIPTION
Random network failures during Cabal dependency installs break Travis builds. Work around this by adding travis_retry to commands that install dependencies.

See #362.