### PR TITLE
Use LTS resolver instead of nightly

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # GHC 7.10
 # resolver: nightly-2015-09-18
 
-resolver: nightly-2016-01-06
+resolver: lts-4.0
 
 compiler-check: newer-minor
 


### PR DESCRIPTION
Currently the stack.yaml plan is using nightly-2016-01-06 which builds against GHC-7.10.3.

Using a LTS resolver allows liquidhaskell to be built inside a Docker container, which may impact reproductibility of builds in a multiple developers environment.

FP Complete provides Docker base images for all their LTS releases, but not for their nightlies.

The most approximate LTS release for `nightly-2016-01-06` is `lts-4.0`, with only two packages differing a version, as it can be seen in the stackage diff at https://www.stackage.org/diff/nightly-2016-01-06/lts-4.0

Namely, the packages are:
- sbv-5.8 (on lts-4.0 it is sbv-5.9)
- web-routes-wai-0.24.2 (on lts-4.0 it is web-routes-wai-0.24.3)

So I wonder whether the resolver can be changed.