### PR TITLE
Dump logs of failed tests when running on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ install:
 
 script:
  - scripts/travis do_build
- - scripts/travis do_test "$TESTS" "$SMT"
- - scripts/travis test_source_pkg
+ - scripts/travis do_test "$TESTS" "$SMT" && scripts/travis test_source_pkg
 
 after_failure:
  - scripts/travis dump_fail_logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ install:
 script:
  - scripts/travis do_build
  - scripts/travis do_test "$TESTS" "$SMT"
- - scripts/travis dump_fail_logs
  - scripts/travis test_source_pkg
+
+after_failure:
+ - scripts/travis dump_fail_logs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,6 @@ install:
 script:
  - scripts/travis do_build
  - scripts/travis do_test "$TESTS" "$SMT"
+ - scripts/travis dump_fail_logs
  - scripts/travis test_source_pkg
 

--- a/scripts/travis
+++ b/scripts/travis
@@ -98,6 +98,13 @@ function do_test {
   loud prevent_timeout ./dist/build/test/test --pattern "$tests/" --smtsolver "$smt" -j2 +RTS -N2 -RTS
 }
 
+function dump_fail_logs {
+  find . -type f -wholename '*/.liquid/*' -name '*.log.fail' -print0 | while IFS= read -r -d $'\0' file; do
+    echo " === Contents of log file ${file} === "
+    cat "$file"
+  done
+}
+
 function test_source_pkg {
   loud cabal sdist
 

--- a/scripts/travis
+++ b/scripts/travis
@@ -57,6 +57,14 @@ function poke_stdout {
   done
 }
 
+function travis_fold_start {
+  echo "travis_fold:start:$1"
+}
+
+function travis_fold_end {
+  echo "travis_fold:end:$1"
+}
+
 ## Testing Stages
 
 function install_ocaml {
@@ -100,8 +108,10 @@ function do_test {
 
 function dump_fail_logs {
   find . -type f -wholename '*/.liquid/*' -name '*.log.fail' -print0 | while IFS= read -r -d $'\0' file; do
+    travis_fold_start "${file}"
     echo " === Contents of log file ${file} === "
     cat "$file"
+    travis_fold_end "${file}"
   done
 }
 

--- a/scripts/travis
+++ b/scripts/travis
@@ -62,22 +62,6 @@ function pastebin {
   curl -s -F 'sprunge=<-' http://sprunge.us
 }
 
-function box_top {
-  echo "╔══════════════════════════════════════════════════════════════════════════════╗"
-}
-
-function box_divider {
-  echo "╠══════════════════════════════════════════════════════════════════════════════╣"
-}
-
-function box_line {
-  printf "║ %-76s ║\n" "${1}"
-}
-
-function box_bottom {
-  echo "╚══════════════════════════════════════════════════════════════════════════════╝"
-}
-
 ## Testing Stages
 
 function install_ocaml {
@@ -120,16 +104,10 @@ function do_test {
 }
 
 function dump_fail_logs {
-  box_top
-  box_line "Log files for failed tests"
-  box_divider
-
   find . -type f -wholename '*/.liquid/*' -name '*.log.fail' -print0 | while IFS= read -r -d $'\0' file; do
-    box_line "${file}:"
-    box_line "    $(pastebin < "${file}")"
+    echo "${file}:"
+    echo "    $(pastebin < "${file}")"
   done
-
-  box_bottom
 }
 
 function test_source_pkg {

--- a/scripts/travis
+++ b/scripts/travis
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-set -e
+set -eu
+set -o pipefail
 
 ## Helper Functions
 

--- a/scripts/travis
+++ b/scripts/travis
@@ -107,7 +107,7 @@ function install_cabal_deps {
 
 function do_build {
   loud cabal configure -fdevel --enable-tests -v2
-  loud cabal build -j2
+  loud prevent_timeout cabal build -j2
   loud cabal copy
   loud cabal register
 }
@@ -139,7 +139,7 @@ function test_source_pkg {
 
   pushd dist
   if [ -f "$src_tgz" ]; then
-    loud cabal install -j4 "$src_tgz"
+    loud prevent_timeout cabal install -j4 "$src_tgz"
   else
     echo "expected '$src_tgz' not found"
     return 1

--- a/scripts/travis
+++ b/scripts/travis
@@ -58,12 +58,24 @@ function poke_stdout {
   done
 }
 
-function travis_fold_start {
-  echo "travis_fold:start:$1"
+function pastebin {
+  curl -s -F 'sprunge=<-' http://sprunge.us
 }
 
-function travis_fold_end {
-  echo "travis_fold:end:$1"
+function box_top {
+  echo "╔══════════════════════════════════════════════════════════════════════════════╗"
+}
+
+function box_divider {
+  echo "╠══════════════════════════════════════════════════════════════════════════════╣"
+}
+
+function box_line {
+  printf "║ %-76s ║\n" "${1}"
+}
+
+function box_bottom {
+  echo "╚══════════════════════════════════════════════════════════════════════════════╝"
 }
 
 ## Testing Stages
@@ -108,12 +120,16 @@ function do_test {
 }
 
 function dump_fail_logs {
+  box_top
+  box_line "Log files for failed tests"
+  box_divider
+
   find . -type f -wholename '*/.liquid/*' -name '*.log.fail' -print0 | while IFS= read -r -d $'\0' file; do
-    travis_fold_start "${file}"
-    echo " === Contents of log file ${file} === "
-    cat "$file"
-    travis_fold_end "${file}"
+    box_line "${file}:"
+    box_line "    $(pastebin < "${file}")"
   done
+
+  box_bottom
 }
 
 function test_source_pkg {

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -93,6 +93,7 @@ mkTest code dir file
           let cmd     = testCmd liquid dir file smt
           (_,_,_,ph) <- createProcess $ (shell cmd) {std_out = UseHandle h, std_err = UseHandle h}
           c          <- waitForProcess ph
+          renameFile log $ log <.> (if code == c then "pass" else "fail")
           assertEqual "Wrong exit code" code c
   where
     test = dir </> file


### PR DESCRIPTION
@nikivazou and I were discussing this earlier today. When a test fails on Travis, right now, we have to re-run it on our own systems to see log output. Besides being inconvenient, sometimes we have test failures on Travis that we can't reproduce ourselves. This PR modifies the test and Travis scripts to dump the logs of failed tests when running on Travis. It also tightens a few things up in the Travis script.

You can view an example here:

https://travis-ci.org/spinda/liquidhaskell/jobs/57744542#L832-L836

with this at the end:

```
(...)
The command "scripts/travis do_test "$TESTS" "$SMT" && scripts/travis test_source_pkg" exited with 1.
$ scripts/travis dump_fail_logs
./benchmarks/bytestring-0.9.2.1/Data/ByteString/Lazy/.liquid/Char8.hs.log.fail:
    http://sprunge.us/FQeJ
./benchmarks/bytestring-0.9.2.1/Data/ByteString/.liquid/Char8.hs.log.fail:
    http://sprunge.us/bhQT
```

I originally had the Travis script dump the logs to stdout, but their length caused Travis to break in strange ways. So I have the script upload them to the http://sprunge.us pastebin instead, printing out links to where the logs can be viewed.