### PR TITLE
Factoring `defaultFoo` functions in CmdLine to fixpoint

### DIFF
--- a/src/Language/Haskell/Liquid/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/CmdLine.hs
@@ -71,18 +71,8 @@ import Text.PrettyPrint.HughesPJ           hiding (Mode)
 -- Config Magic Numbers----------------------------------------------------------
 ---------------------------------------------------------------------------------
 
-defaultCores :: Int
-defaultCores = 1
-
-defaultMinPartSize :: Int
-defaultMinPartSize = 500
-
-defaultMaxPartSize :: Int
-defaultMaxPartSize = 700
-
 defaultMaxParams :: Int
 defaultMaxParams = 2
-
 
 ---------------------------------------------------------------------------------
 -- Parsing Command Line----------------------------------------------------------


### PR DESCRIPTION
Remove `defaultCores`, `defaultMinPartSize`, and `defaultMaxPartSize`declarations. Using versions exported by fixpoint.

Previously liquidhaskell had duplicate versions of these, and the two required synchronization.