### PR TITLE
Add First-Order Data Constructors as Fixpoint Constants

### DIFF
--- a/Liquid.hs
+++ b/Liquid.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TupleSections  #-}
 {-# LANGUAGE CPP #-}
 
+
 {-@ LIQUID "--cabaldir" @-}
 {-@ LIQUID "--diff"     @-}
 

--- a/Liquid.hs
+++ b/Liquid.hs
@@ -33,8 +33,6 @@ import           Language.Haskell.Liquid.Constraint.Types
 import           Language.Haskell.Liquid.TransformRec
 import           Language.Haskell.Liquid.Annotate (mkOutput)
 
-
-
 main :: IO b
 main = do cfg0     <- getOpts
           res      <- mconcat <$> mapM (checkOne cfg0) (files cfg0)

--- a/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -216,7 +216,7 @@ checkRType emb env t         = checkAppTys t <|> checkFunRefs t <|> checkAbstrac
     pbinds p                 = (pname p, pvarRType p :: RSort)
                               : [(x, t) | (t, x, _) <- pargs p]
 
-checkAppTys t = go t
+checkAppTys = go
   where
     go (RAllT _ t)      = go t
     go (RAllP _ t)      = go t
@@ -241,7 +241,8 @@ checkTcArity (RTyCon { rtc_tc = tc }) givenArity
         <+> text "arguments"
   | otherwise
     = Nothing
-  where expectedArity = realTcArity tc
+  where
+    expectedArity = realTcArity tc
 
 
 checkFunRefs t = go t
@@ -358,12 +359,12 @@ checkMeasure emb γ (M name@(Loc src _ n) sort body)
     txerror = ErrMeas (sourcePosSrcSpan src) n
 
 checkMBody γ emb _ sort (Def _ as c _ bs body) = checkMBody' emb sort γ' body
-  where 
+  where
     γ'   = L.foldl' (\γ (x, t) -> insertSEnv x t γ) γ (ats ++ xts)
     ats  = (mapSnd (rTypeSortedReft emb) <$> as)
     xts  = zip (fst <$> bs) $ rTypeSortedReft emb . subsTyVars_meet su <$> ty_args trep
     trep = toRTypeRep ct
-    su   = checkMBodyUnify (ty_res trep) (last txs) 
+    su   = checkMBodyUnify (ty_res trep) (last txs)
     txs  = snd4 $ bkArrowDeep sort
     ct   = ofType $ dataConUserType c :: SpecType
 

--- a/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -6,15 +6,11 @@ module Language.Haskell.Liquid.Bare.Measure (
     makeHaskellMeasures
   , makeHaskellInlines
   , makeHaskellBounds
-
   , makeMeasureSpec
   , makeMeasureSpec'
-
   , makeClassMeasureSpec
   , makeMeasureSelectors
-
   , strengthenHaskellMeasures
-
   , varMeasures
   ) where
 
@@ -26,6 +22,7 @@ import Type hiding (isFunTy)
 import Var
 
 import Prelude hiding (mapM)
+import Control.Arrow ((&&&))
 import Control.Applicative ((<$>), (<*>))
 import Control.Monad hiding (forM, mapM)
 import Control.Monad.Error hiding (Error, forM, mapM)
@@ -46,12 +43,14 @@ import qualified Data.HashSet        as S
 import Language.Fixpoint.Misc
 import Language.Fixpoint.Names
 import Language.Fixpoint.Types (Expr(..))
+import Language.Fixpoint.Sort (isFirstOrder)
+
 import qualified Language.Fixpoint.Types as F
 
 import Language.Haskell.Liquid.CoreToLogic
 import Language.Haskell.Liquid.Misc    (mapSndM)
 import Language.Haskell.Liquid.GhcMisc (getSourcePos, getSourcePosE, sourcePosSrcSpan, isDataConId)
-import Language.Haskell.Liquid.RefType (dataConSymbol, generalize, ofType, uRType)
+import Language.Haskell.Liquid.RefType (dataConSymbol, generalize, ofType, uRType, typeSort)
 import Language.Haskell.Liquid.Types
 import Language.Haskell.Liquid.Bounds
 
@@ -76,7 +75,6 @@ makeHaskellMeasures cbs _     (_   , spec)
     unrec cb@(NonRec _ _) = [cb]
     unrec (Rec xes)       = [NonRec x e | (x, e) <- xes]
 
-
 makeHaskellInlines :: [CoreBind] -> ModName -> (ModName, Ms.BareSpec) -> BareM ()
 makeHaskellInlines _   name' (name, _   ) | name /= name'
   = return mempty
@@ -88,18 +86,17 @@ makeHaskellInlines cbs _     (_   , spec)
     unrec cb@(NonRec _ _) = [cb]
     unrec (Rec xes)       = [NonRec x e | (x, e) <- xes]
 
-
 makeMeasureInline :: LogicMap -> [CoreBind] ->  LocSymbol -> BareM ()
 makeMeasureInline lmap cbs  x
-  = case (filter ((val x `elem`) . (map (dropModuleNames . simplesymbol)) . binders) cbs) of
+  = case filter ((val x `elem`) . map (dropModuleNames . simplesymbol) . binders) cbs of
     (NonRec v def:_)   -> do {e <- coreToFun' x v def; updateInlines x e}
     (Rec [(v, def)]:_) -> do {e <- coreToFun' x v def; updateInlines x e}
     _                  -> throwError $ mkError "Cannot inline haskell function"
   where
-    binders (NonRec x _) = [x]
+    binders (NonRec z _) = [z]
     binders (Rec xes)    = fst <$> xes
 
-    coreToFun' x v def = case (runToLogic lmap mkError $ coreToFun x v def) of
+    coreToFun' x v def = case runToLogic lmap mkError $ coreToFun x v def of
                            Left (xs, e)  -> return (TI (symbol <$> xs) e)
                            Right e -> throwError e
 
@@ -107,40 +104,42 @@ makeMeasureInline lmap cbs  x
     mkError str = ErrHMeas (sourcePosSrcSpan $ loc x) (val x) (text str)
 
 
-
 updateInlines x v = modify $ \s -> let iold  = M.insert (val x) v (inlines s) in
                                    s{inlines = M.map (f iold) iold }
-  where f imap = txRefToLogic mempty imap
-
+  where
+    f             = txRefToLogic mempty
 
 makeMeasureDefinition :: LogicMap -> [CoreBind] -> LocSymbol -> BareM (Measure SpecType DataCon)
 makeMeasureDefinition lmap cbs x
-  = case (filter ((val x `elem`) . (map (dropModuleNames . simplesymbol)) . binders) cbs) of
-    (NonRec v def:_)   -> (Ms.mkM x (logicType $ varType v)) <$> coreToDef' x v def
-    (Rec [(v, def)]:_) -> (Ms.mkM x (logicType $ varType v)) <$> coreToDef' x v def
+  = case filter ((val x `elem`) . map (dropModuleNames . simplesymbol) . binders) cbs of
+    (NonRec v def:_)   -> Ms.mkM x (logicType $ varType v) <$> coreToDef' x v def
+    (Rec [(v, def)]:_) -> Ms.mkM x (logicType $ varType v) <$> coreToDef' x v def
     _                  -> throwError $ mkError "Cannot extract measure from haskell function"
   where
     binders (NonRec x _) = [x]
     binders (Rec xes)    = fst <$> xes
 
-    coreToDef' x v def = case (runToLogic lmap mkError $ coreToDef x v def) of
+    coreToDef' x v def = case runToLogic lmap mkError $ coreToDef x v def of
                            Left l  -> return     l
                            Right e -> throwError e
 
     mkError :: String -> Error
     mkError str = ErrHMeas (sourcePosSrcSpan $ loc x) (val x) (text str)
 
+simplesymbol :: CoreBndr -> Symbol
 simplesymbol = symbol . getName
 
 strengthenHaskellMeasures :: S.HashSet (Located Var) -> [(Var, Located SpecType)]
-strengthenHaskellMeasures hmeas = (\v -> (val v, fmap strengthenResult v)) <$> (S.toList hmeas)
+strengthenHaskellMeasures hmeas
+  = (val &&& fmap strengthenResult) <$> S.toList hmeas
 
 makeMeasureSelectors :: (DataCon, Located DataConP) -> [Measure SpecType DataCon]
-makeMeasureSelectors (dc, (Loc l l' (DataConP _ vs _ _ _ xts r _))) = catMaybes (go <$> zip (reverse xts) [1..])
+makeMeasureSelectors (dc, Loc l l' (DataConP _ vs _ _ _ xts r _))
+  = catMaybes (go <$> zip (reverse xts) [1..])
   where
     go ((x,t), i)
       | isFunTy t = Nothing
-      | True      = Just $ makeMeasureSelector (Loc l l' x) (dty t) dc n i
+      | otherwise = Just $ makeMeasureSelector (Loc l l' x) (dty t) dc n i
 
     dty t         = foldr RAllT  (RFun dummySymbol r (fmap mempty t) mempty) vs
     n             = length xts
@@ -154,9 +153,9 @@ makeMeasureSpec :: (ModName, Ms.Spec BareType LocSymbol) -> BareM (Ms.MSpec Spec
 makeMeasureSpec (mod,spec) = inModule mod mkSpec
   where
     mkSpec = mkMeasureDCon =<< mkMeasureSort =<< m
-    m      = Ms.mkMSpec <$> (mapM expandMeasure $ Ms.measures spec)
+    m      = Ms.mkMSpec <$> mapM expandMeasure (Ms.measures spec)
                         <*> return (Ms.cmeasures spec)
-                        <*> (mapM expandMeasure $ Ms.imeasures spec)
+                        <*> mapM expandMeasure (Ms.imeasures spec)
 
 makeMeasureSpec' = mapFst (mapSnd uRType <$>) . Ms.dataConTypes . first (mapReft ur_reft)
 
@@ -167,8 +166,9 @@ makeClassMeasureSpec (Ms.MSpec {..}) = tx <$> M.elems cmeasMap
 
 
 mkMeasureDCon :: Ms.MSpec t LocSymbol -> BareM (Ms.MSpec t DataCon)
-mkMeasureDCon m = (forM (measureCtors m) $ \n -> (val n,) <$> lookupGhcDataCon n)
-                  >>= (return . mkMeasureDCon_ m)
+mkMeasureDCon m
+  = mkMeasureDCon_ m <$> forM (measureCtors m)
+                           (\n -> (val n,) <$> lookupGhcDataCon n)
 
 mkMeasureDCon_ :: Ms.MSpec t LocSymbol -> [(Symbol, DataCon)] -> Ms.MSpec t DataCon
 mkMeasureDCon_ m ndcs = m' {Ms.ctorMap = cm'}
@@ -186,7 +186,7 @@ mkMeasureSort (Ms.MSpec c mm cm im)
   = Ms.MSpec <$> forM c (mapM txDef) <*> forM mm tx <*> forM cm tx <*> forM im tx
     where
       tx :: Measure BareType ctor -> BareM (Measure SpecType ctor)
-      tx (M n s eqs) = M n <$> (ofMeaSort s) <*> (mapM txDef eqs)
+      tx (M n s eqs) = M n <$> ofMeaSort s <*> mapM txDef eqs
 
       txDef :: Def BareType ctor -> BareM (Def SpecType ctor)
       txDef def = liftM3 (\xs t bds-> def{ dparams = xs, dsort = t, binds = bds})
@@ -195,13 +195,19 @@ mkMeasureSort (Ms.MSpec c mm cm im)
                   (mapM (mapSndM $ mapM ofMeaSort) (binds def))
 
 
--- varMeasures :: [Var] -> [(Symbol, Located Int)]
-varMeasures vars = [ (symbol v, varSpecType v)  | v <- vars, isDataConId v] -- TAKE EM ALL!, isSimpleType $ varType v ]
+varMeasures :: (Monoid r) => [Var] -> [(Symbol, Located (RRType r))]
+varMeasures vars = [ (symbol v, varSpecType v)  | v <- vars
+                                                , isDataConId v
+                                                , isSimpleType $ varType v ]
 
-isSimpleType t   = null tvs && isNothing (splitFunTy_maybe tb)
-  where
-    (tvs, tb)    = splitForAllTys t
+isSimpleType :: Type -> Bool
+isSimpleType = isFirstOrder . typeSort M.empty
 
+-- OLD isSimpleType t   = null tvs && isNothing (splitFunTy_maybe tb)
+-- OLD  where
+-- OLD    (tvs, tb)    = splitForAllTys t
+
+varSpecType :: (Monoid r) => Var -> Located (RRType r)
 varSpecType v    = Loc l l' (ofType $ varType v)
   where
     l            = getSourcePos  v
@@ -223,7 +229,7 @@ makeHaskellBound lmap  cbs (v, x) = case filter ((v  `elem`) . binders) cbs of
     binders (NonRec x _) = [x]
     binders (Rec xes)    = fst <$> xes
 
-    coreToFun' x v def = case (runToLogic lmap mkError $ coreToFun x v def) of
+    coreToFun' x v def = case runToLogic lmap mkError $ coreToFun x v def of
                            Left (xs, e) -> return (xs, e)
                            Right e      -> throwError e
 
@@ -239,7 +245,7 @@ toBound v x (vs, Left p) = (x', Bound x' fvs ps xs p)
     (ps , xs)  = (txp <$> ps', txx <$> xs')
     txp v      = (dummyLoc $ simpleSymbolVar v, ofType $ varType v)
     txx v      = (dummyLoc $ symbol v,          ofType $ varType v)
-    fvs        = (((`RVar` mempty) . RTV) <$> (fst $ splitForAllTys $ varType v)) :: [RSort]
+    fvs        = (((`RVar` mempty) . RTV) <$> fst (splitForAllTys $ varType v)) :: [RSort]
 
 toBound v x (vs, Right e) = toBound v x (vs, Left $ F.PBexp e)
 
@@ -253,7 +259,7 @@ capitalizeBound = fmap (symbol . toUpperHead . symbolString)
 --------------------------------------------------------------------------------
 
 expandMeasure m
-  = do eqns <- sequence $ expandMeasureDef <$> (eqns m)
+  = do eqns <- sequence $ expandMeasureDef <$> eqns m
        return $ m { sort = generalize (sort m)
                   , eqns = eqns }
 

--- a/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -146,7 +146,7 @@ makeMeasureSelectors (dc, (Loc l l' (DataConP _ vs _ _ _ xts r _))) = catMaybes 
     n             = length xts
 
 makeMeasureSelector x s dc n i = M {name = x, sort = s, eqns = [eqn]}
-  where eqn   = Def x [] dc Nothing (((, Nothing) . mkx) <$> [1 .. n]) (E (EVar $ mkx i)) 
+  where eqn   = Def x [] dc Nothing (((, Nothing) . mkx) <$> [1 .. n]) (E (EVar $ mkx i))
         mkx j = symbol ("xx" ++ show j)
 
 
@@ -189,13 +189,14 @@ mkMeasureSort (Ms.MSpec c mm cm im)
       tx (M n s eqs) = M n <$> (ofMeaSort s) <*> (mapM txDef eqs)
 
       txDef :: Def BareType ctor -> BareM (Def SpecType ctor)
-      txDef def = liftM3 (\xs t bds-> def{ dparams = xs, dsort = t, binds = bds}) 
+      txDef def = liftM3 (\xs t bds-> def{ dparams = xs, dsort = t, binds = bds})
                   (mapM (mapSndM ofMeaSort) (dparams def))
                   (mapM ofMeaSort $ dsort def)
                   (mapM (mapSndM $ mapM ofMeaSort) (binds def))
 
 
-varMeasures vars = [ (symbol v, varSpecType v)  | v <- vars, isDataConId v, isSimpleType $ varType v ]
+-- varMeasures :: [Var] -> [(Symbol, Located Int)]
+varMeasures vars = [ (symbol v, varSpecType v)  | v <- vars, isDataConId v] -- TAKE EM ALL!, isSimpleType $ varType v ]
 
 isSimpleType t   = null tvs && isNothing (splitFunTy_maybe tb)
   where

--- a/src/Language/Haskell/Liquid/Errors.hs
+++ b/src/Language/Haskell/Liquid/Errors.hs
@@ -301,4 +301,3 @@ errSaved x = ErrSaved x . text
 -- | Throw a panic exception
 exitWithPanic  :: String -> a
 exitWithPanic  = Ex.throw . errOther . text
-

--- a/src/Language/Haskell/Liquid/GhcInterface.hs
+++ b/src/Language/Haskell/Liquid/GhcInterface.hs
@@ -196,7 +196,7 @@ getGhcModGuts1 fn = do
        -- mod_guts <- modSummaryModGuts modSummary
        mod_p    <- parseModule modSummary
        mod_guts <- coreModule <$> (desugarModule =<< typecheckModule (ignoreInline mod_p))
-       let deriv = getDerivedDictionaries mod_guts 
+       let deriv = getDerivedDictionaries mod_guts
        return   $! (miModGuts (Just deriv) mod_guts)
      Nothing     -> exitWithPanic "Ghc Interface: Unable to get GhcModGuts"
 
@@ -240,8 +240,8 @@ moduleSpec cfg cbs vars defVars target mg tgtSpec logicmap impSpecs
        env        <- getSession
        let specs   = (target,tgtSpec):impSpecs
        let imps    = sortNub $ impNames ++ [ symbolString x
-                                           | (_,spec) <- specs
-                                           , x <- Ms.imports spec
+                                           | (_, sp) <- specs
+                                           , x <- Ms.imports sp
                                            ]
        ghcSpec    <- liftIO $ makeGhcSpec cfg target cbs vars defVars exports env logicmap specs
        return      (ghcSpec, imps, Ms.includes tgtSpec)

--- a/src/Language/Haskell/Liquid/Literals.hs
+++ b/src/Language/Haskell/Liquid/Literals.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE OverloadedStrings #-}
+
 module Language.Haskell.Liquid.Literals (
-        literalFRefType, literalFReft, literalConst
-        ) where
+         literalFRefType
+       , literalFReft
+       , literalConst
+       ) where
 
 import TypeRep
-import Literal 
-
+import Literal
+import qualified TyCon  as TC
 import Language.Haskell.Liquid.Measure
 import Language.Haskell.Liquid.Types
 import Language.Haskell.Liquid.RefType
@@ -47,6 +50,7 @@ mkReft e = case e of
 --    otherwise string-literals show up as global int-constants
 --    which blow up qualifier instantiation.
 
-literalConst tce l         = (sort, mkLit l)
+literalConst :: F.TCEmb TC.TyCon -> Literal -> (F.Sort, Maybe F.Expr)
+literalConst tce l = (t, mkLit l)
   where
-    sort                   = typeSort tce $ literalType l
+    t              = typeSort tce $ literalType l

--- a/src/Language/Haskell/Liquid/Server.hs
+++ b/src/Language/Haskell/Liquid/Server.hs
@@ -1,0 +1,39 @@
+module Language.Haskell.Liquid.Server (getType) where
+
+-- import           Control.Monad ((<<))
+import           Language.Haskell.Liquid.Types (Output(..))
+import qualified Language.Haskell.Liquid.ACSS as A
+import           Text.PrettyPrint.HughesPJ    hiding (Mode)
+import           Language.Fixpoint.Files
+
+data Time = TimeTodo deriving (Eq, Ord, Show)
+
+y << x = x >> y
+
+getType :: IO (Output Doc) -> FilePath -> Int -> Int -> IO String
+getType act srcF line col = do
+  ft  <- modificationTime srcF
+  jt  <- modificationTime jsonF
+  case action ft jt of
+    Reuse    -> getTypeInfo line col <$> getAnnMap jsonF
+    Rebuild  -> getTypeInfo line col <$> getAnnMap jsonF << act
+    NoSource -> return "Missing Source"
+  where
+    jsonF    = extFileName Json  srcF
+
+getAnnMap :: FilePath -> IO A.AnnMap
+getAnnMap jsonF = error "TODO:reuseInfo"
+
+modificationTime :: FilePath -> IO (Maybe Time)
+modificationTime = error "TODO:modificationTime"
+
+data Action = Rebuild | Reuse | NoSource
+
+action :: Maybe Time -> Maybe Time -> Action
+action (Just srcT) (Just jsonT)
+  | srcT < jsonT  = Reuse
+action (Just _) _ = Rebuild
+action Nothing _  = NoSource
+
+getTypeInfo :: Int -> Int -> A.AnnMap -> String
+getTypeInfo line col info = error "TODO:getTypeInfo"

--- a/tests/pos/ResolvePred.hs
+++ b/tests/pos/ResolvePred.hs
@@ -1,4 +1,4 @@
-module ResolvePred () where
+module ResolvePred (myFold) where
 
 {-@ data L [llen] = C (h :: Int) (t :: L) | N @-}
 {-@ invariant {v:L | (llen v) >= 0} @-}


### PR DESCRIPTION
Earlier, given things like:

```
data L a = N | C a (L a)
```

were adding just things like `N` but not the `C` -- deferring the latter to `binds`. In general *all* symbols that appear as applications inside refinements *must* be declared as constants. See #443. 

This particular PR should fix that, by adding all first-order data-constructors.