### PR TITLE
Use stack and Docker to run tests on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ _build
 *.swp
 *.swo
 
+/.stack-work/
+/.vagrant/
 TAGS
 a.out
 *.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "benchmarks/xmonad"]
 	path = benchmarks/xmonad
 	url = https://github.com/nikivazou/xmonad.git
+[submodule "liquid-fixpoint"]
+	path = liquid-fixpoint
+	url = https://github.com/ucsd-progsys/liquid-fixpoint.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,9 @@ env:
  # - TESTS=hscolour
 
 install:
- - scripts/travis install_stack
  - scripts/travis install_smt "$SMT"
+ - scripts/travis install_stack
+ - scripts/travis setup_ghc
  - scripts/travis install_dependencies
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-language: c
+language: haskell
+ghc: 7.8 # Only used for Cabal
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
     packages:
     - ocaml
     - camlidl
+    - libgmp-dev
 
 cache:
   apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,26 +20,30 @@ cache:
   - $HOME/.stack
 
 env:
- - GHC="7.8"  SMT=z3   TESTS=Unit/
- - GHC="7.8"  SMT=z3   TESTS=Benchmarks/text
- - GHC="7.8"  SMT=z3   TESTS=Benchmarks/bytestring
- - GHC="7.8"  SMT=z3   TESTS=Benchmarks/esop
- - GHC="7.8"  SMT=z3   TESTS=Benchmarks/vect-algs
- - GHC="7.8"  SMT=z3   TESTS=Benchmarks/icfp*
+  global:
+  - STACK=0.1.5.0
+  - SMT=z3
+  matrix:
+  - GHC=ghc-7.8.4   TESTS=Unit/
+  - GHC=ghc-7.8.4   TESTS=Benchmarks/text
+  - GHC=ghc-7.8.4   TESTS=Benchmarks/bytestring
+  - GHC=ghc-7.8.4   TESTS=Benchmarks/esop
+  - GHC=ghc-7.8.4   TESTS=Benchmarks/vect-algs
+  - GHC=ghc-7.8.4   TESTS=Benchmarks/icfp*
 
- - GHC="7.10" SMT=z3   TESTS=Unit/
- - GHC="7.10" SMT=z3   TESTS=Benchmarks/text
- - GHC="7.10" SMT=z3   TESTS=Benchmarks/bytestring
- - GHC="7.10" SMT=z3   TESTS=Benchmarks/esop
- - GHC="7.10" SMT=z3   TESTS=Benchmarks/vect-algs
- - GHC="7.10" SMT=z3   TESTS=Benchmarks/icfp*
+  - GHC=ghc-7.10.2  TESTS=Unit/
+  - GHC=ghc-7.10.2  TESTS=Benchmarks/text
+  - GHC=ghc-7.10.2  TESTS=Benchmarks/bytestring
+  - GHC=ghc-7.10.2  TESTS=Benchmarks/esop
+  - GHC=ghc-7.10.2  TESTS=Benchmarks/vect-algs
+  - GHC=ghc-7.10.2  TESTS=Benchmarks/icfp*
 
  # ugh... Classify.hs is too slow and makes travis think the build is stalled
  # - TESTS=hscolour
 
 install:
  - scripts/travis install_smt "$SMT"
- - scripts/travis install_stack
+ - scripts/travis install_stack "$STACK"
  - scripts/travis configure_stack "$GHC"
  - scripts/travis setup_ghc
  - scripts/travis install_dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,45 +5,42 @@ branches:
     - master
     - multiparams
 
+addons:
+  apt:
+    packages:
+    - ocaml
+    - camlidl
+
 cache:
   apt: true
   directories:
-  - $HOME/.cabal
-  - $HOME/.ghc
+  - $HOME/.stack
 
 env:
- - GHC="7.8.4"  CABAL="1.18" SMT=z3   TESTS=Unit/
- - GHC="7.8.4"  CABAL="1.18" SMT=z3   TESTS=Benchmarks/text
- - GHC="7.8.4"  CABAL="1.18" SMT=z3   TESTS=Benchmarks/bytestring
- - GHC="7.8.4"  CABAL="1.18" SMT=z3   TESTS=Benchmarks/esop
- - GHC="7.8.4"  CABAL="1.18" SMT=z3   TESTS=Benchmarks/vect-algs
- - GHC="7.8.4"  CABAL="1.18" SMT=z3   TESTS=Benchmarks/icfp*
+ - RESOLVER="nightly-2015-07-02" SMT=z3   TESTS=Unit/
+ - RESOLVER="nightly-2015-07-02" SMT=z3   TESTS=Benchmarks/text
+ - RESOLVER="nightly-2015-07-02" SMT=z3   TESTS=Benchmarks/bytestring
+ - RESOLVER="nightly-2015-07-02" SMT=z3   TESTS=Benchmarks/esop
+ - RESOLVER="nightly-2015-07-02" SMT=z3   TESTS=Benchmarks/vect-algs
+ - RESOLVER="nightly-2015-07-02" SMT=z3   TESTS=Benchmarks/icfp*
 
- - GHC="7.10.2" CABAL="1.22" SMT=z3   TESTS=Unit/
- - GHC="7.10.2" CABAL="1.22" SMT=z3   TESTS=Benchmarks/text
- - GHC="7.10.2" CABAL="1.22" SMT=z3   TESTS=Benchmarks/bytestring
- - GHC="7.10.2" CABAL="1.22" SMT=z3   TESTS=Benchmarks/esop
- - GHC="7.10.2" CABAL="1.22" SMT=z3   TESTS=Benchmarks/vect-algs
- - GHC="7.10.2" CABAL="1.22" SMT=z3   TESTS=Benchmarks/icfp*
+ - RESOLVER="nightly-2015-09-24" SMT=z3   TESTS=Unit/
+ - RESOLVER="nightly-2015-09-24" SMT=z3   TESTS=Benchmarks/text
+ - RESOLVER="nightly-2015-09-24" SMT=z3   TESTS=Benchmarks/bytestring
+ - RESOLVER="nightly-2015-09-24" SMT=z3   TESTS=Benchmarks/esop
+ - RESOLVER="nightly-2015-09-24" SMT=z3   TESTS=Benchmarks/vect-algs
+ - RESOLVER="nightly-2015-09-24" SMT=z3   TESTS=Benchmarks/icfp*
 
  # ugh... Classify.hs is too slow and makes travis think the build is stalled
  # - TESTS=hscolour
 
-before_install:
- - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
- - travis_retry sudo apt-get update
- - travis_retry sudo apt-get install cabal-install-$CABAL ghc-$GHC ocaml camlidl
- - export PATH="$HOME/.cabal/bin:/opt/ghc/$GHC/bin:/opt/cabal/$CABAL/bin:$PATH"
- - scripts/travis clean_cache "$SMT"
- - scripts/travis clone_fixpoint
-
 install:
- - scripts/travis install_cabal_deps
+ - scripts/travis install_stack
  - scripts/travis install_smt "$SMT"
+ - scripts/travis install_dependencies
 
 script:
- - scripts/travis do_build && scripts/travis do_test "$TESTS" "$SMT" && scripts/travis test_source_pkg
- - scripts/travis clean_cache "$SMT"
+ - scripts/travis do_build && scripts/travis do_test "$TESTS" "$SMT"
 
 after_failure:
  - scripts/travis dump_fail_logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ cache:
   - $HOME/.stack
 
 env:
- - RESOLVER="nightly-2015-07-02" SMT=z3   TESTS=Unit/
- - RESOLVER="nightly-2015-07-02" SMT=z3   TESTS=Benchmarks/text
- - RESOLVER="nightly-2015-07-02" SMT=z3   TESTS=Benchmarks/bytestring
- - RESOLVER="nightly-2015-07-02" SMT=z3   TESTS=Benchmarks/esop
- - RESOLVER="nightly-2015-07-02" SMT=z3   TESTS=Benchmarks/vect-algs
- - RESOLVER="nightly-2015-07-02" SMT=z3   TESTS=Benchmarks/icfp*
+ - RESOLVER="lts-2.22"           SMT=z3   TESTS=Unit/
+ - RESOLVER="lts-2.22"           SMT=z3   TESTS=Benchmarks/text
+ - RESOLVER="lts-2.22"           SMT=z3   TESTS=Benchmarks/bytestring
+ - RESOLVER="lts-2.22"           SMT=z3   TESTS=Benchmarks/esop
+ - RESOLVER="lts-2.22"           SMT=z3   TESTS=Benchmarks/vect-algs
+ - RESOLVER="lts-2.22"           SMT=z3   TESTS=Benchmarks/icfp*
 
  - RESOLVER="nightly-2015-09-24" SMT=z3   TESTS=Unit/
  - RESOLVER="nightly-2015-09-24" SMT=z3   TESTS=Benchmarks/text

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ branches:
     - master
     - multiparams
 
+sudo: false
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ env:
 install:
  - scripts/travis install_smt "$SMT"
  - scripts/travis install_stack
+ - scripts/travis configure_stack "$RESOLVER"
  - scripts/travis setup_ghc
  - scripts/travis install_dependencies
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,19 +18,19 @@ cache:
   - $HOME/.stack
 
 env:
- - RESOLVER="lts-2.22"           SMT=z3   TESTS=Unit/
- - RESOLVER="lts-2.22"           SMT=z3   TESTS=Benchmarks/text
- - RESOLVER="lts-2.22"           SMT=z3   TESTS=Benchmarks/bytestring
- - RESOLVER="lts-2.22"           SMT=z3   TESTS=Benchmarks/esop
- - RESOLVER="lts-2.22"           SMT=z3   TESTS=Benchmarks/vect-algs
- - RESOLVER="lts-2.22"           SMT=z3   TESTS=Benchmarks/icfp*
+ - GHC="7.8"  SMT=z3   TESTS=Unit/
+ - GHC="7.8"  SMT=z3   TESTS=Benchmarks/text
+ - GHC="7.8"  SMT=z3   TESTS=Benchmarks/bytestring
+ - GHC="7.8"  SMT=z3   TESTS=Benchmarks/esop
+ - GHC="7.8"  SMT=z3   TESTS=Benchmarks/vect-algs
+ - GHC="7.8"  SMT=z3   TESTS=Benchmarks/icfp*
 
- - RESOLVER="nightly-2015-09-24" SMT=z3   TESTS=Unit/
- - RESOLVER="nightly-2015-09-24" SMT=z3   TESTS=Benchmarks/text
- - RESOLVER="nightly-2015-09-24" SMT=z3   TESTS=Benchmarks/bytestring
- - RESOLVER="nightly-2015-09-24" SMT=z3   TESTS=Benchmarks/esop
- - RESOLVER="nightly-2015-09-24" SMT=z3   TESTS=Benchmarks/vect-algs
- - RESOLVER="nightly-2015-09-24" SMT=z3   TESTS=Benchmarks/icfp*
+ - GHC="7.10" SMT=z3   TESTS=Unit/
+ - GHC="7.10" SMT=z3   TESTS=Benchmarks/text
+ - GHC="7.10" SMT=z3   TESTS=Benchmarks/bytestring
+ - GHC="7.10" SMT=z3   TESTS=Benchmarks/esop
+ - GHC="7.10" SMT=z3   TESTS=Benchmarks/vect-algs
+ - GHC="7.10" SMT=z3   TESTS=Benchmarks/icfp*
 
  # ugh... Classify.hs is too slow and makes travis think the build is stalled
  # - TESTS=hscolour
@@ -38,7 +38,7 @@ env:
 install:
  - scripts/travis install_smt "$SMT"
  - scripts/travis install_stack
- - scripts/travis configure_stack "$RESOLVER"
+ - scripts/travis configure_stack "$GHC"
  - scripts/travis setup_ghc
  - scripts/travis install_dependencies
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ LiquidHaskell requires (in addition to the cabal dependencies)
 How To Clone, Build and Install
 -------------------------------
 
-
 To begin building, run the following commands in the root
 directory of the distribution:
 
@@ -26,15 +25,15 @@ directory of the distribution:
    is installed in the **same** directory as LiquidHaskell itself
    (i.e. whereever cabal puts your binaries).
 
-2. Create top-level project directory and clone repositories:
+2. Clone the `liquidhaskell` repository *recursively*.
 
     ```
-    mkdir /path/to/liquid
-    cd /path/to/liquid
-    git clone git@github.com:ucsd-progsys/liquid-fixpoint.git
-    git clone git@github.com:ucsd-progsys/liquidhaskell.git
+    git clone --recursive git@github.com:ucsd-progsys/liquidhaskell.git
     cd liquidhaskell
     ```
+
+   This will clone the correct version of `liquid-fixpoint` as a submodule
+   within the `liquidhaskell` repository.
 
 3. (If using **stack**) To build and install
 
@@ -44,10 +43,9 @@ directory of the distribution:
 
    (If using **cabal**) then
 
-
     ```
     cabal sandbox init
-    cabal sandbox add-source ../liquid-fixpoint/
+    cabal sandbox add-source ./liquid-fixpoint
     cabal install
     ```
 
@@ -55,17 +53,12 @@ directory of the distribution:
 
     `make` or `cabal install` or `stack install`
 
-   inside
-
-    /path/to/liquid/liquidhaskell/
-
 How To Run
 ----------
 
 To verify a file called `foo.hs` at type
 
     $ liquid foo.hs
-
 
 How To Run Regression Tests
 ---------------------------
@@ -122,6 +115,30 @@ How to Get Stack Traces On Exceptions
 
     $ liquid +RTS -xc -RTS foo.hs
 
+Working With Submodules
+-----------------------
+
+ - To update the `liquid-fixpoint` submodule, run
+
+    cd ./liquid-fixpoint
+    git fetch --all
+    git checkout <remote>/<branch>
+    cd ..
+
+   This will update `liquid-fixpoint` to the latest version on `<branch>`
+   (usually `master`) from `<remote>` (usually `origin`).
+
+ - After updating `liquid-fixpoint`, make sure to include this change in a
+   commit! Running
+
+    git add ./liquid-fixpoint
+
+   will save the current commit hash of `liquid-fixpoint` in your next commit
+   to the `liquidhaskell` repository.
+
+ - For the best experience, **don't** make changes directly to the
+   `./liquid-fixpoint` submodule, or else git may get confused. Do any
+   `liquid-fixpoint` development inside a separate clone/copy elsewhere.
 
 Command Line Options
 ====================

--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ Working With Submodules
    `./liquid-fixpoint` submodule, or else git may get confused. Do any
    `liquid-fixpoint` development inside a separate clone/copy elsewhere.
 
+ - If something goes wrong, run
+
+    rm -r ./liquid-fixpoint
+    git submodule update --init
+
+   to blow away your copy of the `liquid-fixpoint` submodule and revert to the
+   last saved commit hash.
+
 Command Line Options
 ====================
 

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -117,11 +117,11 @@ Library
                 , Diff >= 0.3 && < 0.4
                 , filepath >= 1.3 && < 1.5
                 , ghc-paths >= 0.1 && < 0.2
-                , hscolour >= 1.23 && < 1.24
+                , hscolour >= 1.22 && < 1.24
                 , mtl >= 2.1 && < 2.3
                 , parsec >= 3.1 && < 3.2
                 , pretty >= 1.1 && < 1.2
-                , syb >= 0.5 && < 0.7
+                , syb >= 0.4.4 && < 0.7
                 , text >= 1.2 && < 1.3
                 , vector >= 0.10 && < 0.12
                 , hashable >= 1.2 && < 1.3
@@ -132,7 +132,7 @@ Library
                 , fingertree >= 0.1 && < 0.2
                 , Cabal >= 1.18
 
-                , bifunctors >= 5 && < 5.1
+                , bifunctors >= 4.2.1 && < 5.1
                 --, process >= 1.2 && < 1.4
                 --, intern
                 --, process >= 1.2
@@ -263,7 +263,7 @@ test-suite test
                      process >= 1.2 && < 1.3,
                      optparse-applicative >= 0.11 && < 0.12,
                      stm >= 2.4 && < 2.5,
-                     tagged >= 0.8 && < 0.9,
+                     tagged >= 0.7.3 && < 0.9,
                      tasty >= 0.10 && < 0.12,
                      tasty-hunit >= 0.9 && < 0.10,
                      tasty-rerun >= 1.1 && < 1.2,

--- a/scripts/travis
+++ b/scripts/travis
@@ -100,7 +100,7 @@ function install_stack {
 function configure_stack {
   local resolver="$1"
 
-  loud sed -i "s,^resolver:.\+,resolver: ${resolver},g" stack.yaml
+  sed -i "s,^resolver:.\+,resolver: ${resolver},g" stack.yaml
   loud cat stack.yaml
 }
 

--- a/scripts/travis
+++ b/scripts/travis
@@ -103,9 +103,12 @@ function install_stack {
 function configure_stack {
   local ghc_version="$1"
 
+  echo "Configuring stack.yaml for GHC ${ghc_version}..."
+
   local resolver="${GHC_7_10_RESOLVER}"
   if [[ "${ghc_version}" == "7.8" ]]; then
     resolver="${GHC_7_8_RESOLVER}"
+    echo                        >> stack.yaml
     echo " - tasty-rerun-1.1.5" >> stack.yaml
   fi
 

--- a/scripts/travis
+++ b/scripts/travis
@@ -115,6 +115,9 @@ flags:
 EOF
 
   loud cat stack.yaml
+
+  echo "Solving Cabal dependency constraints..."
+  loud stack solver --modify-stack-yaml
 }
 
 function setup_ghc {

--- a/scripts/travis
+++ b/scripts/travis
@@ -116,7 +116,8 @@ function configure_stack {
 }
 
 function setup_ghc {
-  stack setup
+  loud stack setup
+  loud stack ghc -- --version
 }
 
 function install_dependencies {

--- a/scripts/travis
+++ b/scripts/travis
@@ -3,6 +3,8 @@
 set -eu
 set -o pipefail
 
+STACK_VERSION="0.1.5.0"
+
 ## Helper Functions
 
 function loud {
@@ -67,58 +69,51 @@ function pastebin {
   curl -s -F 'clbin=<-' https://clbin.com
 }
 
-## Testing Stages
+## Setup Stages
 
-function clean_cache {
-  local smt="$1"
+function install_stack {
+  mkdir -p "${HOME}/.local/bin"
+  mkdir -p '/tmp/stack'
 
-  loud ghc-pkg unregister liquidhaskell --force || true
-  loud ghc-pkg unregister liquid-fixpoint --force || true
-  loud rm "$HOME/.cabal/bin/$smt" || true
-}
+  pushd '/tmp/stack'
 
-function clone_fixpoint {
-  loud git clone git://github.com/ucsd-progsys/liquid-fixpoint.git /tmp/fixpoint
+  local dir_name="stack-${STACK_VERSION}-x86_64-linux"
+  local archive_name="${dir_name}.tar.gz"
+  local stack_url="https://github.com/commercialhaskell/stack/releases/download/v${STACK_VERSION}/${archive_name}"
+
+  loud wget "${stack_url}"
+  loud tar -xzvf "./${archive_name}"
+  loud cp "./${dir_name}/stack" "${HOME}/.local/bin/stack"
+  loud chmod a+x "${HOME}/.local/bin/stack"
+
+  popd
 }
 
 function install_smt {
   local smt="$1"
 
-  mkdir -p "$HOME/.cabal/bin"
-  loud curl "http://goto.ucsd.edu/~gridaphobe/$smt" -o "$HOME/.cabal/bin/$smt"
-  loud chmod a+x "$HOME/.cabal/bin/$smt"
+  mkdir -p "${HOME}/.local/bin"
+  loud curl "http://goto.ucsd.edu/~gridaphobe/$smt" -o "${HOME}/.local/bin/$smt"
+  loud chmod a+x "${HOME}/.local/bin/$smt"
 }
 
-function install_cabal_deps {
-  if ! _install_cabal_deps; then
-    echo " ==> Cabal install failed. Clearing dependency cache and retrying."
-    loud rm -rf "$HOME/.cabal"
-    loud rm -rf "$HOME/.ghc"
-    _install_cabal_deps
-  fi
-
-  # this is dumb, but the -j1 makes cabal print the build log to stdout instead of a file
-  loud travis_retry cabal install -j1 -fbuild-external /tmp/fixpoint
+function install_dependencies {
+  loud stack build 'liquidhaskell' --only-dependencies --test --no-run-tests
 }
 
-function _install_cabal_deps {
-  loud travis_retry cabal update || return 1
-  loud travis_retry cabal install --reorder-goals --only-dependencies --upgrade-dependencies --enable-tests -fbuild-external . /tmp/fixpoint || return 1
-}
+## Building & Testing Stages
 
 function do_build {
-  loud cabal configure -fdevel --enable-tests -v2
-  loud prevent_timeout cabal build -j2
-  loud cabal haddock
-  loud cabal copy
-  loud cabal register
+  loud stack build --test --no-run-tests
 }
 
 function do_test {
   local tests="$1"
   local smt="$2"
 
-  loud prevent_timeout ./dist/build/test/test --pattern "$tests/" --smtsolver "$smt" -j2 +RTS -N2 -RTS
+  local test_runner="$(find .stack-work/ -type f -name test)"
+
+  loud prevent_timeout stack exec -- "${test_runner}" --pattern "$tests/" --smtsolver "$smt" -j2 +RTS -N2 -RTS
 }
 
 function dump_fail_logs {
@@ -126,19 +121,6 @@ function dump_fail_logs {
     echo "${file}:"
     echo "    $(pastebin < "${file}")"
   done
-}
-
-function test_source_pkg {
-  loud cabal sdist
-
-  local src_tgz="dist/$(cabal info . | awk '{print $2 ".tar.gz";exit}')"
-
-  if [ -f "$src_tgz" ]; then
-    loud prevent_timeout cabal install -j4 "$src_tgz"
-  else
-    echo "expected '$src_tgz' not found"
-    return 1
-  fi
 }
 
 ## Run Test Stage

--- a/scripts/travis
+++ b/scripts/travis
@@ -3,11 +3,6 @@
 set -eu
 set -o pipefail
 
-STACK_VERSION="0.1.5.0"
-
-GHC_7_8_RESOLVER="lts-2.22"
-GHC_7_10_RESOLVER="nightly-2015-09-24"
-
 ## Helper Functions
 
 function loud {
@@ -83,14 +78,16 @@ function install_smt {
 }
 
 function install_stack {
+  local stack_version="$1"
+
   mkdir -p "${HOME}/.local/bin"
   mkdir -p '/tmp/stack'
 
   pushd '/tmp/stack'
 
-  local dir_name="stack-${STACK_VERSION}-x86_64-linux"
+  local dir_name="stack-${stack_version}-x86_64-linux"
   local archive_name="${dir_name}.tar.gz"
-  local stack_url="https://github.com/commercialhaskell/stack/releases/download/v${STACK_VERSION}/${archive_name}"
+  local stack_url="https://github.com/commercialhaskell/stack/releases/download/v${stack_version}/${archive_name}"
 
   loud wget "${stack_url}"
   loud tar -xzvf "./${archive_name}"
@@ -103,15 +100,20 @@ function install_stack {
 function configure_stack {
   local ghc_version="$1"
 
-  echo "Configuring stack.yaml for GHC ${ghc_version}..."
+  echo "Configuring stack.yaml for ${ghc_version}..."
 
-  local resolver="${GHC_7_10_RESOLVER}"
-  if [[ "${ghc_version}" == "7.8" ]]; then
-    resolver="${GHC_7_8_RESOLVER}"
-    echo "- tasty-rerun-1.1.5" >> stack.yaml
-  fi
+  cat << EOF > 'stack.yaml'
+resolver: ${ghc_version}
 
-  sed -i "s,^resolver:.\+,resolver: ${resolver},g" stack.yaml
+packages:
+- ./liquid-fixpoint
+- .
+
+flags:
+  liquid-fixpoint:
+    build-external: true
+EOF
+
   loud cat stack.yaml
 }
 

--- a/scripts/travis
+++ b/scripts/travis
@@ -115,9 +115,6 @@ flags:
 EOF
 
   loud cat stack.yaml
-
-  echo "Solving Cabal dependency constraints..."
-  loud stack solver --modify-stack-yaml
 }
 
 function setup_ghc {
@@ -126,6 +123,11 @@ function setup_ghc {
 }
 
 function install_dependencies {
+  echo "Solving dependency constraints..."
+  loud stack update
+  loud stack solver --modify-stack-yaml
+
+  echo "Installing dependencies..."
   loud stack build --only-dependencies --test --no-run-tests
 }
 

--- a/scripts/travis
+++ b/scripts/travis
@@ -108,8 +108,7 @@ function configure_stack {
   local resolver="${GHC_7_10_RESOLVER}"
   if [[ "${ghc_version}" == "7.8" ]]; then
     resolver="${GHC_7_8_RESOLVER}"
-    echo                        >> stack.yaml
-    echo " - tasty-rerun-1.1.5" >> stack.yaml
+    echo "- tasty-rerun-1.1.5" >> stack.yaml
   fi
 
   sed -i "s,^resolver:.\+,resolver: ${resolver},g" stack.yaml

--- a/scripts/travis
+++ b/scripts/travis
@@ -118,7 +118,7 @@ function setup_ghc {
 }
 
 function install_dependencies {
-  loud stack build 'liquidhaskell' --only-dependencies --test --no-run-tests
+  loud stack build --only-dependencies --test --no-run-tests
 }
 
 ## Building & Testing Stages

--- a/scripts/travis
+++ b/scripts/travis
@@ -71,6 +71,14 @@ function pastebin {
 
 ## Setup Stages
 
+function install_smt {
+  local smt="$1"
+
+  mkdir -p "${HOME}/.local/bin"
+  loud curl "http://goto.ucsd.edu/~gridaphobe/$smt" -o "${HOME}/.local/bin/$smt"
+  loud chmod a+x "${HOME}/.local/bin/$smt"
+}
+
 function install_stack {
   mkdir -p "${HOME}/.local/bin"
   mkdir -p '/tmp/stack'
@@ -89,12 +97,8 @@ function install_stack {
   popd
 }
 
-function install_smt {
-  local smt="$1"
-
-  mkdir -p "${HOME}/.local/bin"
-  loud curl "http://goto.ucsd.edu/~gridaphobe/$smt" -o "${HOME}/.local/bin/$smt"
-  loud chmod a+x "${HOME}/.local/bin/$smt"
+function setup_ghc {
+  stack setup
 }
 
 function install_dependencies {

--- a/scripts/travis
+++ b/scripts/travis
@@ -5,6 +5,9 @@ set -o pipefail
 
 STACK_VERSION="0.1.5.0"
 
+GHC_7_8_RESOLVER="lts-2.22"
+GHC_7_10_RESOLVER="nightly-2015-09-24"
+
 ## Helper Functions
 
 function loud {
@@ -98,7 +101,13 @@ function install_stack {
 }
 
 function configure_stack {
-  local resolver="$1"
+  local ghc_version="$1"
+
+  local resolver="${GHC_7_10_RESOLVER}"
+  if [[ "${ghc_version}" == "7.8" ]]; then
+    resolver="${GHC_7_8_RESOLVER}"
+    echo " - tasty-rerun-1.1.5" >> stack.yaml
+  fi
 
   sed -i "s,^resolver:.\+,resolver: ${resolver},g" stack.yaml
   loud cat stack.yaml

--- a/scripts/travis
+++ b/scripts/travis
@@ -97,6 +97,13 @@ function install_stack {
   popd
 }
 
+function configure_stack {
+  local resolver="$1"
+
+  loud sed -i "s,^resolver:.\+,resolver: ${resolver},g" stack.yaml
+  loud cat stack.yaml
+}
+
 function setup_ghc {
   stack setup
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,18 @@
+# GHC 7.10
+resolver: nightly-2015-09-24
+
+# GHC 7.8
+# resolver: lts-2.14
+# resolver: nightly-2015-07-02
+
+packages:
+- ./liquid-fixpoint
+- .
+
+flags:
+  liquid-fixpoint:
+    build-external: true
+
+extra-deps:
+- intern-0.9.1.4
+- located-base-0.1.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,8 +2,7 @@
 resolver: nightly-2015-09-24
 
 # GHC 7.8
-# resolver: lts-2.14
-# resolver: nightly-2015-07-02
+# resolver: lts-2.22
 
 packages:
 - ./liquid-fixpoint


### PR DESCRIPTION
This reworks the Travis build setup to use `stack` for installing GHC, installing dependencies,, and building `liquidhaskell`. This lets us test with multiple GHC versions without relying on either Travis's official GHC support or `multi-ghc-travis`, meaning we can switch back to Travis's Docker system for our builds. That means our builds will run much, much quicker, as (a) the Docker containers take much less time to provision than the full VMs we're currently using, and (b) with the Docker system, we can cache our GHC install and built dependencies across runs, instead of having to rebuild them every single test.

(Note&mdash;this depends on #476 being merged first.)