### PR TITLE
fix for #569

### DIFF
--- a/src/Language/Haskell/Liquid/Bare/GhcSpec.hs
+++ b/src/Language/Haskell/Liquid/Bare/GhcSpec.hs
@@ -9,7 +9,7 @@ module Language.Haskell.Liquid.Bare.GhcSpec (
   ) where
 
 -- import Debug.Trace (trace)
-import Prelude hiding (error)
+-- import Prelude hiding (error)
 import CoreSyn hiding (Expr)
 import HscTypes
 import Id
@@ -100,9 +100,10 @@ postProcess cbs specEnv sp@(SP {..})
   = sp { tySigs = tySigs', texprs = ts, asmSigs = asmSigs', dicts = dicts', invariants = invs', meas = meas' }
   -- HEREHEREHEREHERE (addTyConInfo stuff)
   where
-    (sigs, ts) = replaceLocalBinds tcEmbeds tyconEnv tySigs texprs specEnv cbs
+    (sigs, ts') = replaceLocalBinds tcEmbeds tyconEnv tySigs texprs specEnv cbs
+    (assms, ts) = replaceLocalBinds tcEmbeds tyconEnv asmSigs ts'   specEnv cbs
     tySigs'  = mapSnd (addTyConInfo tcEmbeds tyconEnv <$>) <$> sigs
-    asmSigs' = mapSnd (addTyConInfo tcEmbeds tyconEnv <$>) <$> asmSigs
+    asmSigs' = mapSnd (addTyConInfo tcEmbeds tyconEnv <$>) <$> assms
     dicts'   = dmapty (addTyConInfo tcEmbeds tyconEnv) dicts
     invs'    = (addTyConInfo tcEmbeds tyconEnv <$>) <$> invariants
     meas'    = mapSnd (addTyConInfo tcEmbeds tyconEnv .  txRefSort tyconEnv tcEmbeds <$>) <$> meas

--- a/src/Language/Haskell/Liquid/Bare/GhcSpec.hs
+++ b/src/Language/Haskell/Liquid/Bare/GhcSpec.hs
@@ -9,7 +9,7 @@ module Language.Haskell.Liquid.Bare.GhcSpec (
   ) where
 
 -- import Debug.Trace (trace)
--- import Prelude hiding (error)
+import Prelude hiding (error)
 import CoreSyn hiding (Expr)
 import HscTypes
 import Id

--- a/tests/crash/Assume1.hs
+++ b/tests/crash/Assume1.hs
@@ -1,0 +1,15 @@
+a :: Int
+a = 0
+
+{-@ assume b :: { b : Int | a < b } @-}
+b :: Int
+b = 1
+
+{-@
+f :: a : Int -> { b : Int | a < b } -> ()
+@-}
+f :: Int -> Int -> ()
+f _ _ = ()
+
+g :: ()
+g = f a b


### PR DESCRIPTION
assumed and spec signatures should be treated the same. 
make assumed sigs go though `replaceLocalBinds` 

