### PR TITLE
Set parallel solving be be default

### DIFF
--- a/src/Language/Haskell/Liquid/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/CmdLine.hs
@@ -135,7 +135,7 @@ config = cmdArgsMode $ Config {
     = def &= help "Check tota`lity"
 
  , cores
-    = defaultCores &= help "Use m cores to solve logical constraints"
+    = def &= help "Use m cores to solve logical constraints"
 
  , minPartSize
     = defaultMinPartSize &= help "If solving on multiple cores, ensure that partitions are of at least m size"

--- a/src/Language/Haskell/Liquid/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/CmdLine.hs
@@ -334,7 +334,7 @@ defConfig = Config { files          = def
                    , notruetypes    = def
                    , totality       = def
                    , noPrune        = def
-                   , cores          = defaultCores
+                   , cores          = def
                    , minPartSize    = defaultMinPartSize
                    , maxPartSize    = defaultMaxPartSize
                    , maxParams      = defaultMaxParams

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -269,7 +269,7 @@ data Config = Config {
   , notruetypes    :: Bool       -- ^ disable truing top level types
   , totality       :: Bool       -- ^ check totality in definitions
   , noPrune        :: Bool       -- ^ disable prunning unsorted Refinements
-  , cores          :: Int        -- ^ number of cores used to solve constraints
+  , cores          :: Maybe Int  -- ^ number of cores used to solve constraints
   , minPartSize    :: Int        -- ^ Minimum size of a partition
   , maxPartSize    :: Int        -- ^ Maximum size of a partition. Overrides minPartSize
   , maxParams      :: Int        -- ^ the maximum number of parameters to accept when mining qualifiers


### PR DESCRIPTION
Supporting changes in liquidhaskell for making parallel solving the default in fixpoint.

Also contains minor refactoring of defaultFoo functions (factored out into fixpoint where applicable)