### PR TITLE
Tidy

### DIFF
--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -246,7 +246,6 @@ test-suite test
   ghc-options:       -O2 -threaded
   main-is:           test.hs
   build-depends:     base  >= 4 && < 5,
-                     -- liquidhaskell,
                      containers >= 0.5 && < 0.6,
                      directory >= 1.2 && < 1.3,
                      filepath >= 1.3 && < 1.5,

--- a/src/Language/Haskell/Liquid/Bare/GhcSpec.hs
+++ b/src/Language/Haskell/Liquid/Bare/GhcSpec.hs
@@ -34,7 +34,7 @@ import qualified Data.HashMap.Strict as M
 import qualified Data.HashSet        as S
 
 import Language.Fixpoint.Misc (thd3, traceShow)
-import Language.Fixpoint.Types.Names (takeWhileSym, nilName, consName)
+import Language.Fixpoint.Types.Names (nilName, consName)
 import Language.Fixpoint.Types hiding (Error)
 
 import Language.Haskell.Liquid.Types.Dictionaries
@@ -346,13 +346,17 @@ traverseBinds b k = withExtendedEnv (bindersOf b) $ do
   mapM_ traverseExprs (rhssOfBind b)
   k
 
+
 withExtendedEnv vs k
   = do RE env' fenv' emb tyi <- ask
-       let env  = L.foldl' (\m v -> M.insert (takeWhileSym (/='#') $ symbol v) (symbol v) m) env' vs
+       let env  = L.foldl' (\m v -> M.insert (varShortSymbol v) (symbol v) m) env' vs
            fenv = L.foldl' (\m v -> insertSEnv (symbol v) (rTypeSortedReft emb (ofType $ varType v :: RSort)) m) fenv' vs
        withReaderT (const (RE env fenv emb tyi)) $ do
          mapM_ replaceLocalBindsOne vs
          k
+
+varShortSymbol :: Var -> Symbol
+varShortSymbol = symbol . takeWhile (/= '#') . showPpr . getName
 
 replaceLocalBindsOne :: Var -> ReplaceM ()
 replaceLocalBindsOne v

--- a/src/Language/Haskell/Liquid/Bare/GhcSpec.hs
+++ b/src/Language/Haskell/Liquid/Bare/GhcSpec.hs
@@ -346,7 +346,7 @@ traverseBinds b k = withExtendedEnv (bindersOf b) $ do
   mapM_ traverseExprs (rhssOfBind b)
   k
 
-
+-- RJ: this function is incomprehensible, what does it do?!
 withExtendedEnv vs k
   = do RE env' fenv' emb tyi <- ask
        let env  = L.foldl' (\m v -> M.insert (varShortSymbol v) (symbol v) m) env' vs
@@ -358,6 +358,7 @@ withExtendedEnv vs k
 varShortSymbol :: Var -> Symbol
 varShortSymbol = symbol . takeWhile (/= '#') . showPpr . getName
 
+-- RJ: this function is incomprehensible
 replaceLocalBindsOne :: Var -> ReplaceM ()
 replaceLocalBindsOne v
   = do mt <- gets (M.lookup v . fst)

--- a/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -428,11 +428,11 @@ instance Symbolic TyCon where
   symbol = symbol . qualifiedNameSymbol . getName
 
 instance Symbolic Name where
-  symbol = symbol . showPpr -- qualifiedNameSymbol
-
+  symbol = symbol . showPpr
 
 instance Symbolic Var where
   symbol = varSymbol
+
 
 varSymbol ::  Var -> Symbol
 varSymbol v

--- a/src/Language/Haskell/Liquid/UX/Errors.hs
+++ b/src/Language/Haskell/Liquid/UX/Errors.hs
@@ -35,6 +35,7 @@ tidyError sol
   . tidyErrContext sol
   . applySolution sol
 
+
 tidyErrContext :: FixSolution -> Error -> Error
 tidyErrContext _ e@(ErrSubType {})
   = e { ctx = c', tact = subst θ tA, texp = subst θ tE }

--- a/tests/todo/TypeError.hs
+++ b/tests/todo/TypeError.hs
@@ -1,6 +1,6 @@
-
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ExtendedDefaultRules #-}
+
 
 {-@ LIQUID "--autoproofs"      @-}
 {-@ LIQUID "--totality"        @-}


### PR DESCRIPTION
Matching PR for 

https://github.com/ucsd-progsys/liquid-fixpoint/pull/177

should address 

https://github.com/ucsd-progsys/liquidhaskell/issues/558

however, @nikivazou -- the binder `pr1` does't have a 
non-trivial refinement even in the `.fq` file... hence that 
is what is getting printed out? Please explain!