### PR TITLE
add --scrape-imports to enable scraping qualifiers from imports

### DIFF
--- a/scripts/travis
+++ b/scripts/travis
@@ -126,7 +126,7 @@ function setup_ghc {
 function install_dependencies {
   echo "Solving dependency constraints..."
   loud stack update
-  loud stack solver --modify-stack-yaml
+  loud stack solver --update-config
 
   echo "Installing dependencies..."
   loud stack build liquidhaskell --only-dependencies --test --no-run-tests

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -21,6 +21,8 @@ module Language.Haskell.Liquid.Types (
 
   -- * Options
     Config (..)
+  , HasConfig (..)
+  , hasOpt
 
   -- * Ghc Information
   , GhcInfo (..)
@@ -290,6 +292,10 @@ data GhcInfo = GI {
   , spec     :: !GhcSpec
   }
 
+instance HasConfig GhcInfo where
+  getConfig = getConfig . spec
+
+
 -- | The following is the overall type for /specifications/ obtained from
 -- parsing the target source and dependent libraries
 
@@ -329,6 +335,9 @@ data GhcSpec = SP {
   , logicMap   :: LogicMap
   , proofType  :: Maybe Type
   }
+
+instance HasConfig GhcSpec where
+  getConfig = config
 
 data LogicMap = LM { logic_map :: M.HashMap Symbol LMap
                    , axiom_map :: M.HashMap Var Symbol

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -150,7 +150,6 @@ config = cmdArgsMode $ Config {
 
  , smtsolver
     = def &= help "Name of SMT-Solver"
-          &= explicit
 
  , newcheck
     = True &= help "New fixpoint check"

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -98,10 +98,6 @@ config = cmdArgsMode $ Config {
     = def
           &= help "Supports real number arithmetic"
 
- , exactDC
-    = def &= help "Exact Type for Data Constructors"
-          &= name "exact-data-cons"
-
  , saveQuery
     = def &= help "Save fixpoint query to file (slow)"
 
@@ -154,6 +150,7 @@ config = cmdArgsMode $ Config {
 
  , smtsolver
     = def &= help "Name of SMT-Solver"
+          &= explicit
 
  , newcheck
     = True &= help "New fixpoint check"
@@ -196,6 +193,15 @@ config = cmdArgsMode $ Config {
      = defaultPort
           &= name "port"
           &= help "Port at which lhi should listen"
+
+ , exactDC
+    = def &= help "Exact Type for Data Constructors"
+          &= name "exact-data-cons"
+
+ , scrapeImports
+    = False &= help "Scrape qualifiers from imported specifications"
+            &= name "scrape-imports"
+            &= explicit
 
  } &= verbosity
    &= program "liquid"
@@ -342,14 +348,8 @@ defConfig = Config { files          = def
                    , cFiles         = def
                    , eliminate      = def
                    , port           = defaultPort
+                   , scrapeImports  = False
                    }
-
-instance Monoid SMTSolver where
-  mempty        = def
-  mappend s1 s2
-    | s1 == s2  = s1
-    | s2 == def = s1
-    | otherwise = s2
 
 
 ------------------------------------------------------------------------

--- a/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/src/Language/Haskell/Liquid/UX/Config.hs
@@ -10,7 +10,8 @@ module Language.Haskell.Liquid.UX.Config (
 
    -- * Configuration Options
      Config (..)
-
+   , HasConfig (..)
+   , hasOpt
    ) where
 
 import Data.Serialize ( Serialize )
@@ -52,7 +53,18 @@ data Config = Config {
   , eliminate      :: Bool
   , port           :: Int        -- ^ port at which lhi should listen
   , exactDC        :: Bool       -- ^ Automatically generate singleton types for data constructors
+  , scrapeImports  :: Bool       -- ^ scrape qualifiers from imported specifications
   } deriving (Generic, Data, Typeable, Show, Eq)
 
 instance Serialize SMTSolver
 instance Serialize Config
+
+
+class HasConfig t where
+  getConfig :: t -> Config
+
+hasOpt :: HasConfig t => t -> (Config -> Bool) -> Bool
+hasOpt t f = f (getConfig t)
+
+instance HasConfig Config where
+  getConfig = id


### PR DESCRIPTION
Partially fixes #576 by allowing users to override the defaults and scrape qualifiers from imported modules. It's off by default because of the performance implications (I've seen up to 2x overhead on some modules, eg `Data.Text`).