### PR TITLE
Bug fixes for perf-monitor

### DIFF
--- a/scripts/performance/cleanup-gipeda.bash
+++ b/scripts/performance/cleanup-gipeda.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR=`dirname` $0;
+SCRIPT_DIR=`dirname $0`;
 GIPEDA_DIR="$SCRIPT_DIR/gipeda";
 FAILURES_OCCURRED=false;
 

--- a/scripts/performance/cleanup-gipeda.bash
+++ b/scripts/performance/cleanup-gipeda.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR=`pwd`;
+SCRIPT_DIR=`dirname` $0;
 GIPEDA_DIR="$SCRIPT_DIR/gipeda";
 FAILURES_OCCURRED=false;
 

--- a/scripts/performance/deploy-gipeda.bash
+++ b/scripts/performance/deploy-gipeda.bash
@@ -5,7 +5,7 @@ CABAL=`which cabal`;
 GHC=`which ghc`;
 ALL_FOUND=true;
 
-SCRIPT_DIR=`dirname` $0;
+SCRIPT_DIR=`dirname $0`;
 GIPEDA_DIR="$SCRIPT_DIR/gipeda";
 GIPEDA_REPO="$GIPEDA_DIR/repository";
 REL_SANDBOX_BIN=".cabal-sandbox/bin";

--- a/scripts/performance/deploy-gipeda.bash
+++ b/scripts/performance/deploy-gipeda.bash
@@ -5,7 +5,7 @@ CABAL=`which cabal`;
 GHC=`which ghc`;
 ALL_FOUND=true;
 
-SCRIPT_DIR=`pwd`;
+SCRIPT_DIR=`dirname` $0;
 GIPEDA_DIR="$SCRIPT_DIR/gipeda";
 GIPEDA_REPO="$GIPEDA_DIR/repository";
 REL_SANDBOX_BIN=".cabal-sandbox/bin";

--- a/scripts/performance/generate-site.bash
+++ b/scripts/performance/generate-site.bash
@@ -5,7 +5,7 @@ MAKE=`which make`;
 CABAL=`which cabal`;
 ALL_FOUND=true;
 
-SCRIPT_DIR=`dirname` $0;
+SCRIPT_DIR=`dirname $0`;
 
 GIPEDA_DIR="$SCRIPT_DIR/gipeda";
 GIPEDA_SITE="$GIPEDA_DIR/site";

--- a/scripts/performance/generate-site.bash
+++ b/scripts/performance/generate-site.bash
@@ -164,6 +164,8 @@ else
     exit 1;
 fi
 
+
+
 $CABAL update;
 abort_if_failed "Couldn't perform cabal update...";
 
@@ -180,6 +182,15 @@ abort_if_failed "Couldn't change to $GIPEDA_REPO...";
 
 $GIT pull origin master;
 abort_if_failed "Couldn't pull Liquid Haskell from remote...";
+
+$GIT reset;
+abort_if_failed "Couldn't reset the the liquid-haskell repository...";
+
+$GIT checkout .;
+abort_if_failed "Couldn't discard changes to liquid-haskell...";
+
+$GIT submodule foreach 'git reset ; git checkout . ;';
+abort_if_failed "Couldn't reset and discard changes to submodules...";
 
 if [ $END = 0 ]
 then

--- a/scripts/performance/generate-site.bash
+++ b/scripts/performance/generate-site.bash
@@ -5,7 +5,7 @@ MAKE=`which make`;
 CABAL=`which cabal`;
 ALL_FOUND=true;
 
-SCRIPT_DIR=`pwd`;
+SCRIPT_DIR=`dirname` $0;
 
 GIPEDA_DIR="$SCRIPT_DIR/gipeda";
 GIPEDA_SITE="$GIPEDA_DIR/site";


### PR DESCRIPTION
Fixes 2 issues:

* Previously attempted to use pwd to determine the current directory. It turns out that pwd only works of you executed: `./generate-site.bash` to start the site generation. Since our cron jobs don't do this, switched to dirname to get the working directory.

* Aborted runs leave a bunch of garbage in the repository. Git seems to think this means I made a bunch of changes that I might want to commit, and helpfully doesn't checkout until I commit or stash. Now, we reset and checkout the repository and submodules prior to trying to work.