### PR TITLE
Use a submodule for liquid-fixpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ _build
 *.swp
 *.swo
 
+/.stack-work/
+/.vagrant/
 TAGS
 a.out
 *.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "benchmarks/xmonad"]
 	path = benchmarks/xmonad
 	url = https://github.com/nikivazou/xmonad.git
+[submodule "liquid-fixpoint"]
+	path = liquid-fixpoint
+	url = https://github.com/ucsd-progsys/liquid-fixpoint.git

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ LiquidHaskell requires (in addition to the cabal dependencies)
 How To Clone, Build and Install
 -------------------------------
 
-
 To begin building, run the following commands in the root
 directory of the distribution:
 
@@ -26,15 +25,15 @@ directory of the distribution:
    is installed in the **same** directory as LiquidHaskell itself
    (i.e. whereever cabal puts your binaries).
 
-2. Create top-level project directory and clone repositories:
+2. Clone the `liquidhaskell` repository *recursively*.
 
     ```
-    mkdir /path/to/liquid
-    cd /path/to/liquid
-    git clone git@github.com:ucsd-progsys/liquid-fixpoint.git
-    git clone git@github.com:ucsd-progsys/liquidhaskell.git
+    git clone --recursive git@github.com:ucsd-progsys/liquidhaskell.git
     cd liquidhaskell
     ```
+
+   This will clone the correct version of `liquid-fixpoint` as a submodule
+   within the `liquidhaskell` repository.
 
 3. (If using **stack**) To build and install
 
@@ -44,10 +43,9 @@ directory of the distribution:
 
    (If using **cabal**) then
 
-
     ```
     cabal sandbox init
-    cabal sandbox add-source ../liquid-fixpoint/
+    cabal sandbox add-source ./liquid-fixpoint
     cabal install
     ```
 
@@ -55,17 +53,12 @@ directory of the distribution:
 
     `make` or `cabal install` or `stack install`
 
-   inside
-
-    /path/to/liquid/liquidhaskell/
-
 How To Run
 ----------
 
 To verify a file called `foo.hs` at type
 
     $ liquid foo.hs
-
 
 How To Run Regression Tests
 ---------------------------
@@ -122,6 +115,30 @@ How to Get Stack Traces On Exceptions
 
     $ liquid +RTS -xc -RTS foo.hs
 
+Working With Submodules
+-----------------------
+
+ - To update the `liquid-fixpoint` submodule, run
+
+    cd ./liquid-fixpoint
+    git fetch --all
+    git checkout <remote>/<branch>
+    cd ..
+
+   This will update `liquid-fixpoint` to the latest version on `<branch>`
+   (usually `master`) from `<remote>` (usually `origin`).
+
+ - After updating `liquid-fixpoint`, make sure to include this change in a
+   commit! Running
+
+    git add ./liquid-fixpoint
+
+   will save the current commit hash of `liquid-fixpoint` in your next commit
+   to the `liquidhaskell` repository.
+
+ - For the best experience, **don't** make changes directly to the
+   `./liquid-fixpoint` submodule, or else git may get confused. Do any
+   `liquid-fixpoint` development inside a separate clone/copy elsewhere.
 
 Command Line Options
 ====================

--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ Working With Submodules
    `./liquid-fixpoint` submodule, or else git may get confused. Do any
    `liquid-fixpoint` development inside a separate clone/copy elsewhere.
 
+ - If something goes wrong, run
+
+    rm -r ./liquid-fixpoint
+    git submodule update --init
+
+   to blow away your copy of the `liquid-fixpoint` submodule and revert to the
+   last saved commit hash.
+
 Command Line Options
 ====================
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,18 @@
+# GHC 7.10
+resolver: nightly-2015-09-24
+
+# GHC 7.8
+# resolver: lts-2.14
+# resolver: nightly-2015-07-02
+
+packages:
+- ./liquid-fixpoint
+- .
+
+flags:
+  liquid-fixpoint:
+    build-external: true
+
+extra-deps:
+- intern-0.9.1.4
+- located-base-0.1.0.0


### PR DESCRIPTION
@ranjitjhala, @gridaphobe, @christetreault, and I discussed this today. This sets up `liquid-fixpoint` as a submodule of `liquidhaskell`, and updates the `stack.yaml` file to build from that local copy. (For Cabal users, the sandbox instructions on the README have been updated.)

The process of updating and keeping track of the `liquid-fixpoint` submodule has been documented in the README (under the section "Working With Submodules").

Besides forcing us to keep track of which version of `liquid-fixpoint` we're building against, this lets @christetreault's performance dashboard tie the data it collects to a specific `liquid-fixpoint` commit.