### PR TITLE
prevent declaring multiple instance measures for the same measure-tycon pair

### DIFF
--- a/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -67,6 +67,7 @@ checkGhcSpec specs env sp =  applyNonNull (Right sp) Left errors
                      ++ mapMaybe (checkInv  emb tcEnv env)               (invariants sp)
                      ++ checkIAl  emb tcEnv env (ialiases   sp)
                      ++ checkMeasures emb env ms
+                     ++ checkClassMeasures (measures sp)
                      ++ mapMaybe checkMismatch                     sigs
                      ++ checkDuplicate                             (tySigs sp)
                      ++ checkQualifiers env                        (qualifiers sp)
@@ -413,3 +414,17 @@ checkMBody' emb sort γ body = case body of
     -- psort = FApp propFTyCon []
     sty   = rTypeSortedReft emb sort'
     sort' = ty_res $ toRTypeRep sort
+
+checkClassMeasures :: [Measure SpecType DataCon] -> [Error]
+checkClassMeasures ms = mapMaybe checkOne byTyCon
+  where
+  byName = L.groupBy ((==) `on` (val.name)) ms
+
+  byTyCon = concatMap (L.groupBy ((==) `on` (dataConTyCon . ctor . head . eqns)))
+                      byName
+
+  checkOne [_]    = Nothing
+  checkOne (m:ms) = Just (ErrDupMeas (sourcePosSrcSpan (loc (name m)))
+                                     (pprint (val (name m)))
+                                     (pprint ((dataConTyCon . ctor . head . eqns) m))
+                                     (map (sourcePosSrcSpan.loc.name) (m:ms)))

--- a/src/Language/Haskell/Liquid/Types/Errors.hs
+++ b/src/Language/Haskell/Liquid/Types/Errors.hs
@@ -213,6 +213,13 @@ data TError t =
                 , locs:: ![SrcSpan]
                 } -- ^ multiple specs for same binder error
 
+  | ErrDupMeas  { pos :: !SrcSpan
+                , var :: !Doc
+                , tycon :: !Doc
+                , locs:: ![SrcSpan]
+                } -- ^ multiple definitions of the same measure
+
+
   | ErrBadData  { pos :: !SrcSpan
                 , var :: !Doc
                 , msg :: !Doc
@@ -592,6 +599,12 @@ ppError' _ dSp _ (ErrHMeas _ t s)
 
 ppError' _ dSp _ (ErrDupSpecs _ v ls)
   = dSp <+> text "Multiple Specifications for" <+> pprint v <> colon
+        $+$ (nest 4 $ vcat $ pprint <$> ls)
+
+ppError' _ dSp _ (ErrDupMeas _ v t ls)
+  = dSp <+> text "Multiple Instance Measures for" <+> pprint v
+        <+> text "and" <+> pprint t
+        <> colon
         $+$ (nest 4 $ vcat $ pprint <$> ls)
 
 ppError' _ dSp _ (ErrDupAlias _ k v ls)

--- a/tests/neg/T649.hs
+++ b/tests/neg/T649.hs
@@ -1,0 +1,34 @@
+module Blank where
+
+import Data.Word
+import GHC.Ptr
+
+{-@ class measure sizeOf :: forall a . Ptr a -> Int @-}
+{-@
+instance measure sizeOf :: (Ptr Data.Word.Word16) -> Int
+sizeOf (Ptr x) = 2
+@-}
+{-@
+instance measure sizeOf :: (Ptr Data.Word.Word32) -> Int
+sizeOf (Ptr y) = 4
+@-}
+
+{- measure sizeOf :: forall a . Ptr a -> Int @-}
+
+{- invariant {v:Ptr Word16 | sizeOf v = 2} @-}
+{- invariant {v:Ptr Word32 | sizeOf v = 4} @-}
+
+{-@
+bar :: { p : Ptr Word32 | plen p >= (sizeOf p) }
+    -> ()
+@-}
+bar :: Ptr Word32 -> ()
+bar (Ptr unused) = ()
+
+{-@
+qux :: { p : Ptr Word32 | plen p >= 0 }
+    -> ()
+@-}
+qux :: Ptr Word32 -> ()
+qux (Ptr addr) = let x = Ptr addr in bar x
+


### PR DESCRIPTION
Partial fix for #649.

This fixes the soundness issue by throwing an error if we have two instances of a measure for the same tycon, but doesn't allow for giving precise measure definitions for eg Ptr Word16 vs Ptr Word32.
