### PR TITLE
Qualify `Vector` type in `Data/Vector.spec`

### DIFF
--- a/include/Data/Vector.spec
+++ b/include/Data/Vector.spec
@@ -2,7 +2,7 @@ module spec Data.Vector where
 
 import GHC.Base
 
-data variance Vector covariant
+data variance Data.Vector.Vector covariant
 
 
 measure vlen    :: forall a. (Data.Vector.Vector a) -> Int


### PR DESCRIPTION
Liquid Haskell fails if you use the `Data.Vector` module due to the unqualified reference in `Data/Vector.spec` and succeeds after this change.