### PR TITLE
Add refinement types for the `bytestring` library

### DIFF
--- a/include/Data/ByteString.spec
+++ b/include/Data/ByteString.spec
@@ -1,0 +1,380 @@
+module spec Data.ByteString where
+
+measure bslen :: Data.ByteString.ByteString -> { n : Int | 0 <= n }
+
+invariant { bs : Data.ByteString.ByteString  | 0 <= bslen bs }
+
+assume empty :: { bs : Data.ByteString.ByteString | bslen bs == 0 }
+
+assume singleton
+    :: Data.Word.Word8 -> { bs : Data.ByteString.ByteString | bslen bs == 1 }
+
+assume pack
+    :: w8s : [Data.Word.Word8]
+    -> { bs : Data.ByteString.ByteString | bslen bs == len w8s }
+
+assume unpack
+    :: bs : Data.ByteString.ByteString
+    -> { w8s : [Data.Word.Word8] | len w8s == bslen bs }
+
+assume cons
+    :: Data.Word.Word8
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i + 1 }
+
+assume snoc
+    :: i : Data.ByteString.ByteString
+    -> Data.Word.Word8
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i + 1 }
+
+assume append
+    :: l : Data.ByteString.ByteString
+    -> r : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o == bslen l + bslen r }
+
+head :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Data.Word.Word8
+
+assume uncons
+    :: i : Data.ByteString.ByteString
+    -> Maybe (Data.Word.Word8, { o : Data.ByteString.ByteString | bslen o == bslen i - 1 })
+
+assume unsnoc
+    :: i : Data.ByteString.ByteString
+    -> Maybe ({ o : Data.ByteString.ByteString | bslen o == bslen i - 1 }, Data.Word.Word8)
+
+last :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Data.Word.Word8
+
+tail :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Data.Word.Word8
+
+init :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Data.Word.Word8
+
+assume null
+    :: bs : Data.ByteString.ByteString
+    -> { b : Bool | Prop b <=> bslen bs == 0 }
+
+assume length :: bs : Data.ByteString.ByteString -> { n : Int | bslen bs == n }
+
+assume map
+    :: (Data.Word.Word8 -> Data.Word.Word8)
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i }
+
+assume reverse
+    :: i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i }
+
+assume intersperse
+    :: Data.Word.Word8
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | (bslen i == 0 <=> bslen o == 0) && (1 <= bslen i <=> bslen o == 2 * bslen i - 1) }
+
+assume intercalate
+    :: l : Data.ByteString.ByteString
+    -> rs : [Data.ByteString.ByteString]
+    -> { o : Data.ByteString.ByteString | len rs == 0 ==> bslen o == 0 }
+
+assume transpose
+    :: is : [Data.ByteString.ByteString]
+    -> { os : [{ bs : Data.ByteString.ByteString | bslen bs <= len is }] | len is == 0 ==> len os == 0}
+
+foldl1
+    :: (Data.Word.Word8 -> Data.Word.Word8 -> Data.Word.Word8)
+    -> { bs : Data.ByteString.ByteString | 1 <= bslen bs }
+    -> Data.Word.Word8
+
+foldl1'
+    :: (Data.Word.Word8 -> Data.Word.Word8 -> Data.Word.Word8)
+    -> { bs : Data.ByteString.ByteString | 1 <= bslen bs }
+    -> Data.Word.Word8
+
+foldr1
+    :: (Data.Word.Word8 -> Data.Word.Word8 -> Data.Word.Word8)
+    -> { bs : Data.ByteString.ByteString | 1 <= bslen bs }
+    -> Data.Word.Word8
+
+foldr1'
+    :: (Data.Word.Word8 -> Data.Word.Word8 -> Data.Word.Word8)
+    -> { bs : Data.ByteString.ByteString | 1 <= bslen bs }
+    -> Data.Word.Word8
+
+assume concat
+    :: is : [Data.ByteString.ByteString]
+    -> { o : Data.ByteString.ByteString | len is == 0 ==> bslen o }
+
+assume concatMap
+    :: (Data.Word.Word8 -> Data.ByteString.ByteString)
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen i == 0 ==> bslen o == 0 }
+
+assume any :: (Data.Word.Word8 -> Bool)
+    -> bs : Data.ByteString.ByteString
+    -> { b : Bool | bslen bs == 0 ==> not (Prop b) }
+
+assume all :: (Data.Word.Word8 -> Bool)
+    -> bs : Data.ByteString.ByteString
+    -> { b : Bool | bslen bs == 0 ==> Prop b }
+
+maximum
+    :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Data.Word.Word8
+
+minimum
+    :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Data.Word.Word8
+
+assume scanl
+    :: (Data.Word.Word8 -> Data.Word.Word8 -> Data.Word.Word8)
+    -> Data.Word.Word8
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i }
+
+assume scanl1
+    :: (Data.Word.Word8 -> Data.Word.Word8 -> Data.Word.Word8)
+    -> i : { i : Data.ByteString.ByteString | 1 <= bslen i }
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i }
+
+assume scanr
+    :: (Data.Word.Word8 -> Data.Word.Word8 -> Data.Word.Word8)
+    -> Data.Word.Word8
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i }
+
+assume scanr1
+    :: (Data.Word.Word8 -> Data.Word.Word8 -> Data.Word.Word8)
+    -> i : { i : Data.ByteString.ByteString | 1 <= bslen i }
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i }
+
+assume mapAccumL
+    :: (acc -> Data.Word.Word8 -> (acc, Data.Word.Word8))
+    -> acc
+    -> i : Data.ByteString.ByteString
+    -> (acc, { o : Data.ByteString.ByteString | bslen o == bslen i })
+
+assume mapAccumR
+    :: (acc -> Data.Word.Word8 -> (acc, Data.Word.Word8))
+    -> acc
+    -> i : Data.ByteString.ByteString
+    -> (acc, { o : Data.ByteString.ByteString | bslen o == bslen i })
+
+assume replicate
+    :: n : Int
+    -> Data.Word.Word8
+    -> { bs : Data.ByteString.ByteString | bslen bs == n }
+
+assume unfoldrN
+    :: n : Int
+    -> (a -> Maybe (Data.Word.Word8, a))
+    -> a
+    -> ({ bs : Data.ByteString.ByteString | bslen bs <= n }, Maybe a)
+
+assume take
+    :: n : Int
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | (n <= 0 <=> bslen o == 0) &&
+                                          ((0 <= n && n <= bslen i) <=> bslen o == n) &&
+                                          (bslen i <= n <=> bslen o = bslen i) }
+
+assume drop
+    :: n : Int
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | (n <= 0 <=> bslen o == bslen i) &&
+                                          ((0 <= n && n <= bslen i) <=> bslen o == bslen i - n) &&
+                                          (bslen i <= n <=> bslen o == 0) }
+
+assume splitAt
+    :: n : Int
+    -> i : Data.ByteString.ByteString
+    -> ( { l : Data.ByteString.ByteString | (n <= 0 <=> bslen l == 0) &&
+                                            ((0 <= n && n <= bslen i) <=> bslen l == n) &&
+                                            (bslen i <= n <=> bslen l == bslen i) }
+       , { r : Data.ByteString.ByteString | (n <= 0 <=> bslen r == bslen i) &&
+                                            ((0 <= n && n <= bslen i) <=> bslen r == bslen i - n) &&
+                                            (bslen i <= n <=> bslen r == 0) }
+       )
+
+assume takeWhile
+    :: (Data.Word.Word8 -> Bool)
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o <= bslen i }
+
+assume dropWhile
+    :: (Data.Word.Word8 -> Bool)
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o <= bslen i }
+
+assume span
+    :: (Data.Word.Word8 -> Bool)
+    -> i : Data.ByteString.ByteString
+    -> ( { l : Data.ByteString.ByteString | bslen l <= bslen i }
+       , { r : Data.ByteString.ByteString | bslen r <= bslen i }
+       )
+
+assume spanEnd
+    :: (Data.Word.Word8 -> Bool)
+    -> i : Data.ByteString.ByteString
+    -> ( { l : Data.ByteString.ByteString | bslen l <= bslen i }
+       , { r : Data.ByteString.ByteString | bslen r <= bslen i }
+       )
+
+assume break
+    :: (Data.Word.Word8 -> Bool)
+    -> i : Data.ByteString.ByteString
+    -> ( { l : Data.ByteString.ByteString | bslen l <= bslen i }
+       , { r : Data.ByteString.ByteString | bslen r <= bslen i }
+       )
+
+assume breakEnd
+    :: (Data.Word.Word8 -> Bool)
+    -> i : Data.ByteString.ByteString
+    -> ( { l : Data.ByteString.ByteString | bslen l <= bslen i }
+       , { r : Data.ByteString.ByteString | bslen r <= bslen i }
+       )
+
+assume group
+    :: i : Data.ByteString.ByteString
+    -> [{ o : Data.ByteString.ByteString | 1 <= bslen o && bslen o <= bslen i }]
+
+assume groupBy
+    :: (Data.Word.Word8 -> Data.Word.Word8 -> Bool)
+    -> i : Data.ByteString.ByteString
+    -> [{ o : Data.ByteString.ByteString | 1 <= bslen o && bslen o <= bslen i }]
+
+assume inits
+    :: i : Data.ByteString.ByteString
+    -> [{ o : Data.ByteString.ByteString | bslen o <= bslen i }]
+
+assume tails
+    :: i : Data.ByteString.ByteString
+    -> [{ o : Data.ByteString.ByteString | bslen o <= bslen i }]
+
+assume split
+    :: Data.Word.Word8
+    -> i : Data.ByteString.ByteString
+    -> [{ o : Data.ByteString.ByteString | bslen o <= bslen i }]
+
+assume splitWith
+    :: (Data.Word.Word8 -> Bool)
+    -> i : Data.ByteString.ByteString
+    -> [{ o : Data.ByteString.ByteString | bslen o <= bslen i }]
+
+assume isPrefixOf
+    :: l : Data.ByteString.ByteString
+    -> r : Data.ByteString.ByteString
+    -> { b : Bool | bslen l >= bslen r ==> not (Prop b) }
+
+assume isSuffixOf
+    :: l : Data.ByteString.ByteString
+    -> r : Data.ByteString.ByteString
+    -> { b : Bool | bslen l > bslen r ==> not (Prop b) }
+
+assume isInfixOf
+    :: l : Data.ByteString.ByteString
+    -> r : Data.ByteString.ByteString
+    -> { b : Bool | bslen l > bslen r ==> not (Prop b) }
+
+assume breakSubstring
+    :: il : Data.ByteString.ByteString
+    -> ir : Data.ByteString.ByteString
+    -> ( { ol : Data.ByteString.ByteString | bslen ol <= bslen ir && (bslen il > bslen ir ==> bslen ol == bslen ir)}
+       , { or : Data.ByteString.ByteString | bslen or <= bslen ir && (bslen il > bslen ir ==> bslen or == 0) }
+       )
+
+assume elem
+    :: Data.Word.Word8
+    -> bs : Data.ByteString.ByteString
+    -> { b : Bool | bslen b == 0 ==> not (Prop b) }
+
+assume notElem
+    :: Data.Word.Word8
+    -> bs : Data.ByteString.ByteString
+    -> { b : Bool | bslen b == 0 ==> Prop b }
+
+assume find
+    :: (Data.Word.Word8 -> Bool)
+    -> bs : Data.ByteString.ByteString
+    -> Maybe { w8 : Data.Word.Word8 | bslen bs /= 0 }
+
+assume filter
+    :: (Data.Word.Word8 -> Bool)
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o <= bslen i }
+
+assume partition
+    :: (Data.Word.Word8 -> Bool)
+    -> i : Data.ByteString.ByteString
+    -> ( { l : Data.ByteString.ByteString | bslen l <= bslen i }
+       , { r : Data.ByteString.ByteString | bslen r <= bslen i }
+       )
+
+index
+    :: bs : Data.ByteString.ByteString
+    -> { n : Int | 0 <= n && n < bslen bs }
+    -> Data.Word.Word8
+
+assume elemIndex
+    :: Data.Word.Word8
+    -> bs : Data.ByteString.ByteString
+    -> Maybe { n : Int | 0 <= n && n < bslen bs }
+
+assume elemIndices
+    :: Data.Word.Word8
+    -> bs : Data.ByteString.ByteString
+    -> [{ n : Int | 0 <= n && n < bslen bs }]
+
+assume elemIndexEnd
+    :: Data.Word.Word8
+    -> bs : Data.ByteString.ByteString
+    -> Maybe { n : Int | 0 <= n && n < bslen bs }
+
+assume findIndex
+    :: (Data.Word.Word8 -> Bool)
+    -> bs : Data.ByteString.ByteString
+    -> Maybe { n : Int | 0 <= n && n < bslen bs }
+
+assume findIndices
+    :: (Data.Word.Word8 -> Bool)
+    -> bs : Data.ByteString.ByteString
+    -> [{ n : Int | 0 <= n && n < bslen bs }]
+
+assume count
+    :: Data.Word.Word8
+    -> bs : Data.ByteString.ByteString
+    -> { n : Int | 0 <= n && n < bslen bs }
+
+assume zip
+    :: l : Data.ByteString.ByteString
+    -> r : Data.ByteString.ByteString
+    -> { o : [(Data.Word.Word8, Data.Word.Word8)] | len o <= bslen l && len o <= bslen r }
+
+assume zipWith
+    :: (Data.Word.Word8 -> Data.Word.Word8 -> a)
+    -> l : Data.ByteString.ByteString
+    -> r : Data.ByteString.ByteString
+    -> { o : [a] | len o <= bslen l && len o <= bslen r }
+
+assume unzip
+    :: i : [(Data.Word.Word8, Data.Word.Word8)]
+    -> ( { l : Data.ByteString.ByteString | bslen l == len i }
+       , { r : Data.ByteString.ByteString | bslen r == len i }
+       )
+
+assume sort
+    :: i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i }
+
+assume copy
+    :: i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i }
+
+assume hGet
+    :: System.IO.Handle
+    -> n : { n : Int | 0 <= n }
+    -> IO { bs : Data.ByteString.ByteString | bslen bs == n || bslen bs == 0 }
+
+assume hGetSome
+    :: System.IO.Handle
+    -> n : { n : Int | 0 <= n }
+    -> IO { bs : Data.ByteString.ByteString | bslen bs <= n }
+
+assume hGetNonBlocking
+    :: System.IO.Handle
+    -> n : { n : Int | 0 <= n }
+    -> IO { bs : Data.ByteString.ByteString | bslen bs <= n }

--- a/include/Data/ByteString/Char8.spec
+++ b/include/Data/ByteString/Char8.spec
@@ -1,0 +1,400 @@
+module spec Data.ByteString.Char8 where
+
+assume empty :: { bs : Data.ByteString.ByteString | bslen bs == 0 }
+
+assume singleton
+    :: Char -> { bs : Data.ByteString.ByteString | bslen bs == 1 }
+
+assume pack
+    :: w8s : [Char]
+    -> { bs : Data.ByteString.ByteString | bslen bs == len w8s }
+
+assume unpack
+    :: bs : Data.ByteString.ByteString
+    -> { w8s : [Char] | len w8s == bslen bs }
+
+assume cons
+    :: Char
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i + 1 }
+
+assume snoc
+    :: i : Data.ByteString.ByteString
+    -> Char
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i + 1 }
+
+assume append
+    :: l : Data.ByteString.ByteString
+    -> r : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o == bslen l + bslen r }
+
+head :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Char
+
+assume uncons
+    :: i : Data.ByteString.ByteString
+    -> Maybe (Char, { o : Data.ByteString.ByteString | bslen o == bslen i - 1 })
+
+assume unsnoc
+    :: i : Data.ByteString.ByteString
+    -> Maybe ({ o : Data.ByteString.ByteString | bslen o == bslen i - 1 }, Char)
+
+last :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Char
+
+tail :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Char
+
+init :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Char
+
+assume null
+    :: bs : Data.ByteString.ByteString
+    -> { b : Bool | Prop b <=> bslen bs == 0 }
+
+assume length :: bs : Data.ByteString.ByteString -> { n : Int | bslen bs == n }
+
+assume map
+    :: (Char -> Char)
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i }
+
+assume reverse
+    :: i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i }
+
+assume intersperse
+    :: Char
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | (bslen i == 0 <=> bslen o == 0) && (1 <= bslen i <=> bslen o == 2 * bslen i - 1) }
+
+assume intercalate
+    :: l : Data.ByteString.ByteString
+    -> rs : [Data.ByteString.ByteString]
+    -> { o : Data.ByteString.ByteString | len rs == 0 ==> bslen o == 0 }
+
+assume transpose
+    :: is : [Data.ByteString.ByteString]
+    -> { os : [{ bs : Data.ByteString.ByteString | bslen bs <= len is }] | len is == 0 ==> len os == 0}
+
+foldl1
+    :: (Char -> Char -> Char)
+    -> { bs : Data.ByteString.ByteString | 1 <= bslen bs }
+    -> Char
+
+foldl1'
+    :: (Char -> Char -> Char)
+    -> { bs : Data.ByteString.ByteString | 1 <= bslen bs }
+    -> Char
+
+foldr1
+    :: (Char -> Char -> Char)
+    -> { bs : Data.ByteString.ByteString | 1 <= bslen bs }
+    -> Char
+
+foldr1'
+    :: (Char -> Char -> Char)
+    -> { bs : Data.ByteString.ByteString | 1 <= bslen bs }
+    -> Char
+
+assume concat
+    :: is : [Data.ByteString.ByteString]
+    -> { o : Data.ByteString.ByteString | len is == 0 ==> bslen o }
+
+assume concatMap
+    :: (Char -> Data.ByteString.ByteString)
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen i == 0 ==> bslen o == 0 }
+
+assume any :: (Char -> Bool)
+    -> bs : Data.ByteString.ByteString
+    -> { b : Bool | bslen bs == 0 ==> not (Prop b) }
+
+assume all :: (Char -> Bool)
+    -> bs : Data.ByteString.ByteString
+    -> { b : Bool | bslen bs == 0 ==> Prop b }
+
+maximum
+    :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Char
+
+minimum
+    :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Char
+
+assume scanl
+    :: (Char -> Char -> Char)
+    -> Char
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i }
+
+assume scanl1
+    :: (Char -> Char -> Char)
+    -> i : { i : Data.ByteString.ByteString | 1 <= bslen i }
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i }
+
+assume scanr
+    :: (Char -> Char -> Char)
+    -> Char
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i }
+
+assume scanr1
+    :: (Char -> Char -> Char)
+    -> i : { i : Data.ByteString.ByteString | 1 <= bslen i }
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i }
+
+assume mapAccumL
+    :: (acc -> Char -> (acc, Char))
+    -> acc
+    -> i : Data.ByteString.ByteString
+    -> (acc, { o : Data.ByteString.ByteString | bslen o == bslen i })
+
+assume mapAccumR
+    :: (acc -> Char -> (acc, Char))
+    -> acc
+    -> i : Data.ByteString.ByteString
+    -> (acc, { o : Data.ByteString.ByteString | bslen o == bslen i })
+
+assume replicate
+    :: n : Int
+    -> Char
+    -> { bs : Data.ByteString.ByteString | bslen bs == n }
+
+assume unfoldrN
+    :: n : Int
+    -> (a -> Maybe (Char, a))
+    -> a
+    -> ({ bs : Data.ByteString.ByteString | bslen bs <= n }, Maybe a)
+
+assume take
+    :: n : Int
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | (n <= 0 <=> bslen o == 0) &&
+                                          ((0 <= n && n <= bslen i) <=> bslen o == n) &&
+                                          (bslen i <= n <=> bslen o = bslen i) }
+
+assume drop
+    :: n : Int
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | (n <= 0 <=> bslen o == bslen i) &&
+                                          ((0 <= n && n <= bslen i) <=> bslen o == bslen i - n) &&
+                                          (bslen i <= n <=> bslen o == 0) }
+
+assume splitAt
+    :: n : Int
+    -> i : Data.ByteString.ByteString
+    -> ( { l : Data.ByteString.ByteString | (n <= 0 <=> bslen l == 0) &&
+                                            ((0 <= n && n <= bslen i) <=> bslen l == n) &&
+                                            (bslen i <= n <=> bslen l == bslen i) }
+       , { r : Data.ByteString.ByteString | (n <= 0 <=> bslen r == bslen i) &&
+                                            ((0 <= n && n <= bslen i) <=> bslen r == bslen i - n) &&
+                                            (bslen i <= n <=> bslen r == 0) }
+       )
+
+assume takeWhile
+    :: (Char -> Bool)
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o <= bslen i }
+
+assume dropWhile
+    :: (Char -> Bool)
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o <= bslen i }
+
+assume span
+    :: (Char -> Bool)
+    -> i : Data.ByteString.ByteString
+    -> ( { l : Data.ByteString.ByteString | bslen l <= bslen i }
+       , { r : Data.ByteString.ByteString | bslen r <= bslen i }
+       )
+
+assume spanEnd
+    :: (Char -> Bool)
+    -> i : Data.ByteString.ByteString
+    -> ( { l : Data.ByteString.ByteString | bslen l <= bslen i }
+       , { r : Data.ByteString.ByteString | bslen r <= bslen i }
+       )
+
+assume break
+    :: (Char -> Bool)
+    -> i : Data.ByteString.ByteString
+    -> ( { l : Data.ByteString.ByteString | bslen l <= bslen i }
+       , { r : Data.ByteString.ByteString | bslen r <= bslen i }
+       )
+
+assume breakEnd
+    :: (Char -> Bool)
+    -> i : Data.ByteString.ByteString
+    -> ( { l : Data.ByteString.ByteString | bslen l <= bslen i }
+       , { r : Data.ByteString.ByteString | bslen r <= bslen i }
+       )
+
+assume group
+    :: i : Data.ByteString.ByteString
+    -> [{ o : Data.ByteString.ByteString | 1 <= bslen o && bslen o <= bslen i }]
+
+assume groupBy
+    :: (Char -> Char -> Bool)
+    -> i : Data.ByteString.ByteString
+    -> [{ o : Data.ByteString.ByteString | 1 <= bslen o && bslen o <= bslen i }]
+
+assume inits
+    :: i : Data.ByteString.ByteString
+    -> [{ o : Data.ByteString.ByteString | bslen o <= bslen i }]
+
+assume tails
+    :: i : Data.ByteString.ByteString
+    -> [{ o : Data.ByteString.ByteString | bslen o <= bslen i }]
+
+assume split
+    :: Char
+    -> i : Data.ByteString.ByteString
+    -> [{ o : Data.ByteString.ByteString | bslen o <= bslen i }]
+
+assume splitWith
+    :: (Char -> Bool)
+    -> i : Data.ByteString.ByteString
+    -> [{ o : Data.ByteString.ByteString | bslen o <= bslen i }]
+
+assume lines
+    :: i : Data.ByteString.ByteString
+    -> [{ o : Data.ByteString.ByteString | bslen o <= bslen i }]
+
+assume words
+    :: i : Data.ByteString.ByteString
+    -> [{ o : Data.ByteString.ByteString | bslen o <= bslen i }]
+
+assume unlines
+    :: is : [Data.ByteString.ByteString]
+    -> { o : Data.ByteString.ByteString | (len is == 0 <=> bslen o == 0) && bslen o >= len is }
+
+assume unwords
+    :: is : [Data.ByteString.ByteString]
+    -> { o : Data.ByteString.ByteString | (len is == 0 ==> bslen o == 0) && (1 <= len is ==> bslen o >= len is - 1) }
+
+assume isPrefixOf
+    :: l : Data.ByteString.ByteString
+    -> r : Data.ByteString.ByteString
+    -> { b : Bool | bslen l >= bslen r ==> not (Prop b) }
+
+assume isSuffixOf
+    :: l : Data.ByteString.ByteString
+    -> r : Data.ByteString.ByteString
+    -> { b : Bool | bslen l > bslen r ==> not (Prop b) }
+
+assume isInfixOf
+    :: l : Data.ByteString.ByteString
+    -> r : Data.ByteString.ByteString
+    -> { b : Bool | bslen l > bslen r ==> not (Prop b) }
+
+assume breakSubstring
+    :: il : Data.ByteString.ByteString
+    -> ir : Data.ByteString.ByteString
+    -> ( { ol : Data.ByteString.ByteString | bslen ol <= bslen ir && (bslen il > bslen ir ==> bslen ol == bslen ir)}
+       , { or : Data.ByteString.ByteString | bslen or <= bslen ir && (bslen il > bslen ir ==> bslen or == 0) }
+       )
+
+assume elem
+    :: Char
+    -> bs : Data.ByteString.ByteString
+    -> { b : Bool | bslen b == 0 ==> not (Prop b) }
+
+assume notElem
+    :: Char
+    -> bs : Data.ByteString.ByteString
+    -> { b : Bool | bslen b == 0 ==> Prop b }
+
+assume find
+    :: (Char -> Bool)
+    -> bs : Data.ByteString.ByteString
+    -> Maybe { w8 : Char | bslen bs /= 0 }
+
+assume filter
+    :: (Char -> Bool)
+    -> i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o <= bslen i }
+
+assume partition
+    :: (Char -> Bool)
+    -> i : Data.ByteString.ByteString
+    -> ( { l : Data.ByteString.ByteString | bslen l <= bslen i }
+       , { r : Data.ByteString.ByteString | bslen r <= bslen i }
+       )
+
+index
+    :: bs : Data.ByteString.ByteString
+    -> { n : Int | 0 <= n && n < bslen bs }
+    -> Char
+
+assume elemIndex
+    :: Char
+    -> bs : Data.ByteString.ByteString
+    -> Maybe { n : Int | 0 <= n && n < bslen bs }
+
+assume elemIndices
+    :: Char
+    -> bs : Data.ByteString.ByteString
+    -> [{ n : Int | 0 <= n && n < bslen bs }]
+
+assume elemIndexEnd
+    :: Char
+    -> bs : Data.ByteString.ByteString
+    -> Maybe { n : Int | 0 <= n && n < bslen bs }
+
+assume findIndex
+    :: (Char -> Bool)
+    -> bs : Data.ByteString.ByteString
+    -> Maybe { n : Int | 0 <= n && n < bslen bs }
+
+assume findIndices
+    :: (Char -> Bool)
+    -> bs : Data.ByteString.ByteString
+    -> [{ n : Int | 0 <= n && n < bslen bs }]
+
+assume count
+    :: Char
+    -> bs : Data.ByteString.ByteString
+    -> { n : Int | 0 <= n && n < bslen bs }
+
+assume zip
+    :: l : Data.ByteString.ByteString
+    -> r : Data.ByteString.ByteString
+    -> { o : [(Char, Char)] | len o <= bslen l && len o <= bslen r }
+
+assume zipWith
+    :: (Char -> Char -> a)
+    -> l : Data.ByteString.ByteString
+    -> r : Data.ByteString.ByteString
+    -> { o : [a] | len o <= bslen l && len o <= bslen r }
+
+assume unzip
+    :: i : [(Char, Char)]
+    -> ( { l : Data.ByteString.ByteString | bslen l == len i }
+       , { r : Data.ByteString.ByteString | bslen r == len i }
+       )
+
+assume sort
+    :: i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i }
+
+assume readInt
+    :: i : Data.ByteString.ByteString
+    -> Maybe { p : (Int, { o : Data.ByteString.ByteString | bslen o < bslen i}) | bslen i /= 0 }
+
+assume readInteger
+    :: i : Data.ByteString.ByteString
+    -> Maybe { p : (Integer, { o : Data.ByteString.ByteString | bslen o < bslen i}) | bslen i /= 0 }
+
+assume copy
+    :: i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i }
+
+assume hGet
+    :: System.IO.Handle
+    -> n : { n : Int | 0 <= n }
+    -> IO { bs : Data.ByteString.ByteString | bslen bs == n || bslen bs == 0 }
+
+assume hGetSome
+    :: System.IO.Handle
+    -> n : { n : Int | 0 <= n }
+    -> IO { bs : Data.ByteString.ByteString | bslen bs <= n }
+
+assume hGetNonBlocking
+    :: System.IO.Handle
+    -> n : { n : Int | 0 <= n }
+    -> IO { bs : Data.ByteString.ByteString | bslen bs <= n }

--- a/include/Data/ByteString/Lazy.spec
+++ b/include/Data/ByteString/Lazy.spec
@@ -1,0 +1,397 @@
+module spec Data.ByteString.Lazy where
+
+measure bllen :: Data.ByteString.Lazy.ByteString -> { n : Data.Int.Int64 | 0 <= n }
+
+invariant { bs : Data.ByteString.Lazy.ByteString | 0 <= bllen bs }
+
+assume empty :: { bs : Data.ByteString.Lazy.ByteString | bllen bs == 0 }
+
+assume singleton
+    :: Data.Word.Word8 -> { bs : Data.ByteString.Lazy.ByteString | bllen bs == 1 }
+
+assume pack
+    :: w8s : [Data.Word.Word8]
+    -> { bs : Data.ByteString.ByteString | bllen bs == len w8s }
+
+assume unpack
+    :: bs : Data.ByteString.Lazy.ByteString
+    -> { w8s : [Data.Word.Word8] | len w8s == bllen bs }
+
+assume fromStrict
+    :: i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bslen i }
+
+assume toStrict
+    :: i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o == bllen i }
+
+assume fromChunks
+    :: i : [Data.ByteString.ByteString]
+    -> { o : Data.ByteString.Lazy.ByteString | len i == 0 <=> bllen o == 0 }
+
+assume toChunks
+    :: i : Data.ByteString.Lazy.ByteString
+    -> { os : [{ o : Data.ByteString.ByteString | bslen o <= bllen i}] | len os == 0 <=> bllen i == 0 }
+
+assume cons
+    :: Data.Word.Word8
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i + 1 }
+
+assume snoc
+    :: i : Data.ByteString.Lazy.ByteString
+    -> Data.Word.Word8
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i + 1 }
+
+assume append
+    :: l : Data.ByteString.Lazy.ByteString
+    -> r : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen l + bllen r }
+
+head
+    :: { bs : Data.ByteString.Lazy.ByteString | 1 <= bllen bs }
+    -> Data.Word.Word8
+
+assume uncons
+    :: i : Data.ByteString.Lazy.ByteString
+    -> Maybe (Data.Word.Word8, { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i - 1 })
+
+assume unsnoc
+    :: i : Data.ByteString.Lazy.ByteString
+    -> Maybe ({ o : Data.ByteString.Lazy.ByteString | bllen o == bllen i - 1 }, Data.Word.Word8)
+
+last
+    :: { bs : Data.ByteString.Lazy.ByteString | 1 <= bllen bs }
+    -> Data.Word.Word8
+
+tail
+    :: { bs : Data.ByteString.Lazy.ByteString | 1 <= bllen bs }
+    -> Data.Word.Word8
+
+init
+    :: { bs : Data.ByteString.Lazy.ByteString | 1 <= bllen bs }
+    -> Data.Word.Word8
+
+assume null
+    :: bs : Data.ByteString.Lazy.ByteString
+    -> { b : Bool | Prop b <=> bllen bs == 0 }
+
+assume length
+    :: bs : Data.ByteString.Lazy.ByteString -> { n : Data.Int.Int64 | bllen bs == n }
+
+assume map
+    :: (Data.Word.Word8 -> Data.Word.Word8)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i }
+
+assume reverse
+    :: i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i }
+
+assume intersperse
+    :: Data.Word.Word8
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | (bllen i == 0 <=> bllen o == 0) && (1 <= bllen i <=> bllen o == 2 * bllen i - 1) }
+
+assume intercalate
+    :: l : Data.ByteString.Lazy.ByteString
+    -> rs : [Data.ByteString.Lazy.ByteString]
+    -> { o : Data.ByteString.Lazy.ByteString | len rs == 0 ==> bllen o == 0 }
+
+assume transpose
+    :: is : [Data.ByteString.Lazy.ByteString]
+    -> { os : [{ bs : Data.ByteString.Lazy.ByteString | bllen bs <= len is }] | len is == 0 ==> len os == 0}
+
+foldl1
+    :: (Data.Word.Word8 -> Data.Word.Word8 -> Data.Word.Word8)
+    -> { bs : Data.ByteString.Lazy.ByteString | 1 <= bllen bs }
+    -> Data.Word.Word8
+
+foldl1'
+    :: (Data.Word.Word8 -> Data.Word.Word8 -> Data.Word.Word8)
+    -> { bs : Data.ByteString.Lazy.ByteString | 1 <= bllen bs }
+    -> Data.Word.Word8
+
+foldr1
+    :: (Data.Word.Word8 -> Data.Word.Word8 -> Data.Word.Word8)
+    -> { bs : Data.ByteString.Lazy.ByteString | 1 <= bllen bs }
+    -> Data.Word.Word8
+
+foldr1'
+    :: (Data.Word.Word8 -> Data.Word.Word8 -> Data.Word.Word8)
+    -> { bs : Data.ByteString.Lazy.ByteString | 1 <= bllen bs }
+    -> Data.Word.Word8
+
+assume concat
+    :: is : [Data.ByteString.Lazy.ByteString]
+    -> { o : Data.ByteString.Lazy.ByteString | len is == 0 ==> bllen o }
+
+assume concatMap
+    :: (Data.Word.Word8 -> Data.ByteString.Lazy.ByteString)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen i == 0 ==> bllen o == 0 }
+
+assume any :: (Data.Word.Word8 -> Bool)
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> { b : Bool | bllen bs == 0 ==> not (Prop b) }
+
+assume all :: (Data.Word.Word8 -> Bool)
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> { b : Bool | bllen bs == 0 ==> Prop b }
+
+maximum :: { bs : Data.ByteString.Lazy.ByteString | 1 <= bllen bs } -> Data.Word.Word8
+
+minimum :: { bs : Data.ByteString.Lazy.ByteString | 1 <= bllen bs } -> Data.Word.Word8
+
+assume scanl
+    :: (Data.Word.Word8 -> Data.Word.Word8 -> Data.Word.Word8)
+    -> Data.Word.Word8
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i }
+
+assume scanl1
+    :: (Data.Word.Word8 -> Data.Word.Word8 -> Data.Word.Word8)
+    -> i : { i : Data.ByteString.Lazy.ByteString | 1 <= bllen i }
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i }
+
+assume scanr
+    :: (Data.Word.Word8 -> Data.Word.Word8 -> Data.Word.Word8)
+    -> Data.Word.Word8
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i }
+
+assume scanr1
+    :: (Data.Word.Word8 -> Data.Word.Word8 -> Data.Word.Word8)
+    -> i : { i : Data.ByteString.Lazy.ByteString | 1 <= bllen i }
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i }
+
+assume mapAccumL
+    :: (acc -> Data.Word.Word8 -> (acc, Data.Word.Word8))
+    -> acc
+    -> i : Data.ByteString.Lazy.ByteString
+    -> (acc, { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i })
+
+assume mapAccumR
+    :: (acc -> Data.Word.Word8 -> (acc, Data.Word.Word8))
+    -> acc
+    -> i : Data.ByteString.Lazy.ByteString
+    -> (acc, { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i })
+
+assume replicate
+    :: n : Data.Int.Int64
+    -> Data.Word.Word8
+    -> { bs : Data.ByteString.Lazy.ByteString | bllen bs == n }
+
+assume unfoldrN
+    :: n : Int
+    -> (a -> Maybe (Data.Word.Word8, a))
+    -> a
+    -> ({ bs : Data.ByteString.Lazy.ByteString | bllen bs <= n }, Maybe a)
+
+assume take
+    :: n : Data.Int.Int64
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | (n <= 0 ==> bllen o == 0) &&
+                                               ((0 <= n && n <= bllen i) <=> bllen o == n) &&
+                                               (bllen i <= n <=> bllen o = bllen i) }
+
+assume drop
+    :: n : Data.Int.Int64
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | (n <= 0 <=> bllen o == bllen i) &&
+                                               ((0 <= n && n <= bllen i) <=> bllen o == bllen i - n) &&
+                                               (bllen i <= n <=> bllen o == 0) }
+
+assume splitAt
+    :: n : Data.Int.Int64
+    -> i : Data.ByteString.Lazy.ByteString
+    -> ( { l : Data.ByteString.Lazy.ByteString | (n <= 0 <=> bllen l == 0) &&
+                                                 ((0 <= n && n <= bllen i) <=> bllen l == n) &&
+                                                 (bllen i <= n <=> bllen l == bllen i) }
+       , { r : Data.ByteString.Lazy.ByteString | (n <= 0 <=> bllen r == bllen i) &&
+                                                 ((0 <= n && n <= bllen i) <=> bllen r == bllen i - n) &&
+                                                 (bllen i <= n <=> bllen r == 0) }
+       )
+
+assume takeWhile
+    :: (Data.Word.Word8 -> Bool)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o <= bllen i }
+
+assume dropWhile
+    :: (Data.Word.Word8 -> Bool)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o <= bllen i }
+
+assume span
+    :: (Data.Word.Word8 -> Bool)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> ( { l : Data.ByteString.Lazy.ByteString | bllen l <= bllen i }
+       , { r : Data.ByteString.Lazy.ByteString | bllen r <= bllen i }
+       )
+
+assume spanEnd
+    :: (Data.Word.Word8 -> Bool)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> ( { l : Data.ByteString.Lazy.ByteString | bllen l <= bllen i }
+       , { r : Data.ByteString.Lazy.ByteString | bllen r <= bllen i }
+       )
+
+assume break
+    :: (Data.Word.Word8 -> Bool)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> ( { l : Data.ByteString.Lazy.ByteString | bllen l <= bllen i }
+       , { r : Data.ByteString.Lazy.ByteString | bllen r <= bllen i }
+       )
+
+assume breakEnd
+    :: (Data.Word.Word8 -> Bool)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> ( { l : Data.ByteString.Lazy.ByteString | bllen l <= bllen i }
+       , { r : Data.ByteString.Lazy.ByteString | bllen r <= bllen i }
+       )
+assume group
+    :: i : Data.ByteString.Lazy.ByteString
+    -> [{ o : Data.ByteString.Lazy.ByteString | 1 <= bllen o && bllen o <= bllen i }]
+
+assume groupBy
+    :: (Data.Word.Word8 -> Data.Word.Word8 -> Bool)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> [{ o : Data.ByteString.Lazy.ByteString | 1 <= bllen o && bllen o <= bllen i }]
+
+assume inits
+    :: i : Data.ByteString.Lazy.ByteString
+    -> [{ o : Data.ByteString.Lazy.ByteString | bllen o <= bllen i }]
+
+assume tails
+    :: i : Data.ByteString.Lazy.ByteString
+    -> [{ o : Data.ByteString.Lazy.ByteString | bllen o <= bllen i }]
+
+assume split
+    :: Data.Word.Word8
+    -> i : Data.ByteString.Lazy.ByteString
+    -> [{ o : Data.ByteString.Lazy.ByteString | bllen o <= bllen i }]
+
+assume splitWith
+    :: (Data.Word.Word8 -> Bool)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> [{ o : Data.ByteString.Lazy.ByteString | bllen o <= bllen i }]
+
+assume isPrefixOf
+    :: l : Data.ByteString.Lazy.ByteString
+    -> r : Data.ByteString.Lazy.ByteString
+    -> { b : Bool | bllen l >= bllen r ==> not (Prop b) }
+
+assume isSuffixOf
+    :: l : Data.ByteString.Lazy.ByteString
+    -> r : Data.ByteString.Lazy.ByteString
+    -> { b : Bool | bllen l >= bllen r ==> not (Prop b) }
+
+assume isInfixOf
+    :: l : Data.ByteString.Lazy.ByteString
+    -> r : Data.ByteString.Lazy.ByteString
+    -> { b : Bool | bllen l >= bllen r ==> not (Prop b) }
+
+assume breakSubstring
+    :: il : Data.ByteString.Lazy.ByteString
+    -> ir : Data.ByteString.Lazy.ByteString
+    -> ( { ol : Data.ByteString.Lazy.ByteString | bllen ol <= bllen ir && (bllen il > bllen ir ==> bllen ol == bllen ir)}
+       , { or : Data.ByteString.Lazy.ByteString | bllen or <= bllen ir && (bllen il > bllen ir ==> bllen or == 0) }
+       )
+
+assume elem
+    :: Data.Word.Word8
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> { b : Bool | bllen b == 0 ==> not (Prop b) }
+
+assume notElem
+    :: Data.Word.Word8
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> { b : Bool | bllen b == 0 ==> Prop b }
+
+assume find
+    :: (Data.Word.Word8 -> Bool)
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> Maybe { w8 : Data.Word.Word8 | bllen bs /= 0 }
+
+assume filter
+    :: (Data.Word.Word8 -> Bool)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o <= bllen i }
+
+assume partition
+    :: (Data.Word.Word8 -> Bool)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> ( { l : Data.ByteString.Lazy.ByteString | bllen l <= bllen i }
+       , { r : Data.ByteString.Lazy.ByteString | bllen r <= bllen i }
+       )
+
+index
+    :: bs : Data.ByteString.Lazy.ByteString
+    -> { n : Data.Int.Int64 | 0 <= n && n < bllen bs }
+    -> Data.Word.Word8
+
+assume elemIndex
+    :: Data.Word.Word8
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> Maybe { n : Data.Int.Int64 | 0 <= n && n < bllen bs }
+
+assume elemIndices
+    :: Data.Word.Word8
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> [{ n : Data.Int.Int64 | 0 <= n && n < bllen bs }]
+
+assume elemIndexEnd
+    :: Data.Word.Word8
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> Maybe { n : Data.Int.Int64 | 0 <= n && n < bllen bs }
+
+assume findIndex
+    :: (Data.Word.Word8 -> Bool)
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> Maybe { n : Data.Int.Int64 | 0 <= n && n < bllen bs }
+
+assume findIndices
+    :: (Data.Word.Word8 -> Bool)
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> [{ n : Data.Int.Int64 | 0 <= n && n < bllen bs }]
+
+assume count
+    :: Data.Word.Word8
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> { n : Data.Int.Int64 | 0 <= n && n < bllen bs }
+
+assume zip
+    :: l : Data.ByteString.Lazy.ByteString
+    -> r : Data.ByteString.Lazy.ByteString
+    -> { o : [(Data.Word.Word8, Data.Word.Word8)] | len o <= bllen l && len o <= bllen r }
+
+assume zipWith
+    :: (Data.Word.Word8 -> Data.Word.Word8 -> a)
+    -> l : Data.ByteString.Lazy.ByteString
+    -> r : Data.ByteString.Lazy.ByteString
+    -> { o : [a] | len o <= bllen l && len o <= bllen r }
+
+assume unzip
+    :: i : [(Data.Word.Word8, Data.Word.Word8)]
+    -> ( { l : Data.ByteString.Lazy.ByteString | bllen l == len i }
+       , { r : Data.ByteString.Lazy.ByteString | bllen r == len i }
+       )
+
+assume sort
+    :: i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i }
+
+assume copy
+    :: i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i }
+
+assume hGet
+    :: System.IO.Handle
+    -> n : { n : Int | 0 <= n }
+    -> IO { bs : Data.ByteString.Lazy.ByteString | bllen bs == n || bllen bs == 0 }
+
+assume hGetNonBlocking
+    :: System.IO.Handle
+    -> n : { n : Int | 0 <= n }
+    -> IO { bs : Data.ByteString.Lazy.ByteString | bllen bs <= n }

--- a/include/Data/ByteString/Lazy/Char8.spec
+++ b/include/Data/ByteString/Lazy/Char8.spec
@@ -1,0 +1,417 @@
+module spec Data.ByteString.Lazy where
+
+assume empty :: { bs : Data.ByteString.Lazy.ByteString | bllen bs == 0 }
+
+assume singleton
+    :: Char -> { bs : Data.ByteString.Lazy.ByteString | bllen bs == 1 }
+
+assume pack
+    :: w8s : [Char]
+    -> { bs : Data.ByteString.ByteString | bllen bs == len w8s }
+
+assume unpack
+    :: bs : Data.ByteString.Lazy.ByteString
+    -> { w8s : [Char] | len w8s == bllen bs }
+
+assume fromStrict
+    :: i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bslen i }
+
+assume toStrict
+    :: i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.ByteString | bslen o == bllen i }
+
+assume fromChunks
+    :: i : [Data.ByteString.ByteString]
+    -> { o : Data.ByteString.Lazy.ByteString | len i == 0 <=> bllen o == 0 }
+
+assume toChunks
+    :: i : Data.ByteString.Lazy.ByteString
+    -> { os : [{ o : Data.ByteString.ByteString | bslen o <= bllen i}] | len os == 0 <=> bllen i == 0 }
+
+assume cons
+    :: Char
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i + 1 }
+
+assume snoc
+    :: i : Data.ByteString.Lazy.ByteString
+    -> Char
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i + 1 }
+
+assume append
+    :: l : Data.ByteString.Lazy.ByteString
+    -> r : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen l + bllen r }
+
+head
+    :: { bs : Data.ByteString.Lazy.ByteString | 1 <= bllen bs }
+    -> Char
+
+assume uncons
+    :: i : Data.ByteString.Lazy.ByteString
+    -> Maybe (Char, { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i - 1 })
+
+assume unsnoc
+    :: i : Data.ByteString.Lazy.ByteString
+    -> Maybe ({ o : Data.ByteString.Lazy.ByteString | bllen o == bllen i - 1 }, Char)
+
+last
+    :: { bs : Data.ByteString.Lazy.ByteString | 1 <= bllen bs }
+    -> Char
+
+tail
+    :: { bs : Data.ByteString.Lazy.ByteString | 1 <= bllen bs }
+    -> Char
+
+init
+    :: { bs : Data.ByteString.Lazy.ByteString | 1 <= bllen bs }
+    -> Char
+
+assume null
+    :: bs : Data.ByteString.Lazy.ByteString
+    -> { b : Bool | Prop b <=> bllen bs == 0 }
+
+assume length
+    :: bs : Data.ByteString.Lazy.ByteString -> { n : Data.Int.Int64 | bllen bs == n }
+
+assume map
+    :: (Char -> Char)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i }
+
+assume reverse
+    :: i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i }
+
+assume intersperse
+    :: Char
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | (bllen i == 0 <=> bllen o == 0) && (1 <= bllen i <=> bllen o == 2 * bllen i - 1) }
+
+assume intercalate
+    :: l : Data.ByteString.Lazy.ByteString
+    -> rs : [Data.ByteString.Lazy.ByteString]
+    -> { o : Data.ByteString.Lazy.ByteString | len rs == 0 ==> bllen o == 0 }
+
+assume transpose
+    :: is : [Data.ByteString.Lazy.ByteString]
+    -> { os : [{ bs : Data.ByteString.Lazy.ByteString | bllen bs <= len is }] | len is == 0 ==> len os == 0}
+
+foldl1
+    :: (Char -> Char -> Char)
+    -> { bs : Data.ByteString.Lazy.ByteString | 1 <= bllen bs }
+    -> Char
+
+foldl1'
+    :: (Char -> Char -> Char)
+    -> { bs : Data.ByteString.Lazy.ByteString | 1 <= bllen bs }
+    -> Char
+
+foldr1
+    :: (Char -> Char -> Char)
+    -> { bs : Data.ByteString.Lazy.ByteString | 1 <= bllen bs }
+    -> Char
+
+foldr1'
+    :: (Char -> Char -> Char)
+    -> { bs : Data.ByteString.Lazy.ByteString | 1 <= bllen bs }
+    -> Char
+
+assume concat
+    :: is : [Data.ByteString.Lazy.ByteString]
+    -> { o : Data.ByteString.Lazy.ByteString | len is == 0 ==> bllen o }
+
+assume concatMap
+    :: (Char -> Data.ByteString.Lazy.ByteString)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen i == 0 ==> bllen o == 0 }
+
+assume any :: (Char -> Bool)
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> { b : Bool | bllen bs == 0 ==> not (Prop b) }
+
+assume all :: (Char -> Bool)
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> { b : Bool | bllen bs == 0 ==> Prop b }
+
+maximum :: { bs : Data.ByteString.Lazy.ByteString | 1 <= bllen bs } -> Char
+
+minimum :: { bs : Data.ByteString.Lazy.ByteString | 1 <= bllen bs } -> Char
+
+assume scanl
+    :: (Char -> Char -> Char)
+    -> Char
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i }
+
+assume scanl1
+    :: (Char -> Char -> Char)
+    -> i : { i : Data.ByteString.Lazy.ByteString | 1 <= bllen i }
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i }
+
+assume scanr
+    :: (Char -> Char -> Char)
+    -> Char
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i }
+
+assume scanr1
+    :: (Char -> Char -> Char)
+    -> i : { i : Data.ByteString.Lazy.ByteString | 1 <= bllen i }
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i }
+
+assume mapAccumL
+    :: (acc -> Char -> (acc, Char))
+    -> acc
+    -> i : Data.ByteString.Lazy.ByteString
+    -> (acc, { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i })
+
+assume mapAccumR
+    :: (acc -> Char -> (acc, Char))
+    -> acc
+    -> i : Data.ByteString.Lazy.ByteString
+    -> (acc, { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i })
+
+assume replicate
+    :: n : Data.Int.Int64
+    -> Char
+    -> { bs : Data.ByteString.Lazy.ByteString | bllen bs == n }
+
+assume unfoldrN
+    :: n : Int
+    -> (a -> Maybe (Char, a))
+    -> a
+    -> ({ bs : Data.ByteString.Lazy.ByteString | bllen bs <= n }, Maybe a)
+
+assume take
+    :: n : Data.Int.Int64
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | (n <= 0 ==> bllen o == 0) &&
+                                               ((0 <= n && n <= bllen i) <=> bllen o == n) &&
+                                               (bllen i <= n <=> bllen o = bllen i) }
+
+assume drop
+    :: n : Data.Int.Int64
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | (n <= 0 <=> bllen o == bllen i) &&
+                                               ((0 <= n && n <= bllen i) <=> bllen o == bllen i - n) &&
+                                               (bllen i <= n <=> bllen o == 0) }
+
+assume splitAt
+    :: n : Data.Int.Int64
+    -> i : Data.ByteString.Lazy.ByteString
+    -> ( { l : Data.ByteString.Lazy.ByteString | (n <= 0 <=> bllen l == 0) &&
+                                                 ((0 <= n && n <= bllen i) <=> bllen l == n) &&
+                                                 (bllen i <= n <=> bllen l == bllen i) }
+       , { r : Data.ByteString.Lazy.ByteString | (n <= 0 <=> bllen r == bllen i) &&
+                                                 ((0 <= n && n <= bllen i) <=> bllen r == bllen i - n) &&
+                                                 (bllen i <= n <=> bllen r == 0) }
+       )
+
+assume takeWhile
+    :: (Char -> Bool)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o <= bllen i }
+
+assume dropWhile
+    :: (Char -> Bool)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o <= bllen i }
+
+assume span
+    :: (Char -> Bool)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> ( { l : Data.ByteString.Lazy.ByteString | bllen l <= bllen i }
+       , { r : Data.ByteString.Lazy.ByteString | bllen r <= bllen i }
+       )
+
+assume spanEnd
+    :: (Char -> Bool)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> ( { l : Data.ByteString.Lazy.ByteString | bllen l <= bllen i }
+       , { r : Data.ByteString.Lazy.ByteString | bllen r <= bllen i }
+       )
+
+assume break
+    :: (Char -> Bool)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> ( { l : Data.ByteString.Lazy.ByteString | bllen l <= bllen i }
+       , { r : Data.ByteString.Lazy.ByteString | bllen r <= bllen i }
+       )
+
+assume breakEnd
+    :: (Char -> Bool)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> ( { l : Data.ByteString.Lazy.ByteString | bllen l <= bllen i }
+       , { r : Data.ByteString.Lazy.ByteString | bllen r <= bllen i }
+       )
+assume group
+    :: i : Data.ByteString.Lazy.ByteString
+    -> [{ o : Data.ByteString.Lazy.ByteString | 1 <= bllen o && bllen o <= bllen i }]
+
+assume groupBy
+    :: (Char -> Char -> Bool)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> [{ o : Data.ByteString.Lazy.ByteString | 1 <= bllen o && bllen o <= bllen i }]
+
+assume inits
+    :: i : Data.ByteString.Lazy.ByteString
+    -> [{ o : Data.ByteString.Lazy.ByteString | bllen o <= bllen i }]
+
+assume tails
+    :: i : Data.ByteString.Lazy.ByteString
+    -> [{ o : Data.ByteString.Lazy.ByteString | bllen o <= bllen i }]
+
+assume split
+    :: Char
+    -> i : Data.ByteString.Lazy.ByteString
+    -> [{ o : Data.ByteString.Lazy.ByteString | bllen o <= bllen i }]
+
+assume splitWith
+    :: (Char -> Bool)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> [{ o : Data.ByteString.Lazy.ByteString | bllen o <= bllen i }]
+
+assume lines
+    :: i : Data.ByteString.Lazy.ByteString
+    -> [{ o : Data.ByteString.Lazy.ByteString | bllen o <= bllen i }]
+
+assume words
+    :: i : Data.ByteString.Lazy.ByteString
+    -> [{ o : Data.ByteString.Lazy.ByteString | bllen o <= bllen i }]
+
+assume unlines
+    :: is : [Data.ByteString.Lazy.ByteString]
+    -> { o : Data.ByteString.Lazy.ByteString | (len is == 0 <=> bllen o == 0) && bllen o >= len is }
+
+assume unwords
+    :: is : [Data.ByteString.Lazy.ByteString]
+    -> { o : Data.ByteString.Lazy.ByteString | (len is == 0 ==> bllen o == 0) && (1 <= len is ==> bllen o >= len is - 1) }
+
+assume isPrefixOf
+    :: l : Data.ByteString.Lazy.ByteString
+    -> r : Data.ByteString.Lazy.ByteString
+    -> { b : Bool | bllen l >= bllen r ==> not (Prop b) }
+
+assume isSuffixOf
+    :: l : Data.ByteString.Lazy.ByteString
+    -> r : Data.ByteString.Lazy.ByteString
+    -> { b : Bool | bllen l >= bllen r ==> not (Prop b) }
+
+assume isInfixOf
+    :: l : Data.ByteString.Lazy.ByteString
+    -> r : Data.ByteString.Lazy.ByteString
+    -> { b : Bool | bllen l >= bllen r ==> not (Prop b) }
+
+assume breakSubstring
+    :: il : Data.ByteString.Lazy.ByteString
+    -> ir : Data.ByteString.Lazy.ByteString
+    -> ( { ol : Data.ByteString.Lazy.ByteString | bllen ol <= bllen ir && (bllen il > bllen ir ==> bllen ol == bllen ir)}
+       , { or : Data.ByteString.Lazy.ByteString | bllen or <= bllen ir && (bllen il > bllen ir ==> bllen or == 0) }
+       )
+
+assume elem
+    :: Char
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> { b : Bool | bllen b == 0 ==> not (Prop b) }
+
+assume notElem
+    :: Char
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> { b : Bool | bllen b == 0 ==> Prop b }
+
+assume find
+    :: (Char -> Bool)
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> Maybe { w8 : Char | bllen bs /= 0 }
+
+assume filter
+    :: (Char -> Bool)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o <= bllen i }
+
+assume partition
+    :: (Char -> Bool)
+    -> i : Data.ByteString.Lazy.ByteString
+    -> ( { l : Data.ByteString.Lazy.ByteString | bllen l <= bllen i }
+       , { r : Data.ByteString.Lazy.ByteString | bllen r <= bllen i }
+       )
+
+index
+    :: bs : Data.ByteString.Lazy.ByteString
+    -> { n : Data.Int.Int64 | 0 <= n && n < bllen bs }
+    -> Char
+
+assume elemIndex
+    :: Char
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> Maybe { n : Data.Int.Int64 | 0 <= n && n < bllen bs }
+
+assume elemIndices
+    :: Char
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> [{ n : Data.Int.Int64 | 0 <= n && n < bllen bs }]
+
+assume elemIndexEnd
+    :: Char
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> Maybe { n : Data.Int.Int64 | 0 <= n && n < bllen bs }
+
+assume findIndex
+    :: (Char -> Bool)
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> Maybe { n : Data.Int.Int64 | 0 <= n && n < bllen bs }
+
+assume findIndices
+    :: (Char -> Bool)
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> [{ n : Data.Int.Int64 | 0 <= n && n < bllen bs }]
+
+assume count
+    :: Char
+    -> bs : Data.ByteString.Lazy.ByteString
+    -> { n : Data.Int.Int64 | 0 <= n && n < bllen bs }
+
+assume zip
+    :: l : Data.ByteString.Lazy.ByteString
+    -> r : Data.ByteString.Lazy.ByteString
+    -> { o : [(Char, Char)] | len o <= bllen l && len o <= bllen r }
+
+assume zipWith
+    :: (Char -> Char -> a)
+    -> l : Data.ByteString.Lazy.ByteString
+    -> r : Data.ByteString.Lazy.ByteString
+    -> { o : [a] | len o <= bllen l && len o <= bllen r }
+
+assume unzip
+    :: i : [(Char, Char)]
+    -> ( { l : Data.ByteString.Lazy.ByteString | bllen l == len i }
+       , { r : Data.ByteString.Lazy.ByteString | bllen r == len i }
+       )
+
+assume sort
+    :: i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i }
+
+assume readInt
+    :: i : Data.ByteString.Lazy.ByteString
+    -> Maybe { p : (Int, { o : Data.ByteString.Lazy.ByteString | bllen o < bllen i}) | bllen i /= 0 }
+
+assume readInteger
+    :: i : Data.ByteString.Lazy.ByteString
+    -> Maybe { p : (Integer, { o : Data.ByteString.Lazy.ByteString | bllen o < bllen i}) | bllen i /= 0 }
+
+assume copy
+    :: i : Data.ByteString.Lazy.ByteString
+    -> { o : Data.ByteString.Lazy.ByteString | bllen o == bllen i }
+
+assume hGet
+    :: System.IO.Handle
+    -> n : { n : Int | 0 <= n }
+    -> IO { bs : Data.ByteString.Lazy.ByteString | bllen bs == n || bllen bs == 0 }
+
+assume hGetNonBlocking
+    :: System.IO.Handle
+    -> n : { n : Int | 0 <= n }
+    -> IO { bs : Data.ByteString.Lazy.ByteString | bllen bs <= n }

--- a/include/Data/ByteString/Short.spec
+++ b/include/Data/ByteString/Short.spec
@@ -1,0 +1,35 @@
+module spec Data.ByteString.Short where
+
+measure sbslen :: Data.ByteString.Short.ShortByteString -> { n : Int | 0 <= n }
+
+invariant { bs : Data.ByteString.Short.ShortByteString  | 0 <= sbslen bs }
+
+assume toShort
+    :: i : Data.ByteString.ByteString
+    -> { o : Data.ByteString.Short.ShortByteString | sbslen o == bslen i }
+
+assume fromShort
+    :: o : Data.ByteString.Short.ShortByteString
+    -> { i : Data.ByteString.ByteString | bslen i == sbslen o }
+
+assume pack
+    :: w8s : [Data.Word.Word8]
+    -> { bs : Data.ByteString.Short.ShortByteString | sbslen bs == len w8s }
+
+assume unpack
+    :: bs : Data.ByteString.Short.ShortByteString
+    -> { w8s : [Data.Word.Word8] | len w8s == sbslen bs }
+
+assume empty :: { bs : Data.ByteString.Short.ShortByteString | sbslen bs == 0 }
+
+assume null
+    :: bs : Data.ByteString.Short.ShortByteString
+    -> { b : Bool | Prop b <=> sbslen bs == 0 }
+
+assume length
+    :: bs : Data.ByteString.Short.ShortByteString -> { n : Int | sbslen bs == n }
+
+index
+    :: bs : Data.ByteString.Short.ShortByteString
+    -> { n : Int | 0 <= n && n < sbslen bs }
+    -> Data.Word.Word8

--- a/include/Data/ByteString/Unsafe.spec
+++ b/include/Data/ByteString/Unsafe.spec
@@ -1,0 +1,28 @@
+module spec Data.ByteString.Unsafe where
+
+unsafeHead
+    :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Data.Word.Word8
+
+unsafeTail
+    :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Data.Word.Word8
+
+unsafeInit
+    :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Data.Word.Word8
+
+unsafeLast
+    :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Data.Word.Word8
+
+unsafeIndex
+    :: bs : Data.ByteString.ByteString
+    -> { n : Int | 0 <= n && n < bslen bs }
+    -> Data.Word.Word8
+
+assume unsafeTake
+    :: n : { n : Int | 0 <= n }
+    -> i : { i : Data.ByteString.ByteString | n <= bslen i }
+    -> { o : Data.ByteString.ByteString | bslen o == n }
+
+assume unsafeDrop
+    :: n : { n : Int | 0 <= n }
+    -> i : { i : Data.ByteString.ByteString | n <= bslen i }
+    -> { o : Data.ByteString.ByteString | bslen o == bslen i - n }


### PR DESCRIPTION
The general rules I applied for refinements were:

* Preconditions were only added for things that would cause crashes or
  exceptions.  I did not protect against silly but valid inputs (like
  `Data.ByteString.take (-1)`)
* I added as many postconditions as humanly possible
* I did not add refinements for deprecated functions in order to avoid Liquid
  Haskell failing when the `bytestring` library eventually eliminates them

I didn't cover every single module in the `bytestring` library.  The modules that
I haven't done yet are all the `Builder`-related modules:

* `Data.ByteString.Builder`
* `Data.ByteString.Builder.Extra`
* `Data.ByteString.Builder.Prim`
* `Data.ByteString.Lazy.Builder`
* `Data.ByteString.Lazy.Builder.ASCII`
* `Data.ByteString.Lazy.Builder.Extras`