### PR TITLE
Consistency for `Integral` method refinements

### DIFF
--- a/include/GHC/Real.spec
+++ b/include/GHC/Real.spec
@@ -8,8 +8,10 @@ class (GHC.Num.Num a) => GHC.Real.Fractional a where
   GHC.Real.fromRational :: GHC.Real.Rational -> a
 
 class (GHC.Real.Real a, GHC.Enum.Enum a) => GHC.Real.Integral a where
-  GHC.Real.quot :: a -> {v:a | v /= 0} -> a
-  GHC.Real.rem :: a -> {v:a | v /= 0} -> a
+  GHC.Real.quot :: x:a -> y:{v:a | v /= 0} -> {v:a | (v = (x / y)) &&
+                                                     ((x >= 0 && y >= 0) => v >= 0) &&
+                                                     ((x >= 0 && y >= 1) => v <= x) }
+  GHC.Real.rem :: x:a -> y:{v:a | v /= 0} -> {v:a | ((v >= 0) && (v < y))}
   GHC.Real.mod :: x:a -> y:{v:a | v /= 0} -> {v:a | v = x mod y && ((0 <= x && 0 < y) => (0 <= v && v < y))}
   GHC.Real.div :: x:a -> y:{v:a | v /= 0} -> {v:a | (v = (x / y)) &&
                                                     ((x >= 0 && y >= 0) => v >= 0) &&
@@ -18,7 +20,11 @@ class (GHC.Real.Real a, GHC.Enum.Enum a) => GHC.Real.Integral a where
                                                           ((x >= 0 && y >= 0) => v >= 0) &&
                                                           ((x >= 0 && y >= 1) => v <= x)}
                                                  , {v:a | ((v >= 0) && (v < y))})
-  GHC.Real.divMod :: a -> {v:a | v /= 0} -> (a, a)
+  GHC.Real.divMod :: x:a -> y:{v:a | v /= 0} -> ( {v:a | (v = (x / y)) &&
+                                                         ((x >= 0 && y >= 0) => v >= 0) &&
+                                                         ((x >= 0 && y >= 1) => v <= x) }
+                                                , {v:a | v = x mod y && ((0 <= x && 0 < y) => (0 <= v && v < y))}
+                                                )
   GHC.Real.toInteger :: x:a -> {v:GHC.Integer.Type.Integer | v = x}
 
 // fixpoint can't handle (x mod y), only (x mod c) so we need to be more clever here


### PR DESCRIPTION
The `quot` and `rem` functions have fewer refinements than `quotRem` and the `divMod` function has fewer refinements than `div`/`mod` so this change makes them behave more consistently