### PR TITLE
Diff

### DIFF
--- a/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -77,16 +77,15 @@ checkGhcSpec specs env sp =  applyNonNull (Right sp) Left errors
                      ++ checkRTAliases "Type Alias" env            tAliases
                      ++ checkRTAliases "Pred Alias" env            eAliases
                      ++ checkDuplicateFieldNames                   (dconsP sp)
-                     ++ checkRefinedClasses                        (concatMap (Ms.classes . snd) specs) (concatMap (Ms.rinstance . snd) specs)
-
-
+                     ++ checkRefinedClasses                        rClasses rInsts
+    rClasses         = concatMap (Ms.classes   . snd) specs
+    rInsts           = concatMap (Ms.rinstance . snd) specs
     tAliases         =  concat [Ms.aliases sp  | (_, sp) <- specs]
     eAliases         =  concat [Ms.ealiases sp | (_, sp) <- specs]
     dcons spec       =  [(v, Loc l l' t) | (v, t)   <- dataConSpec (dconsP spec)
                                          | (_, dcp) <- dconsP spec
                                          , let l     = dc_loc  dcp
-                                         , let l'    = dc_locE dcp
-                                         ]
+                                         , let l'    = dc_locE dcp ]
     emb              =  tcEmbeds sp
     tcEnv            =  tyconEnv sp
     ms               =  measures sp
@@ -102,7 +101,7 @@ checkQualifier env q =  mkE <$> checkSortFull γ boolSort  (q_body q)
   where γ   = foldl (\e (x, s) -> insertSEnv x (RR s mempty) e) env (q_params q ++ wiredSortedSyms)
         mkE = ErrBadQual (sourcePosSrcSpan $ q_pos q) (pprint $ q_name q)
 
-checkRefinedClasses :: [RClass BareType] -> [RInstance BareType] -> [Error]
+checkRefinedClasses :: [RClass (Located BareType)] -> [RInstance (Located BareType)] -> [Error]
 checkRefinedClasses definitions instances
   = mkError <$> duplicates
   where
@@ -110,10 +109,8 @@ checkRefinedClasses definitions instances
       = mapMaybe checkCls (rcName <$> definitions)
     checkCls cls
       = case findConflicts cls of
-          [] ->
-            Nothing
-          conflicts ->
-            Just (cls, conflicts)
+          []        -> Nothing
+          conflicts -> Just (cls, conflicts)
     findConflicts cls
       = filter ((== cls) . riclass) instances
 
@@ -278,7 +275,7 @@ checkTcArity (RTyCon { rtc_tc = tc }) givenArity
   where
     expectedArity = realTcArity tc
 
-{- 
+{-
 checkFunRefs t = go t
   where
     go (RAllT _ t)      = go t
@@ -295,7 +292,7 @@ checkFunRefs t = go t
     go (RFun _ t1 t2 r)
       | isTauto r       = go t1 <|> go t2
       | otherwise       = Just $ text "Function types cannot have refinements:" <+> (pprint r)
--} 
+-}
 
 checkAbstractRefs t = go t
   where
@@ -359,7 +356,7 @@ checkAbstractRefs t = go t
 
 
 
-checkReft                    :: (PPrint r, Reftable r, SubsTy RTyVar (RType RTyCon RTyVar ()) r) => SEnv SortedReft -> TCEmb TyCon -> Maybe (RRType (UReft r)) -> (UReft r) -> Maybe Doc
+checkReft                    :: (PPrint r, Reftable r, SubsTy RTyVar (RType RTyCon RTyVar ()) r) => SEnv SortedReft -> TCEmb TyCon -> Maybe (RRType (UReft r)) -> UReft r -> Maybe Doc
 checkReft _   _   Nothing _  = Nothing -- TODO:RPropP/Ref case, not sure how to check these yet.
 checkReft env emb (Just t) _ = (dr $+$) <$> checkSortedReftFull env' r
   where

--- a/src/Language/Haskell/Liquid/Bare/GhcSpec.hs
+++ b/src/Language/Haskell/Liquid/Bare/GhcSpec.hs
@@ -48,7 +48,6 @@ import Language.Haskell.Liquid.Misc (mapSnd)
 import Language.Haskell.Liquid.WiredIn
 
 
-
 import qualified Language.Haskell.Liquid.Measure as Ms
 
 import Language.Haskell.Liquid.Bare.Check
@@ -162,7 +161,7 @@ makeGhcSpec' cfg cbs vars defVars exports specs
 
 addProofType :: GhcSpec -> BareM GhcSpec
 addProofType spec
-  = do tycon <- (Just <$> (lookupGhcTyCon $ dummyLoc proofTyConName)) `catchError` (\_ -> return Nothing)
+  = do tycon <- (Just <$> lookupGhcTyCon (dummyLoc proofTyConName)) `catchError` (\_ -> return Nothing)
        return $ spec {proofType = (`TyConApp` []) <$> tycon}
 
 
@@ -301,7 +300,17 @@ makeGhcSpecCHOP3 cfg vars defVars specs name mts embs
        let asms = [ (x, txRefSort tyi embs $ fmap txExpToBind t) | (_, x, t) <- asms' ]
        return     (invs, ialias, sigs, asms)
 
-
+makeGhcSpecCHOP2 :: [CoreBind]
+                 -> [(ModName, Ms.BareSpec)]
+                 -> [Measure SpecType DataCon]
+                 -> [(DataCon, DataConP)]
+                 -> [(DataCon, DataConP)]
+                 -> TCEmb TyCon
+                 -> BareM ( MSpec SpecType DataCon
+                          , [(Symbol, Located (RRType Reft))]
+                          , [(Symbol, Located (RRType Reft))]
+                          , [(Var,    Located SpecType)]
+                          , [Symbol] )
 makeGhcSpecCHOP2 cbs specs dcSelectors datacons cls embs
   = do measures'   <- mconcat <$> mapM makeMeasureSpec specs
        tyi         <- gets tcEnv

--- a/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -99,7 +99,7 @@ makeMeasureInline tce lmap cbs  x
                            Left (xs, e)  -> return (TI (symbol <$> xs) (fromLR e))
                            Right e -> throwError e
 
-    fromLR (Left l)  = l 
+    fromLR (Left l)  = l
     fromLR (Right r) = r
 
     mkError :: String -> Error
@@ -151,10 +151,10 @@ makeMeasureSelector x s dc n i = M {name = x, sort = s, eqns = [eqn]}
         mkx j = symbol ("xx" ++ show j)
 
 
-makeMeasureSpec :: (ModName, Ms.Spec BareType LocSymbol) -> BareM (Ms.MSpec SpecType DataCon)
-makeMeasureSpec (mod,spec) = inModule mod mkSpec
+makeMeasureSpec :: (ModName, Ms.BareSpec) -> BareM (Ms.MSpec SpecType DataCon)
+makeMeasureSpec (mod, spec) = inModule mod mkSpec
   where
-    mkSpec = mkMeasureDCon =<< mkMeasureSort =<< m
+    mkSpec = mkMeasureDCon =<< mkMeasureSort =<< first val <$> m
     m      = Ms.mkMSpec <$> mapM expandMeasure (Ms.measures spec)
                         <*> return (Ms.cmeasures spec)
                         <*> mapM expandMeasure (Ms.imeasures spec)
@@ -258,11 +258,13 @@ capitalizeBound = fmap (symbol . toUpperHead . symbolString)
 --------------------------------------------------------------------------------
 -- | Expand Measures -----------------------------------------------------------
 --------------------------------------------------------------------------------
+type BareMeasure = Measure (Located BareType) LocSymbol
 
-expandMeasure m
-  = do eqns <- sequence $ expandMeasureDef <$> eqns m
-       return $ m { sort = generalize (sort m)
-                  , eqns = eqns }
+expandMeasure :: BareMeasure -> BareM BareMeasure
+expandMeasure m = do
+  eqns <- sequence $ expandMeasureDef <$> eqns m
+  return $ m { sort = generalize <$> sort m
+             , eqns = eqns }
 
 expandMeasureDef :: Def t LocSymbol -> BareM (Def t LocSymbol)
 expandMeasureDef d

--- a/src/Language/Haskell/Liquid/Bare/OfType.hs
+++ b/src/Language/Haskell/Liquid/Bare/OfType.hs
@@ -5,10 +5,8 @@ module Language.Haskell.Liquid.Bare.OfType (
     ofBareType
   , ofMeaSort
   , ofBSort
-
   , ofBPVar
-
-  , mkSpecType
+  , mkLSpecType
   , mkSpecType'
   ) where
 
@@ -31,7 +29,7 @@ import Text.Printf
 import qualified Control.Exception as Ex
 import qualified Data.HashMap.Strict as M
 
-import Language.Fixpoint.Types (Expr(..), Reftable, Symbol, meet, mkSubst, subst, symbol, mkEApp)
+import Language.Fixpoint.Types (atLoc, Expr(..), Reftable, Symbol, meet, mkSubst, subst, symbol, mkEApp)
 
 import Language.Haskell.Liquid.GHC.Misc
 import Language.Haskell.Liquid.Misc (secondM)
@@ -72,10 +70,11 @@ mapMPvar f (PV x t v txys)
        return $ PV x t' v txys'
 
 --------------------------------------------------------------------------------
+mkLSpecType :: Located BareType -> BareM (Located SpecType)
+mkLSpecType t = atLoc t <$> mkSpecType (loc t) (val t)
 
 mkSpecType :: SourcePos -> BareType -> BareM SpecType
-mkSpecType l t
-  = mkSpecType' l (ty_preds $ toRTypeRep t) t
+mkSpecType l t = mkSpecType' l (ty_preds $ toRTypeRep t) t
 
 mkSpecType' :: SourcePos -> [PVar BSort] -> BareType -> BareM SpecType
 mkSpecType' l πs t

--- a/src/Language/Haskell/Liquid/Bare/Spec.hs
+++ b/src/Language/Haskell/Liquid/Bare/Spec.hs
@@ -26,6 +26,7 @@ import Prelude hiding (error)
 import MonadUtils (mapMaybeM)
 import TyCon
 import Var
+import CoreSyn (CoreBind)
 
 
 import Control.Monad.Except
@@ -37,15 +38,14 @@ import qualified Data.List           as L
 import qualified Data.HashSet        as S
 import qualified Data.HashMap.Strict as M
 
-import Language.Fixpoint.Misc (group, snd3)
-import Language.Fixpoint.Types.Names (dropSym, isPrefixOfSym,  symbolString)
-import Language.Fixpoint.Types (Qualifier(..), symbol, atLoc)
-import Language.Haskell.Liquid.Types.Dictionaries
-import Language.Haskell.Liquid.GHC.Misc ( dropModuleNames, qualifySymbol, takeModuleNames, getSourcePos, showPpr, symbolTyVar)
-import Language.Haskell.Liquid.Misc (addFst3, fourth4, mapFst, concatMapM)
-import Language.Haskell.Liquid.Types.RefType (generalize, rVar, symbolRTyVar)
-import Language.Haskell.Liquid.Types
-import Language.Haskell.Liquid.Types.Bounds
+import           Language.Fixpoint.Misc (group, snd3)
+import qualified Language.Fixpoint.Types as F
+import           Language.Haskell.Liquid.Types.Dictionaries
+import           Language.Haskell.Liquid.GHC.Misc ( dropModuleNames, qualifySymbol, takeModuleNames, getSourcePos, showPpr, symbolTyVar)
+import           Language.Haskell.Liquid.Misc (addFst3, fourth4, mapFst, concatMapM)
+import           Language.Haskell.Liquid.Types.RefType (generalize, rVar, symbolRTyVar)
+import           Language.Haskell.Liquid.Types
+import           Language.Haskell.Liquid.Types.Bounds
 
 import qualified Language.Haskell.Liquid.Measure as Ms
 
@@ -63,42 +63,38 @@ makeClasses cmod cfg vs (mod, spec) = inModule mod $ mapM mkClass $ Ms.classes s
     --FIXME: cleanup this code
     unClass = snd . bkClass . fourth4 . bkUniv
     mkClass (RClass c ss as ms)
-            = do let l   = loc  c
-                 let l'  = locE c
-                 tc  <- lookupGhcTyCon c
-                 ss' <- mapM (mkSpecType l) ss
+            = do let l      = loc  c
+                 let l'     = locE c
+                 tc        <- lookupGhcTyCon c
+                 ss'       <- mapM mkLSpecType ss
                  let (dc:_) = tyConDataCons tc
                  let αs  = map symbolRTyVar as
                  let as' = [rVar $ symbolTyVar a | a <- as ]
-                 let ms' = [ (s, rFun "" (RApp c (flip RVar mempty <$> as) [] mempty) t) | (s, t) <- ms]
+                 let ms' = [ (s, rFun "" (RApp c (flip RVar mempty <$> as) [] mempty) (val t)) | (s, t) <- ms]
                  vts <- makeSpec (noCheckUnknown cfg || cmod /= mod) vs ms'
                  let sts = [(val s, unClass $ val t) | (s, _)    <- ms
                                                      | (_, _, t) <- vts]
                  let t   = rCls tc as'
-                 let dcp = DataConP l αs [] [] ss' (reverse sts) t l'
+                 let dcp = DataConP l αs [] [] (val <$> ss') (reverse sts) t l'
                  return ((dc,dcp),vts)
 
 makeQualifiers (mod,spec) = inModule mod mkQuals
   where
-    mkQuals = mapM (\q -> resolve (q_pos q) q) $ Ms.qualifiers spec
+    mkQuals = mapM (\q -> resolve (F.q_pos q) q) $ Ms.qualifiers spec
 
 makeHints   vs spec = varSymbols id vs $ Ms.decr spec
-makeLVar    vs spec = fmap fst <$> (varSymbols id vs $ [(v, ()) | v <- Ms.lvars spec])
-makeLazy    vs spec = fmap fst <$> (varSymbols id vs $ [(v, ()) | v <- S.toList $ Ms.lazy    spec])
-makeHBounds vs spec = varSymbols id vs $ [(v, v ) | v <- S.toList $ Ms.hbounds spec]
+makeLVar    vs spec = fmap fst <$> varSymbols id vs [(v, ()) | v <- Ms.lvars spec]
+makeLazy    vs spec = fmap fst <$> varSymbols id vs [(v, ()) | v <- S.toList $ Ms.lazy spec]
+makeHBounds vs spec = varSymbols id vs [(v, v ) | v <- S.toList $ Ms.hbounds spec]
 makeTExpr   vs spec = varSymbols id vs $ Ms.termexprs spec
--- makeHIMeas  vs spec = fmap (uncurry $ flip Loc) <$> (varSymbols id vs $ [(v, loc v) | v <- (S.toList $ Ms.hmeas spec) ++ (S.toList $ Ms.inlines spec)])
-makeHIMeas  vs spec = fmap tx <$> (varSymbols id vs $ [(v, (loc v, locE v)) | v <- (S.toList $ Ms.hmeas spec) ++ (S.toList $ Ms.inlines spec)])
+makeHIMeas  vs spec = fmap tx <$> varSymbols id vs [(v, (loc v, locE v)) | v <- S.toList (Ms.hmeas spec) ++ S.toList (Ms.inlines spec)]
   where
     tx (x,(l, l'))  = Loc l l' x
-
-
-
 
 varSymbols :: ([Var] -> [Var]) -> [Var] -> [(LocSymbol, a)] -> BareM [(Var, a)]
 varSymbols f vs  = concatMapM go
   where lvs        = M.map L.sort $ group [(sym v, locVar v) | v <- vs]
-        sym        = dropModuleNames . symbol . showPpr
+        sym        = dropModuleNames . F.symbol . showPpr
         locVar v   = (getSourcePos v, v)
         go (s, ns) = case M.lookup (val s) lvs of
                      Just lvs -> return ((, ns) <$> varsAfter f s lvs)
@@ -125,7 +121,7 @@ makeTargetVars name vs ss
        ns    <- liftIO $ concatMapM (lookupName env name . dummyLoc . prefix) ss
        return $ filter ((`elem` ns) . varName) vs
     where
-       prefix s = qualifySymbol (symbol name) (symbol s)
+       prefix s = qualifySymbol (F.symbol name) (F.symbol s)
 
 
 makeAssertSpec cmod cfg vs lvs (mod,spec)
@@ -143,7 +139,7 @@ makeAssumeSpec cmod cfg vs lvs (mod,spec)
 grepClassAsserts  = concatMap go
    where
     go    = map goOne . risigs
-    goOne = mapFst (fmap (symbol . (".$c" ++ ) . symbolString))
+    goOne = mapFst (fmap (F.symbol . (".$c" ++ ) . F.symbolString))
 
 
 makeDefaultMethods :: [Var] -> [(ModName,Var,Located SpecType)]
@@ -151,11 +147,11 @@ makeDefaultMethods :: [Var] -> [(ModName,Var,Located SpecType)]
 makeDefaultMethods defVs sigs
   = [ (m,dmv,t)
     | dmv <- defVs
-    , let dm = symbol $ showPpr dmv
-    , "$dm" `isPrefixOfSym` dropModuleNames dm
+    , let dm = F.symbol $ showPpr dmv
+    , "$dm" `F.isPrefixOfSym` dropModuleNames dm
     , let mod = takeModuleNames dm
-    , let method = qualifySymbol mod $ dropSym 3 (dropModuleNames dm)
-    , let mb = L.find ((method `isPrefixOfSym`) . symbol . snd3) sigs
+    , let method = qualifySymbol mod $ F.dropSym 3 (dropModuleNames dm)
+    , let mb = L.find ((method `F.isPrefixOfSym`) . F.symbol . snd3) sigs
     , isJust mb
     , let Just (m,_,t) = mb
     ]
@@ -172,9 +168,9 @@ makeLocalSpec cfg mod vs lvs cbs xbs
     (xbs1', xbs2)       = L.partition (modElem mod . fst) xbs
     dupSnd (x, y)       = (dropMod x, (x, y))
     expand3 (x, (y, w)) = (x, y, w)
-    dropMod             = fmap (dropModuleNames . symbol)
+    dropMod             = fmap (dropModuleNames . F.symbol)
     fchoose ls          = maybe ls (:[]) $ L.find (`elem` vs) ls
-    modElem n x         = (takeModuleNames $ val x) == (symbol n)
+    modElem n x         = takeModuleNames (val x) == F.symbol n
 
 makeSpec :: Bool -> [Var] -> [(LocSymbol, BareType)]
                  -> BareM [(ModName, Var, Located SpecType)]
@@ -196,19 +192,18 @@ lookupIds ignoreUnknown
       = throwError err
 
 mkVarSpec :: (Var, LocSymbol, BareType) -> BareM (Var, Located SpecType)
-mkVarSpec (v, Loc l l' _, b) = tx <$> mkSpecType l b
+mkVarSpec (v, x, b) = tx <$> mkLSpecType (F.atLoc x b)
   where
-    tx = (v,) . Loc l l' . generalize
-
+    tx = (v,) . fmap generalize
 
 makeIAliases (mod, spec)
   = inModule mod $ makeIAliases' $ Ms.ialiases spec
 
 makeIAliases' :: [(Located BareType, Located BareType)] -> BareM [(Located SpecType, Located SpecType)]
-makeIAliases' = mapM mkIA
+makeIAliases'     = mapM mkIA
   where
-    mkIA (t1, t2)      = (,) <$> mkI t1 <*> mkI t2
-    mkI (Loc l l' t)   = Loc l l' . generalize <$> mkSpecType l t
+    mkIA (t1, t2) = (,) <$> mkI t1 <*> mkI t2
+    mkI t         = fmap generalize <$> mkLSpecType t
 
 makeInvariants (mod,spec)
   = inModule mod $ makeInvariants' $ Ms.invariants spec
@@ -216,7 +211,7 @@ makeInvariants (mod,spec)
 makeInvariants' :: [Located BareType] -> BareM [Located SpecType]
 makeInvariants' = mapM mkI
   where
-    mkI (Loc l l' t)  = Loc l l' . generalize <$> mkSpecType l t
+    mkI t       = fmap generalize <$> mkLSpecType t
 
 
 makeSpecDictionaries embs vars specs sp
@@ -234,26 +229,27 @@ makeSpecDictionaryOne embs vars (RI x t xts)
        let v = lookupName d
        return ((, dts) <$> v)
   where
-    mkTy  t  = atLoc x         <$> mkSpecType (loc x) t
+    mkTy  t  = mkLSpecType (F.atLoc x t)
     mkTy' t  = fmap generalize <$> mkTy t
     (xs, ts) = unzip xts
     lookupName x
-             = case filter ((==x) . fst) ((\x -> (dropModuleNames $ symbol $ show x, x)) <$> vars) of
+             = case filter ((==x) . fst) ((\x -> (dropModuleNames $ F.symbol $ show x, x)) <$> vars) of
                 [(_, x)] -> Just x
                 _        -> Nothing
 
+makeBounds ::  F.TCEmb TyCon -> ModName -> [Var] -> [CoreBind] -> [(ModName, Ms.BareSpec)] -> BareM ()
 makeBounds tce name defVars cbs specs
   = do bnames  <- mkThing makeHBounds
        hbounds <- makeHaskellBounds tce cbs bnames
        bnds    <- M.fromList <$> mapM go (concatMap (M.toList . Ms.bounds . snd ) specs)
-       modify   $ \env -> env{ bounds = hbounds `mappend` bnds }
+       modify   $ \env -> env { bounds = hbounds `mappend` bnds }
   where
     go (x,bound) = (x,) <$> mkBound bound
     mkThing mk   = S.fromList . mconcat <$> sequence [ mk defVars s | (m, s) <- specs, m == name]
 
-
+mkBound :: (Resolvable a) => Bound (Located BareType) a -> BareM (Bound RSort a)
 mkBound (Bound s vs pts xts r)
-  = do ptys' <- mapM (\(x, t) -> ((x,) . toRSort) <$> mkSpecType (loc x) t) pts
-       xtys' <- mapM (\(x, t) -> ((x,) . toRSort) <$> mkSpecType (loc x) t) xts
-       vs'   <- map toRSort <$> mapM (mkSpecType (loc s)) vs
+  = do ptys' <- mapM (\(x, t) -> ((x,) . toRSort . val) <$> mkLSpecType t) pts
+       xtys' <- mapM (\(x, t) -> ((x,) . toRSort . val) <$> mkLSpecType t) xts
+       vs'   <- map (toRSort . val) <$> mapM mkLSpecType vs
        Bound s vs' ptys' xtys' <$> resolve (loc s) r

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -280,7 +280,7 @@ measEnv sp xts cbs lts asms itys hs autosizes
         , holes = fromListHEnv hs
         , lcs   = mempty
         , aenv  = axiom_map $ logicMap sp
-        , cerr  = Nothing 
+        , cerr  = Nothing
         }
     where
       tce = tcEmbeds sp
@@ -328,7 +328,7 @@ initCGI cfg info = CGInfo {
   , recCount   = 0
   , bindSpans  = M.empty
   , autoSize   = autosize spc
-  , allowHO    = higherorder cfg   
+  , allowHO    = higherorder cfg
   }
   where
     tce        = tcEmbeds spc
@@ -611,8 +611,8 @@ consCBSizedTys γ xes
 
 consCBWithExprs γ xes
   = do xets'     <- forM xes $ \(x, e) -> liftM (x, e,) (varTemplate γ (x, Just e))
-       texprs <- termExprs <$> get
-       let xtes = catMaybes $ (`lookup` texprs) <$> xs
+       texprs    <- termExprs <$> get
+       let xtes   = catMaybes $ (`lookup` texprs) <$> xs
        sflag     <- scheck <$> get
        let cmakeFinType = if sflag then makeFinType else id
        let xets  = mapThd3 (fmap cmakeFinType) <$> xets'
@@ -636,6 +636,9 @@ makeFinTy (ns, t) = fmap go t
         trep = toRTypeRep t
         args' = mapNs ns makeFinType $ ty_args trep
 
+makeTermEnvs :: CGEnv -> [(Var, [F.Located F.Expr])] -> [(Var, CoreExpr)]
+             -> [SpecType] -> [SpecType]
+             -> [CGEnv]
 makeTermEnvs γ xtes xes ts ts' = setTRec γ . zip xs <$> rts
   where
     vs   = zipWith collectArgs ts es
@@ -805,7 +808,7 @@ deriving instance (Show a) => (Show (Template a))
 
 unTemplate (Asserted t) = t
 unTemplate (Assumed t)  = t
-unTemplate (Internal t) = t 
+unTemplate (Internal t) = t
 unTemplate _ = panic Nothing "Constraint.Generate.unTemplate called on `Unknown`"
 
 addPostTemplate γ (Asserted t) = Asserted <$> addPost γ t
@@ -946,7 +949,7 @@ consE :: CGEnv -> Expr Var -> CG SpecType
 --------------------------------------------------------------------------------
 
 -- NV this is a hack to type polymorphic axiomatized functions
--- no need to check this code with flag, the axioms environment withh 
+-- no need to check this code with flag, the axioms environment withh
 -- be empty if there is no axiomatization
 
 consE γ e'@(App e@(Var x) (Type τ)) | (M.member x $ aenv γ)
@@ -958,16 +961,16 @@ consE γ e'@(App e@(Var x) (Type τ)) | (M.member x $ aenv γ)
        return $ strengthenS tt (singletonReft (M.lookup x $ aenv γ) x)
 
 {-
-consE γ (Lam β (e'@(App e@(Var x) (Type τ)))) | (M.member x $ aenv γ) && isTyVar β 
+consE γ (Lam β (e'@(App e@(Var x) (Type τ)))) | (M.member x $ aenv γ) && isTyVar β
   = do RAllT α te <- checkAll ("Non-all TyApp with expr", e) <$> consE γ e
        t          <- if isGeneric α te then freshTy_type TypeInstE e τ else trueTy τ
        addW        $ WfC γ t
        t'         <- refreshVV t
        tt  <- instantiatePreds γ e' $ subsTyVar_meet' (α, t') te
-       return $ RAllT (rTyVar β) 
+       return $ RAllT (rTyVar β)
                   $ strengthenS tt (singletonReft (M.lookup x $ aenv γ) x)
 -}
--- NV END HACK 
+-- NV END HACK
 
 consE γ (Var x)
   = do t <- varRefType γ x
@@ -1025,12 +1028,12 @@ consE γ e'@(App e a)
        let RFun x tx t _ = checkFun ("Non-fun App with caller ", e') te''
        pushConsBind      $ cconsE γ' a tx
        addPost γ'        $ maybe (checkUnbound γ' e' x t a) (F.subst1 t . (x,)) (argExpr γ a)
-       {- 
+       {-
        tt <- addPost γ'        $ maybe (checkUnbound γ' e' x t a) (F.subst1 t . (x,)) (argExpr γ a)
-       let rr = case (argExpr γ e, argExpr γ a) of 
+       let rr = case (argExpr γ e, argExpr γ a) of
                  (Just e', Just a') -> uTop $ F.Reft (F.vv_, F.PAtom F.Eq (F.EVar F.vv_) (F.EApp e' a'))
                  _                  -> mempty
-       return $ tt `strengthen` rr 
+       return $ tt `strengthen` rr
        -}
 
 

--- a/src/Language/Haskell/Liquid/Constraint/Types.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Types.hs
@@ -104,7 +104,7 @@ data CGEnv
         , holes :: !HEnv                                  -- ^ Types with holes, will need refreshing
         , lcs   :: !LConstraint                           -- ^ Logical Constraints
         , aenv  :: !(M.HashMap Var F.Symbol)              -- ^ axiom environment maps axiomatized Haskell functions to the logical functions
-        , cerr  :: !(Maybe (TError SpecType))             -- ^ error that should be reported at the user 
+        , cerr  :: !(Maybe (TError SpecType))             -- ^ error that should be reported at the user
         } -- deriving (Data, Typeable)
 
 data LConstraint = LC [[(F.Symbol, SpecType)]]
@@ -181,7 +181,7 @@ data CGInfo = CGInfo {
   , annotMap   :: !(AnnInfo (Annot SpecType))  -- ^ source-position annotation map
   , tyConInfo  :: !(M.HashMap TC.TyCon RTyCon) -- ^ information about type-constructors
   , specDecr   :: ![(Var, [Int])]              -- ^ ? FIX THIS
-  , termExprs  :: !(M.HashMap Var [F.Expr])    -- ^ Terminating Metrics for Recursive functions
+  , termExprs  :: !(M.HashMap Var [F.Located F.Expr])    -- ^ Terminating Metrics for Recursive functions
   , specLVars  :: !(S.HashSet Var)             -- ^ Set of variables to ignore for termination checking
   , specLazy   :: !(S.HashSet Var)             -- ^ ? FIX THIS
   , autoSize   :: !(S.HashSet TC.TyCon)        -- ^ ? FIX THIS
@@ -196,7 +196,7 @@ data CGInfo = CGInfo {
   , kvProf     :: !KVProf                      -- ^ Profiling distribution of KVars
   , recCount   :: !Int                         -- ^ number of recursive functions seen (for benchmarks)
   , bindSpans  :: M.HashMap F.BindId SrcSpan   -- ^ Source Span associated with Fixpoint Binder
-  , allowHO    :: !Bool  
+  , allowHO    :: !Bool
   }
 
 instance PPrint CGInfo where

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -23,7 +21,7 @@ import           System.Exit
 -- import           Control.DeepSeq
 import           Text.PrettyPrint.HughesPJ
 import           CoreSyn
-import           Var
+-- import           Var
 import           HscTypes                         (SourceError)
 import           System.Console.CmdArgs.Verbosity (whenLoud, whenNormal)
 import           System.Console.CmdArgs.Default
@@ -146,13 +144,6 @@ dumpCs cgi = do
 pprintMany :: (PPrint a) => [a] -> Doc
 pprintMany xs = vcat [ pprint x $+$ text " " | x <- xs ]
 
-checkedNames ::  Maybe DC.DiffCheck -> Maybe [String]
-checkedNames dc          = concatMap names . DC.newBinds <$> dc
-   where
-     names (NonRec v _ ) = [render . text $ shvar v]
-     names (Rec xs)      = map (shvar . fst) xs
-     shvar               = showpp . varName
-
 prune :: Config -> [CoreBind] -> FilePath -> GhcInfo -> IO (Maybe DC.DiffCheck)
 prune cfg cbinds tgt info
   | not (null vs) = return . Just $ DC.DC (DC.thin cbinds vs) mempty sp
@@ -163,12 +154,11 @@ prune cfg cbinds tgt info
     sp            = spec info
 
 
-
 solveCs :: Config -> FilePath -> CGInfo -> GhcInfo -> Maybe DC.DiffCheck -> IO (Output Doc)
 solveCs cfg tgt cgi info dc
   = do finfo        <- cgInfoFInfo info cgi tgt
        F.Result r sol <- solve fx finfo
-       let names = checkedNames dc
+       let names = map show . DC.checkedVars <$> dc
        let warns = logErrors cgi
        let annm  = annotMap cgi
        let res   = ferr sol r

--- a/src/Language/Haskell/Liquid/Measure.hs
+++ b/src/Language/Haskell/Liquid/Measure.hs
@@ -63,19 +63,19 @@ data Spec ty bndr  = Spec
   , ealiases   :: ![RTAlias Symbol Expr]        -- ^ Expression aliases
   , embeds     :: !(TCEmb LocSymbol)            -- ^ GHC-Tycon-to-fixpoint Tycon map
   , qualifiers :: ![Qualifier]                  -- ^ Qualifiers in source/spec files
-  , decr       :: ![(LocSymbol, [Int])]         -- ^ Information on decreasing arguments
-  , lvars      :: ![LocSymbol]                  -- ^ Variables that should be checked in the environment they are used
-  , lazy       :: !(S.HashSet LocSymbol)        -- ^ Ignore Termination Check in these Functions
-  , axioms     :: !(S.HashSet LocSymbol)        -- ^ Binders to turn into axiomatized functions
-  , hmeas      :: !(S.HashSet LocSymbol)        -- ^ Binders to turn into measures using haskell definitions
-  , hbounds    :: !(S.HashSet LocSymbol)        -- ^ Binders to turn into bounds using haskell definitions
-  , inlines    :: !(S.HashSet LocSymbol)        -- ^ Binders to turn into logic inline using haskell definitions
-  , autosize   :: !(S.HashSet LocSymbol)        -- ^ Type Constructors that get automatically sizing info
-  , pragmas    :: ![Located String]             -- ^ Command-line configurations passed in through source
-  , cmeasures  :: ![Measure ty ()]              -- ^ Measures attached to a type-class
-  , imeasures  :: ![Measure ty bndr]            -- ^ Mappings from (measure,type) -> measure
-  , classes    :: ![RClass ty]                  -- ^ Refined Type-Classes
-  , termexprs  :: ![(LocSymbol, [Expr])]        -- ^ Terminating Conditions for functions
+  , decr       :: ![(LocSymbol, [Int])]          -- ^ Information on decreasing arguments
+  , lvars      :: ![LocSymbol]                   -- ^ Variables that should be checked in the environment they are used
+  , lazy       :: !(S.HashSet LocSymbol)         -- ^ Ignore Termination Check in these Functions
+  , axioms     :: !(S.HashSet LocSymbol)         -- ^ Binders to turn into axiomatized functions
+  , hmeas      :: !(S.HashSet LocSymbol)         -- ^ Binders to turn into measures using haskell definitions
+  , hbounds    :: !(S.HashSet LocSymbol)         -- ^ Binders to turn into bounds using haskell definitions
+  , inlines    :: !(S.HashSet LocSymbol)         -- ^ Binders to turn into logic inline using haskell definitions
+  , autosize   :: !(S.HashSet LocSymbol)         -- ^ Type Constructors that get automatically sizing info
+  , pragmas    :: ![Located String]              -- ^ Command-line configurations passed in through source
+  , cmeasures  :: ![Measure ty ()]               -- ^ Measures attached to a type-class
+  , imeasures  :: ![Measure ty bndr]             -- ^ Mappings from (measure,type) -> measure
+  , classes    :: ![RClass ty]                   -- ^ Refined Type-Classes
+  , termexprs  :: ![(LocSymbol, [Located Expr])] -- ^ Terminating Conditions for functions
   , rinstance  :: ![RInstance ty]
   , dvariance  :: ![(LocSymbol, [Variance])]
   , bounds     :: !(RRBEnv ty)

--- a/src/Language/Haskell/Liquid/Measure.hs
+++ b/src/Language/Haskell/Liquid/Measure.hs
@@ -47,15 +47,15 @@ import Language.Haskell.Liquid.Types.Bounds
 import Language.Haskell.Liquid.UX.Tidy
 
 -- MOVE TO TYPES
-type BareSpec      = Spec BareType LocSymbol
+type BareSpec      = Spec (Located BareType) LocSymbol
 
 data Spec ty bndr  = Spec
   { measures   :: ![Measure ty bndr]            -- ^ User-defined properties for ADTs
   , asmSigs    :: ![(LocSymbol, ty)]            -- ^ Assumed (unchecked) types
   , sigs       :: ![(LocSymbol, ty)]            -- ^ Imported functions and types
   , localSigs  :: ![(LocSymbol, ty)]            -- ^ Local type signatures
-  , invariants :: ![Located ty]                 -- ^ Data type invariants
-  , ialiases   :: ![(Located ty, Located ty)]   -- ^ Data type invariants to be checked
+  , invariants :: ![ty]                         -- ^ Data type invariants
+  , ialiases   :: ![(ty, ty)]                   -- ^ Data type invariants to be checked
   , imports    :: ![Symbol]                     -- ^ Loaded spec module names
   , dataDecls  :: ![DataDecl]                   -- ^ Predicated data definitions
   , includes   :: ![FilePath]                   -- ^ Included qualifier files

--- a/src/Language/Haskell/Liquid/Measure.hs
+++ b/src/Language/Haskell/Liquid/Measure.hs
@@ -84,7 +84,6 @@ data Spec ty bndr  = Spec
 
 qualifySpec name sp = sp { sigs      = [ (tx x, t)  | (x, t)  <- sigs sp]
                          , asmSigs   = [ (tx x, t)  | (x, t)  <- asmSigs sp]
---                          , termexprs = [ (tx x, es) | (x, es) <- termexprs sp]
                          }
   where
     tx = fmap (qualifySymbol name)
@@ -104,6 +103,7 @@ mkMSpec' ms = MSpec cm mm M.empty []
     cm     = groupMap (symbol . ctor) $ concatMap eqns ms
     mm     = M.fromList [(name m, m) | m <- ms ]
 
+mkMSpec :: [Measure t LocSymbol] -> [Measure t ()] -> [Measure t LocSymbol] -> MSpec t LocSymbol 
 mkMSpec ms cms ims = MSpec cm mm cmm ims
   where
     cm     = groupMap (val . ctor) $ concatMap eqns (ms'++ims)
@@ -111,16 +111,6 @@ mkMSpec ms cms ims = MSpec cm mm cmm ims
     cmm    = M.fromList [(name m, m) | m <- cms ]
     ms'    = checkDuplicateMeasure ms
     -- ms'    = checkFail "Duplicate Measure Definition" (distinct . fmap name) ms
-
---checkFail ::  [Char] -> (a -> Bool) -> a -> a
---checkFail msg f x
---  | f x
---  = x
---  | otherwise
---  = errorstar $ "Check-Failure: " ++ msg
-
---distinct ::  Ord a => [a] -> Bool
---distinct xs = length xs == length (sortNub xs)
 
 
 checkDuplicateMeasure ms

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -782,9 +782,9 @@ rawBodyP
       p <- predP <* spaces
       return $ R v p
 
-tyBodyP :: BareType -> Parser Body
+tyBodyP :: Located BareType -> Parser Body
 tyBodyP ty
-  = case outTy ty of
+  = case outTy (val ty) of
       Just bt | isPropBareType bt
                 -> P <$> predP
       _         -> E <$> exprP

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -14,6 +14,7 @@ module Language.Haskell.Liquid.Parse
 
 import Prelude hiding (error)
 import Control.Monad
+import Control.Arrow (second)
 import Text.Parsec
 import Text.Parsec.Error (newErrorMessage, Message (..))
 import Text.Parsec.Pos   (newPos)
@@ -45,8 +46,8 @@ import Language.Haskell.Liquid.Types.Bounds
 import qualified Language.Haskell.Liquid.Measure as Measure
 
 import Language.Fixpoint.Parse hiding (angles, refBindP, refP, refDefP)
-
 -- import Debug.Trace
+
 
 ----------------------------------------------------------------------------
 -- Top Level Parsing API ---------------------------------------------------
@@ -103,6 +104,7 @@ parseWithError parser f s
       Right (r, "", _)  -> Right r
       Right (_, rem, _) -> Left  $ parseErrorError f $ remParseError f s rem
 
+
 ---------------------------------------------------------------------------
 parseErrorError     :: SourceName -> ParseError -> Error
 ---------------------------------------------------------------------------
@@ -131,8 +133,6 @@ remLineCol src rem = (line, col)
     remCol         = length $ head remLines
     srcLines       = lines  src
     remLines       = lines  rem
-
-
 
 
 
@@ -169,7 +169,6 @@ stringLiteral = Token.stringLiteral lexer
 -- not supplied, then the default "top" refinement is used.
 
 bareTypeP :: Parser BareType
-
 bareTypeP
   =  try bareAllP
  <|> bareAllS
@@ -264,17 +263,17 @@ bareConstraintP
        t    <- bareTypeP
        return $ rrTy ct t
 
-
 constraintP
   = do xts <- constraintEnvP
-       t1 <- bareTypeP
+       t1  <- bareTypeP
        reserved "<:"
-       t2 <- bareTypeP
-       return $ fromRTypeRep $ RTypeRep [] [] [] ((val . fst <$> xts) ++ [dummySymbol]) (replicate (length xts + 1) mempty) ((snd <$> xts) ++ [t1]) t2
-
+       t2  <- bareTypeP
+       return $ fromRTypeRep $ RTypeRep [] [] [] ((val . fst <$> xts) ++ [dummySymbol])
+                                                 (replicate (length xts + 1) mempty)
+                                                 ((snd <$> xts) ++ [t1]) t2
 
 constraintEnvP
-   =  try (do xts <- sepBy tyBindP comma
+   =  try (do xts <- sepBy tyBindNoLocP comma
               reserved "|-"
               return xts)
   <|> return []
@@ -428,8 +427,7 @@ funArgsP  = try realP <|> empP
     realP = do (EVar lp, xs) <- splitEApp <$> funAppP
                return (lp, xs)
 
-
-
+boundP :: Parser (Bound (Located BareType) Expr)
 boundP = do
   name   <- locParserP upperIdP
   reservedOp "="
@@ -446,9 +444,9 @@ boundP = do
                  )
            <|> return []
     bvsP   = try ( do reserved "forall"
-                      xs <- many symbolP
+                      xs <- many (locParserP symbolP)
                       reserved  "."
-                      return ((`RVar` mempty) <$> xs)
+                      return (fmap (`RVar` mempty) <$> xs)
                  )
            <|> return []
 
@@ -500,12 +498,12 @@ data Pspec ty ctor
   | Assm    (LocSymbol, ty)
   | Asrt    (LocSymbol, ty)
   | LAsrt   (LocSymbol, ty)
-  | Asrts   ([LocSymbol], (ty, Maybe [Expr]))
+  | Asrts   ([LocSymbol], (ty, Maybe [Located Expr]))
   | Impt    Symbol
   | DDecl   DataDecl
   | Incl    FilePath
-  | Invt    (Located ty)
-  | IAlias  (Located ty, Located ty)
+  | Invt    ty
+  | IAlias  (ty, ty)
   | Alias   (RTAlias Symbol BareType)
   | EAlias  (RTAlias Symbol Expr)
   | Embed   (LocSymbol, FTycon)
@@ -558,7 +556,7 @@ instance Show (Pspec a b) where
   show (RInst  _) = "RInst"
   show (ASize  _) = "ASize"
 
-
+mkSpec :: ModName -> [Pspec (Located BareType) LocSymbol] -> (ModName, Measure.Spec (Located BareType) LocSymbol)
 mkSpec name xs         = (name,)
                        $ Measure.qualifySpec (symbol name)
                        $ Measure.Spec
@@ -594,18 +592,18 @@ mkSpec name xs         = (name,)
   , Measure.termexprs  = [(y, es) | Asrts (ys, (_, Just es)) <- xs, y <- ys]
   }
 
-specP :: Parser (Pspec BareType LocSymbol)
+specP :: Parser (Pspec (Located BareType) LocSymbol)
 specP
-  = try (reservedToken "assume"    >> liftM Assm   tyBindP   )
-    <|> (reservedToken "assert"    >> liftM Asrt   tyBindP   )
-    <|> (reservedToken "autosize"  >> liftM ASize  asizeP    )
-    <|> (reservedToken "Local"     >> liftM LAsrt  tyBindP   )
-    <|> (reservedToken "axiomatize" >> liftM Axiom  axiomP )
+  = try (reservedToken "assume"       >> liftM Assm   tyBindP   )
+    <|> (reservedToken "assert"       >> liftM Asrt   tyBindP   )
+    <|> (reservedToken "autosize"     >> liftM ASize  asizeP    )
+    <|> (reservedToken "Local"        >> liftM LAsrt  tyBindP   )
+    <|> (reservedToken "axiomatize"   >> liftM Axiom  axiomP    )
     <|> try (reservedToken "measure"  >> liftM Meas   measureP  )
-    <|> (reservedToken "measure"   >> liftM HMeas  hmeasureP )
-    <|> (reservedToken "inline"   >> liftM Inline  inlineP )
-    <|> try (reservedToken "bound" >> liftM PBound  boundP)
-    <|> (reservedToken "bound"    >> liftM HBound  hboundP)
+    <|> (reservedToken "measure"      >> liftM HMeas  hmeasureP )
+    <|> (reservedToken "inline"       >> liftM Inline  inlineP  )
+    <|> try (reservedToken "bound"    >> liftM PBound  boundP   )
+    <|> (reservedToken "bound"        >> liftM HBound  hboundP  )
     <|> try (reservedToken "class"    >> reserved "measure" >> liftM CMeas cMeasureP)
     <|> try (reservedToken "instance" >> reserved "measure" >> liftM IMeas iMeasureP)
     <|> (reservedToken "instance"  >> liftM RInst  instanceP )
@@ -626,11 +624,12 @@ specP
     <|> (reservedToken "Strict"    >> liftM Lazy   lazyVarP  )
     <|> (reservedToken "Lazy"      >> liftM Lazy   lazyVarP  )
     <|> (reservedToken "LIQUID"    >> liftM Pragma pragmaP   )
-    <|> ({- DEFAULT -}           liftM Asrts  tyBindsP  )
+    <|> ({- DEFAULT -}                liftM Asrts  tyBindsP  )
 
 reservedToken str = try(string str >> spaces1)
 
 spaces1 = satisfy isSpace >> spaces
+
 
 pragmaP :: Parser (Located String)
 pragmaP = locParserP stringLiteral
@@ -672,25 +671,34 @@ varianceP = (reserved "bivariant"     >> return Bivariant)
         <|> (reserved "contravariant" >> return Contravariant)
         <?> "Invalib variance annotation\t Use one of bivariant, invariant, covariant, contravariant"
 
-tyBindsP    :: Parser ([LocSymbol], (BareType, Maybe [Expr]))
+tyBindsP :: Parser ([LocSymbol], (Located BareType, Maybe [Located Expr]))
 tyBindsP = xyP (sepBy (locParserP binderP) comma) dcolon termBareTypeP
 
-tyBindP    :: Parser (LocSymbol, BareType)
-tyBindP    = xyP (locParserP binderP) dcolon genBareTypeP
+tyBindNoLocP :: Parser (LocSymbol, BareType)
+tyBindNoLocP = second val <$> tyBindP
 
-termBareTypeP :: Parser (BareType, Maybe [Expr])
+tyBindP    :: Parser (LocSymbol, Located BareType)
+tyBindP    = xyP xP dcolon tP
+  where
+    xP     = locParserP binderP
+    tP     = locParserP genBareTypeP
+
+termBareTypeP :: Parser (Located BareType, Maybe [Located Expr])
 termBareTypeP
    = try termTypeP
-  <|> (, Nothing) <$> genBareTypeP
+  <|> (, Nothing) <$> locParserP genBareTypeP
 
+termTypeP :: Parser (Located BareType, Maybe [Located Expr])
 termTypeP
-  = do t <- genBareTypeP
+  = do t <- locParserP genBareTypeP
        reserved "/"
-       es <- brackets $ sepBy exprP comma
+       es <- brackets $ sepBy (locParserP exprP) comma
        return (t, Just es)
 
-invariantP   = locParserP genBareTypeP
+invariantP :: Parser (Located BareType)
+invariantP = locParserP genBareTypeP
 
+invaliasP :: Parser (Located BareType, Located BareType)
 invaliasP
   = do t  <- locParserP genBareTypeP
        reserved "as"
@@ -725,55 +733,47 @@ aliasIdP = condIdP alphaNums (isAlpha . head)
            where
              alphaNums = S.fromList $ ['A' .. 'Z'] ++ ['a'..'z'] ++ ['0'..'9']
 
-measureP :: Parser (Measure BareType LocSymbol)
+measureP :: Parser (Measure (Located BareType) LocSymbol)
 measureP
   = do (x, ty) <- tyBindP
        whiteSpace
-       eqns    <- grabs $ measureDefP $ (rawBodyP <|> tyBodyP ty)
+       eqns    <- grabs $ measureDefP (rawBodyP <|> tyBodyP ty)
        return   $ Measure.mkM x ty eqns
 
-cMeasureP :: Parser (Measure BareType ())
+cMeasureP :: Parser (Measure (Located BareType) ())
 cMeasureP
   = do (x, ty) <- tyBindP
        return $ Measure.mkM x ty []
 
-iMeasureP :: Parser (Measure BareType LocSymbol)
+iMeasureP :: Parser (Measure (Located BareType) LocSymbol)
 iMeasureP = measureP
 
+instanceP :: Parser (RInstance (Located BareType))
 instanceP
   = do c  <- locUpperIdP
-       t  <- locUpperIdP
-       as <- classParams
        ts <- sepBy tyBindP semi
-       return $ RI c (RApp t ((`RVar` mempty) <$> as) [] mempty) ts
+       lt <- locParserP $ rit <$> locUpperIdP <*> classParams
+       return $ RI c lt ts
   where
-    classParams
-       =  (reserved "where" >> return [])
-      <|> (liftM2 (:) lowerIdP classParams)
+    rit t as    = RApp t ((`RVar` mempty) <$> as) [] mempty
+    classParams =  (reserved "where" >> return [])
+               <|> ((:) <$> lowerIdP <*> classParams)
 
-classP :: Parser (RClass BareType)
+classP :: Parser (RClass (Located BareType))
 classP
   = do sups <- supersP
-       c <- locUpperIdP
+       c    <- locUpperIdP
        spaces
-       tvs <- manyTill tyVarIdP (try $ reserved "where")
-       ms <- grabs tyBindP
+       tvs  <- manyTill tyVarIdP (try $ reserved "where")
+       ms   <- grabs tyBindP
        spaces
-       return $ RClass (fmap symbol c) sups tvs ms
+       return $ RClass (fmap symbol c) sups tvs ms -- sups tvs ms
   where
-    superP =  toRCls <$> bareAtomP (refBindP bindP)
-      -- c <- locUpperIdP
-      -- spaces
-      -- tvs <- many1 bareAtomNoAppP
-      -- return (RApp c tvs [] mempty)
-
-    supersP = try (((parens (superP `sepBy1` comma)) <|> fmap pure superP)
-                      <* reserved "=>")
-              <|> return []
+    superP   = locParserP (toRCls <$> bareAtomP (refBindP bindP))
+    supersP  = try (((parens (superP `sepBy1` comma)) <|> fmap pure superP)
+                       <* reserved "=>")
+               <|> return []
     toRCls x = x
---     toRCls (RApp c ts rs r) = RCls c ts
---     toRCls t@(RCls _ _)     = t
---     toRCls t                = errorstar $ "Parse.toRCls called with" ++ show t
 
 rawBodyP
   = braces $ do
@@ -801,7 +801,7 @@ upperIdP' = try $ symbol <$> condIdP' (isUpper . head)
 condIdP'  :: (String -> Bool) -> Parser Symbol
 condIdP' f
   = do c  <- letter
-       let isAlphaNumOr' c = (isAlphaNum c) || ('\''== c)
+       let isAlphaNumOr' c = isAlphaNum c || ('\''== c)
        cs <- many (satisfy isAlphaNumOr')
        blanks
        if f (c:cs) then return (symbol $ T.pack $ c:cs) else parserZero
@@ -818,7 +818,7 @@ binderP    =  try $ symbol <$> idP badc
 grabs p = try (liftM2 (:) p (grabs p))
        <|> return []
 
-measureDefP :: Parser Body -> Parser (Def BareType LocSymbol)
+measureDefP :: Parser Body -> Parser (Def (Located BareType) LocSymbol)
 measureDefP bodyP
   = do mname   <- locParserP symbolP
        (c, xs) <- measurePatP
@@ -826,7 +826,7 @@ measureDefP bodyP
        body    <- bodyP
        whiteSpace
        let xs'  = (symbol . val) <$> xs
-       return   $ Def mname [] (symbol <$> c) Nothing ((,Nothing) <$> xs') body
+       return   $ Def mname [] (symbol <$> c) Nothing ((, Nothing) <$> xs') body
 
 measurePatP :: Parser (LocSymbol, [LocSymbol])
 measurePatP
@@ -945,6 +945,7 @@ specWraps = betweenMany (liquidBeginP >> whiteSpace) (whiteSpace >> liquidEndP)
 
 liquidBeginP = string liquidBegin
 liquidEndP   = string liquidEnd
+
 ---------------------------------------------------------------
 -- | Bundling Parsers into a Typeclass ------------------------
 ---------------------------------------------------------------
@@ -952,5 +953,5 @@ liquidEndP   = string liquidEnd
 instance Inputable BareType where
   rr' = doParse' bareTypeP
 
-instance Inputable (Measure BareType LocSymbol) where
-  rr' = doParse' measureP
+-- instance Inputable (Measure BareType LocSymbol) where
+--   rr' = doParse' measureP

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -751,8 +751,8 @@ iMeasureP = measureP
 instanceP :: Parser (RInstance (Located BareType))
 instanceP
   = do c  <- locUpperIdP
+       lt <- locParserP (rit <$> locUpperIdP <*> classParams)
        ts <- sepBy tyBindP semi
-       lt <- locParserP $ rit <$> locUpperIdP <*> classParams
        return $ RI c lt ts
   where
     rit t as    = RApp t ((`RVar` mempty) <$> as) [] mempty

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -80,6 +80,7 @@ module Language.Haskell.Liquid.Types (
   -- * Instantiated RType
   , BareType, PrType
   , SpecType, SpecProp
+  , LocSpecType
   , RSort
   , UsedPVar, RPVar, RReft
   , REnv (..)
@@ -295,17 +296,17 @@ instance HasConfig GhcInfo where
 -- parsing the target source and dependent libraries
 
 data GhcSpec = SP {
-    tySigs     :: ![(Var, Located SpecType)]     -- ^ Asserted Reftypes
+    tySigs     :: ![(Var, LocSpecType)]     -- ^ Asserted Reftypes
                                                  -- eg.  see include/Prelude.spec
-  , asmSigs    :: ![(Var, Located SpecType)]     -- ^ Assumed Reftypes
-  , inSigs     :: ![(Var, Located SpecType)]     -- ^ Auto generated Signatures
-  , ctors      :: ![(Var, Located SpecType)]     -- ^ Data Constructor Measure Sigs
+  , asmSigs    :: ![(Var, LocSpecType)]     -- ^ Assumed Reftypes
+  , inSigs     :: ![(Var, LocSpecType)]     -- ^ Auto generated Signatures
+  , ctors      :: ![(Var, LocSpecType)]     -- ^ Data Constructor Measure Sigs
                                                  -- eg.  (:) :: a -> xs:[a] -> {v: Int | v = 1 + len(xs) }
-  , meas       :: ![(Symbol, Located SpecType)]  -- ^ Measure Types
+  , meas       :: ![(Symbol, LocSpecType)]  -- ^ Measure Types
                                                  -- eg.  len :: [a] -> Int
-  , invariants :: ![Located SpecType]            -- ^ Data Type Invariants
+  , invariants :: ![LocSpecType]                 -- ^ Data Type Invariants
                                                  -- eg.  forall a. {v: [a] | len(v) >= 0}
-  , ialiases   :: ![(Located SpecType, Located SpecType)] -- ^ Data Type Invariant Aliases
+  , ialiases   :: ![(LocSpecType, LocSpecType)]  -- ^ Data Type Invariant Aliases
   , dconsP     :: ![(DataCon, DataConP)]         -- ^ Predicated Data-Constructors
                                                  -- e.g. see tests/pos/Map.hs
   , tconsP     :: ![(TyCon, TyConP)]             -- ^ Predicated Type-Constructors
@@ -318,9 +319,9 @@ data GhcSpec = SP {
                                                  -- e.g tests/pos/qualTest.hs
   , tgtVars    :: ![Var]                         -- ^ Top-level Binders To Verify (empty means ALL binders)
   , decr       :: ![(Var, [Int])]                -- ^ Lexicographically ordered size witnesses for termination
-  , texprs     :: ![(Var, [Expr])]               -- ^ Lexicographically ordered expressions for termination
+  , texprs     :: ![(Var, [Located Expr])]       -- ^ Lexicographically ordered expressions for termination
   , lvars      :: !(S.HashSet Var)               -- ^ Variables that should be checked in the environment they are used
-  , lazy       :: !(S.HashSet Var)             -- ^ Binders to IGNORE during termination checking
+  , lazy       :: !(S.HashSet Var)               -- ^ Binders to IGNORE during termination checking
   , autosize   :: !(S.HashSet TyCon)             -- ^ Binders to IGNORE during termination checking
   , config     :: !Config                        -- ^ Configuration Options
   , exports    :: !NameSet                       -- ^ `Name`s exported by the module being verified
@@ -685,6 +686,7 @@ type SpecType    = RRType    RReft
 type SpecProp    = RRProp    RReft
 type RRProp r    = Ref       RSort (RRType r)
 
+type LocSpecType = Located SpecType
 
 data Stratum    = SVar Symbol | SDiv | SWhnf | SFin
                   deriving (Generic, Data, Typeable, Eq)

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -298,7 +298,7 @@ data GhcSpec = SP {
     tySigs     :: ![(Var, Located SpecType)]     -- ^ Asserted Reftypes
                                                  -- eg.  see include/Prelude.spec
   , asmSigs    :: ![(Var, Located SpecType)]     -- ^ Assumed Reftypes
-  , inSigs     :: ![(Var, Located SpecType)]     -- ^ Auto generated Signatures 
+  , inSigs     :: ![(Var, Located SpecType)]     -- ^ Auto generated Signatures
   , ctors      :: ![(Var, Located SpecType)]     -- ^ Data Constructor Measure Sigs
                                                  -- eg.  (:) :: a -> xs:[a] -> {v: Int | v = 1 + len(xs) }
   , meas       :: ![(Symbol, Located SpecType)]  -- ^ Measure Types
@@ -357,19 +357,19 @@ toLogicMap ls = mempty {logic_map = M.fromList $ map toLMap ls}
     toLMap (x, xs, e) = (x, LMap {lvar = x, largs = xs, lexpr = e})
 
 eAppWithMap lmap f es def
-  | Just (LMap _ xs e) <- M.lookup (val f) (logic_map lmap), length xs == length es 
+  | Just (LMap _ xs e) <- M.lookup (val f) (logic_map lmap), length xs == length es
   = subst (mkSubst $ zip xs es) e
-  | Just (LMap _ xs e) <- M.lookup (val f) (logic_map lmap), isApp e  
+  | Just (LMap _ xs e) <- M.lookup (val f) (logic_map lmap), isApp e
   = subst (mkSubst $ zip xs es) $ dropApp e (length xs - length es)
   | otherwise
   = def
 
-dropApp e i | i <= 0 = e 
+dropApp e i | i <= 0 = e
 dropApp (EApp e _) i = dropApp e (i-1)
 dropApp _ _          = errorstar "impossible"
- 
-isApp (EApp (EVar _) (EVar _)) = True 
-isApp (EApp e (EVar _))        = isApp e 
+
+isApp (EApp (EVar _) (EVar _)) = True
+isApp (EApp e (EVar _))        = isApp e
 isApp _                        = False
 
 data TyConP = TyConP { freeTyVarsTy :: ![RTyVar]
@@ -678,12 +678,12 @@ type RSort      = RRType    ()
 type BPVar      = PVar      BSort
 type RPVar      = PVar      RSort
 
-type RReft      = UReft     Reft
-type PrType     = RRType    Predicate
-type BareType   = BRType    RReft
-type SpecType   = RRType    RReft
-type SpecProp   = RRProp    RReft
-type RRProp r   = Ref       RSort (RRType r)
+type RReft       = UReft     Reft
+type PrType      = RRType    Predicate
+type BareType    = BRType    RReft
+type SpecType    = RRType    RReft
+type SpecProp    = RRProp    RReft
+type RRProp r    = Ref       RSort (RRType r)
 
 
 data Stratum    = SVar Symbol | SDiv | SWhnf | SFin
@@ -801,7 +801,7 @@ type RDEnv = DEnv Var SpecType
 --------------------------------------------------------------------------
 
 data Axiom b s e = Axiom { aname  :: (Var, Maybe DataCon)
-                         , rname  :: Maybe b 
+                         , rname  :: Maybe b
                          , abinds :: [b]
                          , atypes :: [s]
                          , alhs   :: e
@@ -1247,7 +1247,7 @@ rTypeValueVar t = vv where Reft (vv,_) =  rTypeReft t
 rTypeReft :: (Reftable r) => RType c tv r -> Reft
 rTypeReft = fromMaybe trueReft . fmap toReft . stripRTypeBase
 
-  
+
 -- stripRTypeBase ::  RType a -> Maybe a
 stripRTypeBase (RApp _ _ _ x)
   = Just x

--- a/src/Language/Haskell/Liquid/Types/Bounds.hs
+++ b/src/Language/Haskell/Liquid/Types/Bounds.hs
@@ -48,7 +48,7 @@ type RRBEnv tv     = M.HashMap LocSymbol (RRBound tv)
 
 
 instance Hashable (Bound t e) where
-        hashWithSalt i = hashWithSalt i . bname
+  hashWithSalt i = hashWithSalt i . bname
 
 instance Eq (Bound t e) where
   b1 == b2 = (bname b1) == (bname b2)
@@ -120,7 +120,7 @@ partitionPs penv qs = mapFst makeAR $ partition (isPApp penv) qs
     makeAR ps       = M.fromListWith (++) $ map (toUsedPVars penv) ps
 
 isPApp penv (EApp (EVar p) _)  = isJust $ lookup p penv
-isPApp penv (EApp e _)         = isPApp penv e 
+isPApp penv (EApp e _)         = isPApp penv e
 isPApp _    _                  = False
 
 toUsedPVars penv q@(EApp _ e) = (x, [toUsedPVar penv q])
@@ -141,7 +141,7 @@ toUsedPVar penv ee@(EApp _ _)
      EVar e = unProp $ last es
      es'    = init es
      Just q = lookup p penv
-     (EVar p, es) = splitEApp ee 
+     (EVar p, es) = splitEApp ee
 
 toUsedPVar _ _ = impossible Nothing "This cannot happen"
 

--- a/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/src/Language/Haskell/Liquid/Types/Names.hs
@@ -1,6 +1,8 @@
-module Language.Haskell.Liquid.Types.Names where
+module Language.Haskell.Liquid.Types.Names
+  (lenLocSymbol) where
 
 import Language.Fixpoint.Types
 
-
+-- RJ: Please add docs
+lenLocSymbol :: Located Symbol
 lenLocSymbol = dummyLoc $ symbol ("autolen" :: String)

--- a/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -172,7 +172,7 @@ instance ( SubsTy tv (RType c tv ()) c
          , RefTypable c tv r
          , RefTypable c tv ()
          , FreeVar c tv
-         , SubsTy tv (RType c tv ()) r 
+         , SubsTy tv (RType c tv ()) r
          , SubsTy tv (RType c tv ()) (RType c tv ()))
          => Monoid (RTProp c tv r) where
   mempty         = panic Nothing "mempty: RTProp"
@@ -701,7 +701,7 @@ instance (SubsTy tv ty Expr) => SubsTy tv ty Reft where
 
 
 instance (SubsTy tv ty Sort) => SubsTy tv ty Expr where
-  subt su (ELam (x, s) e) = ELam (x, subt su s) $ subt su e 
+  subt su (ELam (x, s) e) = ELam (x, subt su s) $ subt su e
   subt su (EApp e1 e2)    = EApp (subt su e1) (subt su e2)
   subt su (ENeg e)        = ENeg (subt su e)
   subt su (PNot e)        = PNot (subt su e)
@@ -717,30 +717,30 @@ instance (SubsTy tv ty Sort) => SubsTy tv ty Expr where
   subt su (PAtom b e1 e2) = PAtom b (subt su e1) (subt su e2)
   subt su (PAll xes e)    = PAll (subt su <$> xes) (subt su e)
   subt su (PExist xes e)  = PExist (subt su <$> xes) (subt su e)
-  subt _ e                = e  
+  subt _ e                = e
 
 instance (SubsTy tv ty a, SubsTy tv ty b) => SubsTy tv ty (a, b) where
   subt su (x, y) = (subt su x, subt su y)
 
 instance SubsTy Symbol (RType (Located Symbol) Symbol ()) Sort where
-  subt (v, RVar α _) (FObj s) 
+  subt (v, RVar α _) (FObj s)
     | symbol v == s = FObj α
-    | otherwise     = FObj s    
-  subt _ s          = s  
+    | otherwise     = FObj s
+  subt _ s          = s
 
 
 instance SubsTy Symbol RSort Sort where
-  subt (v, RVar α _) (FObj s) 
+  subt (v, RVar α _) (FObj s)
     | symbol v == s = FObj $ rTyVarSymbol α
-    | otherwise     = FObj s    
-  subt _ s          = s  
+    | otherwise     = FObj s
+  subt _ s          = s
 
 
 instance SubsTy RTyVar RSort Sort where
-  subt (v, RVar α _) (FObj s) 
+  subt (v, RVar α _) (FObj s)
     | symbol v == s = FObj $ rTyVarSymbol α
-    | otherwise     = FObj s    
-  subt _ s          = s  
+    | otherwise     = FObj s
+  subt _ s          = s
 
 instance (SubsTy tv ty ty) => SubsTy tv ty (PVKind ty) where
   subt su (PVProp t) = PVProp (subt su t)
@@ -774,7 +774,7 @@ instance SubsTy tv RSort Predicate where
   subt _ = id -- NV TODO
 
 instance (SubsTy tv ty r) => SubsTy tv ty (UReft r) where
-  subt su r = r {ur_reft = subt su $ ur_reft r} 
+  subt su r = r {ur_reft = subt su $ ur_reft r}
 
 -- Here the "String" is a Bare-TyCon. TODO: wrap in newtype
 instance SubsTy Symbol BSort LocSymbol where
@@ -1093,7 +1093,7 @@ cmpLexRef vxs (v, x, g)
 
 makeLexRefa es' es = uTop $ Reft (vv, PIff (EVar vv) $ pOr rs)
   where
-    rs = makeLexReft [] [] es es'
+    rs = makeLexReft [] [] (val <$> es) (val <$> es')
     vv = "vvRec"
 
 makeLexReft _ acc [] []

--- a/src/Language/Haskell/Liquid/UX/DiffCheck.hs
+++ b/src/Language/Haskell/Liquid/UX/DiffCheck.hs
@@ -45,7 +45,7 @@ import            System.Directory                (copyFile, doesFileExist)
 import            Language.Fixpoint.Types         (tracepp, PPrint (..), FixResult (..), Located (..))
 -- import            Language.Fixpoint.Misc          (traceShow)
 import            Language.Fixpoint.Utils.Files
-import            Language.Haskell.Liquid.Types   (LocSpecType, ErrorResult, SpecType, GhcSpec (..), AnnInfo (..), DataConP (..), Output (..))
+import            Language.Haskell.Liquid.Types   (LocSpecType, ErrorResult, GhcSpec (..), AnnInfo (..), DataConP (..), Output (..))
 import            Language.Haskell.Liquid.Misc    (mkGraph)
 import            Language.Haskell.Liquid.GHC.Misc
 import            Language.Haskell.Liquid.Types.Visitors

--- a/src/Language/Haskell/Liquid/UX/DiffCheck.hs
+++ b/src/Language/Haskell/Liquid/UX/DiffCheck.hs
@@ -21,6 +21,8 @@ module Language.Haskell.Liquid.UX.DiffCheck (
    -- * Save current information for next time
    , saveResult
 
+   -- * Names of top-level binders that are rechecked
+   , checkedVars
    )
    where
 
@@ -29,19 +31,19 @@ import            Prelude                       hiding (error)
 import            Data.Aeson
 import qualified  Data.Text as T
 import            Data.Algorithm.Diff
-
 import            Data.Maybe                    (listToMaybe, mapMaybe, fromMaybe)
 import            Data.Hashable
 import qualified  Data.IntervalMap.FingerTree as IM
 import            CoreSyn                       hiding (sourceName)
-import            Name
+import            Name (getSrcSpan)
 import            SrcLoc hiding (Located)
 import            Var
 import qualified  Data.HashSet                  as S
 import qualified  Data.HashMap.Strict           as M
 import qualified  Data.List                     as L
 import            System.Directory                (copyFile, doesFileExist)
-import            Language.Fixpoint.Types         (FixResult (..), Located (..))
+import            Language.Fixpoint.Types         (tracepp, PPrint (..), FixResult (..), Located (..))
+-- import            Language.Fixpoint.Misc          (traceShow)
 import            Language.Fixpoint.Utils.Files
 import            Language.Haskell.Liquid.Types   (ErrorResult, SpecType, GhcSpec (..), AnnInfo (..), DataConP (..), Output (..))
 import            Language.Haskell.Liquid.Misc    (mkGraph)
@@ -66,6 +68,9 @@ data DiffCheck = DC { newBinds  :: [CoreBind]
                     , newSpec   :: !GhcSpec
                     }
 
+instance PPrint DiffCheck where
+  pprintTidy k = pprintTidy k . checkedVars
+
 -- | Variable definitions
 data Def  = D { start  :: Int -- ^ line at which binder definition starts
               , end    :: Int -- ^ line at which binder definition ends
@@ -85,7 +90,14 @@ type ChkItv = IM.IntervalMap Int ()
 instance Show Def where
   show (D i j x) = showPpr x ++ " start: " ++ show i ++ " end: " ++ show j
 
-
+--------------------------------------------------------------------------------
+-- | `checkedNames` returns the names of the top-level binders that will be checked
+--------------------------------------------------------------------------------
+checkedVars              ::  DiffCheck -> [Var]
+checkedVars              = concatMap names . newBinds
+   where
+     names (NonRec v _ ) = [v]
+     names (Rec xs)      = fst <$> xs
 
 -------------------------------------------------------------------------
 -- | `slice` returns a subset of the @[CoreBind]@ of the input `target`
@@ -105,21 +117,22 @@ sliceSaved :: FilePath -> FilePath -> [CoreBind] -> GhcSpec -> IO (Maybe DiffChe
 sliceSaved target savedFile coreBinds spec
   = do (is, lm) <- lineDiff target savedFile
        result   <- loadResult target
-       return    $ sliceSaved' is lm (DC coreBinds result spec)
+       return    $ sliceSaved' target is lm (DC coreBinds result spec)
 
-sliceSaved' :: [Int] -> LMap -> DiffCheck -> Maybe DiffCheck
-sliceSaved' is lm (DC coreBinds result spec)
-  | globalDiff is spec = Nothing
-  | otherwise          = Just $ DC cbs' res' sp'
+sliceSaved' :: FilePath -> [Int] -> LMap -> DiffCheck -> Maybe DiffCheck
+sliceSaved' srcF is lm (DC coreBinds result spec)
+  | gDiff     = Nothing
+  | otherwise = Just $ DC cbs' res' sp'
   where
-    cbs'             = thinWith sigs coreBinds $ diffVars is dfs
-    sigs             = S.fromList $ M.keys sigm
-    sigm             = sigVars is spec
-    res'             = adjustOutput lm cm result
-    cm               = checkedItv chDfs
-    dfs              = coreDefs coreBinds ++ specDefs spec
-    chDfs            = coreDefs cbs'
-    sp'              = assumeSpec sigm spec
+    gDiff     = globalDiff srcF is spec
+    cbs'      = thinWith sigs coreBinds $ diffVars is dfs
+    sigs      = S.fromList $ M.keys sigm
+    sigm      = sigVars srcF is spec
+    res'      = adjustOutput lm cm result
+    cm        = checkedItv chDfs
+    dfs       = coreDefs coreBinds ++ specDefs srcF spec
+    chDfs     = coreDefs cbs'
+    sp'       = assumeSpec sigm spec
 
 -- Add the specified signatures for vars-with-preserved-sigs,
 -- whose bodies have been pruned from [CoreBind] into the "assumes"
@@ -131,8 +144,8 @@ assumeSpec sigm sp = sp { asmSigs = M.toList $ M.union sigm assm }
     -- zs          = M.keys sigm
 
 diffVars :: [Int] -> [Def] -> [Var]
-diffVars ls defs'    = -- tracePpr ("INCCHECK: diffVars lines = " ++ show ls ++ " defs= " ++ show defs) $
-                       go (L.sort ls) defs
+diffVars ls defs'    = tracePpr ("INCCHECK: diffVars lines = " ++ show ls ++ " defs= " ++ show defs) $
+                         go (L.sort ls) defs
   where
     defs             = L.sort defs'
     go _      []     = []
@@ -142,23 +155,23 @@ diffVars ls defs'    = -- tracePpr ("INCCHECK: diffVars lines = " ++ show ls ++ 
       | i > end d    = go (i:is) ds
       | otherwise    = binder d : go (i:is) ds
 
-sigVars :: [Int] -> GhcSpec -> M.HashMap Var (Located SpecType)
-sigVars ls sp = M.fromList $ filter (ok . snd) $ specSigs sp
+sigVars :: FilePath -> [Int] -> GhcSpec -> M.HashMap Var (Located SpecType)
+sigVars srcF ls sp = M.fromList $ filter (ok . snd) $ specSigs sp
   where
-    ok        = not . isDiff ls
+    ok             = not . isDiff srcF ls
 
-globalDiff :: [Int] -> GhcSpec -> Bool
-globalDiff lines spec = measDiff || invsDiff || dconsDiff
+globalDiff :: FilePath -> [Int] -> GhcSpec -> Bool
+globalDiff srcF ls spec = measDiff || invsDiff || dconsDiff
   where
-    measDiff  = any (isDiff lines) (snd <$> meas spec)
-    invsDiff  = any (isDiff lines) (invariants spec)
-    dconsDiff = any (isDiff lines) (dloc . snd <$> dconsP spec)
+    measDiff  = tracepp "measDiff"  $ any (isDiff srcF ls) (snd <$> meas spec)
+    invsDiff  = tracepp "invsDiff"  $ any (isDiff srcF ls) (invariants spec)
+    dconsDiff = tracepp "dconsDiff" $ any (isDiff srcF ls) (dloc . snd <$> dconsP spec)
     dloc dc   = Loc (dc_loc dc) (dc_locE dc) ()
 
-isDiff :: [Int] -> Located a -> Bool
-isDiff lines x = any hits lines
+isDiff :: FilePath -> [Int] -> Located a -> Bool
+isDiff srcF ls x = file x == srcF && any hits ls
   where
-    hits i = line x <= i && i <= lineE x
+    hits i       = line x <= i && i <= lineE x
 
 -------------------------------------------------------------------------
 -- | @thin@ returns a subset of the @[CoreBind]@ given which correspond
@@ -193,7 +206,7 @@ dependsOn cg vars = S.fromList results
       results = map fst $ M.toList $ M.unions filteredMaps
 
 txClosure :: Deps -> S.HashSet Var -> S.HashSet Var -> S.HashSet Var
-txClosure d sigs xs = go S.empty xs
+txClosure d sigs   = go S.empty
   where
     next           = S.unions . fmap deps . S.toList
     deps x         = M.lookupDefault S.empty x d
@@ -216,11 +229,12 @@ filterBinds cbs ys = filter f cbs
 
 
 -------------------------------------------------------------------------
-specDefs :: GhcSpec -> [Def]
+specDefs :: FilePath -> GhcSpec -> [Def]
 -------------------------------------------------------------------------
-specDefs       = map def . specSigs
+specDefs srcF  = map def . filter sameFile . specSigs
   where
     def (x, t) = D (line t) (lineE t) x
+    sameFile   = (srcF ==) . file . snd
 
 specSigs :: GhcSpec -> [(Var, Located SpecType)]
 specSigs sp = tySigs sp ++ asmSigs sp ++ ctors sp
@@ -407,7 +421,7 @@ adjustReal lm rsp
   | otherwise                     = Nothing
   where
     (f, l1, c1, l2, c2)           = unpackRealSrcSpan rsp
-    
+
 
 -- | @getShift lm old@ returns @Just δ@ if the line number @old@ shifts by @δ@
 -- in the diff and returns @Nothing@ otherwise.
@@ -473,6 +487,9 @@ instance ToJSON (Output Doc) where
   toEncoding = genericToEncoding defaultOptions
 instance FromJSON (Output Doc)
 
+
+file :: Located a -> FilePath
+file = sourceName . loc
 
 line :: Located a -> Int
 line  = sourceLine . loc

--- a/src/Language/Haskell/Liquid/UX/DiffCheck.hs
+++ b/src/Language/Haskell/Liquid/UX/DiffCheck.hs
@@ -45,7 +45,7 @@ import            System.Directory                (copyFile, doesFileExist)
 import            Language.Fixpoint.Types         (tracepp, PPrint (..), FixResult (..), Located (..))
 -- import            Language.Fixpoint.Misc          (traceShow)
 import            Language.Fixpoint.Utils.Files
-import            Language.Haskell.Liquid.Types   (ErrorResult, SpecType, GhcSpec (..), AnnInfo (..), DataConP (..), Output (..))
+import            Language.Haskell.Liquid.Types   (LocSpecType, ErrorResult, SpecType, GhcSpec (..), AnnInfo (..), DataConP (..), Output (..))
 import            Language.Haskell.Liquid.Misc    (mkGraph)
 import            Language.Haskell.Liquid.GHC.Misc
 import            Language.Haskell.Liquid.Types.Visitors
@@ -136,7 +136,7 @@ sliceSaved' srcF is lm (DC coreBinds result spec)
 
 -- Add the specified signatures for vars-with-preserved-sigs,
 -- whose bodies have been pruned from [CoreBind] into the "assumes"
-assumeSpec :: M.HashMap Var (Located SpecType) -> GhcSpec -> GhcSpec
+assumeSpec :: M.HashMap Var LocSpecType -> GhcSpec -> GhcSpec
 assumeSpec sigm sp = sp { asmSigs = M.toList $ M.union sigm assm }
   where
     assm           = M.fromList $ asmSigs sp
@@ -155,7 +155,7 @@ diffVars ls defs'    = tracePpr ("INCCHECK: diffVars lines = " ++ show ls ++ " d
       | i > end d    = go (i:is) ds
       | otherwise    = binder d : go (i:is) ds
 
-sigVars :: FilePath -> [Int] -> GhcSpec -> M.HashMap Var (Located SpecType)
+sigVars :: FilePath -> [Int] -> GhcSpec -> M.HashMap Var LocSpecType
 sigVars srcF ls sp = M.fromList $ filter (ok . snd) $ specSigs sp
   where
     ok             = not . isDiff srcF ls
@@ -236,7 +236,7 @@ specDefs srcF  = map def . filter sameFile . specSigs
     def (x, t) = D (line t) (lineE t) x
     sameFile   = (srcF ==) . file . snd
 
-specSigs :: GhcSpec -> [(Var, Located SpecType)]
+specSigs :: GhcSpec -> [(Var, LocSpecType)]
 specSigs sp = tySigs sp ++ asmSigs sp ++ ctors sp
 
 -------------------------------------------------------------------------

--- a/tests/neg/ListElem.hs
+++ b/tests/neg/ListElem.hs
@@ -1,15 +1,15 @@
-module ListElem () where
+module ListElem (listElem) where
 
 import Data.Set
 
-{-@ listElem :: (Eq a) 
-             => y:a 
+{-@ listElem :: (Eq a)
+             => y:a
              -> xs:[a]
-             -> {v:Bool | (Prop(v) <=> Set_mem(y, (listElts(xs))))} 
+             -> {v:Bool | Prop v <=> Set_mem y (listElts xs)}
   @-}
 
 listElem :: (Eq a) => a -> [a] -> Bool
-listElem _ []     = False
-listElem y (x:xs) | x == y    = True
-                  | otherwise = True -- listElem y xs
-
+listElem _ []      = False
+listElem y (x:_xs)
+  | x == y         = True
+  | otherwise      = True -- listElem y xs

--- a/tests/neg/test00c.hs
+++ b/tests/neg/test00c.hs
@@ -2,10 +2,12 @@
 
 module Test (ok, inc) where
 
-{-@ ok :: Nat -> Nat @-}
+{-@ ok
+    ::    Nat -> Nat
+  @-}
 ok :: Int -> Int
 ok x = x + 120
 
 {-@ inc :: Int -> Nat @-}
 inc :: Int -> Int
-inc x = x + 1
+inc x = x + 10

--- a/tests/neg/test00c.hs
+++ b/tests/neg/test00c.hs
@@ -3,7 +3,7 @@
 module Test (ok, inc) where
 
 {-@ ok
-    ::    Nat -> Nat
+    ::    Int -> Nat
   @-}
 ok :: Int -> Int
 ok x = x + 120


### PR DESCRIPTION
Various crosscutting changes to fix the `--diff` mode, including:

1. Modify `DiffCheck` to ignore definitions in _other_ files 
  (undoubtedly will come back to bite later...)

2. Modify `Parse` and `Bare` and `GhcSpec` to ensure that the entities in 
    `GhcSpec` are `Located SpecType` (rather than `SpecType`).