### PR TITLE
Pprinting

### DIFF
--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -1034,7 +1034,7 @@ ppTy_ureft u@(U r p s) d
   | isTauto_ureft  u  = d
   | otherwise         = ppr_reft r (ppTy p d) s
 
-ppr_reft r d s       = braces (toFix v <+> colon <+> d <> ppr_str s <+> text "|" <+> pprint r')
+ppr_reft r d s       = braces (pprint v <+> colon <+> d <> ppr_str s <+> text "|" <+> pprint r')
   where
     r'@(Reft (v, _)) = toReft r
 


### PR DESCRIPTION
Printing 

`?a  : {?a : Int | ?a > 0}` 

instead of 

`?a: {fix#... : Int | ?a > 0}` 

in context of type error messages.


@ranjitjhala this should fix one of the two printing issues.