### PR TITLE
Cutsolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,6 +813,7 @@ verification attempts.
 Editor Integration
 ==================
 
+
 + [Emacs/Flycheck](https://github.com/ucsd-progsys/liquid-types.el)
 + [Vim/Syntastic](https://github.com/ucsd-progsys/liquid-types.vim)
 

--- a/TODO.markdown
+++ b/TODO.markdown
@@ -1,7 +1,6 @@
 TODO
 ====
 
-
 promotion of haskell functions to measures
 ------------------------------------------
 

--- a/include/GHC/Real.spec
+++ b/include/GHC/Real.spec
@@ -1,6 +1,5 @@
 module spec GHC.Real where
 
-
 GHC.Real.fromIntegral    :: (GHC.Real.Integral a, GHC.Num.Num b) => x:a -> {v:b|v=x}
 
 class (GHC.Num.Num a) => GHC.Real.Fractional a where

--- a/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -256,7 +256,7 @@ checkFunRefs t = go t
       | isTauto r
         = go t1 <|> go t2
       | otherwise
-        = Just $ text "Function types cannot have refinements"
+        = Just $ text "Function types cannot have refinements:" <+> (pprint r)
 
 checkAbstractRefs t = go t
   where

--- a/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -150,10 +150,10 @@ checkTerminationExpr emb env (v, Loc l _ t, es) = (mkErr <$> go es) <|> (mkErr' 
     go      = foldl (\err e -> err <|> fmap (e,) (checkSorted env' e)) Nothing
     go'     = foldl (\err e -> err <|> fmap (e,) (checkSorted env' (cmpZero e))) Nothing
     env'    = foldl (\e (x, s) -> insertSEnv x s e) env'' wiredSortedSyms
-    env''   = mapSEnv sr_sort $ foldl (\e (x,s) -> insertSEnv x s e) env xss
+    env''   = sr_sort <$> foldl (\e (x,s) -> insertSEnv x s e) env xss
     xss     = mapSnd rSort <$> (uncurry zip $ (\(x,y,_,_) -> (x,y)) $ bkArrowDeep t)
     rSort   = rTypeSortedReft emb
-    cmpZero = PAtom Le zero
+    cmpZero = PAtom Le $ expr (0 :: Int) -- zero
 
 checkTy :: (Doc -> Error) -> TCEmb TyCon -> TCEnv -> SEnv SortedReft -> SpecType -> Maybe Error
 checkTy mkE emb tcEnv env t = mkE <$> checkRType emb env (txRefSort tcEnv emb t)

--- a/src/Language/Haskell/Liquid/Bare/Existential.hs
+++ b/src/Language/Haskell/Liquid/Bare/Existential.hs
@@ -10,7 +10,7 @@ import qualified Data.HashMap.Strict as M
 
 import Language.Fixpoint.Misc (errorstar, fst3)
 import Language.Fixpoint.Names (headSym)
-import Language.Fixpoint.Types (Brel(..), Expr(..), Pred(..), Refa(..), Reft(..), Symbol, symbol, vv)
+import Language.Fixpoint.Types (Expr(..), Symbol, symbol, exprReft)
 
 import Language.Haskell.Liquid.RefType (strengthen, uTop)
 import Language.Haskell.Liquid.Types
@@ -21,10 +21,10 @@ import Language.Haskell.Liquid.Types
 
 data ExSt = ExSt { fresh :: Int
                  , emap  :: M.HashMap Symbol (RSort, Expr)
-                 , pmap  :: M.HashMap Symbol RPVar 
+                 , pmap  :: M.HashMap Symbol RPVar
                  }
 
--- | Niki: please write more documentation for this, maybe an example? 
+-- | Niki: please write more documentation for this, maybe an example?
 -- I can't really tell whats going on... (RJ)
 
 txExpToBind   :: SpecType -> SpecType
@@ -32,19 +32,19 @@ txExpToBind t = evalState (expToBindT t) (ExSt 0 M.empty πs)
   where πs = M.fromList [(pname p, p) | p <- ty_preds $ toRTypeRep t ]
 
 expToBindT :: SpecType -> State ExSt SpecType
-expToBindT (RVar v r) 
+expToBindT (RVar v r)
   = expToBindRef r >>= addExists . RVar v
-expToBindT (RFun x t1 t2 r) 
+expToBindT (RFun x t1 t2 r)
   = do t1' <- expToBindT t1
        t2' <- expToBindT t2
        expToBindRef r >>= addExists . RFun x t1' t2'
-expToBindT (RAllT a t) 
+expToBindT (RAllT a t)
   = liftM (RAllT a) (expToBindT t)
 expToBindT (RAllP p t)
   = liftM (RAllP p) (expToBindT t)
 expToBindT (RAllS s t)
   = liftM (RAllS s) (expToBindT t)
-expToBindT (RApp c ts rs r) 
+expToBindT (RApp c ts rs r)
   = do ts' <- mapM expToBindT ts
        rs' <- mapM expToBindReft rs
        expToBindRef r >>= addExists . RApp c ts' rs'
@@ -58,7 +58,7 @@ expToBindT (RRTy xts r o t)
        t'   <- expToBindT t
        return $ RRTy xts' r' o t'
   where
-     (xs, ts) = unzip xts 
+     (xs, ts) = unzip xts
 expToBindT t
   = return t
 
@@ -68,7 +68,7 @@ expToBindReft (RPropP s r) = RPropP s <$> expToBindRef r
 expToBindReft (RHProp _ _) = errorstar "TODO:EFFECTS:expToBindReft"
 
 getBinds :: State ExSt (M.HashMap Symbol (RSort, Expr))
-getBinds 
+getBinds
   = do bds <- emap <$> get
        modify $ \st -> st{emap = M.empty}
        return bds
@@ -76,8 +76,9 @@ getBinds
 addExists t = liftM (M.foldlWithKey' addExist t) getBinds
 
 addExist t x (tx, e) = RAllE x t' t
-  where t' = (ofRSort tx) `strengthen` uTop r
-        r  = Reft (vv Nothing, [RConc (PAtom Eq (EVar (vv Nothing)) e)])
+  where
+    t'               = (ofRSort tx) `strengthen` uTop r
+    r                = exprReft e -- Reft (vv Nothing, [RConc (PAtom Eq (EVar (vv Nothing)) e)])
 
 expToBindRef :: UReft r -> State ExSt (UReft r)
 expToBindRef (U r (Pr p) l)
@@ -96,14 +97,13 @@ expToBindParg ((t, s, e), s') = liftM ((,,) t s) (expToBindExpr e s')
 expToBindExpr :: Expr ->  RSort -> State ExSt Expr
 expToBindExpr e@(EVar s) _ | isLower $ headSym $ symbol s
   = return e
-expToBindExpr e t         
+expToBindExpr e t
   = do s <- freshSymbol
        modify $ \st -> st{emap = M.insert s (t, e) (emap st)}
        return $ EVar s
 
 freshSymbol :: State ExSt Symbol
-freshSymbol 
+freshSymbol
   = do n <- fresh <$> get
        modify $ \s -> s{fresh = n+1}
        return $ symbol $ "ex#" ++ show n
-

--- a/src/Language/Haskell/Liquid/Bare/Expand.hs
+++ b/src/Language/Haskell/Liquid/Bare/Expand.hs
@@ -46,7 +46,7 @@ mapPredM f = go
     go (PBexp e)       = PBexp <$> f e
     go (PAtom b e1 e2) = PAtom b <$> f e1 <*> f e2
     go (PAll xs p)     = PAll xs <$> go p
-    go (PEx xs p)      = PEx  xs <$> go p
+    go (PExist xs p)   = PExist xs <$> go p
     go PTop            = return PTop
 
 --------------------------------------------------------------------------------
@@ -77,8 +77,8 @@ expandPred (PIff p q)
   = PIff <$> expandPred p <*> expandPred q
 expandPred (PAll xs p)
   = PAll xs <$> expandPred p
-expandPred (PEx xs p)
-  = PEx xs <$> expandPred p
+expandPred (PExist xs p)
+  = PExist xs <$> expandPred p
 expandPred p
   = return p
 

--- a/src/Language/Haskell/Liquid/Bare/Plugged.hs
+++ b/src/Language/Haskell/Liquid/Bare/Plugged.hs
@@ -24,9 +24,8 @@ import Data.Monoid
 
 import qualified Data.HashMap.Strict as M
 
-import Language.Fixpoint.Visitor 
 import Language.Fixpoint.Names (dummySymbol)
-import Language.Fixpoint.Types (Pred (..), Refa (..), TCEmb)
+import Language.Fixpoint.Types (traceFix, mapPredReft, pAnd, conjuncts, Refa (..), TCEmb)
 
 import Language.Haskell.Liquid.GhcMisc (sourcePosSrcSpan)
 import Language.Haskell.Liquid.RefType (addTyConInfo, ofType, rVar, rTyVar, subts, toType, uReft)
@@ -122,8 +121,14 @@ maybeTrue x target exports r
     name        = getName x
     notExported = not $ getName x `elemNameSet` exports
 
--- killHoles r@(U (Reft (v,rs)) _ _) = r { ur_reft = Reft (v, filter (not . isHole) rs) }
-killHoles x = x { ur_reft = zap $ ur_reft x }
+-- killHoles r@(U (Reft (v, rs)) _ _) = r { ur_reft = Reft (v, filter (not . isHole) rs) }
+
+killHoles r = r { ur_reft = mapPredReft dropHoles' $ ur_reft r }
   where
-    zap     = mapKVars (\k -> if isHole k then Just PTrue else Nothing)
+    dropHoles' p = traceFix ("dropHoles p = " ++ show p) $ dropHoles p
+    dropHoles    = pAnd . filter (not . isHole) . conjuncts
+
+-- NEWCUTSOLVER killHoles x = x { ur_reft = zap $ ur_reft x }
+-- NEWCUTSOLVER   where
+-- NEWCUTSOLVER     zap     = mapKVars (\k -> if isHole k then Just PTrue else Nothing)
 

--- a/src/Language/Haskell/Liquid/Bare/Plugged.hs
+++ b/src/Language/Haskell/Liquid/Bare/Plugged.hs
@@ -25,7 +25,7 @@ import Data.Monoid
 import qualified Data.HashMap.Strict as M
 
 import Language.Fixpoint.Names (dummySymbol)
-import Language.Fixpoint.Types (traceFix, mapPredReft, pAnd, conjuncts, Refa (..), TCEmb)
+import Language.Fixpoint.Types (mapPredReft, pAnd, conjuncts, Refa (..), TCEmb)
 
 import Language.Haskell.Liquid.GhcMisc (sourcePosSrcSpan)
 import Language.Haskell.Liquid.RefType (addTyConInfo, ofType, rVar, rTyVar, subts, toType, uReft)

--- a/src/Language/Haskell/Liquid/Bare/Plugged.hs
+++ b/src/Language/Haskell/Liquid/Bare/Plugged.hs
@@ -121,4 +121,8 @@ maybeTrue x target exports r
     name        = getName x
     notExported = not $ getName x `elemNameSet` exports
 
-killHoles r@(U (Reft (v,rs)) _ _) = r { ur_reft = Reft (v, filter (not . isHole) rs) }
+-- killHoles r@(U (Reft (v,rs)) _ _) = r { ur_reft = Reft (v, filter (not . isHole) rs) }
+killHoles x = x { ur_reft = zap $ ur_reft x }
+  where
+    zap     = mapKVars (\k -> if isHole k then Just PTrue else Nothing)
+

--- a/src/Language/Haskell/Liquid/Bare/Plugged.hs
+++ b/src/Language/Haskell/Liquid/Bare/Plugged.hs
@@ -26,6 +26,7 @@ import qualified Data.HashMap.Strict as M
 
 import Language.Fixpoint.Names (dummySymbol)
 import Language.Fixpoint.Types (mapPredReft, pAnd, conjuncts, Refa (..), TCEmb)
+-- import Language.Fixpoint.Types (traceFix, showFix)
 
 import Language.Haskell.Liquid.GhcMisc (sourcePosSrcSpan)
 import Language.Haskell.Liquid.RefType (addTyConInfo, ofType, rVar, rTyVar, subts, toType, uReft)
@@ -123,12 +124,9 @@ maybeTrue x target exports r
 
 -- killHoles r@(U (Reft (v, rs)) _ _) = r { ur_reft = Reft (v, filter (not . isHole) rs) }
 
-killHoles r = r { ur_reft = mapPredReft dropHoles $ ur_reft r }
+killHoles ur = ur { ur_reft = tx $ ur_reft ur }
   where
-    -- dropHoles' p = traceFix ("dropHoles p = " ++ show p) $ dropHoles p
+    tx r = {- traceFix ("killholes: r = " ++ showFix r) $ -} mapPredReft dropHoles r
     dropHoles    = pAnd . filter (not . isHole) . conjuncts
 
--- NEWCUTSOLVER killHoles x = x { ur_reft = zap $ ur_reft x }
--- NEWCUTSOLVER   where
--- NEWCUTSOLVER     zap     = mapKVars (\k -> if isHole k then Just PTrue else Nothing)
 

--- a/src/Language/Haskell/Liquid/Bare/Plugged.hs
+++ b/src/Language/Haskell/Liquid/Bare/Plugged.hs
@@ -24,8 +24,9 @@ import Data.Monoid
 
 import qualified Data.HashMap.Strict as M
 
+import Language.Fixpoint.Visitor 
 import Language.Fixpoint.Names (dummySymbol)
-import Language.Fixpoint.Types (Reft(..), TCEmb)
+import Language.Fixpoint.Types (Pred (..), Refa (..), TCEmb)
 
 import Language.Haskell.Liquid.GhcMisc (sourcePosSrcSpan)
 import Language.Haskell.Liquid.RefType (addTyConInfo, ofType, rVar, rTyVar, subts, toType, uReft)
@@ -81,7 +82,7 @@ plugHoles tce tyi x f t (Loc l l' st)
     go t                (RHole r)          = return $ (addHoles t') { rt_reft = f r }
       where
         t'       = everywhere (mkT $ addRefs tce tyi) t
-        addHoles = fmap (const $ f $ uReft ("v", [hole]))
+        addHoles = fmap (const $ f $ uReft ("v", Refa hole))
     go (RVar _ _)       v@(RVar _ _)       = return v
     go (RFun _ i o _)   (RFun x i' o' r)   = RFun x <$> go i i' <*> go o o' <*> return r
     go (RAllT _ t)      (RAllT a t')       = RAllT a <$> go t t'

--- a/src/Language/Haskell/Liquid/Bare/Plugged.hs
+++ b/src/Language/Haskell/Liquid/Bare/Plugged.hs
@@ -123,9 +123,9 @@ maybeTrue x target exports r
 
 -- killHoles r@(U (Reft (v, rs)) _ _) = r { ur_reft = Reft (v, filter (not . isHole) rs) }
 
-killHoles r = r { ur_reft = mapPredReft dropHoles' $ ur_reft r }
+killHoles r = r { ur_reft = mapPredReft dropHoles $ ur_reft r }
   where
-    dropHoles' p = traceFix ("dropHoles p = " ++ show p) $ dropHoles p
+    -- dropHoles' p = traceFix ("dropHoles p = " ++ show p) $ dropHoles p
     dropHoles    = pAnd . filter (not . isHole) . conjuncts
 
 -- NEWCUTSOLVER killHoles x = x { ur_reft = zap $ ur_reft x }

--- a/src/Language/Haskell/Liquid/Bare/RefToLogic.hs
+++ b/src/Language/Haskell/Liquid/Bare/RefToLogic.hs
@@ -74,7 +74,7 @@ instance Transformable Pred where
   tx s m (PBexp e)       = PBexp (tx s m e)
   tx s m (PAtom r e1 e2) = PAtom r (tx s m e1) (tx s m e2)
   tx s m (PAll xss p)    = PAll xss $ txQuant xss s m p
-  tx s m (PEx xss p)     = PEx  xss $ txQuant xss s m p
+  tx s m (PExist xss p)  = PExist xss $ txQuant xss s m p
   tx _ _ p@(PKVar _ _)   = p
 
 txQuant xss s m p

--- a/src/Language/Haskell/Liquid/Bare/RefToLogic.hs
+++ b/src/Language/Haskell/Liquid/Bare/RefToLogic.hs
@@ -2,16 +2,16 @@
 {-# LANGUAGE FlexibleInstances    #-}
 
 module Language.Haskell.Liquid.Bare.RefToLogic (
-    txRefToLogic, Transformable
+    Transformable
+   , txRefToLogic
+
   ) where
 
 import Language.Haskell.Liquid.Types
-
-
 import Language.Haskell.Liquid.Bare.Env
 
-import Language.Fixpoint.Types hiding (Def, R)     
-import Language.Fixpoint.Misc      
+import Language.Fixpoint.Types hiding (Def, R)
+import Language.Fixpoint.Misc
 import Language.Fixpoint.Names
 
 import qualified Data.HashMap.Strict as M
@@ -19,119 +19,122 @@ import qualified Data.HashMap.Strict as M
 import Control.Applicative                      ((<$>))
 
 txRefToLogic :: (Transformable r) => LogicMap -> InlnEnv -> r -> r
-txRefToLogic lmap imap t =  tx' lmap imap t
-
+txRefToLogic = tx'
 
 class Transformable a where
-	tx  :: Symbol -> (Either LMap TInline) -> a -> a 
+  tx  :: Symbol -> (Either LMap TInline) -> a -> a
 
-	tx' :: LogicMap -> InlnEnv -> a -> a
-	tx' lmap imap x = M.foldrWithKey tx x limap
-	  where limap = M.fromList ((mapSnd Left <$> M.toList lmap) ++ (mapSnd Right <$> M.toList imap))   
+  tx' :: LogicMap -> InlnEnv -> a -> a
+  tx' lmap imap x = M.foldrWithKey tx x limap
+    where
+      limap       = M.fromList ((mapSnd Left <$> M.toList lmap) ++ (mapSnd Right <$> M.toList imap))
 
 
 instance (Transformable a) => (Transformable [a]) where
-	tx s m xs = tx s m <$> xs 
+  tx s m xs = tx s m <$> xs
 
 instance Transformable DataConP where
-	tx s m x = x{ tyConsts = tx s m (tyConsts x)
-                , tyArgs   = mapSnd (tx s m) <$> (tyArgs x)
-                , tyRes    = tx s m (tyRes x)
-                }
+  tx s m x = x { tyConsts = tx s m (tyConsts x)
+               , tyArgs   = mapSnd (tx s m) <$> (tyArgs x)
+               , tyRes    = tx s m (tyRes x)
+               }
 
 instance Transformable TInline where
-  tx s m (TI xs e) = TI xs (tx s m e) 
+  tx s m (TI xs e) = TI xs (tx s m e)
 
-instance (Transformable r) => Transformable (RType c v r) where 
-	tx s m = fmap (tx s m)
+instance (Transformable r) => Transformable (RType c v r) where
+  tx s m = fmap (tx s m)
 
-instance Transformable RReft where 
-	tx s m = fmap (tx s m)
+instance Transformable RReft where
+  tx s m = fmap (tx s m)
 
-instance Transformable Reft where 
-	tx s m (Reft(v, refas))
-		= if v == s 
-			then errorstar "Transformable: this should not happen"
-			else Reft(v, tx s m <$> refas)
+instance Transformable Reft where
+  tx s m (Reft (v, Refa p)) = if v == s
+                              then errorstar "Transformable: this should not happen"
+			      else Reft(v, Refa $ tx s m p)
 
-instance Transformable Refa where
-	tx s m (RConc p)     = RConc $ tx s m p 
-	tx _ _ (RKvar x sub) = RKvar x sub
+-- OLD instance Transformable Refa where
+-- OLD   tx s m (RConc p)     = RConc $ tx s m p
+-- OLD   tx _ _ (RKvar x sub) = RKvar x sub
 
 instance (Transformable a, Transformable b) => Transformable (Either a b) where
-	tx s m (Left  x) = Left  (tx s m x)
-	tx s m (Right x) = Right (tx s m x)
+  tx s m (Left  x) = Left  (tx s m x)
+  tx s m (Right x) = Right (tx s m x)
 
 instance Transformable Pred where
-	tx _ _ PTrue           = PTrue
-	tx _ _ PFalse          = PFalse
-	tx _ _ PTop            = PTop
-	tx s m (PAnd ps)       = PAnd (tx s m <$> ps)
-	tx s m (POr ps)        = POr (tx s m <$> ps)
-	tx s m (PNot p)        = PNot (tx s m p)
-	tx s m (PImp p1 p2)    = PImp (tx s m p1) (tx s m p2)
-	tx s m (PIff p1 p2)    = PIff (tx s m p1) (tx s m p2)
-	tx s m (PBexp (EApp f es)) = txPApp (s, m) f (tx s m <$> es)
-	tx s m (PBexp e)       = PBexp (tx s m e)
-	tx s m (PAtom r e1 e2) = PAtom r (tx s m e1) (tx s m e2)
-	tx s m (PAll xss p) 
-	    = if (s `elem` (fst <$> xss)) 
-	    	then errorstar "Transformable.tx on Pred: this should not happen" 
-		    else PAll xss (tx s m p) 
+  tx _ _ PTrue           = PTrue
+  tx _ _ PFalse          = PFalse
+  tx _ _ PTop            = PTop
+  tx s m (PAnd ps)       = PAnd (tx s m <$> ps)
+  tx s m (POr ps)        = POr (tx s m <$> ps)
+  tx s m (PNot p)        = PNot (tx s m p)
+  tx s m (PImp p1 p2)    = PImp (tx s m p1) (tx s m p2)
+  tx s m (PIff p1 p2)    = PIff (tx s m p1) (tx s m p2)
+  tx s m (PBexp (EApp f es)) = txPApp (s, m) f (tx s m <$> es)
+  tx s m (PBexp e)       = PBexp (tx s m e)
+  tx s m (PAtom r e1 e2) = PAtom r (tx s m e1) (tx s m e2)
+  tx s m (PAll xss p)    = PAll xss $ txQuant xss s m p
+  tx s m (PEx xss p)     = PEx  xss $ txQuant xss s m p
+  tx _ _ p@(PKVar _ _)   = p
+
+txQuant xss s m p
+  | s `elem` (fst <$> xss) = errorstar "Transformable.tx on Pred: this should not happen"
+  | otherwise              = tx s m p
+
 
 instance Transformable Expr where
-	tx s m (EVar s') 
-	   | cmpSymbol s s'   = mexpr m
-	   | otherwise        = EVar s'
-	tx s m (EApp f es)    = txEApp (s, m) f (tx s m <$> es)
-	tx _ _ (ESym c)       = ESym c
-	tx _ _ (ECon c)       = ECon c
-	tx _ _ (ELit l s')    = ELit l s'
-	tx s m (ENeg e)       = ENeg (tx s m e)
-	tx s m (EBin o e1 e2) = EBin o (tx s m e1) (tx s m e2)
-	tx s m (EIte p e1 e2) = EIte (tx s m p) (tx s m e1) (tx s m e2)
-	tx s m (ECst e s')    = ECst (tx s m e) s'
-	tx _ _ EBot           = EBot
+  tx s m (EVar s')
+    | cmpSymbol s s'    = mexpr m
+    | otherwise         = EVar s'
+  tx s m (EApp f es)    = txEApp (s, m) f (tx s m <$> es)
+  tx _ _ (ESym c)       = ESym c
+  tx _ _ (ECon c)       = ECon c
+  tx _ _ (ELit l s')    = ELit l s'
+  tx s m (ENeg e)       = ENeg (tx s m e)
+  tx s m (EBin o e1 e2) = EBin o (tx s m e1) (tx s m e2)
+  tx s m (EIte p e1 e2) = EIte (tx s m p) (tx s m e1) (tx s m e2)
+  tx s m (ECst e s')    = ECst (tx s m e) s'
+  tx _ _ EBot           = EBot
 
 instance Transformable (Measure t c) where
-	tx s m x = x{eqns = tx s m <$> (eqns x)}
+  tx s m x = x{eqns = tx s m <$> (eqns x)}
 
 instance Transformable (Def c) where
-	tx s m x = x{body = tx s m (body x)} 
+  tx s m x = x{body = tx s m (body x)}
 
 instance Transformable Body where
-   tx s m (E e)   = E $ tx s m e
-   tx s m (P p)   = P $ tx s m p
-   tx s m (R v p) = R v $ tx s m p
+  tx s m (E e)   = E $ tx s m e
+  tx s m (P p)   = P $ tx s m p
+  tx s m (R v p) = R v $ tx s m p
 
 mexpr (Left  (LMap _ _ e)) = e
 mexpr (Right (TI _ (Right e))) = e
 mexpr _ = errorstar "mexpr"
 
-txEApp (s, (Left (LMap _ xs e))) f es 
-  | cmpSymbol s (val f) 
+txEApp (s, (Left (LMap _ xs e))) f es
+  | cmpSymbol s (val f)
   = subst (mkSubst $ zip xs es) e
-  | otherwise  
+  | otherwise
   = EApp f es
 
-txEApp (s, (Right (TI xs (Right e)))) f es 
-  | cmpSymbol s (val f) 
+txEApp (s, (Right (TI xs (Right e)))) f es
+  | cmpSymbol s (val f)
   = subst (mkSubst $ zip xs es) e
-  | otherwise  
+  | otherwise
   = EApp f es
 
 
-txEApp (s, (Right (TI _ (Left _)))) f es 
-  | cmpSymbol s (val f) 
+txEApp (s, (Right (TI _ (Left _)))) f es
+  | cmpSymbol s (val f)
   = errorstar "txEApp: deep internal error"
-  | otherwise  
+  | otherwise
   = EApp f es
 
 
-txPApp (s, (Right (TI xs (Left e)))) f es 
-  | cmpSymbol s (val f) 
+txPApp (s, (Right (TI xs (Left e)))) f es
+  | cmpSymbol s (val f)
   = subst (mkSubst $ zip xs es) e
-  | otherwise  
+  | otherwise
   = PBexp $ EApp f es
 
 txPApp (s, m) f es = PBexp $ txEApp (s, m) f es

--- a/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -42,6 +42,7 @@ instance Resolvable Pred where
   resolve l (PBexp b)       = PBexp   <$> resolve l b
   resolve l (PAtom r e1 e2) = PAtom r <$> resolve l e1 <*> resolve l e2
   resolve l (PAll vs p)     = PAll    <$> mapM (secondM (resolve l)) vs <*> resolve l p
+  resolve l (PEx  vs p)     = PEx     <$> mapM (secondM (resolve l)) vs <*> resolve l p
   resolve _ p               = return p
 
 instance Resolvable Expr where
@@ -94,10 +95,9 @@ instance Resolvable (UReft Reft) where
   resolve l (U r p s) = U <$> resolve l r <*> resolve l p <*> return s
 
 instance Resolvable Reft where
-  resolve l (Reft (s, ras)) = Reft . (s,) <$> mapM resolveRefa ras
+  resolve l (Reft (s, ra)) = Reft . (s,) <$> resolveRefa ra
     where
-      resolveRefa (RConc p) = RConc <$> resolve l p
-      resolveRefa kv        = return kv
+      resolveRefa (Refa p) = Refa <$> resolve l p
 
 instance Resolvable Predicate where
   resolve l (Pr pvs) = Pr <$> resolve l pvs

--- a/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -42,7 +42,7 @@ instance Resolvable Pred where
   resolve l (PBexp b)       = PBexp   <$> resolve l b
   resolve l (PAtom r e1 e2) = PAtom r <$> resolve l e1 <*> resolve l e2
   resolve l (PAll vs p)     = PAll    <$> mapM (secondM (resolve l)) vs <*> resolve l p
-  resolve l (PEx  vs p)     = PEx     <$> mapM (secondM (resolve l)) vs <*> resolve l p
+  resolve l (PExist vs p)   = PExist  <$> mapM (secondM (resolve l)) vs <*> resolve l p
   resolve _ p               = return p
 
 instance Resolvable Expr where

--- a/src/Language/Haskell/Liquid/Constraint/Constraint.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Constraint.hs
@@ -5,7 +5,7 @@ module Language.Haskell.Liquid.Constraint.Constraint  where
 
 import Data.Monoid
 import Data.Maybe
-import Control.Applicative 
+import Control.Applicative
 
 import Language.Haskell.Liquid.Types
 import Language.Haskell.Liquid.Constraint.Types
@@ -14,24 +14,23 @@ import Language.Fixpoint.Types
 
 instance Monoid LConstraint where
 	mempty  = LC []
-	mappend (LC cs1) (LC cs2) = LC (cs1 ++ cs2) 
+	mappend (LC cs1) (LC cs2) = LC (cs1 ++ cs2)
 
 typeToConstraint t = LC [t]
-
 
 addConstraints t γ = γ {lcs = mappend (typeToConstraint t) (lcs γ)}
 
 constraintToLogic γ (LC ts) = pAnd (constraintToLogicOne γ  <$> ts)
 
 constraintToLogicOne γ env
-  =  pAnd [subConstraintToLogicOne 
-            (zip xs xts) 
-            (last xs, 
-            (last $ (fst <$> xts), r))  
+  =  pAnd [subConstraintToLogicOne
+            (zip xs xts)
+            (last xs,
+            (last $ (fst <$> xts), r))
           | xts <- xss]
-  where 
-   xts      = init env 
-   (xs, ts) = unzip xts 
+  where
+   xts      = init env
+   (xs, ts) = unzip xts
    r        = snd $ last env
    xss      = combinations ((\t -> [(x, t) | x <- grapBindsWithType t γ]) <$> ts)
 
@@ -39,9 +38,10 @@ subConstraintToLogicOne xts (x', (x, t)) = PImp (pAnd rs) r
   where
   	(rs , su) = foldl go ([], []) xts
   	([r], _ ) = go ([], su) (x', (x, t))
-  	go (acc, su) (x', (x, t)) = let (Reft(v, rr)) = toReft (fromMaybe mempty (stripRTypeBase t)) in
-                                let su' = (x', EVar x):(v, EVar x):su in
-                                (subst (mkSubst su') (pAnd [p | RConc p <- rr]):acc, su')
+  	go (acc, su) (x', (x, t)) = let (Reft(v, Refa p)) = toReft (fromMaybe mempty (stripRTypeBase t))
+                                        su'               = (x', EVar x):(v, EVar x) : su
+                                    in
+                                     (subst (mkSubst su') p : acc, su')
 
 
 
@@ -49,4 +49,3 @@ combinations :: [[a]] -> [[a]]
 combinations []           = [[]]
 combinations ([]:_)       = []
 combinations ((y:ys):yss) = [y:xs | xs <- combinations yss] ++ combinations (ys:yss)
-

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -1724,16 +1724,18 @@ instance NFData CGInfo where
 
 forallExprRefType     :: CGEnv -> SpecType -> SpecType
 forallExprRefType γ t = t `strengthen` (uTop r')
-  where r'            = fromMaybe mempty $ forallExprReft γ r
-        r             = F.sr_reft $ rTypeSortedReft (emb γ) t
+  where
+    r'                = fromMaybe mempty $ forallExprReft γ r
+    r                 = F.sr_reft $ rTypeSortedReft (emb γ) t
 
-forallExprReft γ r
--- NV to RJ the type of ex Nil is {v:List a | PAnd [v = Nil]}
--- which was rejected by F.isSignletonReft
-  = do e  <- F.isSingletonReft r
-       r' <- forallExprReft_ γ e
-       return r'
+forallExprReft :: CGEnv -> F.Reft -> Maybe F.Reft
+forallExprReft γ r = F.isSingletonReft r >>= forallExprReft_ γ
 
+--   = do e  <- F.isSingletonReft r
+--        r' <- forallExprReft_ γ e
+--        return r'
+
+forallExprReft_ :: CGEnv -> F.Expr -> Maybe F.Reft
 forallExprReft_ γ (F.EApp f es)
   = case forallExprReftLookup γ (val f) of
       Just (xs,_,_,t) -> let su = F.mkSubst $ safeZip "fExprRefType" xs es in

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -1209,7 +1209,7 @@ killSubst :: RReft -> RReft
 killSubst = fmap killSubstReft
 
 killSubstReft :: F.Reft -> F.Reft
-killSubstReft = trans kv () []
+killSubstReft = trans kv () ()
   where
     kv    = defaultVisitor { txPred = ks }
     ks _ (F.PKVar k _) = F.PKVar k mempty

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -13,26 +13,26 @@
 {-# LANGUAGE MultiParamTypeClasses     #-}
 {-# LANGUAGE OverloadedStrings         #-}
 
--- | This module defines the representation of Subtyping and WF Constraints, and 
--- the code for syntax-directed constraint generation. 
+-- | This module defines the representation of Subtyping and WF Constraints, and
+-- the code for syntax-directed constraint generation.
 
 module Language.Haskell.Liquid.Constraint.Generate (
-    
+
    generateConstraints
-    
+
   ) where
 
 import CoreUtils     (exprType)
 
 import CoreSyn
-import SrcLoc           
+import SrcLoc
 import Type
 import PrelNames
-import TypeRep 
+import TypeRep
 import Class            (Class, className)
 import Var
 import Id
-import Name            
+import Name
 import NameSet
 import Text.PrettyPrint.HughesPJ hiding (first)
 
@@ -55,6 +55,7 @@ import Text.Printf
 
 import qualified Language.Haskell.Liquid.CTags      as Tg
 import Language.Fixpoint.Sort (pruneUnsortedReft)
+import Language.Fixpoint.Visitor
 
 import Language.Haskell.Liquid.Fresh
 
@@ -64,10 +65,10 @@ import Language.Haskell.Liquid.Dictionaries
 import Language.Haskell.Liquid.Variance
 import Language.Haskell.Liquid.Types            hiding (binds, Loc, loc, freeTyVars, Def)
 import Language.Haskell.Liquid.Strata
-import Language.Haskell.Liquid.Bounds 
+import Language.Haskell.Liquid.Bounds
 import Language.Haskell.Liquid.RefType
 import Language.Haskell.Liquid.Visitors
-import Language.Haskell.Liquid.PredType         hiding (freeTyVars)          
+import Language.Haskell.Liquid.PredType         hiding (freeTyVars)
 import Language.Haskell.Liquid.GhcMisc          ( isInternal, collectArguments, tickSrcSpan
                                                 , hasBaseTypeVar, showPpr, isDataConId)
 import Language.Haskell.Liquid.Misc
@@ -84,7 +85,7 @@ import Language.Haskell.Liquid.Constraint.Constraint
 
 generateConstraints      :: GhcInfo -> CGInfo
 generateConstraints info = {-# SCC "ConsGen" #-} execState act $ initCGI cfg info
-  where 
+  where
     act                  = consAct info
     cfg                  = config $ spec info
 
@@ -93,11 +94,11 @@ consAct info
   = do γ     <- initEnv info
        sflag <- scheck <$> get
        tflag <- trustghc <$> get
-       let trustBinding x = if tflag 
-                             then (x `elem` (derVars info) || isInternal x) 
-                             else False 
+       let trustBinding x = if tflag
+                             then (x `elem` (derVars info) || isInternal x)
+                             else False
        foldM_ (consCBTop trustBinding) γ (cbs info)
-       hcs <- hsCs  <$> get 
+       hcs <- hsCs  <$> get
        hws <- hsWfs <$> get
        scss <- sCs <$> get
        annot <- annotMap <$> get
@@ -105,15 +106,15 @@ consAct info
                        else return []
        let smap = if sflag then solveStrata scs else []
        let hcs' = if sflag then subsS smap hcs else hcs
-       fcs <- concat <$> mapM splitC (subsS smap hcs') 
+       fcs <- concat <$> mapM splitC (subsS smap hcs')
        fws <- concat <$> mapM splitW hws
        let annot' = if sflag then (\t -> subsS smap t) <$> annot else annot
        modify $ \st -> st { fixCs = fcs } { fixWfs = fws } {annotMap = annot'}
 
 ------------------------------------------------------------------------------------
-initEnv :: GhcInfo -> CG CGEnv  
+initEnv :: GhcInfo -> CG CGEnv
 ------------------------------------------------------------------------------------
-initEnv info 
+initEnv info
   = do let tce   = tcEmbeds sp
        let fVars = impVars info ++ filter isConLikeId (snd <$> freeSyms sp)
        defaults <- forM fVars $ \x -> liftM (x,) (trueTy $ varType x)
@@ -134,7 +135,7 @@ initEnv info
        foldM (++=) γ0 [("initEnv", x, y) | (x, y) <- concat $ tail bs]
   where
     sp           = spec info
-    ialias       = mkRTyConIAl $ ialiases sp 
+    ialias       = mkRTyConIAl $ ialiases sp
     vals f       = map (mapSnd val) . f
 
 refreshHoles vts = first catMaybes . unzip . map extract <$> mapM refreshHoles' vts
@@ -145,7 +146,7 @@ refreshHoles' (x,t)
     tx r | hasHole r = refresh r
          | otherwise = return r
 extract (a,b,c) = (a,(b,c))
-    
+
 refreshArgs' = mapM (mapSndM refreshArgs)
 
 strataUnify :: [(Var, SpecType)] -> (Var, SpecType) -> (Var, SpecType)
@@ -162,11 +163,11 @@ strataUnify senv (x, t) = (x, maybe t (mappend t) pt)
 
 predsUnify :: GhcSpec -> (Var, RRType RReft) -> (Var, RRType RReft)
 predsUnify sp = second (addTyConInfo tce tyi) -- needed to eliminate some @RPropH@
-                             
+
   where
-    tce            = tcEmbeds sp 
+    tce            = tcEmbeds sp
     tyi            = tyconEnv sp
- 
+
  ---------------------------------------------------------------------------------------
  ---------------------------------------------------------------------------------------
  ---------------------------------------------------------------------------------------
@@ -177,29 +178,29 @@ measEnv sp xts cbs lts asms hs
         , syenv = F.fromListSEnv $ freeSyms sp
         , fenv  = initFEnv $ lts ++ (second (rTypeSort tce . val) <$> meas sp)
         , denv  = dicts sp
-        , recs  = S.empty 
+        , recs  = S.empty
         , invs  = mkRTyConInv    $ invariants sp
         , ial   = mkRTyConIAl    $ ialiases   sp
         , grtys = fromListREnv xts
         , assms = fromListREnv asms
-        , emb   = tce 
+        , emb   = tce
         , tgEnv = Tg.makeTagEnv cbs
         , tgKey = Nothing
         , trec  = Nothing
         , lcb   = M.empty
         , holes = fromListHEnv hs
         , lcs   = mempty
-        } 
+        }
     where
       tce = tcEmbeds sp
 
 assm = assm_grty impVars
 grty = assm_grty defVars
 
-assm_grty f info = [ (x, val t) | (x, t) <- sigs, x `S.member` xs ] 
-  where 
-    xs           = S.fromList $ f info 
-    sigs         = tySigs     $ spec info  
+assm_grty f info = [ (x, val t) | (x, t) <- sigs, x `S.member` xs ]
+  where
+    xs           = S.fromList $ f info
+    sigs         = tySigs     $ spec info
 
 grtyTop info     = forM topVs $ \v -> (v,) <$> (trueTy $ varType v) -- val $ varSpecType v) | v <- defVars info, isTop v]
   where
@@ -220,11 +221,11 @@ getTag :: CGEnv -> F.Tag
 getTag γ = maybe Tg.defaultTag (`Tg.getTag` (tgEnv γ)) (tgKey γ)
 
 setLoc :: CGEnv -> SrcSpan -> CGEnv
-γ `setLoc` src 
-  | isGoodSrcSpan src = γ { loc = src } 
+γ `setLoc` src
+  | isGoodSrcSpan src = γ { loc = src }
   | otherwise         = γ
 
-withRecs :: CGEnv -> [Var] -> CGEnv 
+withRecs :: CGEnv -> [Var] -> CGEnv
 withRecs γ xs  = γ { recs = foldl' (flip S.insert) (recs γ) xs }
 
 withTRec γ xts = γ' {trec = Just $ M.fromList xts' `M.union` trec'}
@@ -232,8 +233,8 @@ withTRec γ xts = γ' {trec = Just $ M.fromList xts' `M.union` trec'}
         trec' = fromMaybe M.empty $ trec γ
         xts'  = mapFst F.symbol <$> xts
 
-setBind :: CGEnv -> Tg.TagKey -> CGEnv  
-setBind γ k 
+setBind :: CGEnv -> Tg.TagKey -> CGEnv
+setBind γ k
   | Tg.memTagEnv k (tgEnv γ) = γ { tgKey = Just k }
   | otherwise                = γ
 
@@ -253,53 +254,53 @@ isGeneric α t =  all (\(c, α') -> (α'/=α) || isOrd c || isEq c ) (classConst
 
 splitW ::  WfC -> CG [FixWfC]
 
-splitW (WfC γ t@(RFun x t1 t2 _)) 
+splitW (WfC γ t@(RFun x t1 t2 _))
   =  do ws   <- bsplitW γ t
-        ws'  <- splitW (WfC γ t1) 
+        ws'  <- splitW (WfC γ t1)
         γ'   <- (γ, "splitW") += (x, t1)
         ws'' <- splitW (WfC γ' t2)
         return $ ws ++ ws' ++ ws''
 
-splitW (WfC γ t@(RAppTy t1 t2 _)) 
+splitW (WfC γ t@(RAppTy t1 t2 _))
   =  do ws   <- bsplitW γ t
-        ws'  <- splitW (WfC γ t1) 
+        ws'  <- splitW (WfC γ t1)
         ws'' <- splitW (WfC γ t2)
         return $ ws ++ ws' ++ ws''
 
-splitW (WfC γ (RAllT _ r)) 
+splitW (WfC γ (RAllT _ r))
   = splitW (WfC γ r)
 
-splitW (WfC γ (RAllP _ r)) 
+splitW (WfC γ (RAllP _ r))
   = splitW (WfC γ r)
 
 splitW (WfC γ t@(RVar _ _))
-  = bsplitW γ t 
+  = bsplitW γ t
 
 splitW (WfC γ t@(RApp _ ts rs _))
-  =  do ws    <- bsplitW γ t 
-        γ'    <- γ `extendEnvWithVV` t 
+  =  do ws    <- bsplitW γ t
+        γ'    <- γ `extendEnvWithVV` t
         ws'   <- concat <$> mapM splitW (map (WfC γ') ts)
         ws''  <- concat <$> mapM (rsplitW γ) rs
         return $ ws ++ ws' ++ ws''
 
 splitW (WfC γ (RAllE x tx t))
-  = do  ws  <- splitW (WfC γ tx) 
+  = do  ws  <- splitW (WfC γ tx)
         γ'  <- (γ, "splitW") += (x, tx)
         ws' <- splitW (WfC γ' t)
         return $ ws ++ ws'
 
 splitW (WfC γ (REx x tx t))
-  = do  ws  <- splitW (WfC γ tx) 
+  = do  ws  <- splitW (WfC γ tx)
         γ'  <- (γ, "splitW") += (x, tx)
         ws' <- splitW (WfC γ' t)
         return $ ws ++ ws'
 
-splitW (WfC _ t) 
+splitW (WfC _ t)
   = errorstar $ "splitW cannot handle: " ++ showpp t
 
-rsplitW _ (RPropP _ _)  
+rsplitW _ (RPropP _ _)
   = errorstar "Constrains: rsplitW for RPropP"
-rsplitW γ (RProp ss t0) 
+rsplitW γ (RProp ss t0)
   = do γ' <- foldM (++=) γ [("rsplitC", x, ofRSort s) | (x, s) <- ss]
        splitW $ WfC γ' t0
 rsplitW _ (RHProp _ _)
@@ -309,9 +310,9 @@ bsplitW :: CGEnv -> SpecType -> CG [FixWfC]
 bsplitW γ t = pruneRefs <$> get >>= return . bsplitW' γ t
 
 bsplitW' γ t pflag
-  | F.isNonTrivialSortedReft r' = [F.wfC (fe_binds $ fenv γ) r' Nothing ci] 
+  | F.isNonTrivialSortedReft r' = [F.wfC (fe_binds $ fenv γ) r' Nothing ci]
   | otherwise                   = []
-  where 
+  where
     r'                          = rTypeSortedReft' pflag γ t
     ci                          = Ci (loc γ) Nothing
 
@@ -323,10 +324,10 @@ bsplitS :: SpecType -> SpecType -> CG [([Stratum], [Stratum])]
 splitS (SubC γ (REx x _ t1) (REx x2 _ t2)) | x == x2
   = splitS (SubC γ t1 t2)
 
-splitS (SubC γ t1 (REx _ _ t2)) 
+splitS (SubC γ t1 (REx _ _ t2))
   = splitS (SubC γ t1 t2)
 
-splitS (SubC γ (REx _ _ t1) t2) 
+splitS (SubC γ (REx _ _ t1) t2)
   = splitS (SubC γ t1 t2)
 
 splitS (SubC γ (RAllE x _ t1) (RAllE x2 _ t2)) | x == x2
@@ -338,50 +339,51 @@ splitS (SubC γ (RAllE _ _ t1) t2)
 splitS (SubC γ t1 (RAllE _ _ t2))
   = splitS (SubC γ t1 t2)
 
-splitS (SubC γ (RRTy _ _ _ t1) t2) 
+splitS (SubC γ (RRTy _ _ _ t1) t2)
   = splitS (SubC γ t1 t2)
 
-splitS (SubC γ t1 (RRTy _ _ _ t2)) 
+splitS (SubC γ t1 (RRTy _ _ _ t2))
   = splitS (SubC γ t1 t2)
 
-splitS (SubC γ t1@(RFun x1 r1 r1' _) t2@(RFun x2 r2 r2' _)) 
-  =  do cs       <- bsplitS t1 t2 
-        cs'      <- splitS  (SubC γ r2 r1) 
-        γ'       <- (γ, "splitC") += (x2, r2) 
-        let r1x2' = r1' `F.subst1` (x1, F.EVar x2) 
-        cs''     <- splitS  (SubC γ' r1x2' r2') 
+splitS (SubC γ t1@(RFun x1 r1 r1' _) t2@(RFun x2 r2 r2' _))
+  =  do cs       <- bsplitS t1 t2
+        cs'      <- splitS  (SubC γ r2 r1)
+        γ'       <- (γ, "splitC") += (x2, r2)
+        let r1x2' = r1' `F.subst1` (x1, F.EVar x2)
+        cs''     <- splitS  (SubC γ' r1x2' r2')
         return    $ cs ++ cs' ++ cs''
 
-splitS (SubC γ t1@(RAppTy r1 r1' _) t2@(RAppTy r2 r2' _)) 
-  =  do cs    <- bsplitS t1 t2 
-        cs'   <- splitS  (SubC γ r1 r2) 
-        cs''  <- splitS  (SubC γ r1' r2') 
-        cs''' <- splitS  (SubC γ r2' r1') 
+splitS (SubC γ t1@(RAppTy r1 r1' _) t2@(RAppTy r2 r2' _))
+  =  do cs    <- bsplitS t1 t2
+        cs'   <- splitS  (SubC γ r1 r2)
+        cs''  <- splitS  (SubC γ r1' r2')
+        cs''' <- splitS  (SubC γ r2' r1')
         return $ cs ++ cs' ++ cs'' ++ cs'''
 
 splitS (SubC γ t1 (RAllP p t))
   = splitS $ SubC γ t1 t'
-  where t' = fmap (replacePredsWithRefs su) t
-        su = (uPVar p, pVartoRConc p)
+  where
+    t' = fmap (replacePredsWithRefs su) t
+    su = (uPVar p, pVartoRConc p)
 
-splitS (SubC _ t1@(RAllP _ _) t2) 
+splitS (SubC _ t1@(RAllP _ _) t2)
   = errorstar $ "Predicate in lhs of constrain:" ++ showpp t1 ++ "\n<:\n" ++ showpp t2
 
 splitS (SubC γ (RAllT α1 t1) (RAllT α2 t2))
-  |  α1 ==  α2 
+  |  α1 ==  α2
   = splitS $ SubC γ t1 t2
-  | otherwise   
-  = splitS $ SubC γ t1 t2' 
+  | otherwise
+  = splitS $ SubC γ t1 t2'
   where t2' = subsTyVar_meet' (α2, RVar α1 mempty) t2
 
-splitS (SubC _ (RApp c1 _ _ _) (RApp c2 _ _ _)) | isClass c1 && c1 == c2 
+splitS (SubC _ (RApp c1 _ _ _) (RApp c2 _ _ _)) | isClass c1 && c1 == c2
   = return []
 
 
 splitS (SubC γ t1@(RApp _ _ _ _) t2@(RApp _ _ _ _))
   = do (t1',t2') <- unifyVV t1 t2
        cs    <- bsplitS t1' t2'
-       γ'    <- γ `extendEnvWithVV` t1' 
+       γ'    <- γ `extendEnvWithVV` t1'
        let RApp c t1s r1s _ = t1'
        let RApp _ t2s r2s _ = t2'
        let tyInfo = rtc_info c
@@ -389,24 +391,24 @@ splitS (SubC γ t1@(RApp _ _ _ _) t2@(RApp _ _ _ _))
        csvar' <- rsplitsSWithVariance γ' r1s r2s $ variancePsArgs tyInfo
        return $ cs ++ csvar ++ csvar'
 
-splitS (SubC _ t1@(RVar a1 _) t2@(RVar a2 _)) 
+splitS (SubC _ t1@(RVar a1 _) t2@(RVar a2 _))
   | a1 == a2
   = bsplitS t1 t2
 
-splitS (SubC _ t1 t2) 
+splitS (SubC _ t1 t2)
   = errorstar $ "(Another Broken Test!!!) splitS unexpected: " ++ showpp t1 ++ "\n\n" ++ showpp t2
 
 splitS (SubR _ _ _)
   = return []
 
-splitsSWithVariance γ t1s t2s variants 
+splitsSWithVariance γ t1s t2s variants
   = concatMapM (\(t1, t2, v) -> splitfWithVariance (\s1 s2 -> splitS (SubC γ s1 s2)) t1 t2 v) (zip3 t1s t2s variants)
 
-rsplitsSWithVariance γ t1s t2s variants 
+rsplitsSWithVariance γ t1s t2s variants
   = concatMapM (\(t1, t2, v) -> splitfWithVariance (rsplitS γ) t1 t2 v) (zip3 t1s t2s variants)
 
-bsplitS t1 t2 
-  = return $ [(s1, s2)] 
+bsplitS t1 t2
+  = return $ [(s1, s2)]
   where [s1, s2]   = getStrata <$> [t1, t2]
 
 rsplitS γ (RProp s1 r1) (RProp s2 r2)
@@ -415,7 +417,7 @@ rsplitS γ (RProp s1 r1) (RProp s2 r2)
 
 rsplitS _ _ _
   = errorstar "rspliS Rpoly - RPropP"
-  
+
 
 
 splitfWithVariance f t1 t2 Invariant     = liftM2 (++) (f t1 t2) (f t2 t1) -- return []
@@ -432,15 +434,15 @@ splitC (SubC γ (REx x tx t1) (REx x2 _ t2)) | x == x2
   = do γ' <- (γ, "addExBind 0") += (x, forallExprRefType γ tx)
        splitC (SubC γ' t1 t2)
 
-splitC (SubC γ t1 (REx x tx t2)) 
+splitC (SubC γ t1 (REx x tx t2))
   = do γ' <- (γ, "addExBind 1") += (x, forallExprRefType γ tx)
        let xs  = grapBindsWithType tx γ
        let t2' = splitExistsCases x xs tx t2
        splitC (SubC γ' t1 t2')
 
 -- existential at the left hand side is treated like forall
-splitC (SubC γ (REx x tx t1) t2) 
-  = do -- let tx' = traceShow ("splitC: " ++ showpp z) tx 
+splitC (SubC γ (REx x tx t1) t2)
+  = do -- let tx' = traceShow ("splitC: " ++ showpp z) tx
        γ' <- (γ, "addExBind 1") += (x, forallExprRefType γ tx)
        splitC (SubC γ' t1 t2)
 
@@ -463,42 +465,43 @@ splitC (SubC γ (RRTy env _ OCons t1) t2)
        c2 <- splitC (SubC γ  t1  t2 )
        return $ c1 ++ c2
   where
-    (xts, t1', t2') = envToSub env 
+    (xts, t1', t2') = envToSub env
 
-splitC (SubC γ (RRTy e r o t1) t2) 
-  = do γ' <- foldM (\γ (x, t) -> γ `addSEnv` ("splitS", x,t)) γ e 
+splitC (SubC γ (RRTy e r o t1) t2)
+  = do γ' <- foldM (\γ (x, t) -> γ `addSEnv` ("splitS", x,t)) γ e
        c1 <- splitC (SubR γ' o  r )
        c2 <- splitC (SubC γ t1 t2)
        return $ c1 ++ c2
 
-splitC (SubC γ t1@(RFun x1 r1 r1' _) t2@(RFun x2 r2 r2' _)) 
-  =  do cs       <- bsplitC γ t1 t2 
-        cs'      <- splitC  (SubC γ r2 r1) 
-        γ'       <- (γ, "splitC") += (x2, r2) 
-        let r1x2' = r1' `F.subst1` (x1, F.EVar x2) 
-        cs''     <- splitC  (SubC γ' r1x2' r2') 
+splitC (SubC γ t1@(RFun x1 r1 r1' _) t2@(RFun x2 r2 r2' _))
+  =  do cs       <- bsplitC γ t1 t2
+        cs'      <- splitC  (SubC γ r2 r1)
+        γ'       <- (γ, "splitC") += (x2, r2)
+        let r1x2' = r1' `F.subst1` (x1, F.EVar x2)
+        cs''     <- splitC  (SubC γ' r1x2' r2')
         return    $ cs ++ cs' ++ cs''
 
-splitC (SubC γ t1@(RAppTy r1 r1' _) t2@(RAppTy r2 r2' _)) 
-  =  do cs    <- bsplitC γ t1 t2 
-        cs'   <- splitC  (SubC γ r1 r2) 
-        cs''  <- splitC  (SubC γ r1' r2') 
-        cs''' <- splitC  (SubC γ r2' r1') 
+splitC (SubC γ t1@(RAppTy r1 r1' _) t2@(RAppTy r2 r2' _))
+  =  do cs    <- bsplitC γ t1 t2
+        cs'   <- splitC  (SubC γ r1 r2)
+        cs''  <- splitC  (SubC γ r1' r2')
+        cs''' <- splitC  (SubC γ r2' r1')
         return $ cs ++ cs' ++ cs'' ++ cs'''
 
 splitC (SubC γ t1 (RAllP p t))
   = splitC $ SubC γ t1 t'
-  where t' = fmap (replacePredsWithRefs su) t
-        su = (uPVar p, pVartoRConc p)
+  where
+    t' = fmap (replacePredsWithRefs su) t
+    su = (uPVar p, pVartoRConc p)
 
-splitC (SubC _ t1@(RAllP _ _) t2) 
+splitC (SubC _ t1@(RAllP _ _) t2)
   = errorstar $ "Predicate in lhs of constraint:" ++ showpp t1 ++ "\n<:\n" ++ showpp t2
 
 splitC (SubC γ (RAllT α1 t1) (RAllT α2 t2))
-  |  α1 ==  α2 
+  |  α1 ==  α2
   = splitC $ SubC γ t1 t2
-  | otherwise   
-  = splitC $ SubC γ t1 t2' 
+  | otherwise
+  = splitC $ SubC γ t1 t2'
   where t2' = subsTyVar_meet' (α2, RVar α1 mempty) t2
 
 
@@ -508,7 +511,7 @@ splitC (SubC _ (RApp c1 _ _ _) (RApp c2 _ _ _)) | isClass c1 && c1 == c2
 splitC (SubC γ t1@(RApp _ _ _ _) t2@(RApp _ _ _ _))
   = do (t1',t2') <- unifyVV t1 t2
        cs    <- bsplitC γ t1' t2'
-       γ'    <- γ `extendEnvWithVV` t1' 
+       γ'    <- γ `extendEnvWithVV` t1'
        let RApp c t1s r1s _ = t1'
        let RApp _ t2s r2s _ = t2'
        let tyInfo = rtc_info c
@@ -516,43 +519,43 @@ splitC (SubC γ t1@(RApp _ _ _ _) t2@(RApp _ _ _ _))
        csvar' <- rsplitsCWithVariance γ' r1s r2s $ variancePsArgs tyInfo
        return $ cs ++ csvar ++ csvar'
 
-splitC (SubC γ t1@(RVar a1 _) t2@(RVar a2 _)) 
+splitC (SubC γ t1@(RVar a1 _) t2@(RVar a2 _))
   | a1 == a2
   = bsplitC γ t1 t2
 
-splitC (SubC _ t1 t2) 
+splitC (SubC _ t1 t2)
   = errorstar $ "(Another Broken Test!!!) splitc unexpected: " ++ showpp t1 ++ "\n\n" ++ showpp t2
 
 splitC (SubR γ o r)
-  = do fg     <- pruneRefs <$> get 
+  = do fg     <- pruneRefs <$> get
        let r1' = if fg then pruneUnsortedReft γ'' r1 else r1
        return $ F.subC γ' F.PTrue r1' r2 Nothing tag ci
   where
     γ'' = fe_env $ fenv γ
     γ'  = fe_binds $ fenv γ
     r1  = F.RR s $ F.toReft r
-    r2  = F.RR s $ F.Reft (vv, [F.RConc $ F.PBexp $ F.EVar vv])
+    r2  = F.RR s $ F.Reft (vv, F.Refa $ F.PBexp $ F.EVar vv)
     vv  = "vvRec"
     s   = F.FApp F.boolFTyCon []
     ci  = Ci src err
     err = Just $ ErrAssType src o (text $ show o ++ "type error") r
     tag = getTag γ
-    src = loc γ 
+    src = loc γ
 
 
-splitsCWithVariance γ t1s t2s variants 
+splitsCWithVariance γ t1s t2s variants
   = concatMapM (\(t1, t2, v) -> splitfWithVariance (\s1 s2 -> (splitC (SubC γ s1 s2))) t1 t2 v) (zip3 t1s t2s variants)
 
-rsplitsCWithVariance γ t1s t2s variants 
+rsplitsCWithVariance γ t1s t2s variants
   = concatMapM (\(t1, t2, v) -> splitfWithVariance (rsplitC γ) t1 t2 v) (zip3 t1s t2s variants)
 
 
 
 bsplitC γ t1 t2
-  = do checkStratum γ t1 t2 
+  = do checkStratum γ t1 t2
        pflag <- pruneRefs <$> get
-       γ' <- γ ++= ("bsplitC", v, t1) 
-       let r = (mempty :: UReft F.Reft){ur_reft = F.Reft (F.dummySymbol,  [F.RConc $ constraintToLogic γ' (lcs γ')])}
+       γ' <- γ ++= ("bsplitC", v, t1)
+       let r = (mempty :: UReft F.Reft){ur_reft = F.Reft (F.dummySymbol,  F.Refa $ constraintToLogic γ' (lcs γ'))}
        let t1' = addRTyConInv (invs γ')  t1 `strengthen` r
        return $ bsplitC' γ' t1' t2 pflag
   where
@@ -562,7 +565,7 @@ checkStratum γ t1 t2
   | s1 <:= s2 = return ()
   | otherwise = addWarning wrn
   where [s1, s2]   = getStrata <$> [t1, t2]
-        wrn        =  ErrOther (loc γ) (text $ "Stratum Error : " ++ show s1 ++ " > " ++ show s2) 
+        wrn        =  ErrOther (loc γ) (text $ "Stratum Error : " ++ show s1 ++ " > " ++ show s2)
 
 bsplitC' γ t1 t2 pflag
   | F.isFunctionSortedReft r1' && F.isNonTrivialSortedReft r2'
@@ -571,15 +574,15 @@ bsplitC' γ t1 t2 pflag
   = F.subC γ' grd r1'  r2' Nothing tag ci
   | otherwise
   = []
-  where 
+  where
     γ'     = fe_binds $ fenv γ
     r1'    = rTypeSortedReft' pflag γ t1
     r2'    = rTypeSortedReft' pflag γ t2
     ci     = Ci src err
     tag    = getTag γ
-    err    = Just $ ErrSubType src (text "subtype") g t1 t2 
+    err    = Just $ ErrSubType src (text "subtype") g t1 t2
     src    = loc γ
-    REnv g = renv γ 
+    REnv g = renv γ
     grd    = F.PTrue
 
 
@@ -588,10 +591,10 @@ unifyVV t1@(RApp _ _ _ _) t2@(RApp _ _ _ _)
   = do vv     <- (F.vv . Just) <$> fresh
        return  $ (shiftVV t1 vv,  (shiftVV t2 vv) ) -- {rt_pargs = r2s'})
 
-unifyVV _ _ 
+unifyVV _ _
   = errorstar $ "Constraint.Generate.unifyVV called on invalid inputs"
 
-rsplitC _ (RPropP _ _) (RPropP _ _) 
+rsplitC _ (RPropP _ _) (RPropP _ _)
   = errorstar "RefTypes.rsplitC on RPropP"
 
 rsplitC γ (RProp s1 r1) (RProp s2 r2)
@@ -599,26 +602,26 @@ rsplitC γ (RProp s1 r1) (RProp s2 r2)
        splitC (SubC γ' (F.subst su r1) r2)
   where su = F.mkSubst [(x, F.EVar y) | ((x,_), (y,_)) <- zip s1 s2]
 
-rsplitC _ _ _  
+rsplitC _ _ _
   = errorstar "rsplit Rpoly - RPropP"
 
 
 type CG = State CGInfo
 
 initCGI cfg info = CGInfo {
-    hsCs       = [] 
-  , sCs        = [] 
-  , hsWfs      = [] 
+    hsCs       = []
+  , sCs        = []
+  , hsWfs      = []
   , fixCs      = []
   , isBind     = []
-  , fixWfs     = [] 
+  , fixWfs     = []
   , freshIndex = 0
   , binds      = F.emptyBindEnv
   , annotMap   = AI M.empty
   , tyConInfo  = tyi
-  , tyConEmbed = tce  
-  , kuts       = F.ksEmpty 
-  , lits       = coreBindLits tce info 
+  , tyConEmbed = tce
+  , kuts       = F.ksEmpty
+  , lits       = coreBindLits tce info
   , termExprs  = M.fromList $ texprs spc
   , specDecr   = decr spc
   , specLVars  = lvars spc
@@ -630,9 +633,9 @@ initCGI cfg info = CGInfo {
   , logErrors  = []
   , kvProf     = emptyKVProf
   , recCount   = 0
-  } 
-  where 
-    tce        = tcEmbeds spc 
+  }
+  where
+    tce        = tcEmbeds spc
     spc        = spec info
     tyi        = tyconEnv spc -- EFFECTS HEREHEREHERE makeTyConInfo (tconsP spc)
 
@@ -640,48 +643,48 @@ coreBindLits tce info
   = sortNub      $ [ (val x, so) | (_, Just (F.ELit x so)) <- lconsts ]
                 ++ [(F.symbol x, F.strSort) | (_, Just (F.ESym x)) <- lconsts ]
                 ++ [ (dconToSym dc, dconToSort dc) | dc <- dcons ]
-  where 
+  where
     lconsts      = literalConst tce <$> literals (cbs info)
     dcons        = filter isDCon $ impVars info -- ++ (snd <$> freeSyms (spec info))
-    dconToSort   = typeSort tce . expandTypeSynonyms . varType 
+    dconToSort   = typeSort tce . expandTypeSynonyms . varType
     dconToSym    = dataConSymbol . idDataCon
     isDCon x     = isDataConId x && not (hasBaseTypeVar x)
 
-extendEnvWithVV γ t 
+extendEnvWithVV γ t
   | F.isNontrivialVV vv
   = (γ, "extVV") += (vv, t)
   | otherwise
   = return γ
   where vv = rTypeValueVar t
 
-{- see tests/pos/polyfun for why you need everything in fixenv -} 
+{- see tests/pos/polyfun for why you need everything in fixenv -}
 addCGEnv :: (SpecType -> SpecType) -> CGEnv -> (String, F.Symbol, SpecType) -> CG CGEnv
 addCGEnv tx γ (msg, x, RAllE y tyy tyx)
-  = do y' <- fresh 
+  = do y' <- fresh
        γ' <- addCGEnv tx γ (msg, y', tyy)
        addCGEnv tx γ' (msg, x, tyx `F.subst1` (y, F.EVar y'))
 
-addCGEnv tx γ (_, x, t') 
+addCGEnv tx γ (_, x, t')
   = do idx   <- fresh
-       let t  = tx $ normalize {-x-} idx t'  
-       let γ' = γ { renv = insertREnv x t (renv γ) }  
+       let t  = tx $ normalize {-x-} idx t'
+       let γ' = γ { renv = insertREnv x t (renv γ) }
        pflag <- pruneRefs <$> get
-       is    <- if isBase t 
+       is    <- if isBase t
                   then liftM2 (++) (liftM single $ addBind x $ rTypeSortedReft' pflag γ' t) (addClassBind t)
-                  else return [] -- addClassBind t 
+                  else return [] -- addClassBind t
        return $ γ' { fenv = insertsFEnv (fenv γ) is }
 
 (++=) :: CGEnv -> (String, F.Symbol, SpecType) -> CG CGEnv
-(++=) γ = addCGEnv (addRTyConInv (M.unionWith mappend (invs γ) (ial γ))) γ  
+(++=) γ = addCGEnv (addRTyConInv (M.unionWith mappend (invs γ) (ial γ))) γ
 
 addSEnv :: CGEnv -> (String, F.Symbol, SpecType) -> CG CGEnv
 addSEnv γ = addCGEnv (addRTyConInv (invs γ)) γ
 
-rTypeSortedReft' pflag γ 
+rTypeSortedReft' pflag γ
   | pflag
   = pruneUnsortedReft (fe_env $ fenv γ) . f
   | otherwise
-  = f 
+  = f
   where f = rTypeSortedReft (emb γ)
 
 (+++=) :: (CGEnv, String) -> (F.Symbol, CoreExpr, SpecType) -> CG CGEnv
@@ -693,43 +696,43 @@ rTypeSortedReft' pflag γ
   | x == F.dummySymbol
   = return γ
   | x `memberREnv` (renv γ)
-  = err 
+  = err
   | otherwise
-  =  γ ++= (msg, x, r) 
-  where err = errorstar $ msg ++ " Duplicate binding for " 
-                              ++ F.symbolString x 
+  =  γ ++= (msg, x, r)
+  where err = errorstar $ msg ++ " Duplicate binding for "
+                              ++ F.symbolString x
                               ++ "\n New: " ++ showpp r
                               ++ "\n Old: " ++ showpp (x `lookupREnv` (renv γ))
-                        
+
 γ -= x =  γ {renv = deleteREnv x (renv γ), lcb  = M.delete x (lcb γ)}
 
 (??=) :: CGEnv -> F.Symbol -> CG SpecType
-γ ??= x 
+γ ??= x
   = case M.lookup x (lcb γ) of
     Just e  -> consE (γ-=x) e
     Nothing -> refreshTy $ γ ?= x
 
-(?=) ::  CGEnv -> F.Symbol -> SpecType 
+(?=) ::  CGEnv -> F.Symbol -> SpecType
 γ ?= x = fromMaybe err $ lookupREnv x (renv γ)
-         where err = errorstar $ "EnvLookup: unknown " 
-                               ++ showpp x 
-                               ++ " in renv " 
+         where err = errorstar $ "EnvLookup: unknown "
+                               ++ showpp x
+                               ++ " in renv "
                                ++ showpp (renv γ)
 
-normalize idx 
-  = normalizeVV idx 
+normalize idx
+  = normalizeVV idx
   . normalizePds
 
 normalizeVV idx t@(RApp _ _ _ _)
   | not (F.isNontrivialVV (rTypeValueVar t))
   = shiftVV t (F.vv $ Just idx)
 
-normalizeVV _ t 
-  = t 
+normalizeVV _ t
+  = t
 
 
 addBind :: F.Symbol -> F.SortedReft -> CG ((F.Symbol, F.Sort), F.BindId)
-addBind x r 
+addBind x r
   = do st          <- get
        let (i, bs') = F.insertBindEnv x r (binds st)
        put          $ st { binds = bs' }
@@ -745,94 +748,94 @@ pushConsBind act
        modify $ \s -> s { isBind = tail (isBind s) }
        return z
 
-addC :: SubC -> String -> CG ()  
-addC !c@(SubC γ t1 t2) _msg 
+addC :: SubC -> String -> CG ()
+addC !c@(SubC γ t1 t2) _msg
   = do -- trace ("addC at " ++ show (loc γ) ++ _msg++ showpp t1 ++ "\n <: \n" ++ showpp t2 ) $
        modify $ \s -> s { hsCs  = c : (hsCs s) }
        bflag <- headDefault True . isBind <$> get
-       sflag <- scheck                 <$> get 
+       sflag <- scheck                 <$> get
        if bflag && sflag
          then modify $ \s -> s {sCs = (SubC γ t2 t1) : (sCs s) }
          else return ()
-  where 
+  where
     headDefault a []    = a
     headDefault _ (x:_) = x
 
 
-addC !c _msg 
+addC !c _msg
   = modify $ \s -> s { hsCs  = c : (hsCs s) }
 
-addPost γ (RRTy e r OInv t) 
-  = do γ' <- foldM (\γ (x, t) -> γ `addSEnv` ("addPost", x,t)) γ e 
+addPost γ (RRTy e r OInv t)
+  = do γ' <- foldM (\γ (x, t) -> γ `addSEnv` ("addPost", x,t)) γ e
        addC (SubR γ' OInv r) "precondition" >> return t
 
-addPost γ (RRTy e r OTerm t) 
-  = do γ' <- foldM (\γ (x, t) -> γ ++= ("addPost", x,t)) γ e 
+addPost γ (RRTy e r OTerm t)
+  = do γ' <- foldM (\γ (x, t) -> γ ++= ("addPost", x,t)) γ e
        addC (SubR γ' OTerm r) "precondition" >> return t
 
-addPost _ (RRTy _ _ OCons t) 
+addPost _ (RRTy _ _ OCons t)
   = return t
 
-addPost _ t  
+addPost _ t
   = return t
 
-addW   :: WfC -> CG ()  
+addW   :: WfC -> CG ()
 addW !w = modify $ \s -> s { hsWfs = w : (hsWfs s) }
 
-addWarning   :: TError SpecType -> CG ()  
+addWarning   :: TError SpecType -> CG ()
 addWarning w = modify $ \s -> s { logErrors = w : (logErrors s) }
 
 -- | Used for annotation binders (i.e. at binder sites)
 
 addIdA            :: Var -> Annot SpecType -> CG ()
 addIdA !x !t      = modify $ \s -> s { annotMap = upd $ annotMap s }
-  where 
+  where
     loc           = getSrcSpan x
     upd m@(AI _)  = if boundRecVar loc m then m else addA loc (Just x) t m
 
 boundRecVar l (AI m) = not $ null [t | (_, AnnRDf t) <- M.lookupDefault [] l m]
 
 
--- | Used for annotating reads (i.e. at Var x sites) 
+-- | Used for annotating reads (i.e. at Var x sites)
 
 addLocA :: Maybe Var -> SrcSpan -> Annot SpecType -> CG ()
-addLocA !xo !l !t 
+addLocA !xo !l !t
   = modify $ \s -> s { annotMap = addA l xo t $ annotMap s }
 
 -- | Used to update annotations for a location, due to (ghost) predicate applications
 
 updateLocA (_:_)  (Just l) t = addLocA Nothing l (AnnUse t)
-updateLocA _      _        _ = return () 
+updateLocA _      _        _ = return ()
 
 addA !l xo@(Just _) !t (AI m)
-  | isGoodSrcSpan l 
+  | isGoodSrcSpan l
   = AI $ inserts l (T.pack . showPpr <$> xo, t) m
 addA !l xo@Nothing  !t (AI m)
   | l `M.member` m                  -- only spans known to be variables
   = AI $ inserts l (T.pack . showPpr <$> xo, t) m
-addA _ _ _ !a 
+addA _ _ _ !a
   = a
 
 -------------------------------------------------------------------
 ------------------------ Generation: Freshness --------------------
 -------------------------------------------------------------------
 
--- | Right now, we generate NO new pvars. Rather than clutter code 
---   with `uRType` calls, put it in one place where the above 
+-- | Right now, we generate NO new pvars. Rather than clutter code
+--   with `uRType` calls, put it in one place where the above
 --   invariant is /obviously/ enforced.
 --   Constraint generation should ONLY use @freshTy_type@ and @freshTy_expr@
 
-freshTy_type        :: KVKind -> CoreExpr -> Type -> CG SpecType 
+freshTy_type        :: KVKind -> CoreExpr -> Type -> CG SpecType
 freshTy_type k _ τ  = freshTy_reftype k $ ofType τ
 
-freshTy_expr        :: KVKind -> CoreExpr -> Type -> CG SpecType 
+freshTy_expr        :: KVKind -> CoreExpr -> Type -> CG SpecType
 freshTy_expr k e _  = freshTy_reftype k $ exprRefType e
 
-freshTy_reftype     :: KVKind -> SpecType -> CG SpecType 
--- freshTy_reftype k t = do t <- refresh =<< fixTy t 
+freshTy_reftype     :: KVKind -> SpecType -> CG SpecType
+-- freshTy_reftype k t = do t <- refresh =<< fixTy t
 --                          addKVars k t
 --                          return t
-                       
+
 freshTy_reftype k t = (fixTy t >>= refresh) =>> addKVars k
 
 -- | Used to generate "cut" kvars for fixpoint. Typically, KVars for recursive
@@ -849,37 +852,37 @@ isKut RecBindE = True
 isKut _        = False
 
 specTypeKVars :: SpecType -> [F.Symbol]
-specTypeKVars = foldReft ((++) . (F.reftKVars . ur_reft)) []
+specTypeKVars = foldReft ((++) . (kvars . ur_reft)) []
 
 trueTy  :: Type -> CG SpecType
 trueTy = ofType' >=> true
 
 ofType' :: Type -> CG SpecType
 ofType' = fixTy . ofType
-  
+
 fixTy :: SpecType -> CG SpecType
 fixTy t = do tyi   <- tyConInfo  <$> get
              tce   <- tyConEmbed <$> get
              return $ addTyConInfo tce tyi t
 
 refreshArgsTop :: (Var, SpecType) -> CG SpecType
-refreshArgsTop (x, t) 
+refreshArgsTop (x, t)
   = do (t', su) <- refreshArgsSub t
        modify $ \s -> s {termExprs = M.adjust (F.subst su <$>) x $ termExprs s}
        return t'
-  
+
 refreshArgs :: SpecType -> CG SpecType
-refreshArgs t 
+refreshArgs t
   = fst <$> refreshArgsSub t
 
 
 -- NV TODO: this does not refreshes args if they are wrapped in an RRTy
 refreshArgsSub :: SpecType -> CG (SpecType, F.Subst)
-refreshArgsSub t 
+refreshArgsSub t
   = do ts     <- mapM refreshArgs ts_u
        xs'    <- mapM (\_ -> fresh) xs
        let sus = F.mkSubst <$> (L.inits $ zip xs (F.EVar <$> xs'))
-       let su  = last sus 
+       let su  = last sus
        let ts' = zipWith F.subst sus ts
        let t'  = fromRTypeRep $ trep {ty_binds = xs', ty_args = ts', ty_res = F.subst su tbd}
        return (t', su)
@@ -894,7 +897,7 @@ instance Freshable CG Integer where
              let n = freshIndex s
              put $ s { freshIndex = n + 1 }
              return n
-  	
+
 
 -------------------------------------------------------------------------------
 ----------------------- TERMINATION TYPE --------------------------------------
@@ -923,17 +926,17 @@ makeDecrIndexTy x t
        ts         = ty_args $ toRTypeRep $ unOCons t
        checkHint' = checkHint x ts isDecreasing
        dindex     = L.findIndex isDecreasing ts
-       msg        = ErrTermin [x] (getSrcSpan x) (text "No decreasing parameter") 
+       msg        = ErrTermin [x] (getSrcSpan x) (text "No decreasing parameter")
 
 
 recType ((_, []), (_, [], t))
   = t
 
 recType ((vs, indexc), (_, index, t))
-  = makeRecType t v dxt index       
+  = makeRecType t v dxt index
   where v    = (vs !!)  <$> indexc
         dxt  = (xts !!) <$> index
-        xts  = zip (ty_binds trep) (ty_args trep) 
+        xts  = zip (ty_binds trep) (ty_args trep)
         trep = toRTypeRep $ unOCons t
 
 checkIndex (x, vs, t, index)
@@ -954,35 +957,35 @@ makeRecType t vs dxs is
     trep       = toRTypeRep $ unOCons t
 
 unOCons (RAllT v t)        = RAllT v $ unOCons t
-unOCons (RAllP p t)        = RAllP p $ unOCons t 
-unOCons (RFun x tx t r)    = RFun x (unOCons tx) (unOCons t) r 
+unOCons (RAllP p t)        = RAllP p $ unOCons t
+unOCons (RFun x tx t r)    = RFun x (unOCons tx) (unOCons t) r
 unOCons (RRTy _ _ OCons t) = unOCons t
-unOCons t                  = t 
+unOCons t                  = t
 
 
-mergecondition (RAllT _ t1) (RAllT v t2) 
+mergecondition (RAllT _ t1) (RAllT v t2)
   = RAllT v $ mergecondition t1 t2
-mergecondition (RAllP _ t1) (RAllP p t2) 
+mergecondition (RAllP _ t1) (RAllP p t2)
   = RAllP p $ mergecondition t1 t2
-mergecondition (RRTy xts r OCons t1) t2 
+mergecondition (RRTy xts r OCons t1) t2
   = RRTy xts r OCons (mergecondition t1 t2)
 mergecondition (RFun _ t11 t12 _) (RFun x2 t21 t22 r2)
   = RFun x2 (mergecondition t11 t21) (mergecondition t12 t22) r2
-mergecondition _ t 
-  = t  
+mergecondition _ t
+  = t
 
 safeLogIndex err ls n
   | n >= length ls = addWarning err >> return Nothing
   | otherwise      = return $ Just $ ls !! n
 
-checkHint _ _ _ Nothing 
+checkHint _ _ _ Nothing
   = return Nothing
 
 checkHint x _ _ (Just ns) | L.sort ns /= ns
   = addWarning (ErrTermin [x] loc (text "The hints should be increasing")) >> return Nothing
   where loc = getSrcSpan x
 
-checkHint x ts f (Just ns) 
+checkHint x ts f (Just ns)
   = (mapM (checkValidHint x ts f) ns) >>= (return . Just . catMaybes)
 
 checkValidHint x ts f n
@@ -995,8 +998,8 @@ checkValidHint x ts f n
 -------------------------------------------------------------------
 -------------------- Generation: Corebind -------------------------
 -------------------------------------------------------------------
-consCBTop :: (Var -> Bool) -> CGEnv -> CoreBind -> CG CGEnv 
-consCBLet :: CGEnv -> CoreBind -> CG CGEnv 
+consCBTop :: (Var -> Bool) -> CGEnv -> CoreBind -> CG CGEnv
+consCBLet :: CGEnv -> CoreBind -> CG CGEnv
 -------------------------------------------------------------------
 
 consCBLet γ cb
@@ -1031,7 +1034,7 @@ tcond cb strict
         binds (Rec xes)    = fst $ unzip xes
 
 -------------------------------------------------------------------
-consCB :: Bool -> Bool -> CGEnv -> CoreBind -> CG CGEnv 
+consCB :: Bool -> Bool -> CGEnv -> CoreBind -> CG CGEnv
 -------------------------------------------------------------------
 
 consCBSizedTys γ xes
@@ -1064,9 +1067,9 @@ consCBSizedTys γ xes
        loc            = getSrcSpan (head xs)
 
        checkAll _   _ []            = return []
-       checkAll err f (x:xs) 
+       checkAll err f (x:xs)
          | all (==(f x)) (f <$> xs) = return (x:xs)
-         | otherwise                = addWarning err >> return [] 
+         | otherwise                = addWarning err >> return []
 
 consCBWithExprs γ xes
   = do xets'     <- forM xes $ \(x, e) -> liftM (x, e,) (varTemplate γ (x, Just e))
@@ -1104,22 +1107,22 @@ makeTermEnvs γ xtes xes ts ts' = withTRec γ . zip xs <$> rts
     sus' = zipWith mkSub ys ys'
     sus  = zipWith mkSub ys ((F.symbol <$>) <$> vs)
     ess  = (\x -> (safeFromJust (err x) $ (x `L.lookup` xtes))) <$> xs
-    tes  = zipWith (\su es -> F.subst su <$> es)  sus ess 
-    tes' = zipWith (\su es -> F.subst su <$> es)  sus' ess 
+    tes  = zipWith (\su es -> F.subst su <$> es)  sus ess
+    tes' = zipWith (\su es -> F.subst su <$> es)  sus' ess
     rss  = zipWith makeLexRefa tes' <$> (repeat <$> tes)
     rts  = zipWith addTermCond ts' <$> rss
     (xs, es)     = unzip xes
     mkSub ys ys' = F.mkSubst [(x, F.EVar y) | (x, y) <- zip ys ys']
     collectArgs  = collectArguments . length . ty_binds . toRTypeRep
-    err x        = "Constant: makeTermEnvs: no terminating expression for " ++ showPpr x 
+    err x        = "Constant: makeTermEnvs: no terminating expression for " ++ showPpr x
 
 
-                   
-consCB tflag _ γ (Rec xes) | tflag 
+
+consCB tflag _ γ (Rec xes) | tflag
   = do texprs <- termExprs <$> get
        modify $ \i -> i { recCount = recCount i + length xes }
        let xxes = catMaybes $ (`lookup` texprs) <$> xs
-       if null xxes 
+       if null xxes
          then consCBSizedTys γ xes
          else check xxes <$> consCBWithExprs γ xes
   where xs = fst $ unzip xes
@@ -1139,22 +1142,22 @@ consCB _ str γ (Rec xes) | not str
        let xts = [(x, to) | (x, _, to) <- xets]
        γ'     <- foldM extender (γ `withRecs` (fst <$> xts)) xts
        mapM_ (consBind True γ') xets
-       return γ' 
+       return γ'
 
-consCB _ _ γ (Rec xes) 
+consCB _ _ γ (Rec xes)
   = do xets   <- forM xes $ \(x, e) -> liftM (x, e,) (varTemplate γ (x, Just e))
        modify $ \i -> i { recCount = recCount i + length xes }
        let xts = [(x, to) | (x, _, to) <- xets]
        γ'     <- foldM extender (γ `withRecs` (fst <$> xts)) xts
        mapM_ (consBind True γ') xets
-       return γ' 
+       return γ'
 
--- | NV: Dictionaries are not checked, because 
+-- | NV: Dictionaries are not checked, because
 -- | class methods' preconditions are not satisfied
 consCB _ _ γ (NonRec x _) | isDictionary x
   = do t  <- trueTy (varType x)
        extender γ (x, Assumed t)
-  where     
+  where
     isDictionary = isJust . dlookup (denv γ)
 
 
@@ -1172,11 +1175,11 @@ consCB _ _ γ (NonRec x (App (Var w) (Type τ))) | isDictionary w
 
 
 consCB _ _ γ (NonRec x e)
-  = do to  <- varTemplate γ (x, Nothing) 
+  = do to  <- varTemplate γ (x, Nothing)
        to' <- consBind False γ (x, e, to) >>= (addPostTemplate γ)
        extender γ (x, to')
 
-consBind isRec γ (x, e, Asserted spect) 
+consBind isRec γ (x, e, Asserted spect)
   = do let γ'         = (γ `setLoc` getSrcSpan x) `setBind` x
            (_,πs,_,_) = bkUniv spect
        γπ    <- foldM addPToEnv γ' πs
@@ -1187,7 +1190,7 @@ consBind isRec γ (x, e, Asserted spect)
        addIdA x (defAnn isRec spect)
        return $ Asserted spect -- Nothing
 
-consBind isRec γ (x, e, Assumed spect) 
+consBind isRec γ (x, e, Assumed spect)
   = do let γ' = (γ `setLoc` getSrcSpan x) `setBind` x
        γπ    <- foldM addPToEnv γ' πs
        cconsE γπ e =<< true spect
@@ -1203,11 +1206,18 @@ consBind isRec γ (x, e, Unknown)
 noHoles = and . foldReft (\r bs -> not (hasHole r) : bs) []
 
 killSubst :: RReft -> RReft
-killSubst = fmap tx
+killSubst = fmap killSubstReft
+
+killSubstReft :: F.Reft -> F.Reft
+killSubstReft = trans kv () []
   where
-    tx (F.Reft (s, rs)) = F.Reft (s, map f rs)
-    f (F.RKvar k _) = F.RKvar k mempty
-    f (F.RConc p)   = F.RConc p
+    kv    = defaultVisitor { txPred = ks }
+    ks _ (F.PKVar k _) = F.PKVar k mempty
+    ks _ p             = p
+
+    -- tx (F.Reft (s, rs)) = F.Reft (s, map f rs)
+    -- f (F.RKvar k _)     = F.RKvar k mempty
+    -- f (F.RConc p)       = F.RConc p
 
 defAnn True  = AnnRDf
 defAnn False = AnnDef
@@ -1232,10 +1242,10 @@ unTemplate _ = errorstar "Constraint.Generate.unTemplate called on `Unknown`"
 
 addPostTemplate γ (Asserted t) = Asserted <$> addPost γ t
 addPostTemplate γ (Assumed  t) = Assumed  <$> addPost γ t
-addPostTemplate _ Unknown      = return Unknown 
+addPostTemplate _ Unknown      = return Unknown
 
 safeFromAsserted _ (Asserted t) = t
-safeFromAsserted msg _ = errorstar $ "safeFromAsserted:" ++ msg 
+safeFromAsserted msg _ = errorstar $ "safeFromAsserted:" ++ msg
 
 -- | @varTemplate@ is only called with a `Just e` argument when the `e`
 -- corresponds to the body of a @Rec@ binder.
@@ -1254,12 +1264,12 @@ varTemplate γ (x, eo)
 -------------------------------------------------------------------
 
 ----------------------- Type Checking -----------------------------
-cconsE :: CGEnv -> Expr Var -> SpecType -> CG () 
+cconsE :: CGEnv -> Expr Var -> SpecType -> CG ()
 -------------------------------------------------------------------
 cconsE γ e@(Let b@(NonRec x _) ee) t
   = do sp <- specLVars <$> get
-       if (x `S.member` sp) || isDefLazyVar x  
-        then cconsLazyLet γ e t 
+       if (x `S.member` sp) || isDefLazyVar x
+        then cconsLazyLet γ e t
         else do γ'  <- consCBLet γ b
                 cconsE γ' ee t
   where
@@ -1271,33 +1281,33 @@ cconsE γ e (RAllP p t)
     t'         = replacePredsWithRefs su <$> t
     su         = (uPVar p, pVartoRConc p)
     (css, t'') = splitConstraints t'
-    γ'         = foldl (flip addConstraints) γ css 
+    γ'         = foldl (flip addConstraints) γ css
 
-cconsE γ (Let b e) t    
+cconsE γ (Let b e) t
   = do γ'  <- consCBLet γ b
-       cconsE γ' e t 
+       cconsE γ' e t
 
-cconsE γ (Case e x _ cases) t 
+cconsE γ (Case e x _ cases) t
   = do γ'  <- consCBLet γ (NonRec x e)
-       forM_ cases $ cconsCase γ' x t nonDefAlts 
-    where 
+       forM_ cases $ cconsCase γ' x t nonDefAlts
+    where
        nonDefAlts = [a | (a, _, _) <- cases, a /= DEFAULT]
 
-cconsE γ (Lam α e) (RAllT α' t) | isTyVar α 
-  = cconsE γ e $ subsTyVar_meet' (α', rVar α) t 
+cconsE γ (Lam α e) (RAllT α' t) | isTyVar α
+  = cconsE γ e $ subsTyVar_meet' (α', rVar α) t
 
-cconsE γ (Lam x e) (RFun y ty t _) 
-  | not (isTyVar x) 
+cconsE γ (Lam x e) (RFun y ty t _)
+  | not (isTyVar x)
   = do γ' <- (γ, "cconsE") += (F.symbol x, ty)
        cconsE γ' e (t `F.subst1` (y, F.EVar $ F.symbol x))
-       addIdA x (AnnDef ty) 
+       addIdA x (AnnDef ty)
 
-cconsE γ (Tick tt e) t   
+cconsE γ (Tick tt e) t
   = cconsE (γ `setLoc` tickSrcSpan tt) e t
 
-cconsE γ e@(Cast e' _) t     
+cconsE γ e@(Cast e' _) t
   = do t' <- castTy γ (exprType e) e'
-       addC (SubC γ t' t) ("cconsE Cast" ++ showPpr e) 
+       addC (SubC γ t' t) ("cconsE Cast" ++ showPpr e)
 
 cconsE γ e t
   = do te  <- consE γ e
@@ -1305,17 +1315,17 @@ cconsE γ e t
        addC (SubC γ te' t) ("cconsE" ++ showPpr e)
 
 
-splitConstraints (RRTy cs _ OCons t) 
+splitConstraints (RRTy cs _ OCons t)
   = let (css, t') = splitConstraints t in (cs:css, t')
 splitConstraints (RFun x tx@(RApp c _ _ _) t r) | isClass c
   = let (css, t') = splitConstraints t in (css, RFun x tx t' r)
-splitConstraints t                       
-  = ([], t) 
+splitConstraints t
+  = ([], t)
 -------------------------------------------------------------------
 -- | @instantiatePreds@ peels away the universally quantified @PVars@
 --   of a @RType@, generates fresh @Ref@ for them and substitutes them
 --   in the body.
-       
+
 instantiatePreds γ e (RAllP π t)
   = do r     <- freshPredRef γ e π
        instantiatePreds γ e $ replacePreds "consE" t [(π, r)]
@@ -1343,78 +1353,78 @@ cconsLazyLet γ (Let (NonRec x ex) e) t
     where
        x' = F.symbol x
 
-cconsLazyLet _ _ _ 
+cconsLazyLet _ _ _
   = errorstar "Constraint.Generate.cconsLazyLet called on invalid inputs"
 
 -------------------------------------------------------------------
 -- | Type Synthesis -----------------------------------------------
 -------------------------------------------------------------------
-consE :: CGEnv -> Expr Var -> CG SpecType 
+consE :: CGEnv -> Expr Var -> CG SpecType
 -------------------------------------------------------------------
 
-consE γ (Var x)   
+consE γ (Var x)
   = do t <- varRefType γ x
        addLocA (Just x) (loc γ) (varAnn γ x t)
        return t
 
-consE γ (Lit c) 
+consE γ (Lit c)
   = refreshVV $ uRType $ literalFRefType (emb γ) c
 
-consE γ e'@(App e (Type τ)) 
+consE γ e'@(App e (Type τ))
   = do RAllT α te <- checkAll ("Non-all TyApp with expr", e) <$> consE γ e
        t          <- if isGeneric α te then freshTy_type TypeInstE e τ else trueTy τ
        addW        $ WfC γ t
        t'         <- refreshVV t
        instantiatePreds γ e' $ subsTyVar_meet' (α, t') te
 
-consE γ e'@(App e a) | isDictionary a               
-  = if isJust tt 
+consE γ e'@(App e a) | isDictionary a
+  = if isJust tt
       then return $ fromJust tt
       else do ([], πs, ls, te) <- bkUniv <$> consE γ e
-              te0              <- instantiatePreds γ e' $ foldr RAllP te πs 
+              te0              <- instantiatePreds γ e' $ foldr RAllP te πs
               te'              <- instantiateStrata ls te0
               (γ', te''')      <- dropExists γ te'
               te''             <- dropConstraints γ te'''
-              updateLocA πs (exprLoc e) te'' 
+              updateLocA πs (exprLoc e) te''
               let RFun x tx t _ = checkFun ("Non-fun App with caller ", e') te''
-              pushConsBind      $ cconsE γ' a tx 
+              pushConsBind      $ cconsE γ' a tx
               addPost γ'        $ maybe (checkUnbound γ' e' x t) (F.subst1 t . (x,)) (argExpr γ a)
   where
     grepfunname (App x (Type _)) = grepfunname x
     grepfunname (Var x)          = x
-    grepfunname e                = errorstar $ "grepfunname on \t" ++ showPpr e  
-    mdict w                      = case w of 
-                                     Var x    -> case dlookup (denv γ) x of {Just _ -> Just x; Nothing -> Nothing}    
+    grepfunname e                = errorstar $ "grepfunname on \t" ++ showPpr e
+    mdict w                      = case w of
+                                     Var x    -> case dlookup (denv γ) x of {Just _ -> Just x; Nothing -> Nothing}
                                      Tick _ e -> mdict e
-                                     _        -> Nothing    
+                                     _        -> Nothing
     isDictionary _               = isJust (mdict a)
     d = fromJust (mdict a)
     dinfo = dlookup (denv γ) d
     tt = dhasinfo dinfo $ grepfunname e
 
-consE γ e'@(App e a)               
+consE γ e'@(App e a)
   = do ([], πs, ls, te) <- bkUniv <$> consE γ e
-       te0              <- instantiatePreds γ e' $ foldr RAllP te πs 
+       te0              <- instantiatePreds γ e' $ foldr RAllP te πs
        te'              <- instantiateStrata ls te0
        (γ', te''')      <- dropExists γ te'
        te''             <- dropConstraints γ te'''
-       updateLocA πs (exprLoc e) te'' 
+       updateLocA πs (exprLoc e) te''
        let RFun x tx t _ = checkFun ("Non-fun App with caller ", e') te''
-       pushConsBind      $ cconsE γ' a tx 
+       pushConsBind      $ cconsE γ' a tx
        addPost γ'        $ maybe (checkUnbound γ' e' x t) (F.subst1 t . (x,)) (argExpr γ a)
 
-consE γ (Lam α e) | isTyVar α 
-  = liftM (RAllT (rTyVar α)) (consE γ e) 
+consE γ (Lam α e) | isTyVar α
+  = liftM (RAllT (rTyVar α)) (consE γ e)
 
-consE γ  e@(Lam x e1) 
-  = do tx      <- freshTy_type LamE (Var x) τx 
+consE γ  e@(Lam x e1)
+  = do tx      <- freshTy_type LamE (Var x) τx
        γ'      <- ((γ, "consE") += (F.symbol x, tx))
        t1      <- consE γ' e1
-       addIdA x $ AnnDef tx 
-       addW     $ WfC γ tx 
+       addIdA x $ AnnDef tx
+       addW     $ WfC γ tx
        return   $ rFun (F.symbol x) tx t1
     where
-      FunTy τx _ = exprType e 
+      FunTy τx _ = exprType e
 
 -- EXISTS-BASED CONSTRAINTS HEREHEREHEREHERE
 -- Currently suppressed because they break all sorts of invariants,
@@ -1422,16 +1432,16 @@ consE γ  e@(Lam x e1)
 -- consE γ e@(Let b@(NonRec x _) e')
 --   = do γ'    <- consCBLet γ b
 --        consElimE γ' [F.symbol x] e'
--- 
--- consE γ (Case e x _ [(ac, ys, ce)]) 
+--
+-- consE γ (Case e x _ [(ac, ys, ce)])
 --   = do γ'  <- consCBLet γ (NonRec x e)
 --        γ'' <- caseEnv γ' x [] ac ys
---        consElimE γ'' (F.symbol <$> (x:ys)) ce 
+--        consElimE γ'' (F.symbol <$> (x:ys)) ce
 
-consE γ e@(Let _ _) 
+consE γ e@(Let _ _)
   = cconsFreshE LetE γ e
 
-consE γ e@(Case _ _ _ _) 
+consE γ e@(Case _ _ _ _)
   = cconsFreshE CaseE γ e
 
 consE γ (Tick tt e)
@@ -1440,31 +1450,31 @@ consE γ (Tick tt e)
        return t
     where l = tickSrcSpan tt
 
-consE γ e@(Cast e' _)      
+consE γ e@(Cast e' _)
   = castTy γ (exprType e) e'
 
 consE _ e@(Coercion _)
    = trueTy $ exprType e
 
-consE _ e@(Type t)     
-  = errorstar $ "consE cannot handle type" ++ showPpr (e, t) 
+consE _ e@(Type t)
+  = errorstar $ "consE cannot handle type" ++ showPpr (e, t)
 
 castTy _ τ (Var x)
-  = do t <- trueTy τ 
+  = do t <- trueTy τ
        return $  t `strengthen` (uTop $ F.uexprReft $ F.expr x)
 
 castTy γ τ e
   = do t <- trueTy (exprType e)
        cconsE γ e t
-       trueTy τ 
+       trueTy τ
 
-singletonReft = uTop . F.symbolReft . F.symbol 
+singletonReft = uTop . F.symbolReft . F.symbol
 
--- | @consElimE@ is used to *synthesize* types by **existential elimination** 
+-- | @consElimE@ is used to *synthesize* types by **existential elimination**
 --   instead of *checking* via a fresh template. That is, assuming
 --      γ |- e1 ~> t1
 --   we have
---      γ |- let x = e1 in e2 ~> Ex x t1 t2 
+--      γ |- let x = e1 in e2 ~> Ex x t1 t2
 --   where
 --      γ, x:t1 |- e2 ~> t2
 --   instead of the earlier case where we generate a fresh template `t` and check
@@ -1484,10 +1494,10 @@ cconsFreshE kvkind γ e
        cconsE γ e t
        return t
 
-checkUnbound γ e x t 
-  | x `notElem` (F.syms t) 
+checkUnbound γ e x t
+  | x `notElem` (F.syms t)
   = t
-  | otherwise              
+  | otherwise
   = errorstar $ "checkUnbound: " ++ show x ++ " is elem of syms of " ++ show t
                  ++ "\nIn\t"  ++ showPpr e ++ " at " ++ showPpr (loc γ)
 
@@ -1496,13 +1506,13 @@ dropExists γ t            = return (γ, t)
 
 dropConstraints :: CGEnv -> SpecType -> CG SpecType
 dropConstraints γ (RFun x tx@(RApp c _ _ _) t r) | isClass c
-  = (flip (RFun x tx)) r <$> dropConstraints γ t 
-dropConstraints γ (RRTy cts _ OCons t) 
+  = (flip (RFun x tx)) r <$> dropConstraints γ t
+dropConstraints γ (RRTy cts _ OCons t)
   = do γ' <- foldM (\γ (x, t) -> γ `addSEnv` ("splitS", x,t)) γ xts
        addC (SubC  γ' t1 t2)  "dropConstraints"
        dropConstraints γ t
   where
-    (xts, t1, t2) = envToSub cts 
+    (xts, t1, t2) = envToSub cts
 
 dropConstraints _ t = return t
 
@@ -1510,7 +1520,7 @@ dropConstraints _ t = return t
 cconsCase :: CGEnv -> Var -> SpecType -> [AltCon] -> (AltCon, [Var], CoreExpr) -> CG ()
 -------------------------------------------------------------------------------------
 cconsCase γ x t acs (ac, ys, ce)
-  = do cγ <- caseEnv γ x acs ac ys 
+  = do cγ <- caseEnv γ x acs ac ys
        cconsE cγ ce t
 
 refreshTy t = refreshVV t >>= refreshArgs
@@ -1535,39 +1545,39 @@ refreshVV (RApp c ts rs r)
        rs' <- mapM refreshVVRef rs
        liftM (shiftVV (RApp c ts' rs' r)) fresh
 
-refreshVV t           
+refreshVV t
   = return t
 
 
-refreshVVRef (RProp ss t) 
+refreshVVRef (RProp ss t)
   = do xs    <- mapM (\_ -> fresh) (fst <$> ss)
        let su = F.mkSubst $ zip (fst <$> ss) (F.EVar <$> xs)
        liftM (RProp (zip xs (snd <$> ss)) . F.subst su) (refreshVV t)
 
-refreshVVRef (RPropP ss r) 
+refreshVVRef (RPropP ss r)
   = return $ RPropP ss r
 
-refreshVVRef (RHProp _ _) 
-  = errorstar "TODO: EFFECTS refreshVVRef" 
+refreshVVRef (RHProp _ _)
+  = errorstar "TODO: EFFECTS refreshVVRef"
 
 
 -------------------------------------------------------------------------------------
-caseEnv   :: CGEnv -> Var -> [AltCon] -> AltCon -> [Var] -> CG CGEnv 
+caseEnv   :: CGEnv -> Var -> [AltCon] -> AltCon -> [Var] -> CG CGEnv
 -------------------------------------------------------------------------------------
 caseEnv γ x _   (DataAlt c) ys
   = do let (x' : ys')    = F.symbol <$> (x:ys)
        xt0              <- checkTyCon ("checkTycon cconsCase", x) <$> γ ??= x'
        tdc              <- γ ??= (dataConSymbol c) >>= refreshVV
        let (rtd, yts, _) = unfoldR tdc (shiftVV xt0 x') ys
-       let r1            = dataConReft   c   ys' 
+       let r1            = dataConReft   c   ys'
        let r2            = dataConMsReft rtd ys'
        let xt            = xt0 `strengthen` (uTop (r1 `F.meet` r2))
        let cbs           = safeZip "cconsCase" (x':ys') (xt0:yts)
        cγ'              <- addBinders γ x' cbs
        cγ               <- addBinders cγ' x' [(x', xt)]
-       return cγ 
+       return cγ
 
-caseEnv γ x acs a _ 
+caseEnv γ x acs a _
   = do let x'  = F.symbol x
        xt'    <- (`strengthen` uTop (altReft γ acs a)) <$> (γ ??= x')
        cγ     <- addBinders γ x' [(x', xt')]
@@ -1579,7 +1589,7 @@ altReft γ acs DEFAULT    = mconcat [notLiteralReft l | LitAlt l <- acs]
 altReft _ _ _            = error "Constraint : altReft"
 
 unfoldR td (RApp _ ts rs _) ys = (t3, tvys ++ yts, ignoreOblig rt)
-  where 
+  where
         tbody              = instantiatePvs (instantiateTys td ts) $ reverse rs
         (ys0, yts', _, rt) = safeBkArrow $ instantiateTys tbody tvs'
         yts''              = zipWith F.subst sus (yts'++[rt])
@@ -1593,11 +1603,11 @@ unfoldR _  _                _  = error "Constraint.hs : unfoldR"
 
 instantiateTys = foldl' go
   where go (RAllT α tbody) t = subsTyVar_meet' (α, t) tbody
-        go _ _               = errorstar "Constraint.instanctiateTy" 
+        go _ _               = errorstar "Constraint.instanctiateTy"
 
-instantiatePvs = foldl' go 
+instantiatePvs = foldl' go
   where go (RAllP p tbody) r = replacePreds "instantiatePv" tbody [(p, r)]
-        go _ _               = errorstar "Constraint.instanctiatePv" 
+        go _ _               = errorstar "Constraint.instanctiatePv"
 
 checkTyCon _ t@(RApp _ _ _ _) = t
 checkTyCon x t                = checkErr x t --errorstar $ showPpr x ++ "type: " ++ showPpr t
@@ -1610,13 +1620,13 @@ checkAll x t                  = checkErr x t
 
 checkErr (msg, e) t          = errorstar $ msg ++ showPpr e ++ ", type: " ++ showpp t
 
-varAnn γ x t 
+varAnn γ x t
   | x `S.member` recs γ
-  = AnnLoc (getSrcSpan' x) 
-  | otherwise 
+  = AnnLoc (getSrcSpan' x)
+  | otherwise
   = AnnUse t
 
-getSrcSpan' x 
+getSrcSpan' x
   | loc == noSrcSpan
   = loc
   | otherwise
@@ -1653,7 +1663,7 @@ argExpr _ e           = errorstar $ "argExpr: " ++ showPpr e
 varRefType γ x = liftM (varRefType' γ x) (γ ??= F.symbol x)
 
 varRefType' γ x t'
-  | Just tys <- trec γ, Just tr <- M.lookup x' tys 
+  | Just tys <- trec γ, Just tr <- M.lookup x' tys
   = tr `strengthen` xr
   | otherwise
   = t
@@ -1670,16 +1680,16 @@ subsTyVar_meet' (α, t) = subsTyVar_meet (α, toRSort t, t)
 
 instance NFData CGEnv where
   rnf (CGE x1 x2 x3 _ x5 x6 x7 x8 x9 _ _ x10 _ _ _ _ _)
-    = x1 `seq` rnf x2 `seq` seq x3 `seq` rnf x5 `seq` 
+    = x1 `seq` rnf x2 `seq` seq x3 `seq` rnf x5 `seq`
       rnf x6  `seq` x7 `seq` rnf x8 `seq` rnf x9 `seq` rnf x10
 
 instance NFData FEnv where
   rnf (FE x1 _) = rnf x1
 
 instance NFData SubC where
-  rnf (SubC x1 x2 x3) 
+  rnf (SubC x1 x2 x3)
     = rnf x1 `seq` rnf x2 `seq` rnf x3
-  rnf (SubR x1 _ x2) 
+  rnf (SubR x1 _ x2)
     = rnf x1 `seq` rnf x2
 
 instance NFData Class where
@@ -1688,71 +1698,70 @@ instance NFData Class where
 instance NFData RTyCon where
   rnf _ = ()
 
-instance NFData Type where 
+instance NFData Type where
   rnf _ = ()
 
 instance NFData WfC where
-  rnf (WfC x1 x2)   
+  rnf (WfC x1 x2)
     = rnf x1 `seq` rnf x2
 
 instance NFData CGInfo where
-  rnf x = ({-# SCC "CGIrnf1" #-}  rnf (hsCs x))       `seq` 
-          ({-# SCC "CGIrnf2" #-}  rnf (hsWfs x))      `seq` 
-          ({-# SCC "CGIrnf3" #-}  rnf (fixCs x))      `seq` 
-          ({-# SCC "CGIrnf4" #-}  rnf (fixWfs x))     `seq` 
+  rnf x = ({-# SCC "CGIrnf1" #-}  rnf (hsCs x))       `seq`
+          ({-# SCC "CGIrnf2" #-}  rnf (hsWfs x))      `seq`
+          ({-# SCC "CGIrnf3" #-}  rnf (fixCs x))      `seq`
+          ({-# SCC "CGIrnf4" #-}  rnf (fixWfs x))     `seq`
           ({-# SCC "CGIrnf6" #-}  rnf (freshIndex x)) `seq`
           ({-# SCC "CGIrnf7" #-}  rnf (binds x))      `seq`
           ({-# SCC "CGIrnf8" #-}  rnf (annotMap x))   `seq`
           ({-# SCC "CGIrnf10" #-} rnf (kuts x))       `seq`
           ({-# SCC "CGIrnf10" #-} rnf (lits x))       `seq`
-          ({-# SCC "CGIrnf10" #-} rnf (kvProf x)) 
+          ({-# SCC "CGIrnf10" #-} rnf (kvProf x))
 
 -------------------------------------------------------------------------------
 --------------------- Reftypes from F.Fixpoint Expressions ----------------------
 -------------------------------------------------------------------------------
 
 forallExprRefType     :: CGEnv -> SpecType -> SpecType
-forallExprRefType γ t = t `strengthen` (uTop r') 
-  where r'            = fromMaybe mempty $ forallExprReft γ r 
+forallExprRefType γ t = t `strengthen` (uTop r')
+  where r'            = fromMaybe mempty $ forallExprReft γ r
         r             = F.sr_reft $ rTypeSortedReft (emb γ) t
 
-forallExprReft γ r 
+forallExprReft γ r
   = do e  <- F.isSingletonReft r
        r' <- forallExprReft_ γ e
        return r'
 
-forallExprReft_ γ (F.EApp f es) 
+forallExprReft_ γ (F.EApp f es)
   = case forallExprReftLookup γ (val f) of
       Just (xs,_,_,t) -> let su = F.mkSubst $ safeZip "fExprRefType" xs es in
                        Just $ F.subst su $ F.sr_reft $ rTypeSortedReft (emb γ) t
       Nothing       -> Nothing -- F.exprReft e
 
-forallExprReft_ γ (F.EVar x) 
-  = case forallExprReftLookup γ x of 
+forallExprReft_ γ (F.EVar x)
+  = case forallExprReftLookup γ x of
       Just (_,_,_,t)  -> Just $ F.sr_reft $ rTypeSortedReft (emb γ) t
       Nothing       -> Nothing -- F.exprReft e
 
-forallExprReft_ _ _ = Nothing -- F.exprReft e 
+forallExprReft_ _ _ = Nothing -- F.exprReft e
 
 forallExprReftLookup γ x = snap <$> F.lookupSEnv x (syenv γ)
-  where 
+  where
     snap                 = mapFourth4 ignoreOblig . bkArrow . fourth4 . bkUniv . (γ ?=) . F.symbol
 
 splitExistsCases z xs tx
   = fmap $ fmap (exrefAddEq z xs tx)
 
-exrefAddEq z xs t (F.Reft(s, rs))
-  = F.Reft(s, [F.RConc (F.POr [ pand x | x <- xs])])
-  where tref                = fromMaybe mempty $ stripRTypeBase t
-        pand x              = F.PAnd $ (substzx x) (fFromRConc <$> rs)
-                                       ++ exrefToPred x tref
-        substzx x           = F.subst (F.mkSubst [(z, F.EVar x)])
+exrefAddEq z xs t (F.Reft (s, F.Refa rs))
+  = F.Reft(s, F.Refa (F.POr [ pand x | x <- xs]))
+  where
+    tref      = fromMaybe mempty $ stripRTypeBase t
+    pand x    = substzx x rs `mappend` exrefToPred x tref
+    substzx x = F.subst (F.mkSubst [(z, F.EVar x)])
 
-exrefToPred x uref
-  = F.subst (F.mkSubst [(v, F.EVar x)]) ((fFromRConc <$> r))
-  where (F.Reft(v, r))         = ur_reft uref
-fFromRConc (F.RConc p) = p
-fFromRConc _           = errorstar "can not hanlde existential type with kvars"
+exrefToPred x u             = F.subst (F.mkSubst [(v, F.EVar x)]) p
+  where
+    F.Reft (v, F.Refa p)    = ur_reft u
+
 
 -------------------------------------------------------------------------------
 -------------------- Cleaner Signatures For Rec-bindings ----------------------
@@ -1768,23 +1777,23 @@ isType (Type _)                 = True
 isType a                        = eqType (exprType a) predType
 
 
-exprRefType :: CoreExpr -> SpecType 
-exprRefType = exprRefType_ M.empty 
+exprRefType :: CoreExpr -> SpecType
+exprRefType = exprRefType_ M.empty
 
-exprRefType_ :: M.HashMap Var SpecType -> CoreExpr -> SpecType 
-exprRefType_ γ (Let b e) 
+exprRefType_ :: M.HashMap Var SpecType -> CoreExpr -> SpecType
+exprRefType_ γ (Let b e)
   = exprRefType_ (bindRefType_ γ b) e
 
 exprRefType_ γ (Lam α e) | isTyVar α
   = RAllT (rTyVar α) (exprRefType_ γ e)
 
-exprRefType_ γ (Lam x e) 
+exprRefType_ γ (Lam x e)
   = rFun (F.symbol x) (ofType $ varType x) (exprRefType_ γ e)
 
 exprRefType_ γ (Tick _ e)
   = exprRefType_ γ e
 
-exprRefType_ γ (Var x) 
+exprRefType_ γ (Var x)
   = M.lookupDefault (ofType $ varType x) x γ
 
 exprRefType_ _ e

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -310,11 +310,11 @@ bsplitW :: CGEnv -> SpecType -> CG [FixWfC]
 bsplitW γ t = pruneRefs <$> get >>= return . bsplitW' γ t
 
 bsplitW' γ t pflag
-  | F.isNonTrivialSortedReft r' = [F.wfC (fe_binds $ fenv γ) r' Nothing ci]
-  | otherwise                   = []
+  | F.isNonTrivial r' = [F.wfC (fe_binds $ fenv γ) r' Nothing ci]
+  | otherwise         = []
   where
-    r'                          = rTypeSortedReft' pflag γ t
-    ci                          = Ci (loc γ) Nothing
+    r'                = rTypeSortedReft' pflag γ t
+    ci                = Ci (loc γ) Nothing
 
 ------------------------------------------------------------
 splitS  :: SubC -> CG [([Stratum], [Stratum])]
@@ -564,13 +564,14 @@ bsplitC γ t1 t2
 checkStratum γ t1 t2
   | s1 <:= s2 = return ()
   | otherwise = addWarning wrn
-  where [s1, s2]   = getStrata <$> [t1, t2]
-        wrn        =  ErrOther (loc γ) (text $ "Stratum Error : " ++ show s1 ++ " > " ++ show s2)
+  where
+    [s1, s2]  = getStrata <$> [t1, t2]
+    wrn       =  ErrOther (loc γ) (text $ "Stratum Error : " ++ show s1 ++ " > " ++ show s2)
 
 bsplitC' γ t1 t2 pflag
-  | F.isFunctionSortedReft r1' && F.isNonTrivialSortedReft r2'
+  | F.isFunctionSortedReft r1' && F.isNonTrivial r2'
   = F.subC γ' grd (r1' {F.sr_reft = mempty}) r2' Nothing tag ci
-  | F.isNonTrivialSortedReft r2'
+  | F.isNonTrivial r2'
   = F.subC γ' grd r1'  r2' Nothing tag ci
   | otherwise
   = []

--- a/src/Language/Haskell/Liquid/Fresh.hs
+++ b/src/Language/Haskell/Liquid/Fresh.hs
@@ -26,14 +26,16 @@ instance Freshable m Integer => Freshable m Symbol where
   fresh = tempSymbol "x" <$> fresh
 
 instance Freshable m Integer => Freshable m Refa where
-  fresh = ((`RKvar` mkSubst []) . intKvar) <$> fresh
+  fresh  = kv <$> fresh
+    where
+      kv = Refa . (`PKVar` mempty) . intKvar
 
 instance Freshable m Integer => Freshable m [Refa] where
   fresh = single <$> fresh
 
 instance Freshable m Integer => Freshable m Reft where
   fresh                = errorstar "fresh Reft"
-  true    (Reft (v,_)) = return $ Reft (v, [])
+  true    (Reft (v,_)) = return $ Reft (v, mempty)
   refresh (Reft (_,_)) = (Reft .) . (,) <$> freshVV <*> fresh
     where
       freshVV          = vv . Just <$> fresh

--- a/src/Language/Haskell/Liquid/PredType.hs
+++ b/src/Language/Haskell/Liquid/PredType.hs
@@ -29,7 +29,7 @@ import DataCon
 
 import qualified Data.HashMap.Strict as M
 import Data.List        (partition, foldl')
-import Data.Monoid      (mempty, mappend)
+import Data.Monoid      (mempty, mappend, mconcat)
 
 import Language.Fixpoint.Misc
 import Language.Fixpoint.Types hiding (Predicate, Expr)
@@ -103,16 +103,19 @@ dataConTy _ _
 ----------------------------------------------------------------------------
 
 replacePredsWithRefs (p, r) (U (Reft(v, rs)) (Pr ps) s)
-  = U (Reft (v, rs ++ rs')) (Pr ps2) s
-  where rs'              = r . (v,) . pargs <$> ps1
-        (ps1, ps2)       = partition (==p) ps
+  = U (Reft (v, rs'')) (Pr ps2) s
+  where
+    rs''             = mconcat $ rs : rs'
+    rs'              = r . (v,) . pargs <$> ps1
+    (ps1, ps2)       = partition (== p) ps
 
 pVartoRConc p (v, args) | length args == length (pargs p)
-  = RConc $ pApp (pname p) $ EVar v:(thd3 <$> args)
+  = pApp (pname p) $ EVar v : (thd3 <$> args)
 
 pVartoRConc p (v, args)
-  = RConc $ pApp (pname p) $ EVar v : args'
-  where args' = (thd3 <$> args) ++ (drop (length args) (thd3 <$> pargs p))
+  = pApp (pname p) $ EVar v : args'
+  where
+    args' = (thd3 <$> args) ++ (drop (length args) (thd3 <$> pargs p))
 
 -----------------------------------------------------------------------
 -- | @pvarRType π@ returns a trivial @RType@ corresponding to the

--- a/src/Language/Haskell/Liquid/PredType.hs
+++ b/src/Language/Haskell/Liquid/PredType.hs
@@ -102,8 +102,8 @@ dataConTy _ _
 ----- Interface: Replace Predicate With Uninterprented Function Symbol -----
 ----------------------------------------------------------------------------
 
-replacePredsWithRefs (p, r) (U (Reft(v, rs)) (Pr ps) s)
-  = U (Reft (v, rs'')) (Pr ps2) s
+replacePredsWithRefs (p, r) (U (Reft(v, Refa rs)) (Pr ps) s)
+  = U (Reft (v, Refa rs'')) (Pr ps2) s
   where
     rs''             = mconcat $ rs : rs'
     rs'              = r . (v,) . pargs <$> ps1

--- a/src/Language/Haskell/Liquid/Qualifier.hs
+++ b/src/Language/Haskell/Liquid/Qualifier.hs
@@ -99,8 +99,8 @@ refTypeQuals' l tce t0        = go emptySEnv t0
 
 refTopQuals l tce t0 γ t
   = [ mkQual l t0 γ v so pa  | let (RR so (Reft (v, ra))) = rTypeSortedReft tce t
-                             , let (Refa p)               = ra
-                             , pa                        <- atoms p
+                             , pa                        <- conjuncts $ raPred ra
+                             , not $ isHole pa
     ] ++
     [ mkPQual l tce t0 γ s e | let (U _ (Pr ps) _) = fromMaybe (msg t) $ stripRTypeBase t
                              , p <- findPVar (ty_preds $ toRTypeRep t0) <$> ps
@@ -129,5 +129,5 @@ lookupSort t0 x γ  = fromMaybe (errorstar msg) $ lookupSEnv x γ
 
 orderedFreeVars γ = nub . filter (`memberSEnv` γ) . syms
 
-atoms (PAnd ps)   = concatMap atoms ps
-atoms p           = [p]
+-- atoms (PAnd ps)   = concatMap atoms ps
+-- atoms p           = [p]

--- a/src/Language/Haskell/Liquid/Qualifier.hs
+++ b/src/Language/Haskell/Liquid/Qualifier.hs
@@ -16,7 +16,7 @@ import Control.Applicative      ((<$>))
 import Data.List                (delete, nub)
 import Data.Maybe               (fromMaybe)
 import qualified Data.HashSet as S
-import Data.Bifunctor           (second) 
+import Data.Bifunctor           (second)
 
 -----------------------------------------------------------------------------------
 specificationQualifiers :: Int -> GhcInfo -> [Qualifier]
@@ -31,24 +31,24 @@ specificationQualifiers k info
     ]
 
 -- GRAVEYARD: scraping quals from imports kills the system with too much crap
--- specificationQualifiers info = {- filter okQual -} qs 
+-- specificationQualifiers info = {- filter okQual -} qs
 --   where
---     qs                       = concatMap refTypeQualifiers ts 
---     refTypeQualifiers        = refTypeQuals $ tcEmbeds spc 
---     ts                       = val <$> t1s ++ t2s 
---     t1s                      = [t | (x, t) <- tySigs spc, x `S.member` definedVars] 
+--     qs                       = concatMap refTypeQualifiers ts
+--     refTypeQualifiers        = refTypeQuals $ tcEmbeds spc
+--     ts                       = val <$> t1s ++ t2s
+--     t1s                      = [t | (x, t) <- tySigs spc, x `S.member` definedVars]
 --     t2s                      = [] -- [t | (_, t) <- ctor spc                            ]
 --     definedVars              = S.fromList $ defVars info
 --     spc                      = spec info
--- 
--- okQual                       = not . any isPred . map snd . q_params 
+--
+-- okQual                       = not . any isPred . map snd . q_params
 --   where
---     isPred (FApp tc _)       = tc == stringFTycon "Pred" 
+--     isPred (FApp tc _)       = tc == stringFTycon "Pred"
 --     isPred _                 = False
 
 
-refTypeQuals l tce t  = quals ++ pAppQuals l tce preds quals 
-  where 
+refTypeQuals l tce t  = quals ++ pAppQuals l tce preds quals
+  where
     quals             = refTypeQuals' l tce t
     preds             = filter isPropPV $ ty_preds $ toRTypeRep t
 
@@ -56,15 +56,15 @@ pAppQuals l tce ps qs = [ pAppQual l tce p xs (v, e) | p <- ps, (s, v, _) <- par
   where
     mkE s             = concatMap (expressionsOfSort (rTypeSort tce s)) qs
 
-expressionsOfSort sort (Q _ pars (PAtom Eq (EVar v) e2) _) 
+expressionsOfSort sort (Q _ pars (PAtom Eq (EVar v) e2) _)
   | (v, sort) `elem` pars
   = [(filter (/=(v, sort)) pars, e2)]
 
-expressionsOfSort _ _  
-  = [] 
+expressionsOfSort _ _
+  = []
 
 pAppQual l tce p args (v, expr) =  Q "Auto" freeVars pred l
-  where 
+  where
     freeVars                  = (vv, tyvv) : (predv, typred) : args
     pred                      = pApp predv $ EVar vv:predArgs
     vv                        = "v"
@@ -72,23 +72,23 @@ pAppQual l tce p args (v, expr) =  Q "Auto" freeVars pred l
     tyvv                      = rTypeSort tce $ pvType p
     typred                    = rTypeSort tce (pvarRType p :: RSort)
     predArgs                  = mkexpr <$> (snd3 <$> pargs p)
-    mkexpr x                  = if x == v then expr else EVar x 
+    mkexpr x                  = if x == v then expr else EVar x
 
--- refTypeQuals :: SpecType -> [Qualifier] 
+-- refTypeQuals :: SpecType -> [Qualifier]
 refTypeQuals' l tce t0        = go emptySEnv t0
-  where 
-    go γ t@(RVar _ _)         = refTopQuals l tce t0 γ t     
-    go γ (RAllT _ t)          = go γ t 
-    go γ (RAllP _ t)          = go γ t 
+  where
+    go γ t@(RVar _ _)         = refTopQuals l tce t0 γ t
+    go γ (RAllT _ t)          = go γ t
+    go γ (RAllP _ t)          = go γ t
     go γ t@(RAppTy t1 t2 _)   = go γ t1 ++ go γ t2 ++ refTopQuals l tce t0 γ t
-    go γ (RFun x t t' _)      = (go γ t) 
+    go γ (RFun x t t' _)      = (go γ t)
                                 ++ (go (insertSEnv x (rTypeSort tce t) γ) t')
-    go γ t@(RApp c ts rs _)   = (refTopQuals l tce t0 γ t) 
-                                ++ concatMap (go (insertSEnv (rTypeValueVar t) (rTypeSort tce t) γ)) ts 
-                                ++ goRefs c (insertSEnv (rTypeValueVar t) (rTypeSort tce t) γ) rs 
-    go γ (RAllE x t t')       = (go γ t) 
+    go γ t@(RApp c ts rs _)   = (refTopQuals l tce t0 γ t)
+                                ++ concatMap (go (insertSEnv (rTypeValueVar t) (rTypeSort tce t) γ)) ts
+                                ++ goRefs c (insertSEnv (rTypeValueVar t) (rTypeSort tce t) γ) rs
+    go γ (RAllE x t t')       = (go γ t)
                                 ++ (go (insertSEnv x (rTypeSort tce t) γ) t')
-    go γ (REx x t t')         = (go γ t) 
+    go γ (REx x t t')         = (go γ t)
                                 ++ (go (insertSEnv x (rTypeSort tce t) γ) t')
     go _ _                    = []
     goRefs c g rs             = concat $ zipWith (goRef g) rs (rTyConPVs c)
@@ -97,39 +97,37 @@ refTypeQuals' l tce t0        = go emptySEnv t0
     goRef _ (RHProp _ _)  _   = errorstar "TODO: EFFECTS"
     insertsSEnv               = foldr (\(x, t) γ -> insertSEnv x (rTypeSort tce t) γ)
 
-refTopQuals l tce t0 γ t 
-  = [ mkQual l t0 γ v so pa  | let (RR so (Reft (v, ras))) = rTypeSortedReft tce t 
-                             , RConc p                    <- ras                 
-                             , pa                         <- atoms p
+refTopQuals l tce t0 γ t
+  = [ mkQual l t0 γ v so pa  | let (RR so (Reft (v, ra))) = rTypeSortedReft tce t
+                             , let (Refa p)               = ra
+                             , pa                        <- atoms p
     ] ++
     [ mkPQual l tce t0 γ s e | let (U _ (Pr ps) _) = fromMaybe (msg t) $ stripRTypeBase t
-                             , p <- (findPVar (ty_preds $ toRTypeRep t0)) <$> ps
+                             , p <- findPVar (ty_preds $ toRTypeRep t0) <$> ps
                              , (s, _, e) <- pargs p
-    ] 
-    where 
+    ]
+    where
       msg t = errorstar $ "Qualifier.refTopQuals: no typebase" ++ showpp t
 
 mkPQual l tce t0 γ t e = mkQual l t0 γ' v so pa
-  where 
+  where
     v                  = "vv"
     so                 = rTypeSort tce t
     γ'                 = insertSEnv v so γ
-    pa                 = PAtom Eq (EVar v) e   
+    pa                 = PAtom Eq (EVar v) e
 
-mkQual l t0 γ v so p   = Q "Auto" ((v, so) : yts) p' l 
-  where 
+mkQual l t0 γ v so p   = Q "Auto" ((v, so) : yts) p' l
+  where
     yts                = [(y, lookupSort t0 x γ) | (x, y) <- xys ]
     p'                 = subst (mkSubst (second EVar <$> xys)) p
     xys                = zipWith (\x i -> (x, symbol ("~A" ++ show i))) xs [0..]
     xs                 = delete v $ orderedFreeVars γ p
 
-lookupSort t0 x γ  = fromMaybe (errorstar msg) $ lookupSEnv x γ 
-  where 
+lookupSort t0 x γ  = fromMaybe (errorstar msg) $ lookupSEnv x γ
+  where
     msg            = "Unknown freeVar " ++ show x ++ " in specification " ++ show t0
 
-orderedFreeVars γ = nub . filter (`memberSEnv` γ) . syms 
+orderedFreeVars γ = nub . filter (`memberSEnv` γ) . syms
 
 atoms (PAnd ps)   = concatMap atoms ps
 atoms p           = [p]
-
-

--- a/src/Language/Haskell/Liquid/RefType.hs
+++ b/src/Language/Haskell/Liquid/RefType.hs
@@ -83,6 +83,7 @@ import Text.PrettyPrint.HughesPJ
 import Language.Haskell.Liquid.PrettyPrint
 import qualified Language.Fixpoint.Types as F
 import Language.Fixpoint.Types hiding (shiftVV, Predicate)
+import Language.Fixpoint.Visitor (mapKVars)
 import Language.Haskell.Liquid.Types hiding (R, DataConP (..), sort)
 
 import Language.Haskell.Liquid.Variance
@@ -114,9 +115,9 @@ uRTypeGen       :: Reftable b => RType c tv a -> RType c tv b
 uRTypeGen       = fmap $ const mempty
 
 uPVar           :: PVar t -> UsedPVar
-uPVar           = void -- fmap (const ())
+uPVar           = void
 
-uReft           ::  (Symbol, [Refa]) -> UReft Reft
+uReft           :: (Symbol, Refa) -> UReft Reft
 uReft           = uTop . Reft
 
 uTop            ::  r -> UReft r
@@ -750,21 +751,24 @@ dataConSymbol = symbol . dataConWorkId
 dataConReft ::  DataCon -> [Symbol] -> Reft
 dataConReft c []
   | c == trueDataCon
-  = Reft (vv_, [RConc $ eProp vv_])
+  = predReft $ eProp vv_
   | c == falseDataCon
-  = Reft (vv_, [RConc $ PNot $ eProp vv_])
+  = predReft $ PNot $ eProp vv_
+
 dataConReft c [x]
   | c == intDataCon
-  = Reft (vv_, [RConc (PAtom Eq (EVar vv_) (EVar x))])
+  = symbolReft x -- OLD (vv_, [RConc (PAtom Eq (EVar vv_) (EVar x))])
 dataConReft c _
   | not $ isBaseDataCon c
   = mempty
 dataConReft c xs
-  = Reft (vv_, [RConc (PAtom Eq (EVar vv_) dcValue)])
-  where dcValue | null xs && null (dataConUnivTyVars c)
-                = EVar $ dataConSymbol c
-                | otherwise
-                = EApp (dummyLoc $ dataConSymbol c) (EVar <$> xs)
+  = exprReft dcValue -- OLD Reft (vv_, [RConc (PAtom Eq (EVar vv_) dcValue)])
+  where
+    dcValue
+      | null xs && null (dataConUnivTyVars c)
+      = EVar $ dataConSymbol c
+      | otherwise
+      = EApp (dummyLoc $ dataConSymbol c) (eVar <$> xs)
 
 isBaseDataCon c = and $ isBaseTy <$> dataConOrigArgTys c ++ dataConRepArgTys c
 
@@ -775,13 +779,13 @@ isBaseTy (FunTy _ _)     = False
 isBaseTy (ForAllTy _ _)  = False
 isBaseTy (LitTy _)       = True
 
-vv_ = vv Nothing
 
 dataConMsReft ty ys  = subst su (rTypeReft (ignoreOblig $ ty_res trep))
-  where trep = toRTypeRep ty
-        xs   = ty_binds trep
-        ts   = ty_args  trep
-        su   = mkSubst $ [(x, EVar y) | ((x, _), y) <- zip (zip xs ts) ys]
+  where
+    trep = toRTypeRep ty
+    xs   = ty_binds trep
+    ts   = ty_args  trep
+    su   = mkSubst $ [(x, EVar y) | ((x, _), y) <- zip (zip xs ts) ys]
 
 ---------------------------------------------------------------
 ---------------------- Embedding RefTypes ---------------------
@@ -832,12 +836,15 @@ rTypeSort tce = typeSort tce . toType
 -------------------------------------------------------------------------------
 applySolution :: (Functor f) => FixSolution -> f SpecType -> f SpecType
 -------------------------------------------------------------------------------
-applySolution = fmap . fmap . mapReft . map . appSolRefa
+applySolution = fmap . fmap . mapReft . appSolRefa
   where
-    appSolRefa _ ra@(RConc _)        = ra
-    -- appSolRefa _ p@(RPvar _)  = p
-    appSolRefa s (RKvar k su)        = RConc $ subst su $ M.lookupDefault PTop k s
-    mapReft f (U (Reft (x, zs)) p s) = U (Reft (x, squishRefas $ f zs)) p s
+    mapReft f (U (Reft (x, z)) p s) = U (Reft (x, f z)) p s
+-- OLD    appSolRefa _ ra@(RConc _)        = ra
+-- OLD    appSolRefa s (RKvar k su)        = RConc $ subst su $ M.lookupDefault PTop k s
+
+appSolRefa s (Refa p) = Refa $ mapKVars f p
+  where
+    f k               = Just $ M.lookupDefault PTop k s
 
 -------------------------------------------------------------------------------
 shiftVV :: SpecType -> Symbol -> SpecType
@@ -958,11 +965,12 @@ makeDecrType = mkDType [] []
 
 mkDType xvs acc [(v, (x, t@(RApp c _ _ _)))]
   = (x, ) $ t `strengthen` tr
-  where tr     = uTop $ Reft (vv, [RConc $ pOr (r:acc)])
-        r      = cmpLexRef xvs (v', vv, f)
-        v'     = symbol v
-        Just f = sizeFunction $ rtc_info c
-        vv     = "vvRec"
+  where
+    tr     = uTop $ Reft (vv, Refa $ pOr (r:acc))
+    r      = cmpLexRef xvs (v', vv, f)
+    v'     = symbol v
+    Just f = sizeFunction $ rtc_info c
+    vv     = "vvRec"
 
 mkDType xvs acc ((v, (x, (RApp c _ _ _))):vxts)
   = mkDType ((v', x, f):xvs) (r:acc) vxts
@@ -978,9 +986,10 @@ cmpLexRef vxs (v, x, g)
          ++ [PAtom Ge (f y) zero  | (y, _, f) <- vxs]
   where zero = ECon $ I 0
 
-makeLexRefa es' es = uTop $ Reft (vv, [RConc $ PIff (PBexp $ EVar vv) $ pOr rs])
-  where rs = makeLexReft [] [] es es'
-        vv = "vvRec"
+makeLexRefa es' es = uTop $ Reft (vv, Refa $ PIff (PBexp $ EVar vv) $ pOr rs)
+  where
+    rs = makeLexReft [] [] es es'
+    vv = "vvRec"
 
 makeLexReft _ acc [] []
   = acc

--- a/src/Language/Haskell/Liquid/Tidy.hs
+++ b/src/Language/Haskell/Liquid/Tidy.hs
@@ -23,7 +23,7 @@ import qualified Data.Text           as T
 
 import Language.Fixpoint.Names              (symSepName, isPrefixOfSym, takeWhileSym)
 import Language.Fixpoint.Types
-import Language.Haskell.Liquid.GhcMisc      (stringTyVar) 
+import Language.Haskell.Liquid.GhcMisc      (stringTyVar)
 import Language.Haskell.Liquid.Types
 import Language.Haskell.Liquid.RefType hiding (shiftVV)
 
@@ -40,50 +40,49 @@ isTmpSymbol x  = any (`isPrefixOfSym` x) [anfPrefix, tempPrefix, "ds_"]
 
 
 -------------------------------------------------------------------------
-tidySpecType :: Tidy -> SpecType -> SpecType  
+tidySpecType :: Tidy -> SpecType -> SpecType
 -------------------------------------------------------------------------
 tidySpecType k = tidyValueVars
                . tidyDSymbols
-               . tidySymbols 
-               . tidyLocalRefas k 
+               . tidySymbols
+               . tidyLocalRefas k
                . tidyFunBinds
-               . tidyTyVars 
+               . tidyTyVars
 
 tidyValueVars :: SpecType -> SpecType
 tidyValueVars = mapReft $ \u -> u { ur_reft = tidyVV $ ur_reft u }
 
 tidyVV r@(Reft (va,_))
   | isJunk va = shiftVV r v'
-  | otherwise = r  
+  | otherwise = r
   where
     v'        = if v `elem` xs then symbol ("v'" :: T.Text) else v
     v         = symbol ("v" :: T.Text)
     xs        = syms r
     isJunk    = isPrefixOfSym "x"
-    
+
 tidySymbols :: SpecType -> SpecType
-tidySymbols t = substa tidySymbol $ mapBind dropBind t  
-  where 
+tidySymbols t = substa tidySymbol $ mapBind dropBind t
+  where
     xs         = S.fromList (syms t)
-    dropBind x = if x `S.member` xs then tidySymbol x else nonSymbol  
+    dropBind x = if x `S.member` xs then tidySymbol x else nonSymbol
 
 
 tidyLocalRefas   :: Tidy -> SpecType -> SpecType
 tidyLocalRefas k = mapReft (txStrata . txReft' k)
   where
-    txReft' Full                  = id 
+    txReft' Full                  = id
     txReft' Lossy                 = txReft
-    txStrata (U r p l)            = U r p (txStr l) 
-    txReft (U (Reft (v,ras)) p l) = U (Reft (v, dropLocals ras)) p l
-    dropLocals                    = filter (not . any isTmp . syms) . flattenRefas
+    txStrata (U r p l)            = U r p (txStr l)
+    txReft u                      = u { ur_reft = mapPredReft dropLocals $ ur_reft u }
+    dropLocals                    = pAnd . filter (not . any isTmp . syms) . conjuncts
     isTmp x                       = any (`isPrefixOfSym` x) [anfPrefix, "ds_"]
-    txStr                         = filter (not . isSVar) 
+    txStr                         = filter (not . isSVar)
 
 
-
-tidyDSymbols :: SpecType -> SpecType  
+tidyDSymbols :: SpecType -> SpecType
 tidyDSymbols t = mapBind tx $ substa tx t
-  where 
+  where
     tx         = bindersTx [x | x <- syms t, isTmp x]
     isTmp      = (tempPrefix `isPrefixOfSym`)
 
@@ -92,28 +91,28 @@ tidyFunBinds t = mapBind tx $ substa tx t
   where
     tx         = bindersTx $ filter isTmpSymbol $ funBinds t
 
-tidyTyVars :: SpecType -> SpecType  
-tidyTyVars t = subsTyVarsAll αβs t 
-  where 
-    αβs  = zipWith (\α β -> (α, toRSort β, β)) αs βs 
+tidyTyVars :: SpecType -> SpecType
+tidyTyVars t = subsTyVarsAll αβs t
+  where
+    αβs  = zipWith (\α β -> (α, toRSort β, β)) αs βs
     αs   = L.nub (tyVars t)
     βs   = map (rVar . stringTyVar) pool
     pool = [[c] | c <- ['a'..'z']] ++ [ "t" ++ show i | i <- [1..]]
 
 
-bindersTx ds   = \y -> M.lookupDefault y y m  
-  where 
+bindersTx ds   = \y -> M.lookupDefault y y m
+  where
     m          = M.fromList $ zip ds $ var <$> [1..]
     var        = symbol . ('x' :) . show
- 
+
 
 tyVars (RAllP _ t)     = tyVars t
 tyVars (RAllS _ t)     = tyVars t
 tyVars (RAllT α t)     = α : tyVars t
-tyVars (RFun _ t t' _) = tyVars t ++ tyVars t' 
-tyVars (RAppTy t t' _) = tyVars t ++ tyVars t' 
+tyVars (RFun _ t t' _) = tyVars t ++ tyVars t'
+tyVars (RAppTy t t' _) = tyVars t ++ tyVars t'
 tyVars (RApp _ ts _ _) = concatMap tyVars ts
-tyVars (RVar α _)      = [α] 
+tyVars (RVar α _)      = [α]
 tyVars (RAllE _ _ t)   = tyVars t
 tyVars (REx _ _ t)     = tyVars t
 tyVars (RExprArg _)    = []
@@ -121,7 +120,7 @@ tyVars (RRTy _ _ _ t)  = tyVars t
 tyVars (RHole _)       = []
 
 subsTyVarsAll ats = go
-  where 
+  where
     abm            = M.fromList [(a, b) | (a, _, (RVar b _)) <- ats]
     go (RAllT a t) = RAllT (M.lookupDefault a a abm) (go t)
     go t           = subsTyVars_meet ats t
@@ -134,9 +133,8 @@ funBinds (RFun b t1 t2 _) = b : funBinds t1 ++ funBinds t2
 funBinds (RApp _ ts _ _)  = concatMap funBinds ts
 funBinds (RAllE b t1 t2)  = b : funBinds t1 ++ funBinds t2
 funBinds (REx b t1 t2)    = b : funBinds t1 ++ funBinds t2
-funBinds (RVar _ _)       = [] 
+funBinds (RVar _ _)       = []
 funBinds (RRTy _ _ _ t)   = funBinds t
 funBinds (RAppTy t1 t2 _) = funBinds t1 ++ funBinds t2
 funBinds (RExprArg _)     = []
 funBinds (RHole _)        = []
-

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -1809,6 +1809,7 @@ instance NFData KVProf where
 hasHole :: Reftable r => r -> Bool
 hasHole = any isHole . kvars . toReft
 
+hole :: Pred
 hole = PKVar "HOLE" mempty
 
 isHole :: KVar -> Bool

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -1096,9 +1096,6 @@ pApp p es = PBexp $ EApp (dummyLoc $ pappSym $ length es) (EVar p:es)
 
 pappSym n  = symbol $ "papp" ++ show n
 
-refa :: [Pred] -> Refa
-refa = Refa . pAnd
-
 ---------------------------------------------------------------
 --------------------------- Visitors --------------------------
 ---------------------------------------------------------------

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -234,7 +234,6 @@ import Text.Parsec.Error            (ParseError)
 import Text.PrettyPrint.HughesPJ
 import Language.Fixpoint.Config     hiding (Config)
 import Language.Fixpoint.Misc
-import Language.Fixpoint.Visitor    (kvars)
 import Language.Fixpoint.Types      hiding (Predicate, Def, R)
 import Language.Fixpoint.Names      (funConName, listConName, tupConName)
 import qualified Language.Fixpoint.PrettyPrint as F
@@ -1802,19 +1801,22 @@ instance PPrint KVProf where
 instance NFData KVProf where
   rnf (KVP m) = rnf m `seq` ()
 
--- isHole (PKVar ("HOLE") _) = True
--- isHole _                  = False
 -- hasHole (toReft -> (Reft (_, rs))) = any isHole rs
-
-hasHole :: Reftable r => r -> Bool
-hasHole = any isHole . kvars . toReft
 
 hole :: Pred
 hole = PKVar "HOLE" mempty
 
-isHole :: KVar -> Bool
-isHole "HOLE" = True
-isHole _      = False
+isHole :: Pred -> Bool
+isHole (PKVar ("HOLE") _) = True
+isHole _                  = False
+
+hasHole :: Reftable r => r -> Bool
+hasHole = any isHole . conjuncts . reftPred . toReft
+
+
+-- isHole :: KVar -> Bool
+-- isHole "HOLE" = True
+-- isHole _      = False
 
 
 -- classToRApp :: SpecType -> SpecType

--- a/tests/pos/ex1.hs
+++ b/tests/pos/ex1.hs
@@ -11,63 +11,61 @@ data Vec a = Nil | Cons a (Vec a)
 
 {-@ data Vec [llen] a = Nil | Cons (x::a) (xs::(Vec a)) @-}
 
--- | We can encode the notion of length as an inductive measure @llen@ 
+-- | We can encode the notion of length as an inductive measure @llen@
 
-{-@ measure llen     :: forall a. Vec a -> Int 
-    llen (Nil)       = 0 
+{-@ measure llen     :: forall a. Vec a -> Int
+    llen (Nil)       = 0
     llen (Cons x xs) = 1 + llen(xs)
   @-}
 
 {-@ invariant {v:Vec a | (llen v) >= 0} @-}
+
 -- | As a warmup, lets check that a /real/ length function indeed computes
 -- the length of the list.
 
-{-@ sizeOf :: xs:Vec a -> {v: Int | v = llen(xs)} @-}
+{-@ sizeOf :: xs:Vec a -> {v: Int | v = llen xs} @-}
 sizeOf             :: Vec a -> Int
 sizeOf Nil         = 0
 sizeOf (Cons _ xs) = 1 + sizeOf xs
 
 -------------------------------------------------------------------------
--- | Higher-order fold -------------------------------------------------- 
+-- | Higher-order fold --------------------------------------------------
 -------------------------------------------------------------------------
 
 -- | Time to roll up the sleeves. Here's a a higher-order @foldr@ function
 -- for our `Vec` type. Note that the `op` argument takes an extra /ghost/
--- parameter that will let us properly describe the type of `efoldr` 
+-- parameter that will let us properly describe the type of `efoldr`
 
-{-@ efoldr :: forall a b <p :: x0:Vec a -> x1:b -> Prop>. 
-                (xs:Vec a -> x:a -> b <p xs> -> b <p (Ex.Cons x xs)>) 
-              -> b <p Ex.Nil> 
+{-@ efoldr :: forall a b <p :: x0:Vec a -> x1:b -> Prop>.
+                (xs:Vec a -> x:a -> b <p xs> -> b <p (Ex.Cons x xs)>)
+              -> b <p Ex.Nil>
               -> ys: Vec a
               -> b <p ys>
   @-}
 efoldr :: (Vec a -> a -> b -> b) -> b -> Vec a -> b
 efoldr op b Nil         = b
-efoldr op b (Cons x xs) = op xs x (efoldr op b xs) 
+efoldr op b (Cons x xs) = op xs x (efoldr op b xs)
 
 -------------------------------------------------------------------------
--- | Clients of `efold` ------------------------------------------------- 
+-- | Clients of `efold` -------------------------------------------------
 -------------------------------------------------------------------------
 
--- | Finally, lets write a few /client/ functions that use `efoldr` to 
--- operate on the `Vec`s. 
+-- | Finally, lets write a few /client/ functions that use `efoldr` to
+-- operate on the `Vec`s.
 
 -- | First: Computing the length using `efoldr`
-{-@ size :: xs:Vec a -> {v: Int | v = llen(xs)} @-}
+{-@ size :: xs:Vec a -> {v: Int | v = llen xs} @-}
 size :: Vec a -> Int
 size = efoldr (\_ _ n -> n + 1) 0
 
 -- | The above uses a helper that counts up the size. (Pesky hack to avoid writing qualifier v = ~A + 1)
 {-@ suc :: x:Int -> {v: Int | v = x + 1} @-}
 suc :: Int -> Int
-suc x = x + 1 
+suc x = x + 1
 
 
 
 -- | Second: Appending two lists using `efoldr`
-{-@ app  :: xs: Vec a -> ys: Vec a -> {v: Vec a | llen(v) = llen(xs) + llen(ys) } @-} 
-app xs ys = efoldr (\_ z zs -> Cons z zs) ys xs 
-
-
-
-
+{-@ app  :: xs: Vec Int -> ys: Vec Int -> {v: Vec Int | llen v = llen xs + llen ys } @-}
+app :: Vec Int -> Vec Int -> Vec Int
+app xs ys = efoldr (\_ z zs -> Cons z zs) ys xs

--- a/tests/pos/kmpIO.hs
+++ b/tests/pos/kmpIO.hs
@@ -1,5 +1,6 @@
 {-@ LIQUID "--no-termination" @-}
 {-@ LIQUID "--short-names"    @-}
+{-@ LIQUID "--diff"           @-}
 
 module KMP (search) where
 
@@ -8,31 +9,36 @@ import Data.IORef
 import Control.Applicative ((<$>))
 import qualified Data.Map as M
 
-search pat str = kmpSearch (ofList pat) (ofList str) 
+{-@ type Upto N = {v:Nat | v < N} @-}
+
+---------------------------------------------------------------------------
+{-@ search :: String -> str:String -> Maybe (Upto (len str)) @-}
+---------------------------------------------------------------------------
+search :: String -> String -> Maybe Int
+search pat str = kmpSearch (ofList pat) (ofList str)
+
 
 -------------------------------------------------------------
 -- | Do the Search ------------------------------------------
 -------------------------------------------------------------
 
-{-@ type Upto N = {v:Nat | v < N} @-} 
-
 {-@ kmpSearch :: (Eq a) => p:Arr a -> s:Arr a -> Maybe (Upto (alen s)) @-}
-kmpSearch p@(A m _) s@(A n _) = go 0 0 
+kmpSearch p@(A m _) s@(A n _) = go 0 0
   where
     t              = kmpTable p
     go i j
-      | i >= n     = Nothing 
+      | i >= n     = Nothing
       | j >= m     = Just (i - m)
       | s!i == p!j = go (i+1) (j+1)
       | j == 0     = go (i+1) j
-      | otherwise  = go i     (t!j) 
+      | otherwise  = go i     (t!j)
 
 
 -------------------------------------------------------------
 -- | Make Table ---------------------------------------------
 -------------------------------------------------------------
 
-kmpTable p@(A m _) = go t 1 0 
+kmpTable p@(A m _) = go t 1 0
   where
     t              = new m (\_ -> 0)
     go t i j
@@ -41,14 +47,14 @@ kmpTable p@(A m _) = go t 1 0
       | p!i == p!j = let i' = i + 1
                          j' = j + 1
                          t' = set t i' j'
-                     in go t' i' j'           
-    
+                     in go t' i' j'
+
       | (j == 0)   = let i' = i + 1
                          t' = set t i' 0
                      in go t' i' j
-                             
+
       | otherwise  = let j' = t ! j
-                     in go t i j' 
+                     in go t i j'
 
 
 -------------------------------------------------------------
@@ -60,7 +66,7 @@ data Arr a   = A { alen :: Int
                  }
 
 {-@ data Arr a <p :: Int -> a -> Prop>
-             = A { alen :: Nat 
+             = A { alen :: Nat
                  , aval :: i:Upto alen -> a<p i>
                  }
   @-}
@@ -80,23 +86,23 @@ new n v = A { alen = n
   @-}
 
 (A _ f) ! i = f i
-  
+
 {-@ set :: forall <p :: Int -> a -> Prop>.
              a:Arr<p> a -> i:Upto (alen a) -> a<p i> -> {v:Arr<p> a | alen v = alen a}
   @-}
 set a@(A _ f) i v = a { aval = \j -> if (i == j) then v else f j }
 
 
-{-@ ofList :: xs:[a] -> {v:Arr a | alen v = len xs} @-} 
+{-@ ofList :: xs:[a] -> {v:Arr a | alen v = len xs} @-}
 ofList xs = new n f
   where
     n     = length xs
     m     = M.fromList $ zip [0..] xs
-    f i   = (M.!) m i 
+    f i   = (M.!) m i
 
 {-@ map :: (a -> b) -> a:Arr a -> {v:Arr b | alen v = alen a} @-}
-map f a@(A n z) = A n (f . z) 
-                  
+map f a@(A n z) = A n (f . z)
+
 
 
 -------------------------------------------------------------
@@ -112,7 +118,7 @@ data IOArr a = IOA { size :: Int
             , pntr :: IORef ({v:Arr<p> a | alen v = size})
             }
   @-}
-               
+
 
 {-@ newIO :: forall <p :: Int -> a -> Prop>.
                n:Nat -> (i:Upto n -> a<p i>) -> IO ({v: IOArr<p> a | size v = n})
@@ -123,14 +129,13 @@ newIO n f = IOA n <$> newIORef (new n f)
               a:IOArr<p> a -> i:Upto (size a) -> IO (a<p i>)
   @-}
 getIO a@(IOA sz p) i
-  = do arr   <- readIORef p 
-       return $ (arr ! i) 
+  = do arr   <- readIORef p
+       return $ (arr ! i)
 
 {-@ setIO :: forall <p :: Int -> a -> Prop>.
               a:IOArr<p> a -> i:Upto (size a) -> a<p i> -> IO ()
   @-}
 setIO a@(IOA sz p) i v
   = do arr     <- readIORef p
-       let arr' = set arr i v 
+       let arr' = set arr i v
        writeIORef p arr'
-

--- a/tests/pos/test00-int.hs
+++ b/tests/pos/test00-int.hs
@@ -1,0 +1,16 @@
+module Test0 () where
+
+import Language.Haskell.Liquid.Prelude
+
+{-@ qualif Zog(v:FooBar, x:FooBar): v = x + 29 @-}
+
+data FooBar = Foo Int
+
+x :: Int
+x = choose 0
+
+prop_abs ::  Bool
+prop_abs = if x > 0 then baz x else False
+
+baz :: Int -> Bool
+baz gooberding = liquidAssertB (gooberding >= 0)

--- a/tests/todo/kmpMonad.hs
+++ b/tests/todo/kmpMonad.hs
@@ -1,0 +1,180 @@
+{-@ LIQUID "--no-termination" @-}
+{-@ LIQUID "--short-names"    @-}
+{-@ LIQUID "--diff"           @-}
+
+module KMP (search) where
+
+import Language.Haskell.Liquid.Prelude (liquidError, liquidAssert)
+import Data.IORef
+import Control.Applicative ((<$>))
+import qualified Data.Map as M
+import Prelude hiding (map)
+
+{-@ type Upto N = {v:Nat | v < N} @-}
+
+---------------------------------------------------------------------------
+{-@ search :: pat:String -> str:String -> IO (Maybe (Upto (len str))) @-}
+---------------------------------------------------------------------------
+search :: String -> String -> IO (Maybe Int)
+search pat str = do
+  p <- ofListIO pat
+  s <- ofListIO str
+  kmpSearch p s
+
+---------------------------------------------------------------------------
+-- | Do the Search --------------------------------------------------------
+---------------------------------------------------------------------------
+
+kmpSearch p@(IOA m _) s@(IOA n _) = do
+  t <- kmpTable p
+  find p s t 0 0
+
+find p@(IOA m _) s@(IOA n _) t = go
+  where
+    go i j
+      | i >= n    = return $ Nothing
+      | j >= m    = return $ Just (i - m)
+      | otherwise = do si <- getIO s i
+                       pj <- getIO p j
+                       tj <- getIO t j
+                       case () of
+                        _ | si == pj  -> go (i+1) (j+1)
+                          | j == 0    -> go (i+1) j
+                          | otherwise -> go i     tj
+
+---------------------------------------------------------------------------
+-- | Make Table -----------------------------------------------------------
+---------------------------------------------------------------------------
+
+-- BUG WHAT's going on? 
+{-@ bob :: Nat -> IO () @-}
+bob n = do
+  t <- newIO (n + 1) (\_ -> 0)
+  setIO t 0 100
+  r <- getIO t 0
+  liquidAssert (r == 100) $ return ()
+
+
+kmpTable p@(IOA m _) = do
+  t <- newIO m (\_ -> 0)
+  fill p t 1 0
+  return t
+
+fill p t@(IOA m _) = go
+  where
+    go i j
+      | i < m - 1  = do
+          pi <- getIO p (id i)
+          pj <- getIO p j
+          case () of
+            _ | pi == pj -> do
+                  let i' = i + 1
+                  let j' = j + 1
+                  setIO t i' j'
+                  go i' j'
+              | j == 0 -> do
+                  let i' = i + 1
+                  setIO t i' 0
+                  go i' j
+              | otherwise -> do
+                  j' <- getIO t j
+                  go i j'
+      | otherwise = return t
+
+
+-------------------------------------------------------------------------------
+-- | An Imperative Array ------------------------------------------------------
+-------------------------------------------------------------------------------
+
+data IOArr a = IOA { size :: Int
+                   , pntr :: IORef (Arr a)
+                   }
+
+{-@ data IOArr a <p :: Int -> a -> Prop>
+      = IOA { size :: Nat
+            , pntr :: IORef ({v:Arr<p> a | alen v = size})
+            }
+  @-}
+
+
+{-@ newIO :: forall <p :: Int -> a -> Prop>.
+               n:Nat -> (i:Upto n -> a<p i>) -> IO ({v: IOArr<p> a | size v = n})
+  @-}
+newIO n f = IOA n <$> newIORef (new n f)
+
+{-@ getIO :: forall <p :: Int -> a -> Prop>.
+              a:IOArr<p> a -> i:Upto (size a) -> IO (a<p i>)
+  @-}
+getIO a@(IOA sz p) i
+  = do arr   <- readIORef p
+       return $ (arr ! i)
+
+{-@ setIO :: forall <p :: Int -> a -> Prop>.
+              a:IOArr<p> a -> i:Upto (size a) -> a<p i> -> IO ()
+  @-}
+setIO a@(IOA sz p) i v
+  = do arr     <- readIORef p
+       let arr' = set arr i v
+       writeIORef p arr'
+
+
+{-@ ofListIO :: xs:[a] -> IO ({v:IOArr a | size v = len xs}) @-}
+ofListIO xs  = newIO n f
+  where
+    n        = length xs
+    m        = M.fromList $ zip [0..] xs
+    f i      = (M.!) m i
+
+
+{-@ mapIO :: (a -> b) -> a:IOArr a -> IO ({v:IOArr b | size v = size a}) @-}
+mapIO f (IOA n p)
+  = do a <- readIORef p
+       IOA n <$> newIORef (map f a)
+
+
+
+-------------------------------------------------------------------------------
+-- | A Pure Array -------------------------------------------------------------
+-------------------------------------------------------------------------------
+
+data Arr a   = A { alen :: Int
+                 , aval :: Int -> a
+                 }
+
+{-@ data Arr a <p :: Int -> a -> Prop>
+             = A { alen :: Nat
+                 , aval :: i:Upto alen -> a<p i>
+                 }
+  @-}
+
+
+{-@ new :: forall <p :: Int -> a -> Prop>.
+             n:Nat -> (i:Upto n -> a<p i>) -> {v: Arr<p> a | alen v = n}
+  @-}
+new n v = A { alen = n
+            , aval = \i -> if (0 <= i && i < n)
+                             then v i
+                             else liquidError "Out of Bounds!"
+            }
+
+{-@ (!) :: forall <p :: Int -> a -> Prop>.
+             a:Arr<p> a -> i:Upto (alen a) -> a<p i>
+  @-}
+
+(A _ f) ! i = f i
+
+{-@ set :: forall <p :: Int -> a -> Prop>.
+             a:Arr<p> a -> i:Upto (alen a) -> a<p i> -> {v:Arr<p> a | alen v = alen a}
+  @-}
+set a@(A _ f) i v = a { aval = \j -> if (i == j) then v else f j }
+
+
+{-@ ofList :: xs:[a] -> {v:Arr a | alen v = len xs} @-}
+ofList xs = new n f
+  where
+    n     = length xs
+    m     = M.fromList $ zip [0..] xs
+    f i   = (M.!) m i
+
+{-@ map :: (a -> b) -> a:Arr a -> {v:Arr b | alen v = alen a} @-}
+map f a@(A n z) = A n (f . z)


### PR DESCRIPTION
Many crosscutting changes as `KVar` is placed *inside* `Pred` (instead of at the top level inside `Refa`).

See: https://github.com/ucsd-progsys/liquid-fixpoint/pull/63
