### PR TITLE
fix for #638

### DIFF
--- a/include/Data/Vector.spec
+++ b/include/Data/Vector.spec
@@ -2,6 +2,9 @@ module spec Data.Vector where
 
 import GHC.Base
 
+data variance Vector covariant
+
+
 measure vlen    :: forall a. (Data.Vector.Vector a) -> Int
 
 invariant       {v: Data.Vector.Vector a | 0 <= vlen v } 

--- a/include/GHC/Types.spec
+++ b/include/GHC/Types.spec
@@ -18,6 +18,7 @@ GHC.Types.False :: {v:GHC.Types.Bool | (~ (Prop(v)))}
 GHC.Types.isTrue#  :: n:_ -> {v:GHC.Types.Bool | ((n = 1) <=> (Prop(v)))}
 
 
+GHC.Types.W# :: w:_ -> {v:GHC.Types.Word | v == w }
 
 
 

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -262,7 +262,7 @@ data PPEnv
 
 ppEnv           = ppEnvCurrent
 ppEnvCurrent    = PP False False False False
-ppEnvPrintPreds = PP False False False False
+_ppEnvPrintPreds = PP False False False False
 ppEnvShort pp   = pp { ppShort = True }
 
 

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -260,8 +260,8 @@ data PPEnv
        , ppShort :: Bool
        }
 
-ppEnv           = ppEnvPrintPreds
-_ppEnvCurrent   = PP False False False False
+ppEnv           = ppEnvCurrent
+ppEnvCurrent    = PP False False False False
 ppEnvPrintPreds = PP False False False False
 ppEnvShort pp   = pp { ppShort = True }
 

--- a/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
+++ b/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
@@ -237,8 +237,8 @@ ppAllExpr bb p t
           split zs t                = (reverse zs, t)
 
 ppReftPs _ _ rs
-  --- | all isTauto rs   = empty
-  --- | not (ppPs ppEnv) = empty
+  | all isTauto rs   = empty
+  | not (ppPs ppEnv) = empty
   | otherwise        = angleBrackets $ hsep $ punctuate comma $ ppr_ref <$> rs
 
 -- ppr_dbind :: (RefTypable p c tv (), RefTypable p c tv r) => Bool -> Prec -> Symbol -> RType p c tv r -> Doc

--- a/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -1080,7 +1080,7 @@ makeTyConVariance c = varSignToVariance <$> tvs
 
     goDCon dc = concatMap (go True) (DataCon.dataConOrigArgTys dc)
 
-    go pos (ForAllTy v t)  = go pos t
+    go pos (ForAllTy _ t)  = go pos t
     go pos (TyVarTy v)     = [(v, pos)]
     go pos (AppTy t1 t2)   = go pos t1 ++ go pos t2
     go pos (TyConApp c' ts) 
@@ -1102,9 +1102,6 @@ makeTyConVariance c = varSignToVariance <$> tvs
     goTyConApp pos Bivariant     t = goTyConApp pos Contravariant t ++ goTyConApp pos Covariant t
     goTyConApp pos Covariant     t = go pos       t 
     goTyConApp pos Contravariant t = go (not pos) t 
-
-    varLookup v m = fromMaybe (errmsg v) $ L.lookup v m
-    errmsg v      = panic Nothing $ "GhcMisc.makeTyConVariance: var not found" ++ showPpr v
 
 
 --------------------------------------------------------------------------------

--- a/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -1103,7 +1103,7 @@ makeTyConVariance c = varSignToVariance <$> tvs
     goTyConApp pos Covariant     t = go pos       t 
     goTyConApp pos Contravariant t = go (not pos) t 
 
-    mutuallyRecursive c c' = (c `S.member` (dataConsOfTyCon c')) || (c' `S.member` (dataConsOfTyCon c))
+    mutuallyRecursive c c' = c `S.member` (dataConsOfTyCon c')
 
 
 dataConsOfTyCon :: TyCon -> S.HashSet TyCon

--- a/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -80,7 +80,7 @@ import TysWiredIn       (listTyCon, intDataCon, trueDataCon, falseDataCon,
                          intTyCon, charTyCon)
 
 -- import           Data.Monoid      hiding ((<>))
-import           Data.Maybe               (fromMaybe, isJust)
+import           Data.Maybe               (fromMaybe, isJust, fromJust)
 import           Data.Hashable
 import qualified Data.HashMap.Strict  as M
 import qualified Data.HashSet         as S
@@ -1060,29 +1060,51 @@ mkTyConInfo :: TyCon -> VarianceInfo -> VarianceInfo -> (Maybe (Symbol -> Expr))
 mkTyConInfo c usertyvar userprvariance f
   = TyConInfo (if null usertyvar then defaulttyvar else usertyvar) userprvariance f
   where
-        defaulttyvar      = varSignToVariance <$> [0 ..n]
+        defaulttyvar      = makeTyConVariance c 
 
-        varSignToVariance i = case filter (\p -> fst p == i) varsigns of
-                                []       -> Invariant
-                                [(_, b)] -> if b then Covariant else Contravariant
-                                _        -> Bivariant
 
-        varsigns  = L.nub $ concatMap goDCon $ TC.tyConDataCons c
-        initmap   = zip (showPpr <$> tyvars) [0..n]
-        mkmap vs  = zip (showPpr <$> vs) (repeat dindex) ++ initmap
-        goDCon dc = concatMap (go (mkmap (DataCon.dataConExTyVars dc)) True) (DataCon.dataConOrigArgTys dc)
-        go m pos (ForAllTy v t)  = go ((showPpr v, dindex):m) pos t
-        go m pos (TyVarTy v)     = [(varLookup (showPpr v) m, pos)]
-        go m pos (AppTy t1 t2)   = go m pos t1 ++ go m pos t2
-        go m pos (TyConApp _ ts) = concatMap (go m pos) ts
-        go m pos (FunTy t1 t2)   = go m (not pos) t1 ++ go m pos t2
-        go _ _   (LitTy _)       = []
+makeTyConVariance :: TyCon -> VarianceInfo
+makeTyConVariance c = varSignToVariance <$> tvs 
+  where
+    tvs = tyConTyVarsDef c
 
-        varLookup v m = fromMaybe (errmsg v) $ L.lookup v m
-        tyvars        = tyConTyVarsDef c
-        n             = (TC.tyConArity c) - 1
-        errmsg v      = panic Nothing $ "GhcMisc.getTyConInfo: var not found" ++ showPpr v
-        dindex        = -1
+    varsigns = if TC.isTypeSynonymTyCon c 
+                  then go True (fromJust $ TC.synTyConRhs_maybe c)
+                  else L.nub $ concatMap goDCon $ TC.tyConDataCons c 
+
+    varSignToVariance v = case filter (\p -> showPpr (fst p) == showPpr v) varsigns of
+                            []       -> Invariant
+                            [(_, b)] -> if b then Covariant else Contravariant
+                            _        -> Bivariant
+
+
+    goDCon dc = concatMap (go True) (DataCon.dataConOrigArgTys dc)
+
+    go pos (ForAllTy v t)  = go pos t
+    go pos (TyVarTy v)     = [(v, pos)]
+    go pos (AppTy t1 t2)   = go pos t1 ++ go pos t2
+    go pos (TyConApp c' ts) 
+       | c == c' 
+       = []
+{-
+ -- NV fix that: what happens if we have mutually recursive data types?
+ -- I cannot check them because the check will diverge  
+       | mutuallyRecursive c c'
+       = concat $ zipWith goTyConApp (repeat Bivariant) ts 
+-}
+       | otherwise 
+       = concat $ zipWith (goTyConApp pos) (makeTyConVariance c') ts
+
+    go pos (FunTy t1 t2)   = go (not pos) t1 ++ go pos t2
+    go _   (LitTy _)       = []
+
+    goTyConApp _   Invariant     _ = [] 
+    goTyConApp pos Bivariant     t = goTyConApp pos Contravariant t ++ goTyConApp pos Covariant t
+    goTyConApp pos Covariant     t = go pos       t 
+    goTyConApp pos Contravariant t = go (not pos) t 
+
+    varLookup v m = fromMaybe (errmsg v) $ L.lookup v m
+    errmsg v      = panic Nothing $ "GhcMisc.makeTyConVariance: var not found" ++ showPpr v
 
 
 --------------------------------------------------------------------------------

--- a/tests/neg/Variance1.hs
+++ b/tests/neg/Variance1.hs
@@ -1,0 +1,11 @@
+import Data.Binary
+
+
+{-@
+error :: { x : String | false } -> a
+@-}
+
+example :: Get ()
+example = do
+    _ <- return ()
+    error "URK"

--- a/tests/pos/Words.hs
+++ b/tests/pos/Words.hs
@@ -1,0 +1,5 @@
+import Data.Word
+
+{-@ foo :: {v:Word | v = 4} @-}
+foo :: Word
+foo = 4

--- a/tests/pos/Words1.hs
+++ b/tests/pos/Words1.hs
@@ -1,0 +1,3 @@
+import Data.Word
+
+main = print (quotRem (4 :: Word8) 128)


### PR DESCRIPTION
Fix for #638.

To compute variance we need to take into account the variance of the type constructors that appear in type definitions.

Before, we assumed all type constructors used in the definitions were covariant.