### PR TITLE
Implement maxpartsize option

### DIFF
--- a/Liquid.hs
+++ b/Liquid.hs
@@ -105,6 +105,7 @@ solveCs cfg target cgi info dc
                        , FC.srcFile     = target
                        , FC.cores       = cores       cfg
                        , FC.minPartSize = minPartSize cfg
+                       , FC.maxPartSize = maxPartSize cfg
                        -- , FC.stats   = True
                        }
        ferr s r  = fmap (tidyError s) $ result $ sinfo <$> r

--- a/src/Language/Haskell/Liquid/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/CmdLine.hs
@@ -75,6 +75,9 @@ defaultCores = 1
 defaultMinPartSize :: Int
 defaultMinPartSize = 500
 
+defaultMaxPartSize :: Int
+defaultMaxPartSize = 700
+
 defaultMaxParams :: Int
 defaultMaxParams = 2
 
@@ -144,6 +147,11 @@ config = cmdArgsMode $ Config {
 
  , minPartSize
     = defaultMinPartSize &= help "If solving on multiple cores, ensure that partitions are of at least m size"
+
+ , maxPartSize
+    = defaultMaxPartSize &= help "If solving on multiple cores, once there are as many partitions " ++
+      "as there are cores, don't merge partitions if they will exceed this size. Overrides the " ++
+      "minpartsize option."
 
  , smtsolver
     = def &= help "Name of SMT-Solver"
@@ -307,6 +315,7 @@ fixCabalDirs' cfg i = cfg { idirs      = nub $ idirs cfg ++ sourceDirs i ++ buil
      dbOpts         = ["-package-db " ++ db | db <- packageDbs  i]
      pkOpts         = ["-package "    ++ n  | n  <- packageDeps i] -- SPEED HIT for smaller benchmarks
 
+defConfig :: Config
 defConfig = Config { files          = def
                    , idirs          = def
                    , fullcheck      = def
@@ -325,6 +334,7 @@ defConfig = Config { files          = def
                    , noPrune        = def
                    , cores          = defaultCores
                    , minPartSize    = defaultMinPartSize
+                   , maxPartSize    = defaultMaxPartSize
                    , maxParams      = defaultMaxParams
                    , smtsolver      = def
                    , shortNames     = def

--- a/src/Language/Haskell/Liquid/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/CmdLine.hs
@@ -44,8 +44,8 @@ import System.Console.CmdArgs.Text
 import Data.List                           (intercalate, nub)
 import Data.Monoid
 
-import           System.FilePath                     (dropFileName, isAbsolute,
-                                                      takeDirectory, (</>))
+import System.FilePath                     (dropFileName, isAbsolute,
+                                            takeDirectory, (</>))
 
 import Language.Fixpoint.Config            hiding (Config, real, native,
                                                    getOpts, cores, minPartSize,

--- a/src/Language/Haskell/Liquid/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/CmdLine.hs
@@ -47,7 +47,9 @@ import Data.Monoid
 import           System.FilePath                     (dropFileName, isAbsolute,
                                                       takeDirectory, (</>))
 
-import Language.Fixpoint.Config            hiding (Config, real, native, getOpts, cores, minPartSize)
+import Language.Fixpoint.Config            hiding (Config, real, native,
+                                                   getOpts, cores, minPartSize,
+                                                   maxPartSize)
 import Language.Fixpoint.Files
 import Language.Fixpoint.Misc
 import Language.Fixpoint.Names             (dropModuleNames)
@@ -149,9 +151,9 @@ config = cmdArgsMode $ Config {
     = defaultMinPartSize &= help "If solving on multiple cores, ensure that partitions are of at least m size"
 
  , maxPartSize
-    = defaultMaxPartSize &= help "If solving on multiple cores, once there are as many partitions " ++
-      "as there are cores, don't merge partitions if they will exceed this size. Overrides the " ++
-      "minpartsize option."
+    = defaultMaxPartSize &= help ("If solving on multiple cores, once there are as many partitions " ++
+                                  "as there are cores, don't merge partitions if they will exceed this " ++
+                                  "size. Overrides the minpartsize option.")
 
  , smtsolver
     = def &= help "Name of SMT-Solver"

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -271,6 +271,7 @@ data Config = Config {
   , noPrune        :: Bool       -- ^ disable prunning unsorted Refinements
   , cores          :: Int        -- ^ number of cores used to solve constraints
   , minPartSize    :: Int        -- ^ Minimum size of a partition
+  , maxPartSize    :: Int        -- ^ Maximum size of a partition. Overrides minPartSize
   , maxParams      :: Int        -- ^ the maximum number of parameters to accept when mining qualifiers
   , smtsolver      :: Maybe SMTSolver  -- ^ name of smtsolver to use [default: try z3, cvc4, mathsat in order]
   , shortNames     :: Bool       -- ^ drop module qualifers from pretty-printed names.


### PR DESCRIPTION
Implements supporting config option passing for implementing a maximum partition size limit in fixpoint.

Depends on Fixpoint pull request [#107](https://github.com/ucsd-progsys/liquid-fixpoint/pull/107)