### PR TITLE
Json

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## NEXT
 
+- Add a `--json` flag that runs in quiet mode where all output is
+  suppressed and only the list of errors is returned as a JSON object to be
+  consumed by an editor.
+
+
 ## 0.5.0.1
 
 - Fixed a bug in the specification for `Data.Traversable.sequence`

--- a/TODO.markdown
+++ b/TODO.markdown
@@ -1,6 +1,8 @@
 TODO
 ====
 
+
+
 Check Covariance
 ----------------
 

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -20,7 +20,7 @@ module Language.Haskell.Liquid.Liquid (
 import           Prelude hiding (error)
 import           Data.Maybe
 import           System.Exit
-import           Control.DeepSeq
+-- import           Control.DeepSeq
 import           Text.PrettyPrint.HughesPJ
 import           CoreSyn
 import           Var
@@ -126,7 +126,7 @@ liquidOne tgt info = do
   let cbs'' = maybe cbs' DC.newBinds dc
   let info' = maybe info (\z -> info {spec = DC.newSpec z}) dc
   let cgi   = {-# SCC "generateConstraints" #-} generateConstraints $! info' {cbs = cbs''}
-  cgi `deepseq` donePhase Loud "generateConstraints"
+  -- cgi `deepseq` whenLoud (donePhase Loud "generateConstraints")
   whenLoud  $ dumpCs cgi
   out      <- solveCs cfg tgt cgi info' dc
   whenNormal $ donePhase Loud "solve"

--- a/src/Language/Haskell/Liquid/UX/Annotate.hs
+++ b/src/Language/Haskell/Liquid/UX/Annotate.hs
@@ -82,7 +82,7 @@ mkOutput cfg res sol anna
 
 -- | @annotate@ actually renders the output to files
 -------------------------------------------------------------------
-annotate :: Config -> FilePath -> Output Doc -> IO ()
+annotate :: Config -> FilePath -> Output Doc -> IO ACSS.AnnMap
 -------------------------------------------------------------------
 annotate cfg srcF out
   = do generateHtml srcF tpHtmlF tplAnnMap
@@ -90,6 +90,7 @@ annotate cfg srcF out
        writeFile         vimF  $ vimAnnot cfg annTyp
        B.writeFile       jsonF $ encode typAnnMap
        when showWarns $ forM_ bots (printf "WARNING: Found false in %s\n" . showPpr)
+       return typAnnMap
     where
        tplAnnMap  = mkAnnMap cfg res annTpl
        typAnnMap  = mkAnnMap cfg res annTyp

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -30,6 +30,7 @@ module Language.Haskell.Liquid.UX.CmdLine (
 
 import Prelude hiding (error)
 
+
 import Control.Monad
 import Data.Maybe
 import Data.Aeson (encode)
@@ -60,7 +61,7 @@ import Language.Haskell.Liquid.GHC.Misc
 import Language.Haskell.Liquid.Misc
 import Language.Haskell.Liquid.Types.PrettyPrint
 import Language.Haskell.Liquid.Types       hiding (config, name, typ)
-
+import qualified Language.Haskell.Liquid.UX.ACSS as ACSS
 
 
 import Text.Parsec.Pos                     (newPos)
@@ -399,8 +400,8 @@ consoleResultFull cfg out r _ = do
    writeResult cfg (colorResult r) cr
    -- writeFile   (extFileName Result target) (showFix cr)
 
-consoleResultJson _ _ _ annm =
-  B.putStrLn $ encode annm
+consoleResultJson _ _ _ =
+  B.putStrLn . encode . ACSS.errors 
 
 resultWithContext :: ErrorResult -> IO (FixResult CError)
 resultWithContext = mapM errorWithContext

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -217,6 +217,9 @@ config = cmdArgsMode $ Config {
     = False &= name "elimStats"
             &= help "Print eliminate stats"
 
+ , json
+    = False &= name "json"
+            &= help "Print results in JSON (for editor integration)"
  } &= verbosity
    &= program "liquid"
    &= help    "Refinement Types for Haskell"
@@ -237,6 +240,7 @@ getOpts as = do
                          config { modeValue = (modeValue config) { cmdArgsValue = cfg0 } }
                          as
   cfg    <- fixConfig cfg1
+  when (json cfg) $ setVerbosity Quiet
   whenNormal $ putStrLn copyright
   withSmtSolver cfg
 
@@ -366,6 +370,7 @@ defConfig = Config { files          = def
                    , scrapeImports  = False
                    , scrapeUsedImports  = False
                    , elimStats      = False
+                   , json           = False
                    }
 
 
@@ -378,7 +383,7 @@ exitWithResult :: Config -> FilePath -> Output Doc -> IO (Output Doc)
 ------------------------------------------------------------------------
 exitWithResult cfg target out
   = do {-# SCC "annotate" #-} annotate cfg target out
-       donePhase Loud "annotate"
+       whenNormal $ donePhase Loud "annotate"
        writeCheckVars $ o_vars  out
        cr <- resultWithContext r
        writeResult cfg (colorResult r) cr

--- a/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/src/Language/Haskell/Liquid/UX/Config.hs
@@ -59,6 +59,7 @@ data Config = Config {
   , scrapeImports  :: Bool       -- ^ scrape qualifiers from imported specifications
   , scrapeUsedImports  :: Bool   -- ^ scrape qualifiers from used, imported specifications
   , elimStats      :: Bool       -- ^ print eliminate stats
+  , json           :: Bool       -- ^ print results (safe/errors) as JSON
   } deriving (Generic, Data, Typeable, Show, Eq)
 
 instance Serialize SMTSolver


### PR DESCRIPTION
This adds a `--json` flag that runs in quiet mode where all output is suppressed and only the list of errors is returned as a JSON object to be consumed by an editor.

https://github.com/ucsd-progsys/liquid-fixpoint/pull/221