### PR TITLE
Use Travis containers for stabler and 2x faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
  - SMT=z3 TESTS=Benchmarks/text
  - SMT=z3 TESTS=Benchmarks/bytestring
  - SMT=z3 TESTS=Benchmarks/esop
- - SMT=z3 TESTS=Benchmarks/vector-algorithms
+ - SMT=z3 TESTS=Benchmarks/vect-algs
  - SMT=cvc4 TESTS=Unit/pos
  - SMT=cvc4 TESTS=Unit/neg
  - SMT=cvc4 TESTS=Unit/crash

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,17 +33,17 @@ env:
  # - TESTS=hscolour
 
 before_install:
- - scripts/travis setup_cabal
+ - scripts/travis clean_cache "$SMT"
  - scripts/travis clone_fixpoint
- - scripts/travis install_smt "$SMT"
 
 install:
  - scripts/travis install_cabal_deps
+ - scripts/travis install_smt "$SMT"
 
 script:
  - scripts/travis do_build
  - scripts/travis do_test "$TESTS" "$SMT" && scripts/travis test_source_pkg
- - scripts/travis do_cleanup
+ - scripts/travis clean_cache "$SMT"
 
 after_failure:
  - scripts/travis dump_fail_logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,7 @@ install:
  - scripts/travis install_smt "$SMT"
 
 script:
- - scripts/travis do_build
- - scripts/travis do_test "$TESTS" "$SMT" && scripts/travis test_source_pkg
+ - scripts/travis do_build && scripts/travis do_test "$TESTS" "$SMT" && scripts/travis test_source_pkg
  - scripts/travis clean_cache "$SMT"
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,20 @@
 language: haskell
 
+ghc: 7.8
+
+addons:
+  apt:
+    packages:
+    - ocaml
+    - camlidl
+
+sudo: false
+
+cache:
+  apt: true
+  directories:
+  - .cabal-sandbox
+
 env:
  - SMT=z3 TESTS=Unit/pos
  - SMT=z3 TESTS=Unit/neg
@@ -16,10 +31,7 @@ env:
  # ugh... Classify.hs is too slow and makes travis think the build is stalled
  # - TESTS=hscolour
 
-ghc: 7.8
-
 before_install:
- - scripts/travis install_ocaml
  - scripts/travis setup_cabal
  - scripts/travis clone_fixpoint
  - scripts/travis install_smt "$SMT"
@@ -30,6 +42,7 @@ install:
 script:
  - scripts/travis do_build
  - scripts/travis do_test "$TESTS" "$SMT" && scripts/travis test_source_pkg
+ - scripts/travis do_cleanup
 
 after_failure:
  - scripts/travis dump_fail_logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ sudo: false
 cache:
   apt: true
   directories:
-  - .cabal-sandbox
+  - $HOME/.cabal
+  - $HOME/.ghc
 
 env:
  - SMT=z3 TESTS=Unit/pos

--- a/scripts/travis
+++ b/scripts/travis
@@ -69,7 +69,6 @@ function pastebin {
 
 function setup_cabal {
   loud travis_retry cabal update
-  loud cabal sandbox init
 }
 
 function clone_fixpoint {
@@ -86,7 +85,6 @@ function install_smt {
 function install_cabal_deps {
   loud travis_retry cabal install --only-dependencies --enable-tests -fbuild-external . /tmp/fixpoint
   loud travis_retry cabal install -fbuild-external /tmp/fixpoint
-  loud cp .cabal-sandbox/bin/* "$HOME/.cabal/bin/"
 }
 
 function do_build {
@@ -126,9 +124,6 @@ function test_source_pkg {
 function do_cleanup {
   loud ghc-pkg unregister liquidhaskell --force || true
   loud ghc-pkg unregister liquid-fixpoint --force || true
-
-  loud cabal sandbox hc-pkg -- unregister liquidhaskell --force || true
-  loud cabal sandbox hc-pkg -- unregister liquid-fixpoint --force || true
 }
 
 ## Run Test Stage

--- a/scripts/travis
+++ b/scripts/travis
@@ -102,7 +102,7 @@ function install_cabal_deps {
 
 function _install_cabal_deps {
   loud travis_retry cabal update || return 1
-  loud travis_retry cabal install --only-dependencies --upgrade-dependencies --enable-tests -fbuild-external . /tmp/fixpoint || return 1
+  loud travis_retry cabal install --max-backjumps 2000 --only-dependencies --upgrade-dependencies --enable-tests -fbuild-external . /tmp/fixpoint || return 1
 }
 
 function do_build {

--- a/scripts/travis
+++ b/scripts/travis
@@ -75,9 +75,6 @@ function clean_cache {
   loud ghc-pkg unregister liquidhaskell --force || true
   loud ghc-pkg unregister liquid-fixpoint --force || true
   loud rm "$HOME/.cabal/bin/$smt" || true
-
-  loud find "$HOME/.cabal"
-  loud find "$HOME/.ghc"
 }
 
 function clone_fixpoint {

--- a/scripts/travis
+++ b/scripts/travis
@@ -11,6 +11,9 @@ function loud {
 }
 
 # Source: https://github.com/travis-ci/travis-build/blob/fc4ae8a2ffa1f2b3a2f62533bbc4f8a9be19a8ae/lib/travis/build/script/templates/header.sh
+RED="\033[31;1m"
+GREEN="\033[32;1m"
+RESET="\033[0m"
 function travis_retry {
   local result=0
   local count=1

--- a/scripts/travis
+++ b/scripts/travis
@@ -10,7 +10,7 @@ function loud {
   $@
 }
 
-# Source: https://github.com/travis-ci/travis-build/blob/fc4ae8a2ffa1f2b3a2f62533bbc4f8a9be19a8ae/lib/travis/build/script/templates/header.sh
+# Source: https://github.com/travis-ci/travis-build/blob/fc4ae8a2ffa1f2b3a2f62533bbc4f8a9be19a8ae/lib/travis/build/script/templates/header.sh#L104-L123
 RED="\033[31;1m"
 GREEN="\033[32;1m"
 RESET="\033[0m"
@@ -26,11 +26,12 @@ function travis_retry {
     result=$?
     set -e
     [ $result -eq 0 ] && break
+    result=$?
     count=$(($count + 1))
     sleep 1
   done
 
-  [ $count -eq 3 ] && {
+  [ $count -eq 4 ] && {
     echo "\n${RED}The command \"$@\" failed 3 times.${RESET}\n" >&2
   }
 
@@ -67,8 +68,15 @@ function pastebin {
 
 ## Testing Stages
 
-function setup_cabal {
-  loud travis_retry cabal update
+function clean_cache {
+  local smt="$1"
+
+  loud ghc-pkg unregister liquidhaskell --force || true
+  loud ghc-pkg unregister liquid-fixpoint --force || true
+  loud rm "$HOME/.cabal/bin/$smt" || true
+
+  loud find "$HOME/.cabal"
+  loud find "$HOME/.ghc"
 }
 
 function clone_fixpoint {
@@ -76,15 +84,27 @@ function clone_fixpoint {
 }
 
 function install_smt {
- local smt="$1"
- mkdir -p "$HOME/.cabal/bin"
- loud curl "http://goto.ucsd.edu/~gridaphobe/$smt" -o "$HOME/.cabal/bin/$smt"
- loud chmod a+x "$HOME/.cabal/bin/$smt"
+  local smt="$1"
+
+  mkdir -p "$HOME/.cabal/bin"
+  loud curl "http://goto.ucsd.edu/~gridaphobe/$smt" -o "$HOME/.cabal/bin/$smt"
+  loud chmod a+x "$HOME/.cabal/bin/$smt"
 }
 
 function install_cabal_deps {
-  loud travis_retry cabal install --only-dependencies --upgrade-dependencies --enable-tests -fbuild-external . /tmp/fixpoint
+  if ! _install_cabal_deps; then
+    echo " ==> Cabal install failed. Clearing dependency cache and retrying."
+    loud rm -rf "$HOME/.cabal"
+    loud rm -rf "$HOME/.ghc"
+    _install_cabal_deps
+  fi
+
   loud travis_retry cabal install -fbuild-external /tmp/fixpoint
+}
+
+function _install_cabal_deps {
+  loud travis_retry cabal update || return 1
+  loud travis_retry cabal install --only-dependencies --upgrade-dependencies --enable-tests -fbuild-external . /tmp/fixpoint || return 1
 }
 
 function do_build {
@@ -119,11 +139,6 @@ function test_source_pkg {
     echo "expected '$src_tgz' not found"
     return 1
   fi
-}
-
-function do_cleanup {
-  loud ghc-pkg unregister liquidhaskell --force || true
-  loud ghc-pkg unregister liquid-fixpoint --force || true
 }
 
 ## Run Test Stage

--- a/scripts/travis
+++ b/scripts/travis
@@ -40,12 +40,12 @@ function prevent_timeout {
   $cmd &
   local cmd_pid=$!
 
-  poke_stdout &
+  poke_stdout 2>/dev/null &
   local poke_pid=$!
 
   wait $cmd_pid
   exit_code=$?
-  kill $poke_pid
+  kill $poke_pid &>/dev/null
 
   return $exit_code
 }
@@ -64,13 +64,9 @@ function pastebin {
 
 ## Testing Stages
 
-function install_ocaml {
-  loud travis_retry sudo apt-get update
-  loud travis_retry sudo apt-get install ocaml camlidl
-}
-
 function setup_cabal {
   loud travis_retry cabal update
+  loud cabal sandbox init
 }
 
 function clone_fixpoint {
@@ -87,6 +83,7 @@ function install_smt {
 function install_cabal_deps {
   loud travis_retry cabal install --only-dependencies --enable-tests -fbuild-external . /tmp/fixpoint
   loud travis_retry cabal install -fbuild-external /tmp/fixpoint
+  loud cp .cabal-sandbox/bin/* "$HOME/.cabal/bin/"
 }
 
 function do_build {
@@ -113,16 +110,22 @@ function dump_fail_logs {
 function test_source_pkg {
   loud cabal sdist
 
-  local src_tgz="$(cabal info . | awk '{print $2 ".tar.gz";exit}')"
+  local src_tgz="dist/$(cabal info . | awk '{print $2 ".tar.gz";exit}')"
 
-  pushd dist
   if [ -f "$src_tgz" ]; then
     loud prevent_timeout cabal install -j4 "$src_tgz"
   else
     echo "expected '$src_tgz' not found"
     return 1
   fi
-  popd dist
+}
+
+function do_cleanup {
+  loud ghc-pkg unregister liquidhaskell --force || true
+  loud ghc-pkg unregister liquid-fixpoint --force || true
+
+  loud cabal sandbox hc-pkg -- unregister liquidhaskell --force || true
+  loud cabal sandbox hc-pkg -- unregister liquid-fixpoint --force || true
 }
 
 ## Run Test Stage

--- a/scripts/travis
+++ b/scripts/travis
@@ -64,7 +64,7 @@ function poke_stdout {
 }
 
 function pastebin {
-  curl -s -F 'sprunge=<-' http://sprunge.us
+  curl -s -F 'clbin=<-' https://clbin.com
 }
 
 ## Testing Stages
@@ -102,7 +102,7 @@ function install_cabal_deps {
 
 function _install_cabal_deps {
   loud travis_retry cabal update || return 1
-  loud travis_retry cabal install --max-backjumps 2000 --only-dependencies --upgrade-dependencies --enable-tests -fbuild-external . /tmp/fixpoint || return 1
+  loud travis_retry cabal install --reorder-goals --only-dependencies --upgrade-dependencies --enable-tests -fbuild-external . /tmp/fixpoint || return 1
 }
 
 function do_build {

--- a/scripts/travis
+++ b/scripts/travis
@@ -83,7 +83,7 @@ function install_smt {
 }
 
 function install_cabal_deps {
-  loud travis_retry cabal install --only-dependencies --enable-tests -fbuild-external . /tmp/fixpoint
+  loud travis_retry cabal install --only-dependencies --upgrade-dependencies --enable-tests -fbuild-external . /tmp/fixpoint
   loud travis_retry cabal install -fbuild-external /tmp/fixpoint
 }
 

--- a/scripts/travis
+++ b/scripts/travis
@@ -26,7 +26,6 @@ function travis_retry {
     result=$?
     set -e
     [ $result -eq 0 ] && break
-    result=$?
     count=$(($count + 1))
     sleep 1
   done
@@ -44,12 +43,14 @@ function prevent_timeout {
   $cmd &
   local cmd_pid=$!
 
-  poke_stdout 2>/dev/null &
+  poke_stdout &
   local poke_pid=$!
 
   wait $cmd_pid
   exit_code=$?
-  kill $poke_pid &>/dev/null
+
+  kill $poke_pid
+  (wait $poke_pid 2>/dev/null) || true
 
   return $exit_code
 }


### PR DESCRIPTION
Travis has two build systems: a VM-based system and a [Linux containers-based system](http://docs.travis-ci.com/user/workers/container-based-infrastructure/). The latter can run your builds if you don't need `sudo` support. It's much faster to start up and run builds, it has more memory available, it's stabler, and it allows the caching of files between builds. This is the biggest win for us, as caching our Cabal dependencies instead of recompiling them every time cuts total build time in half ([before](https://travis-ci.org/ucsd-progsys/liquidhaskell/builds/57073862) / [after](https://travis-ci.org/spinda/liquidhaskell/builds/59090800)).

Travis can install `apt` packages before removing privileges from your container, as long as they're on a [whitelist](https://github.com/travis-ci/apt-package-whitelist), for security reasons. [I got `ocaml` and `camlidl` whitelisted](https://github.com/travis-ci/travis-ci/issues/3639), and since we're now using Travis's built-in GHC support instead of installing our own copy, we don't need `sudo` anymore.

Also, I noticed that the [`vector-algorithms` benchmarks haven't actually been running](https://travis-ci.org/ucsd-progsys/liquidhaskell/jobs/57073869#L808): the Travis script tried to run `Benchmarks/vector-algorithms` instead of `Benchmarks/vect-algs`. I went and fixed that here. Fortunately, they're still passing.