### PR TITLE
Changed reading space to reading blanks in dataDeclFullP

### DIFF
--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -864,7 +864,7 @@ dataDeclFullP
        spaces
        fsize <- dataSizeP
        spaces
-       ts  <- sepBy tyVarIdP spaces
+       ts  <- sepBy tyVarIdP blanks
        ps  <- predVarDefsP
        whiteSpace >> reservedOp "=" >> whiteSpace
        dcs <- sepBy dataConP (reserved "|")


### PR DESCRIPTION
Just a small change but it seems to fix the issue of paring refined data definitions. #399 