### PR TITLE
Enabled -Werror in cabal file, fixed warnings

### DIFF
--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -219,9 +219,7 @@ Library
                     Language.Haskell.Liquid.Desugar710.Match,
                     Language.Haskell.Liquid.Desugar710.MatchCon,
                     Language.Haskell.Liquid.Desugar710.MatchLit
-   ghc-options: -W -fno-warn-unused-imports -fno-warn-dodgy-imports -fno-warn-deprecated-flags -fno-warn-deprecations -fno-warn-missing-methods -threaded
-   if flag(devel)
-     ghc-options: -Werror
+   ghc-options: -Werror -W -fno-warn-unused-imports -fno-warn-dodgy-imports -fno-warn-deprecated-flags -fno-warn-deprecations -fno-warn-missing-methods -threaded
    if flag(include)
      hs-source-dirs: devel
    ghc-prof-options: -fprof-auto

--- a/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -72,11 +72,12 @@ makeAxiom lmap cbs _ _ x
                                      defAxioms v def)
     _                  -> throwError $ mkError "Cannot extract measure from haskell function"
   where
-
+     {-
+         TODO: Not called, do I need to exist?
     coreToDef' x v def = case runToLogic lmap mkError $ coreToDef x v def of
                             Left l  -> l :: [Def (RRType ()) DataCon] -- return     l
                             Right _ -> error $ "ERROR" -- throwError e
-
+     -}
     mkError :: String -> Error
     mkError str = ErrHMeas (sourcePosSrcSpan $ loc x) (val x) (text str)
 
@@ -86,9 +87,12 @@ makeAxiom lmap cbs _ _ x
 binders (NonRec x _) = [x]
 binders (Rec xes)    = fst <$> xes
 
-
+{- TODO: first argument never used. Given that this function is called
+   "updateLMap", and the LogicMap argument is unused, I suspect this
+   probably does something other than updating a LogicMap and should
+   be renamed-}
 updateLMap :: LogicMap -> LocSymbol -> LocSymbol -> Var -> BareM ()
-updateLMap lmap x y vv -- v axm@(Axiom (vv, _) xs _ lhs rhs)
+updateLMap _ x y vv -- v axm@(Axiom (vv, _) xs _ lhs rhs)
   = insertLogicEnv (val x) ys runFun
   where
     nargs = dropWhile isClassType $ ty_args $ toRTypeRep $ ((ofType $ varType vv) :: RRType ())
@@ -97,7 +101,7 @@ updateLMap lmap x y vv -- v axm@(Axiom (vv, _) xs _ lhs rhs)
     runFun = F.EApp (dummyLoc runFunName) [F.EApp (dummyLoc runFunName) [F.EVar $ val y, F.EVar x1], F.EVar x2]
 
 makeAxiomType :: LogicMap -> LocSymbol -> Var -> HAxiom -> BareM (Var, Located SpecType)
-makeAxiomType lmap x v axm@(Axiom (vv, _) xs _ lhs rhs)
+makeAxiomType lmap x v axm@(Axiom _ xs _ lhs rhs)
   = return (v, x{val = t})
   where
     t   = traceShow  "\n\nmakeAxiomType\n\n" $ fromRTypeRep $  tr{ty_res = res, ty_binds = symbol <$> xs}
@@ -112,21 +116,22 @@ makeAxiomType lmap x v axm@(Axiom (vv, _) xs _ lhs rhs)
        Left e -> e
        Right e -> error $ show e
     ref = F.Reft (F.vv_, F.PAtom F.Eq llhs lrhs)
-
+   {- TODO: unsued, do I need to exist?
     nargs = dropWhile isClassType $ ty_args $ toRTypeRep $ ((ofType $ varType vv) :: RRType ())
 
-    ys@[x1, x2] = zipWith (\i _ -> symbol (("x" ++ show i) :: String)) [1..] nargs
+   -- ys@[x1, x2] = zipWith (\i _ -> symbol (("x" ++ show i) :: String)) [1..] nargs -}
 
     lmap' = lmap -- M.insert v' (LMap v' ys runFun) lmap
-
-    runFun = F.EApp (dummyLoc runFunName) [F.EApp (dummyLoc runFunName) [F.EVar $ val x, F.EVar x1], F.EVar x2]
+    {- TODO: unsued, do I need to exist?
+    runFun = F.EApp (dummyLoc runFunName) [F.EApp (dummyLoc runFunName) [F.EVar $ val x, F.EVar x1], F.EVar x2] -}
 
     mkErr s = ErrHMeas (sourcePosSrcSpan $ loc x) (val x) (text s)
-
+    {- TODO: unused, do I need to exist?
     mkBinds (x:xs) (v:vs) = v:mkBinds xs vs
     mkBinds _ _ = []
 
     v' = val x -- symbol $ showPpr $ getName vv
+-}
 
 
 
@@ -207,8 +212,8 @@ axiomType s τ = fromRTypeRep $ t{ty_res = res, ty_binds = xs}
     ref = F.Reft (x, F.PAtom F.Eq (F.EVar x) (mkApp xs))
 
     mkApp = F.EApp s . map F.EVar -- foldl runFun (F.EVar $ val s)
-
-    runFun e x = F.EApp (dummyLoc runFunName) [e, F.EVar x]
+    {- TODO: unused, do I need to exist?
+    runFun e x = F.EApp (dummyLoc runFunName) [e, F.EVar x] -}
 
 
 -- | Type for uninterpreted function that approximated Haskell function into logic

--- a/src/Language/Haskell/Liquid/Bare/Plugged.hs
+++ b/src/Language/Haskell/Liquid/Bare/Plugged.hs
@@ -85,8 +85,8 @@ plugHoles tce tyi x f t (Loc l l' st)
         addHoles = everywhere (mkT $ addHole)
         -- NOTE: make sure we only add holes to RVar and RApp (NOT RFun)
         addHole :: SpecType -> SpecType
-        addHole t@(RVar v r)       = RVar v (f t (uReft ("v", hole)))
-        addHole t@(RApp c ts ps r) = RApp c ts ps (f t (uReft ("v", hole)))
+        addHole t@(RVar v _)       = RVar v (f t (uReft ("v", hole)))
+        addHole t@(RApp c ts ps _) = RApp c ts ps (f t (uReft ("v", hole)))
         addHole t                  = t
 
     go (RVar _ _)       v@(RVar _ _)       = return v

--- a/src/Language/Haskell/Liquid/Constraint/ProofToCore.hs
+++ b/src/Language/Haskell/Liquid/Constraint/ProofToCore.hs
@@ -15,6 +15,8 @@ import TypeRep
 import Language.Haskell.Liquid.GHC.Misc
 import Language.Haskell.Liquid.WiredIn
 
+import Language.Fixpoint.Misc (errorstar)
+
 import Prover.Types
 
 import qualified Data.List as L
@@ -69,11 +71,16 @@ combineProofs c _ es = foldl (flip Let) (combine [1..] c (H.Var v) (H.Var <$> vs
       (v:vs, bs) = unzip [let v = (varANF i (exprType e)) in (v, NonRec v e)
                               | (e, i) <- zip es [1..] ]
 
-combine _ c e []             = e
+combine _ _ e []             = e
 combine _ c e' [e]           = c e' e
 combine (i:uniq) c e' (e:es) = Let (NonRec v (c e' e)) (combine uniq c (H.Var v) es)
   where
-  	v = varCombine i (exprType $ c e' e)
+     v = varCombine i (exprType $ c e' e)
+combine _ _ _ _              = errorstar err -- TODO: Does this case have a
+   where                                     -- sane implementation?
+     err = "Language.Haskell.Liquid.Constraint.ProofToCore.combine called with"
+           ++ " empty first argument and non-empty fourth argument. This should"
+           ++ " never happen!"
 
 
 -------------------------------------------------------------------------------
@@ -90,7 +97,7 @@ makeApp :: CoreExpr -> [CoreExpr] -> CoreExpr
 makeApp f es = foldl (flip Let) (foldl App f' (reverse es')) (reverse  bs)
   where
    vts      = resolveVs $ zip ts (exprType <$> es)
-   (as, ts) = bkArrow (exprType f)
+   (_, ts) = bkArrow (exprType f)
    f'       = instantiateVars vts f
    ds       = makeDictionaries dictionaryVar f'
    (bs, es', _) = foldl anf ([], [], [1..]) (ds ++ (instantiateVars vts <$> es))
@@ -123,8 +130,8 @@ instantiateVars vts e = go e (exprType e)
 
 resolveVs :: [(Type, Type)] -> [(Id, Type)]
 resolveVs []                                     = []
-resolveVs ((ForAllTy a t1, t2):ts)               = resolveVs ((t1, t2):ts)
-resolveVs ((t1, ForAllTy a t2):ts)               = resolveVs ((t1, t2):ts)
+resolveVs ((ForAllTy _ t1, t2):ts)               = resolveVs ((t1, t2):ts)
+resolveVs ((t1, ForAllTy _ t2):ts)               = resolveVs ((t1, t2):ts)
 resolveVs ((FunTy   t1 t2, FunTy t1' t2'):ts)    = resolveVs ((t1, t1'):(t2, t2'):ts)
 resolveVs ((AppTy t1 t2, AppTy t1' t2'):ts)      = resolveVs ((t1, t1'):(t2, t2'):ts)
 resolveVs ((TyVarTy a, TyVarTy a'):ts) | a == a' = resolveVs ts
@@ -132,9 +139,9 @@ resolveVs ((TyVarTy a, t):ts)                    = let vts = (resolveVs (substTy
 resolveVs ((t, TyVarTy a):ts)                    = let vts = (resolveVs (substTyV (a, t) <$> ts)) in (a, resolveVar a t vts) : vts
 resolveVs ((TyConApp _ cts,TyConApp _ cts'):ts)  = resolveVs (zip cts cts' ++ ts)
 resolveVs ((LitTy _, LitTy _):ts)                = resolveVs ts
-resolveVs (tt:ts)                                = error $ showPpr tt
+resolveVs (tt:_)                                = error $ showPpr tt
 
-resolveVar a t [] = t
+resolveVar _ t [] = t
 resolveVar a t ((a', t'):ats)
   | a == a'           = resolveVar a' t' ats
   | TyVarTy a'' <- t' = resolveVar a'' t' ats

--- a/src/Language/Haskell/Liquid/Constraint/Qualifier.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Qualifier.hs
@@ -6,6 +6,8 @@ module Language.Haskell.Liquid.Constraint.Qualifier (
   specificationQualifiers
   ) where
 
+import TyCon
+
 import Language.Haskell.Liquid.Bare
 import Language.Haskell.Liquid.Types.RefType
 import Language.Haskell.Liquid.GHC.Misc  (getSourcePos)
@@ -54,7 +56,7 @@ specificationQualifiers k info lEnv
 
 -- TODO: rewrite using foldReft'
 -- refTypeQuals :: SpecType -> [Qualifier]
-refTypeQuals :: SEnv Sort -> _ -> _ -> SpecType -> [Qualifier]
+refTypeQuals :: SEnv Sort -> SourcePos -> TCEmb TyCon -> SpecType -> [Qualifier]
 refTypeQuals lEnv l tce t0    = go emptySEnv t0
   where
     scrape                    = refTopQuals lEnv l tce t0
@@ -100,7 +102,7 @@ mkPQual lEnv l tce t0 γ t e = mkQual lEnv l t0 γ' v so pa
 
 mkQual = mkQualNEW
 
-mkQualNEW lEnv l t0 γ v so p   = Q "Auto" ((v, so) : xts) p l
+mkQualNEW lEnv l _ γ v so p   = Q "Auto" ((v, so) : xts) p l
   where
     xs   = delete v $ nub $ syms p
     xts = catMaybes $ zipWith (envSort l lEnv γ) xs [0..]
@@ -108,6 +110,8 @@ mkQualNEW lEnv l t0 γ v so p   = Q "Auto" ((v, so) : xts) p l
     -- msg  = "Free Vars in: " ++ showFix p ++ " in " ++ show t0
 
 -- OLD
+{-
+  TODO: If it's so OLD, do we need to keep it? Never called, etc...
 mkQualOLD lEnv l t0 γ v so p   = Q "Auto" ((v, so) : yts) p' l
   where
     yts                = [(y, lookupSort l γ i x) | (x, i, y) <- xys ]
@@ -120,21 +124,27 @@ mkQualOLD lEnv l t0 γ v so p   = Q "Auto" ((v, so) : yts) p' l
 
 orderedFreeVarsOLD :: SEnv Sort -> Pred -> [Symbol]
 orderedFreeVarsOLD γ = nub . filter (`memberSEnv` γ) . syms
+-}
 
-
+{-
+   TODO: Never used, do I need to exist?
 orderedFreeVars :: SEnv Sort -> Pred -> [Symbol]
 orderedFreeVars lEnv = nub . filter (not . (`memberSEnv` lEnv)) . syms
+-}
 
-envSort :: _ -> SEnv Sort -> SEnv Sort -> Symbol -> Integer -> Maybe (Symbol, Sort)
+envSort :: SourcePos -> SEnv Sort -> SEnv Sort -> Symbol -> Integer -> Maybe (Symbol, Sort)
 envSort l lEnv tEnv x i
   | Just t <- lookupSEnv x tEnv = Just (x, t)
-  | Just t <- lookupSEnv x lEnv = Nothing
+  | Just _ <- lookupSEnv x lEnv = Nothing
   | otherwise                   = Just (x, ai)
   where
     ai             = trace msg $ fObj $ Loc l l $ tempSymbol "LHTV" i
     msg            = "unknown symbol in qualifier: " ++ show x
 
+{-
+   TODO: Never used, do I need to exist?
 lookupSort l γ i x = fromMaybe ai $ lookupSEnv x γ
   where
     ai             = trace msg $ fObj $ Loc l l $ tempSymbol "LHTV" i
     msg            = "unknown symbol in qualifier: " ++ show x
+-}

--- a/src/Language/Haskell/Liquid/Interactive/Types.hs
+++ b/src/Language/Haskell/Liquid/Interactive/Types.hs
@@ -5,10 +5,10 @@
 module Language.Haskell.Liquid.Interactive.Types
   (
     -- * Commands
-    Command (..)
+    Command
 
     -- * Response
-  , Response (..)
+  , Response
   , status
 
     -- * State

--- a/src/Language/Haskell/Liquid/UX/Annotate.hs
+++ b/src/Language/Haskell/Liquid/UX/Annotate.hs
@@ -208,7 +208,6 @@ mkAnnMap cfg res ann     = ACSS.Ann (mkAnnMapTyp cfg ann) (mkAnnMapErr res) (mkS
 mkStatus (Safe)          = ACSS.Safe
 mkStatus (Unsafe _)      = ACSS.Unsafe
 mkStatus (Crash _ _)     = ACSS.Error
-mkStatus _               = ACSS.Crash
 
 mkAnnMapErr (Unsafe ls)  = mapMaybe cinfoErr ls
 mkAnnMapErr (Crash ls _) = mapMaybe cinfoErr ls

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -414,7 +414,9 @@ resDocs k (Crash xs s)     = text ("RESULT: ERROR") : text s : pprManyOrdered k 
 resDocs k (Unsafe xs)      = text "RESULT: UNSAFE" : pprManyOrdered k "" (nub xs)
 -- resDocs _ (UnknownError d) = [text $ "RESULT: PANIC: Unexpected Error: " ++ d, reportUrl]
 
-reportUrl              = text "Please submit a bug report at: https://github.com/ucsd-progsys/liquidhaskell"
+{-
+   TODO: Never used, do I need to exist?
+reportUrl              = text "Please submit a bug report at: https://github.com/ucsd-progsys/liquidhaskell" -}
 
 
 addErrors r []             = r

--- a/src/Language/Haskell/Liquid/UX/PrettyPrint.hs
+++ b/src/Language/Haskell/Liquid/UX/PrettyPrint.hs
@@ -321,6 +321,9 @@ pprXOT (x, v) = (xd, pprint v)
   where
     xd = maybe (text "unknown") pprint x
 
+{-
+   TODO: Not exported/never called. Do I have any reason to exist?
+
 ppTable m = vcat $ pprxt <$> xts
   where
     pprxt (x,t) = pprint x $$ nest n (colon <+> pprint t)
@@ -331,5 +334,5 @@ ppTable m = vcat $ pprxt <$> xts
 
 maximumWithDefault zero [] = zero
 maximumWithDefault _    xs = maximum xs
-
+-}
 dot                = char '.'


### PR DESCRIPTION
I've enabled `-Werror` unconditionally in the `liquidhaskell.cabal` file. I fixed the warnings that then became build failures. The following commented blocks of code could use the attention (at some point) of their owners:

Bare/Axiom.hs:
- https://github.com/ucsd-progsys/liquidhaskell/blob/9dd983ce0a9a95ad9a0929a8a09ad04164bc23d1/src/Language/Haskell/Liquid/Bare/Axiom.hs#L75-L80
- https://github.com/ucsd-progsys/liquidhaskell/blob/9dd983ce0a9a95ad9a0929a8a09ad04164bc23d1/src/Language/Haskell/Liquid/Bare/Axiom.hs#L90-L101
- https://github.com/ucsd-progsys/liquidhaskell/blob/9dd983ce0a9a95ad9a0929a8a09ad04164bc23d1/src/Language/Haskell/Liquid/Bare/Axiom.hs#L119-L122
- https://github.com/ucsd-progsys/liquidhaskell/blob/9dd983ce0a9a95ad9a0929a8a09ad04164bc23d1/src/Language/Haskell/Liquid/Bare/Axiom.hs#L125-L126
- https://github.com/ucsd-progsys/liquidhaskell/blob/9dd983ce0a9a95ad9a0929a8a09ad04164bc23d1/src/Language/Haskell/Liquid/Bare/Axiom.hs#L129-L134

Constraint/ProofToCore.hs:
- https://github.com/ucsd-progsys/liquidhaskell/blob/9dd983ce0a9a95ad9a0929a8a09ad04164bc23d1/src/Language/Haskell/Liquid/Constraint/ProofToCore.hs#L79-L83

Constraint/Qualifier.hs:
- https://github.com/ucsd-progsys/liquidhaskell/blob/9dd983ce0a9a95ad9a0929a8a09ad04164bc23d1/src/Language/Haskell/Liquid/Constraint/Qualifier.hs#L113-L133
- https://github.com/ucsd-progsys/liquidhaskell/blob/9dd983ce0a9a95ad9a0929a8a09ad04164bc23d1/src/Language/Haskell/Liquid/Constraint/Qualifier.hs#L144-L150

UX/CmdLine.hs:
- https://github.com/ucsd-progsys/liquidhaskell/blob/9dd983ce0a9a95ad9a0929a8a09ad04164bc23d1/src/Language/Haskell/Liquid/UX/CmdLine.hs#L417-L419

UX/PrettyPrint.hs
- https://github.com/ucsd-progsys/liquidhaskell/blob/9dd983ce0a9a95ad9a0929a8a09ad04164bc23d1/src/Language/Haskell/Liquid/UX/PrettyPrint.hs#L324-L337