### PR TITLE
ApiAnnotations

### DIFF
--- a/benchmarks/bytestring-0.9.2.1/Data/ByteString/Internal.hs
+++ b/benchmarks/bytestring-0.9.2.1/Data/ByteString/Internal.hs
@@ -4,8 +4,6 @@
 {-# LANGUAGE UnliftedFFITypes, MagicHash,
             UnboxedTuples, DeriveDataTypeable #-}
 {-# OPTIONS_HADDOCK hide #-}
-{-@ LIQUID "--c-files=../../cbits/fpstring.c" @-}
-{-@ LIQUID "-i../../include" @-}
 -- |
 -- Module      : Data.ByteString.Internal
 -- License     : BSD-style

--- a/benchmarks/text-0.11.2.3/Data/Text/Array.hs
+++ b/benchmarks/text-0.11.2.3/Data/Text/Array.hs
@@ -2,7 +2,6 @@
     RecordWildCards, UnboxedTuples, UnliftedFFITypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-unused-matches #-}
-{-@ LIQUID "--c-files=../../cbits/cbits.c" @-}
 -- |
 -- Module      : Data.Text.Array
 -- Copyright   : (c) 2009, 2010, 2011 Bryan O'Sullivan

--- a/benchmarks/text-0.11.2.3/Data/Text/Encoding.hs
+++ b/benchmarks/text-0.11.2.3/Data/Text/Encoding.hs
@@ -1,7 +1,3 @@
-{-@ LIQUID "--idirs=../../../bytestring-0.9.2.1/" @-}
-{-@ LIQUID "--idirs=../../../../include/" @-}
-{-@ LIQUID "--c-files=../../cbits/cbits.c" @-}
-
 {-# LANGUAGE BangPatterns, CPP, ForeignFunctionInterface, MagicHash,
     UnliftedFFITypes #-}
 {-# LANGUAGE PackageImports, RankNTypes #-}

--- a/benchmarks/text-0.11.2.3/Data/Text/Lazy/Encoding.hs
+++ b/benchmarks/text-0.11.2.3/Data/Text/Lazy/Encoding.hs
@@ -1,6 +1,4 @@
 {-@ LIQUID "--notermination" @-}
-{-@ LIQUID "--idirs=../../../../bytestring-0.9.2.1/" @-}
-{-@ LIQUID "--idirs=../../../../../include/" @-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE Rank2Types #-}
 -- |

--- a/benchmarks/vector-0.10.0.1/Data/Vector/Fusion/Stream/Monadic.hs
+++ b/benchmarks/vector-0.10.0.1/Data/Vector/Fusion/Stream/Monadic.hs
@@ -13,7 +13,6 @@
 --
 
 {-@ LIQUID "--no-termination" @-}
-{-@ LIQUID "--idirs=/Users/rjhala/research/liquid/liquidhaskell/benchmarks/vector-0.10.0.1/" @-}
 {-@ LIQUID "--diffcheck" @-}
 
 module Data.Vector.Fusion.Stream.Monadic (

--- a/benchmarks/vector-0.10.0.1/Data/Vector/Fusion/Stream/Monadic.nocpp.hs
+++ b/benchmarks/vector-0.10.0.1/Data/Vector/Fusion/Stream/Monadic.nocpp.hs
@@ -13,7 +13,6 @@
 --
 
 {-@ LIQUID "--no-termination" @-}
-{-@ LIQUID "--idirs=/Users/rjhala/research/liquid/liquidhaskell/benchmarks/vector-0.10.0.1/" @-}
 {-@ LIQUID "--diffcheck" @-}
 
 module Data.Vector.Fusion.Stream.Monadic (

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -121,7 +121,6 @@ Library
                 , cmdargs >= 0.10
                 , time
                 , containers >= 0.5
-                , cpphs >= 1.19
                 , data-default >= 0.5
                 , deepseq >= 1.3
                 , directory >= 1.2

--- a/src/Language/Haskell/Liquid/GHC/Interface.hs
+++ b/src/Language/Haskell/Liquid/GHC/Interface.hs
@@ -266,7 +266,7 @@ getSpecComments parsed = mapMaybe getSpecComment comments
 
 getSpecComment :: GHC.Located AnnotationComment -> Maybe (SourcePos, String)
 getSpecComment (GHC.L span (AnnBlockComment text))
-  | length text > 2 && isPrefixOf "{-@" text && isSuffixOf "@-}" text =
+  | isPrefixOf "{-@" text && isSuffixOf "@-}" text =
     Just (offsetPos, take (length text - 6) $ drop 3 text)
   where
     offsetPos = incSourceColumn (srcSpanSourcePos span) 3

--- a/src/Language/Haskell/Liquid/GHC/Interface.hs
+++ b/src/Language/Haskell/Liquid/GHC/Interface.hs
@@ -242,7 +242,7 @@ processModule cfg logicMap tgtFiles depGraph specEnv modSummary = do
   _                   <- loadModule typechecked
   let specComments     = getSpecComments parsed
   (modName, bareSpec) <- either throw return $ hsSpecificationP (moduleName mod) specComments
-  let specEnv'         = extendModuleEnv specEnv mod (modName, bareSpec)
+  let specEnv'         = extendModuleEnv specEnv mod (modName, noTerm bareSpec)
   (specEnv', ) <$> if not (file `S.member` tgtFiles)
     then return Nothing
     else Just <$> processTargetModule cfg logicMap depGraph specEnv file typechecked bareSpec
@@ -380,7 +380,9 @@ transParseSpecs paths seenFiles specs newFiles = do
   transParseSpecs paths seenFiles' specs' newFiles'
   where
     specsImports ss = nub $ concatMap (map symbolString . Ms.imports . snd) ss
-    noTerm spec = spec { Ms.decr = mempty, Ms.lazy = mempty, Ms.termexprs = mempty }
+
+noTerm :: Ms.BareSpec -> Ms.BareSpec
+noTerm spec = spec { Ms.decr = mempty, Ms.lazy = mempty, Ms.termexprs = mempty }
 
 parseSpecFile :: FilePath -> IO (ModName, Ms.BareSpec)
 parseSpecFile file = either throw return . specSpecificationP file =<< readFile file

--- a/src/Language/Haskell/Liquid/GHC/Interface.hs
+++ b/src/Language/Haskell/Liquid/GHC/Interface.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE NoMonomorphismRestriction #-}
-{-# LANGUAGE TypeSynonymInstances      #-}
-{-# LANGUAGE FlexibleInstances         #-}
-{-# LANGUAGE TupleSections             #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
-{-# LANGUAGE OverloadedStrings         #-}
+{-# LANGUAGE NoMonomorphismRestriction  #-}
+{-# LANGUAGE TypeSynonymInstances       #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE TupleSections              #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Language.Haskell.Liquid.GHC.Interface (
 
@@ -27,30 +28,34 @@ import Class
 import CoreMonad
 import CoreSyn
 import DataCon
+import Digraph
 import DriverPhases
 import DriverPipeline
 import DynFlags
 import ErrUtils
+import Finder
 import HscTypes hiding (Target)
 import IdInfo
 import InstEnv
+import Module
+import Panic (throwGhcExceptionIO)
 import Var
 
 import Control.Exception
 import Control.Monad
 
+import Data.Bifunctor
 import Data.List hiding (intersperse)
 import Data.Maybe
 -- import Data.Function (on)
-import qualified Data.HashSet        as S
-import qualified Data.HashMap.Strict as M
+import qualified Data.HashSet as S
 
 import System.Console.CmdArgs.Verbosity hiding (Loud)
 import System.Directory
 import System.FilePath
 import System.IO.Temp
 
-import Text.PrettyPrint.HughesPJ
+import Text.PrettyPrint.HughesPJ hiding (first)
 
 import Language.Fixpoint.Types hiding (Error, Result, Expr)
 import Language.Fixpoint.Misc
@@ -73,36 +78,26 @@ import Language.Fixpoint.Utils.Files
 --------------------------------------------------------------------------------
 
 getGhcInfo :: Maybe HscEnv -> Config -> FilePath -> IO (GhcInfo, HscEnv)
-getGhcInfo hscEnv cfg0 target = do
-  tryIgnore "create temp directory" $
-    createDirectoryIfMissing False $ tempDirectory target
-  (cfg, name, tgtSpec) <- parseRootTarget cfg0 target
-  runLiquidGhc hscEnv cfg $ getGhcInfo' cfg target name tgtSpec
+getGhcInfo hscEnv cfg tgtFile' = do
+  tgtFile  <- canonicalizePath tgtFile'
+  _        <- tryIgnore "create temp directory" $
+                createDirectoryIfMissing False $ tempDirectory tgtFile
+  logicMap <- liftIO makeLogicMap
+  first head <$> runLiquidGhc hscEnv cfg (getGhcInfo' cfg logicMap [tgtFile])
 
-getGhcInfo' :: Config -> FilePath -> ModName -> Ms.BareSpec -> Ghc (GhcInfo, HscEnv)
-getGhcInfo' cfg target name tgtSpec = do
-  paths     <- importPaths <$> getSessionDynFlags
-  liftIO     $ whenLoud $ putStrLn $ "paths = " ++ show paths
-  impSpecs  <- findAndLoadTargets cfg paths target
-  modGuts   <- makeMGIModGuts target
-  hscEnv    <- getSession
-  coreBinds <- liftIO $ anormalize (not $ nocaseexpand cfg) hscEnv modGuts
-  logicMap  <- liftIO makeLogicMap
-  let dataCons = concatMap (map dataConWorkId . tyConDataCons) (mgi_tcs modGuts)
-  let impVs = importVars coreBinds ++ classCons (mgi_cls_inst modGuts)
-  let defVs = definedVars coreBinds
-  let useVs = readVars coreBinds
-  let letVs = letVars coreBinds
-  let derVs = derivedVars coreBinds $ ((is_dfun <$>) <$>) $ mgi_cls_inst modGuts
-  (spc, imps, incs) <- moduleSpec cfg coreBinds (impVs ++ defVs) letVs name modGuts tgtSpec logicMap impSpecs
-  liftIO $ whenLoud $ putStrLn $ "Module Imports: " ++ show imps
-  hqualFiles <- moduleHquals modGuts paths target imps incs
-  let info    = GI target (getModName name) hscEnv coreBinds derVs impVs (letVs ++ dataCons) useVs hqualFiles imps incs spc
-  hscEnv'    <- getSession
-  return (info, hscEnv')
+getGhcInfo' :: Config -> Either Error LogicMap
+            -> [FilePath]
+            -> Ghc ([GhcInfo], HscEnv)
+getGhcInfo' cfg logicMap tgtFiles = do
+  homeModules <- configureGhcTargets tgtFiles
+  _           <- compileCFiles cfg
+  depGraph    <- buildDepGraph homeModules
+  ghcInfo     <- processModules cfg logicMap tgtFiles depGraph homeModules
+  hscEnv      <- getSession
+  return (ghcInfo, hscEnv)
 
 --------------------------------------------------------------------------------
--- Configure GHC for Liquid Haskell --------------------------------------------
+-- GHC Configuration & Setup ---------------------------------------------------
 --------------------------------------------------------------------------------
 
 runLiquidGhc :: Maybe HscEnv -> Config -> Ghc a -> IO a
@@ -110,94 +105,324 @@ runLiquidGhc hscEnv cfg act =
   withSystemTempDirectory "liquid" $ \tmp ->
     runGhc (Just libdir) $ do
       maybe (return ()) setSession hscEnv
-      df <- getSessionDynFlags
-      (df',_,_) <- parseDynamicFlags df (map noLoc $ ghcOptions cfg)
-      loud <- liftIO isLoud
-      let df'' = df' { importPaths  = nub $ idirs cfg ++ importPaths df'
-                     , libraryPaths = nub $ idirs cfg ++ libraryPaths df'
-                     , includePaths = nub $ idirs cfg ++ includePaths df'
-                     , packageFlags = ExposePackage (PackageArg "ghc-prim")
-                                                    (ModRenaming True [])
-                                    : packageFlags df'
-                     -- , profAuto     = ProfAutoCalls
-                     , ghcLink      = LinkInMemory
-                     -- FIXME: this *should* be HscNothing, but that prevents us from
-                     -- looking up *unexported* names in another source module..
-                     , hscTarget    = HscInterpreted -- HscNothing
-                     , ghcMode      = CompManager
-                     -- prevent GHC from printing anything, unless in Loud mode
-                     , log_action   = if loud
-                                        then defaultLogAction
-                                        else \_ _ _ _ _ -> return ()
-                     -- redirect .hi/.o/etc files to temp directory
-                     , objectDir    = Just tmp
-                     , hiDir        = Just tmp
-                     , stubDir      = Just tmp
-                     } `xopt_set` Opt_MagicHash
-                       `xopt_set` Opt_DeriveGeneric
-                       `xopt_set` Opt_StandaloneDeriving
-                       `gopt_set` Opt_ImplicitImportQualified
-                       `gopt_set` Opt_PIC
-      _ <- setSessionDynFlags df''
-      defaultCleanupHandler df'' act
+      df <- configureDynFlags cfg tmp
+      defaultCleanupHandler df act
 
---------------------------------------------------------------------------------
--- Parse, Find, & Load Targets -------------------------------------------------
---------------------------------------------------------------------------------
+configureDynFlags :: Config -> FilePath -> Ghc DynFlags
+configureDynFlags cfg tmp = do
+  df <- getSessionDynFlags
+  (df',_,_) <- parseDynamicFlags df $ map noLoc $ ghcOptions cfg
+  loud <- liftIO isLoud
+  let df'' = df' { importPaths  = nub $ idirs cfg ++ importPaths df'
+                 , libraryPaths = nub $ idirs cfg ++ libraryPaths df'
+                 , includePaths = nub $ idirs cfg ++ includePaths df'
+                 , packageFlags = ExposePackage (PackageArg "ghc-prim")
+                                                (ModRenaming True [])
+                                : packageFlags df'
+                 -- , profAuto     = ProfAutoCalls
+                 , ghcLink      = LinkInMemory
+                 -- FIXME: this *should* be HscNothing, but that prevents us from
+                 -- looking up *unexported* names in another source module..
+                 , hscTarget    = HscInterpreted -- HscNothing
+                 , ghcMode      = CompManager
+                 -- prevent GHC from printing anything, unless in Loud mode
+                 , log_action   = if loud
+                                    then defaultLogAction
+                                    else \_ _ _ _ _ -> return ()
+                 -- redirect .hi/.o/etc files to temp directory
+                 , objectDir    = Just tmp
+                 , hiDir        = Just tmp
+                 , stubDir      = Just tmp
+                 } `xopt_set` Opt_MagicHash
+                   `xopt_set` Opt_DeriveGeneric
+                   `xopt_set` Opt_StandaloneDeriving
+                   `gopt_set` Opt_ImplicitImportQualified
+                   `gopt_set` Opt_PIC
+  _ <- setSessionDynFlags df''
+  return df''
 
-parseRootTarget :: Config -> FilePath -> IO (Config, ModName, Ms.BareSpec)
-parseRootTarget cfg0 target = do
-  (name, tgtSpec) <- parseSpec target
-  cfg <- withPragmas cfg0 target $ Ms.pragmas tgtSpec
-  return (cfg, ModName Target $ getModName name, tgtSpec)
+configureGhcTargets :: [FilePath] -> Ghc ModuleGraph
+configureGhcTargets tgtFiles = do
+  targets         <- mapM (`guessTarget` Nothing) tgtFiles 
+  _               <- setTargets targets
+  moduleGraph     <- depanal [] False
+  let homeModules  = flattenSCCs $ topSortModuleGraph False moduleGraph Nothing
+  _               <- setTargetModules $ moduleName . ms_mod <$> homeModules
+  return homeModules
 
-findAndLoadTargets :: Config -> [FilePath] -> FilePath -> Ghc [(ModName, Ms.BareSpec)]
-findAndLoadTargets cfg paths target = do
-  setTargets . return =<< guessTarget target Nothing
-  impNames <- allDepNames <$> depanal [] False
-  impSpecs <- getSpecs cfg paths target impNames [Spec, Hs, LHs]
-  liftIO $ whenNormal $ donePhase Loud "Parsed All Specifications"
-  compileCFiles =<< liftIO (foldM (\c (f,_,s) -> withPragmas c f (Ms.pragmas s)) cfg impSpecs)
-  impSpecs' <- forM impSpecs $ \(f, n, s) -> do
-                 unless (isSpecImport n) $
-                   addTarget =<< guessTarget f Nothing
-                 return (n, s)
-  load LoadAllTargets
-  liftIO $ whenNormal $ donePhase Loud "Loaded Targets"
-  return impSpecs'
-
-allDepNames :: [ModSummary] -> [String]
-allDepNames = concatMap (map declNameString . ms_textual_imps)
-
-declNameString :: GHC.Located (ImportDecl RdrName) -> String
-declNameString = moduleNameString . unLoc . ideclName . unLoc
+setTargetModules :: [ModuleName] -> Ghc ()
+setTargetModules modNames = setTargets $ mkTarget <$> modNames
+  where
+    mkTarget modName = GHC.Target (TargetModule modName) True Nothing
 
 compileCFiles :: Config -> Ghc ()
 compileCFiles cfg = do
   df  <- getSessionDynFlags
-  setSessionDynFlags $ df { includePaths = nub $ idirs cfg ++ includePaths df
-                          , importPaths  = nub $ idirs cfg ++ importPaths df
-                          , libraryPaths = nub $ idirs cfg ++ libraryPaths df }
+  _   <- setSessionDynFlags $
+           df { includePaths = nub $ idirs cfg ++ includePaths df
+              , importPaths  = nub $ idirs cfg ++ importPaths df
+              , libraryPaths = nub $ idirs cfg ++ libraryPaths df }
   hsc <- getSession
   os  <- mapM (\x -> liftIO $ compileFile hsc StopLn (x,Nothing)) (nub $ cFiles cfg)
   df  <- getSessionDynFlags
-  void $ setSessionDynFlags $ df { ldInputs = map (FileOption "") os ++ ldInputs df }
+  void $ setSessionDynFlags $ df { ldInputs = nub $ map (FileOption "") os ++ ldInputs df }
+
+--------------------------------------------------------------------------------
+-- Home Module Dependency Graph ------------------------------------------------
+--------------------------------------------------------------------------------
+
+type DepGraph = Graph DepGraphNode
+type DepGraphNode = Node Module ()
+
+reachableModules :: DepGraph -> Module -> [Module]
+reachableModules depGraph mod =
+  snd3 <$> tail (reachableG depGraph ((), mod, []))
+
+buildDepGraph :: ModuleGraph -> Ghc DepGraph
+buildDepGraph homeModules =
+  graphFromEdgedVertices <$> mapM mkDepGraphNode homeModules
+
+mkDepGraphNode :: ModSummary -> Ghc DepGraphNode
+mkDepGraphNode modSummary = ((), ms_mod modSummary, ) <$>
+  (filterM isHomeModule =<< modSummaryImports modSummary)
+
+isHomeModule :: Module -> Ghc Bool
+isHomeModule mod = do
+  moduleGraph <- hsc_mod_graph <$> getSession
+  return $ any ((== mod) . ms_mod) moduleGraph
+
+modSummaryImports :: ModSummary -> Ghc [Module]
+modSummaryImports modSummary =
+  mapM (importDeclModule (ms_mod modSummary) . unLoc)
+       (ms_textual_imps modSummary)
+
+importDeclModule :: Module -> ImportDecl a -> Ghc Module
+importDeclModule fromMod decl = do
+  hscEnv <- getSession
+  let modName = (unLoc $ ideclName decl)
+  let pkgQual = ideclPkgQual decl
+  result <- liftIO $ findImportedModule hscEnv modName pkgQual
+  case result of
+    Finder.Found _ mod -> return mod
+    _ -> do
+      dflags <- getSessionDynFlags
+      liftIO $ throwGhcExceptionIO $ ProgramError $
+        O.showPpr dflags (moduleName fromMod) ++ ": " ++
+        O.showSDoc dflags (cannotFindModule dflags modName result)
+
+--------------------------------------------------------------------------------
+-- Per-Module Pipeline ---------------------------------------------------------
+--------------------------------------------------------------------------------
+
+type SpecEnv = ModuleEnv (ModName, Ms.BareSpec)
+
+processModules :: Config -> Either Error LogicMap -> [FilePath] -> DepGraph
+               -> ModuleGraph
+               -> Ghc [GhcInfo]
+processModules cfg logicMap tgtFiles depGraph homeModules =
+  catMaybes . snd <$> mapAccumM go emptyModuleEnv homeModules
+  where
+    go = processModule cfg logicMap (S.fromList tgtFiles) depGraph
+  
+processModule :: Config -> Either Error LogicMap -> S.HashSet FilePath -> DepGraph
+              -> SpecEnv -> ModSummary
+              -> Ghc (SpecEnv, Maybe GhcInfo)
+processModule cfg logicMap tgtFiles depGraph specEnv modSummary = do
+  let mod              = ms_mod modSummary
+  _                   <- liftIO $ whenLoud $ putStrLn $ "Module: " ++ showPpr (moduleName mod)
+  file                <- liftIO $ canonicalizePath $ modSummaryHsFile modSummary
+  _                   <- load $ LoadDependenciesOf $ moduleName mod
+  parsed              <- parseModule $ modSummary
+  typechecked         <- typecheckModule $ ignoreInline parsed
+  _                   <- loadModule typechecked
+  (modName, bareSpec) <- liftIO $ parseBareSpec file
+  let specEnv'         = extendModuleEnv specEnv mod (modName, bareSpec)
+  (specEnv', ) <$> if not (file `S.member` tgtFiles)
+    then return Nothing
+    else Just <$> processTargetModule cfg logicMap depGraph specEnv file typechecked bareSpec
+
+processTargetModule :: Config -> Either Error LogicMap -> DepGraph
+                    -> SpecEnv
+                    -> FilePath -> TypecheckedModule -> Ms.BareSpec
+                    -> Ghc GhcInfo
+processTargetModule cfg0 logicMap depGraph specEnv file typechecked bareSpec = do
+  cfg               <- liftIO $ withPragmas cfg0 file $ Ms.pragmas bareSpec
+  let modSummary     = pm_mod_summary $ tm_parsed_module typechecked
+  let mod            = ms_mod modSummary
+  let modName        = ModName Target $ moduleName mod
+  desugared         <- desugarModule typechecked
+  let modGuts        = makeMGIModGuts desugared
+  hscEnv            <- getSession
+  coreBinds         <- liftIO $ anormalize (not $ nocaseexpand cfg) hscEnv modGuts
+  let dataCons       = concatMap (map dataConWorkId . tyConDataCons) (mgi_tcs modGuts)
+  let impVs          = importVars coreBinds ++ classCons (mgi_cls_inst modGuts)
+  let defVs          = definedVars coreBinds
+  let useVs          = readVars coreBinds
+  let letVs          = letVars coreBinds
+  let derVs          = derivedVars coreBinds $ ((is_dfun <$>) <$>) $ mgi_cls_inst modGuts
+  let paths          = nub $ idirs cfg ++ importPaths (ms_hspp_opts modSummary)
+  _                 <- liftIO $ whenLoud $ putStrLn $ "paths = " ++ show paths
+  specSpecs         <- findAndParseSpecFiles cfg paths modSummary
+  let homeSpecs      = reachableBareSpecs depGraph specEnv mod
+  let impSpecs       = specSpecs ++ homeSpecs
+  (spc, imps, incs) <- toGhcSpec cfg coreBinds (impVs ++ defVs) letVs modName modGuts bareSpec logicMap impSpecs
+  _                 <- liftIO $ whenLoud $ putStrLn $ "Module Imports: " ++ show imps
+  hqualsFiles       <- moduleHquals modGuts paths file imps incs
+  return $ GI file (moduleName mod) hscEnv coreBinds derVs impVs (letVs ++ dataCons) useVs hqualsFiles imps incs spc
+
+toGhcSpec :: GhcMonad m
+          => Config
+          -> [CoreBind]
+          -> [Var]
+          -> [Var]
+          -> ModName
+          -> MGIModGuts
+          -> Ms.Spec (Located BareType) LocSymbol
+          -> Either Error LogicMap
+          -> [(ModName, Ms.BareSpec)]
+          -> m (GhcSpec, [String], [FilePath])
+toGhcSpec cfg cbs vars letVs tgtMod mgi tgtSpec lm impSpecs = do
+  let tgtCxt    = IIModule $ getModName tgtMod
+  let impCxt    = map (IIDecl . qualImportDecl . getModName . fst) impSpecs
+  _            <- setContext (tgtCxt : impCxt)
+  hsc          <- getSession
+  let impNames  = map (getModString . fst) impSpecs
+  let exports   = mgi_exports mgi
+  let specs     = (tgtMod, tgtSpec) : impSpecs
+  let imps      = sortNub $ impNames ++ [ symbolString x | (_, sp) <- specs, x <- Ms.imports sp ]
+  ghcSpec      <- liftIO $ makeGhcSpec cfg tgtMod cbs vars letVs exports hsc lm specs
+  return (ghcSpec, imps, Ms.includes tgtSpec)
+
+modSummaryHsFile :: ModSummary -> FilePath
+modSummaryHsFile modSummary =
+  case ml_hs_file $ ms_location modSummary of
+    Just file -> file
+    Nothing -> panic Nothing $
+      "modSummaryHsFile: missing .hs file for " ++ showPpr (ms_mod modSummary)
+
+reachableBareSpecs :: DepGraph -> SpecEnv -> Module -> [(ModName, Ms.BareSpec)]
+reachableBareSpecs depGraph specEnv mod =
+  lookupBareSpec <$> reachableModules depGraph mod
+  where
+    lookupBareSpec mod = case lookupModuleEnv specEnv mod of
+      Just bareSpec -> bareSpec
+      Nothing -> impossible Nothing $
+        "lookupBareSpec: missing module " ++ showPpr mod
+
+--------------------------------------------------------------------------------
+-- Finding & Parsing Files -----------------------------------------------------
+--------------------------------------------------------------------------------
+
+-- Parse File to BareSpec ------------------------------------------------------
+
+parseBareSpec :: FilePath -> IO (ModName, Ms.BareSpec)
+parseBareSpec file = either throw return . specParser file =<< readFile file
+
+specParser :: FilePath -> String -> Either Error (ModName, Ms.BareSpec)
+specParser f str
+  | isExtFile Spec   f = specSpecificationP f str
+  | isExtFile Hs     f = hsSpecificationP   f str
+  | isExtFile HsBoot f = hsSpecificationP   f str
+  | isExtFile LHs    f = lhsSpecificationP  f str
+  | otherwise          = panic Nothing $ "specParser: unrecognized file extension " ++ f
+
+-- Handle Spec Files -----------------------------------------------------------
+
+findAndParseSpecFiles :: Config -> [FilePath] -> ModSummary
+                      -> Ghc [(ModName, Ms.BareSpec)]
+findAndParseSpecFiles cfg paths modSummary = do
+  imps'    <- filterM ((not <$>) . isHomeModule) =<< modSummaryImports modSummary
+  let imps  = moduleNameString . moduleName <$> imps'
+  fs'      <- moduleFiles Spec paths imps
+  patSpec  <- getPatSpec paths $ totality cfg
+  rlSpec   <- getRealSpec paths $ not $ linear cfg
+  let fs    = patSpec ++ rlSpec ++ fs'
+  transParseSpecs paths mempty mempty fs
+
+getPatSpec :: [FilePath] -> Bool -> Ghc [FilePath]
+getPatSpec paths totalitycheck
+ | totalitycheck = moduleFiles Spec paths [patErrorName]
+ | otherwise     = return []
+ where
+  patErrorName = "PatErr"
+
+getRealSpec :: [FilePath] -> Bool -> Ghc [FilePath]
+getRealSpec paths freal
+  | freal     = moduleFiles Spec paths [realSpecName]
+  | otherwise = moduleFiles Spec paths [notRealSpecName]
+  where
+    realSpecName    = "Real"
+    notRealSpecName = "NotReal"
+
+transParseSpecs :: [FilePath]
+                -> S.HashSet FilePath -> [(ModName, Ms.BareSpec)]
+                -> [FilePath]
+                -> Ghc [(ModName, Ms.BareSpec)]
+transParseSpecs _ _ specs [] = return specs
+transParseSpecs paths seenFiles specs newFiles = do
+  newSpecs      <- liftIO $ mapM parseBareSpec newFiles
+  impFiles      <- moduleFiles Spec paths $specsImports newSpecs
+  let seenFiles' = seenFiles `S.union` S.fromList newFiles
+  let specs'     = specs ++ map (second noTerm) newSpecs
+  let newFiles'  = filter (not . (`S.member` seenFiles')) impFiles
+  transParseSpecs paths seenFiles' specs' newFiles'
+  where
+    specsImports ss = nub $ concatMap (map symbolString . Ms.imports . snd) ss
+    noTerm spec = spec { Ms.decr = mempty, Ms.lazy = mempty, Ms.termexprs = mempty }
+
+-- Find Hquals Files -----------------------------------------------------------
+
+moduleHquals :: MGIModGuts
+             -> [FilePath]
+             -> FilePath
+             -> [String]
+             -> [FilePath]
+             -> Ghc [FilePath]
+moduleHquals mgi paths target imps incs = do
+  hqs   <- specIncludes Hquals paths incs
+  hqs'  <- moduleFiles Hquals paths (mgi_namestring mgi : imps)
+  hqs'' <- liftIO $ filterM doesFileExist [extFileName Hquals target]
+  return $ sortNub $ hqs'' ++ hqs ++ hqs'
+
+-- Find Files for Modules ------------------------------------------------------
+
+moduleFiles :: Ext -> [FilePath] -> [String] -> Ghc [FilePath]
+moduleFiles ext paths names = catMaybes <$> mapM (moduleFile ext paths) names
+
+moduleFile :: Ext -> [FilePath] -> String -> Ghc (Maybe FilePath)
+moduleFile ext paths name
+  | ext `elem` [Hs, LHs] = do
+    graph <- getModuleGraph
+    case find (\m -> not (isBootSummary m) &&
+                     name == moduleNameString (ms_mod_name m)) graph of
+      Nothing -> liftIO $ getFileInDirs (extModuleName name ext) paths
+      Just ms -> return $ normalise <$> ml_hs_file (ms_location ms)
+  | otherwise = liftIO $ getFileInDirs (extModuleName name ext) paths
+
+specIncludes :: Ext -> [FilePath] -> [FilePath] -> Ghc [FilePath]
+specIncludes ext paths reqs = do
+  let libFile = extFileNameR ext $ symbolString preludeName
+  let incFiles = catMaybes $ reqFile ext <$> reqs
+  liftIO $ forM (libFile : incFiles) $ \f -> do
+    mfile <- getFileInDirs f paths
+    case mfile of
+      Just file -> return file
+      Nothing -> panic Nothing $ "cannot find " ++ f ++ " in " ++ show paths
+
+reqFile :: Ext -> FilePath -> Maybe FilePath
+reqFile ext s
+  | isExtFile ext s = Just s
+  | otherwise = Nothing
 
 --------------------------------------------------------------------------------
 -- Assemble Information for Spec Extraction ------------------------------------
 --------------------------------------------------------------------------------
 
-makeMGIModGuts :: FilePath -> Ghc MGIModGuts
-makeMGIModGuts f = do
-  modGraph <- getModuleGraph
-  case find (\m -> not (isBootSummary m) && f == msHsFilePath m) modGraph of
-    Just modSummary -> do
-      parsed   <- parseModule modSummary
-      modGuts  <- coreModule <$> (desugarModule =<< typecheckModule (ignoreInline parsed))
-      let deriv = Just $ instEnvElts $ mg_inst_env modGuts
-      return $! miModGuts deriv modGuts
-    Nothing ->
-      panic Nothing "Ghc Interface: Unable to get GhcModGuts"
+makeMGIModGuts :: DesugaredModule -> MGIModGuts
+makeMGIModGuts desugared = miModGuts deriv modGuts
+  where
+    modGuts = coreModule desugared
+    deriv = Just $ instEnvElts $ mg_inst_env modGuts
 
 makeLogicMap :: IO (Either Error LogicMap)
 makeLogicMap = do
@@ -247,151 +472,6 @@ definedVars = concatMap defs
 --------------------------------------------------------------------------------
 -- Find & Parse Specs ----------------------------------------------------------
 --------------------------------------------------------------------------------
-type FileSpec = (FilePath, ModName, Ms.BareSpec)
-
-getSpecs :: Config -> [FilePath] -> FilePath -> [String] -> [Ext] -> Ghc [FileSpec]
-getSpecs cfg paths target names exts = do
-  fSpecs <- getSpecs' cfg paths target names exts
-  -- liftIO $ putStrLn $ "getSpecs    [RAW]: " ++ show [(f, n) | (f, n, _) <- fSpecs]
-  let fSpecs' = normalizeFileSpec fSpecs
-  -- liftIO $ putStrLn $ "getSpecs [NORMAL]: " ++ showTable [(n, text f) | (f, n, _) <- fSpecs']
-  return fSpecs'
-
--- showTable = render . pprintKVs Full . sortBy (compare `on` fst)
-
-getSpecs' :: Config -> [FilePath] -> FilePath -> [String] -> [Ext] -> Ghc [FileSpec]
-getSpecs' cfg paths target names exts = do
-  fs'     <- sortNub <$> moduleImports exts paths names
-  patSpec <- getPatSpec paths $ totality cfg
-  rlSpec  <- getRealSpec paths $ not $ linear cfg
-  let fs   = patSpec ++ rlSpec ++ fs'
-  transParseSpecs exts paths (S.singleton target) mempty (map snd fs \\ [target])
-  -- liftIO $ putStrLn $ "getSpecs [NORMAL]: " ++ showTable [(n, text f) | (f, n, _) <- fSpecs]
-  -- return fSpecs
-  -- where
-  --   showTable = render . pprintKVs Full . sortBy (compare `on` fst)
-
-normalizeFileSpec :: [FileSpec] -> [FileSpec]
-normalizeFileSpec = concat
-                  . M.elems
-                  . fmap partSpecs
-                  . groupMap (show . snd3)
-
-partSpecs :: [FileSpec] -> [FileSpec]
-partSpecs fs = case partition isSpecFile fs of
-                 (sFs, [] ) -> sFs
-                 (_  , cFs) -> cFs
-
-isSpecFile :: FileSpec -> Bool
-isSpecFile (f, _, _)
-  | isExtFile Spec f = True
-  | otherwise        = False
-
-getPatSpec :: [FilePath] -> Bool -> Ghc [(String, FilePath)]
-getPatSpec paths totalitycheck
- | totalitycheck = map (patErrorName,) . maybeToList <$> moduleFile paths patErrorName Spec
- | otherwise     = return []
- where
-  patErrorName = "PatErr"
-
-getRealSpec :: [FilePath] -> Bool -> Ghc [(String, FilePath)]
-getRealSpec paths freal
-  | freal     = map (realSpecName,)    . maybeToList <$> moduleFile paths realSpecName    Spec
-  | otherwise = map (notRealSpecName,) . maybeToList <$> moduleFile paths notRealSpecName Spec
-  where
-    realSpecName    = "Real"
-    notRealSpecName = "NotReal"
-
-transParseSpecs :: [Ext] -> [FilePath] -> S.HashSet FilePath -> [FileSpec] -> [FilePath]
-                -> Ghc [FileSpec]
-transParseSpecs _ _ _ specs [] = return specs
-transParseSpecs exts paths seenFiles specs newFiles = do
-  newSpecs      <- liftIO $ mapM (\f -> addFst3 f <$> parseSpec f) newFiles
-  impFiles      <- moduleImports exts paths $ specsImports newSpecs
-  let seenFiles' = seenFiles `S.union` S.fromList newFiles
-  let specs'     = specs ++ map (third3 noTerm) newSpecs
-  let newFiles'  = [f | (_, f) <- impFiles, not (f `S.member` seenFiles')]
-  transParseSpecs exts paths seenFiles' specs' newFiles'
-  where
-    specsImports ss = nub $ concatMap (map symbolString . Ms.imports . thd3) ss
-    noTerm spec = spec { Ms.decr = mempty, Ms.lazy = mempty, Ms.termexprs = mempty }
-
-parseSpec :: FilePath -> IO (ModName, Ms.BareSpec)
-parseSpec file = either throw return . specParser file =<< readFile file
-
-specParser :: FilePath -> String -> Either Error (ModName, Ms.BareSpec)
-specParser f str
-  | isExtFile Spec   f = specSpecificationP f str
-  | isExtFile Hs     f = hsSpecificationP   f str
-  | isExtFile HsBoot f = hsSpecificationP   f str
-  | isExtFile LHs    f = lhsSpecificationP  f str
-  | otherwise          = panic Nothing $ "SpecParser: Cannot Parse File " ++ f
-
-
-moduleSpec :: GhcMonad m
-           => Config
-           -> [CoreBind]
-           -> [Var]
-           -> [Var]
-           -> ModName
-           -> MGIModGuts
-           -> Ms.Spec (Located BareType) LocSymbol
-           -> Either Error LogicMap
-           -> [(ModName, Ms.BareSpec)]
-           -> m (GhcSpec, [String], [FilePath])
-moduleSpec cfg cbs vars letVs tgtMod mgi tgtSpec lm impSpecs = do
-  let tgtCxt = IIModule $ getModName tgtMod
-  let impCxt = map (IIDecl . qualImportDecl . getModName . fst) impSpecs
-  setContext (tgtCxt : impCxt)
-  hsc <- getSession
-  let impNames = map (getModString . fst) impSpecs
-  let exports  = mgi_exports mgi
-  let specs = (tgtMod, tgtSpec) : impSpecs
-  let imps  = sortNub $ impNames ++ [ symbolString x | (_, sp) <- specs, x <- Ms.imports sp ]
-  ghcSpec <- liftIO $ makeGhcSpec cfg tgtMod cbs vars letVs exports hsc lm specs
-  return (ghcSpec, imps, Ms.includes tgtSpec)
-
-moduleHquals :: MGIModGuts
-             -> [FilePath]
-             -> FilePath
-             -> [String]
-             -> [FilePath]
-             -> Ghc [FilePath]
-moduleHquals mgi paths target imps incs = do
-  hqs   <- specIncludes Hquals paths incs
-  hqs'  <- moduleImports [Hquals] paths (mgi_namestring mgi : imps)
-  hqs'' <- liftIO $ filterM doesFileExist [extFileName Hquals target]
-  return $ sortNub $ hqs'' ++ hqs ++ (snd <$> hqs')
-
-
-moduleImports :: [Ext] -> [FilePath] -> [String] -> Ghc [(String, FilePath)]
-moduleImports exts paths names = liftM concat $ forM names $ \name ->
-  map (name,) . catMaybes <$> mapM (moduleFile paths name) exts
-
-moduleFile :: [FilePath] -> String -> Ext -> Ghc (Maybe FilePath)
-moduleFile paths name ext
-  | ext `elem` [Hs, LHs] = do
-    graph <- getModuleGraph
-    case find (\m -> not (isBootSummary m) &&
-                     name == moduleNameString (ms_mod_name m)) graph of
-      Nothing -> liftIO $ getFileInDirs (extModuleName name ext) paths
-      Just ms -> return $ normalise <$> ml_hs_file (ms_location ms)
-  | otherwise = liftIO $ getFileInDirs (extModuleName name ext) paths
-
-specIncludes :: Ext -> [FilePath] -> [FilePath] -> Ghc [FilePath]
-specIncludes ext paths reqs = do
-  let libFile = extFileNameR ext $ symbolString preludeName
-  let incFiles = catMaybes $ reqFile ext <$> reqs
-  liftIO $ forM (libFile : incFiles) $ \f -> do
-    mfile <- getFileInDirs f paths
-    case mfile of
-      Just file -> return file
-      Nothing -> panic Nothing $ "cannot find " ++ f ++ " in " ++ show paths
-
-reqFile :: Ext -> FilePath -> Maybe FilePath
-reqFile ext s
-  | isExtFile ext s = Just s
-  | otherwise = Nothing
 
 --------------------------------------------------------------------------------
 -- Pretty Printing -------------------------------------------------------------
@@ -455,3 +535,4 @@ instance Result SourceError where
 
 errMsgErrors :: ErrMsg -> [TError t]
 errMsgErrors e = [ ErrGhc (errMsgSpan e) (pprint e)]
+

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -86,11 +86,8 @@ checkOne :: Config -> GhcInfo -> IO (Output Doc)
 checkOne cfg g = do
   z <- actOrDie $ liquidOne g
   case z of
-    Left e -> do
-      d <- exitWithResult cfg [target g] $ mempty { o_result = e }
-      return d
-    Right r ->
-      return r
+    Left  e -> exitWithResult cfg [target g] $ mempty { o_result = e }
+    Right r -> return r
 
 
 actOrDie :: IO a -> IO (Either ErrorResult a)

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -16,6 +16,7 @@ module Language.Haskell.Liquid.Liquid (
   ) where
 
 import           Prelude hiding (error)
+import           Data.Bifunctor
 import           Data.Maybe
 import           System.Exit
 import           Text.PrettyPrint.HughesPJ
@@ -58,39 +59,33 @@ liquid args = getOpts args >>= runLiquid Nothing >>= exitWith . fst
 runLiquid :: MbEnv -> Config -> IO (ExitCode, MbEnv)
 ------------------------------------------------------------------------------
 runLiquid mE cfg = do
-  (d, mE') <- checkMany cfg mempty mE (files cfg)
-  return      (ec d, mE')
+  (gs, mE') <- second Just <$> getGhcInfo mE cfg (files cfg)
+  d         <- checkMany cfg mempty gs
+  return       (ec d, mE')
   where
-    ec     = resultExit . o_result
+    ec       = resultExit . o_result
 
 ------------------------------------------------------------------------------
-checkMany :: Config -> Output Doc -> MbEnv -> [FilePath] -> IO (Output Doc, MbEnv)
+checkMany :: Config -> Output Doc -> [GhcInfo] -> IO (Output Doc)
 ------------------------------------------------------------------------------
-checkMany cfg d mE (f:fs) = do
-  (d', mE') <- checkOne mE cfg f
-  checkMany cfg (d `mappend` d') mE' fs
+checkMany cfg d (g:gs) = do
+  d' <- checkOne cfg g
+  checkMany cfg (d `mappend` d') gs
 
-checkMany _   d mE [] =
-  return (d, mE)
+checkMany _   d [] =
+  return d
 
 ------------------------------------------------------------------------------
-checkOne :: MbEnv -> Config -> FilePath -> IO (Output Doc, Maybe HscEnv)
+checkOne :: Config -> GhcInfo -> IO (Output Doc)
 ------------------------------------------------------------------------------
-checkOne mE cfg t = do
-  z <- actOrDie (checkOne' mE cfg t)
+checkOne cfg g = do
+  z <- actOrDie $ liquidOne g
   case z of
     Left e -> do
-      d <- exitWithResult cfg t $ mempty { o_result = e }
-      return (d, Nothing)
+      d <- exitWithResult cfg (target g) $ mempty { o_result = e }
+      return d
     Right r ->
       return r
-
-
-checkOne' :: MbEnv -> Config -> FilePath -> IO (Output Doc, Maybe HscEnv)
-checkOne' mE cfg t = do
-  (gInfo, hEnv) <- getGhcInfo mE cfg t
-  d <- liquidOne t gInfo
-  return (d, Just hEnv)
 
 
 actOrDie :: IO a -> IO (Either ErrorResult a)
@@ -105,11 +100,12 @@ handle :: (Result a) => a -> IO (Either ErrorResult b)
 handle = return . Left . result
 
 ------------------------------------------------------------------------------
-liquidOne :: FilePath -> GhcInfo -> IO (Output Doc)
+liquidOne :: GhcInfo -> IO (Output Doc)
 ------------------------------------------------------------------------------
-liquidOne tgt info = do
+liquidOne info = do
   whenNormal $ donePhase Loud "Extracted Core using GHC"
   let cfg   = config $ spec info
+  let tgt   = target info
   -- whenLoud  $ do putStrLn $ showpp info
                  -- putStrLn "*************** Original CoreBinds ***************************"
                  -- putStrLn $ render $ pprintCBs (cbs info)

--- a/src/Language/Haskell/Liquid/Misc.hs
+++ b/src/Language/Haskell/Liquid/Misc.hs
@@ -3,7 +3,7 @@
 module Language.Haskell.Liquid.Misc where
 
 import Prelude hiding (error)
-import Control.Monad (liftM2)
+import Control.Monad.State
 
 import Control.Arrow (first)
 import System.FilePath
@@ -13,6 +13,7 @@ import qualified Data.HashSet          as S
 import qualified Data.HashMap.Strict   as M
 import qualified Data.List             as L
 import           Data.Maybe
+import           Data.Tuple
 import           Data.Hashable
 import           Data.Time
 import           Data.Function (on)
@@ -231,3 +232,8 @@ intToString 1 = "1st"
 intToString 2 = "2nd"
 intToString 3 = "3rd"
 intToString n = show n ++ "th"
+
+mapAccumM :: (Monad m, Traversable t) => (a -> b -> m (a, c)) -> a -> t b -> m (a, t c)
+mapAccumM f acc0 xs =
+  swap <$> runStateT (traverse (StateT . (\x acc -> swap <$> f acc x)) xs) acc0
+

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE OverloadedStrings         #-}
 
 module Language.Haskell.Liquid.Parse
-  ( hsSpecificationP, lhsSpecificationP, specSpecificationP
+  ( hsSpecificationP, specSpecificationP
   , parseSymbolToLogic
   )
   where
@@ -19,6 +19,7 @@ import           Prelude                                hiding (error)
 import           Text.Parsec
 import           Text.Parsec.Error                      (newErrorMessage, Message (..))
 import           Text.Parsec.Pos                        (newPos)
+
 import qualified Text.Parsec.Token                      as Token
 import qualified Data.Text                              as T
 import qualified Data.HashMap.Strict                    as M
@@ -26,9 +27,11 @@ import qualified Data.HashSet                           as S
 import           Data.Monoid
 import           Data.Char                              (isSpace, isAlpha, isUpper, isAlphaNum)
 import           Data.List                              (foldl', partition)
-import           GHC                                    (mkModuleName)
+import           Data.Either                            
+
+import           GHC                                    (ModuleName, mkModuleName)
 import           Text.PrettyPrint.HughesPJ              (text)
-import           Language.Preprocessor.Unlit            (unlit)
+
 import           Language.Fixpoint.Types                hiding (Error, R, Predicate)
 import           Language.Haskell.Liquid.GHC.Misc
 import           Language.Haskell.Liquid.Types          hiding (Axiom)
@@ -45,42 +48,28 @@ import           Language.Fixpoint.Parse                hiding (angles, refBindP
 -- | Top Level Parsing API -----------------------------------------------------
 --------------------------------------------------------------------------------
 
--------------------------------------------------------------------------------
-hsSpecificationP :: SourceName -> String -> Either Error (ModName, Measure.BareSpec)
--------------------------------------------------------------------------------
-
-hsSpecificationP = parseWithError $ do
-    name <-  try (lookAhead $ skipMany (commentP >> spaces)
-                           >> reserved "module" >> symbolP)
-         <|> return "Main"
-    liftM (mkSpec (ModName SrcImport $ mkModuleName $ symbolString name)) $ specWraps specP
+-- | Used to parse .hs and .lhs files (via ApiAnnotations)
 
 -------------------------------------------------------------------------------
-lhsSpecificationP :: SourceName -> String -> Either Error (ModName, Measure.BareSpec)
+hsSpecificationP :: ModuleName
+                 -> [(SourcePos, String)]
+                 -> Either [Error] (ModName, Measure.BareSpec)
 -------------------------------------------------------------------------------
 
-lhsSpecificationP sn s = hsSpecificationP sn $ unlit sn s
-
-commentP :: Stream s m Char => ParsecT s u m [Char]
-commentP =  simpleComment (string "{-") (string "-}")
-        <|> simpleComment (string "--") newlineP
-        <|> simpleComment (string "\\") newlineP
-        <|> simpleComment (string "#")  newlineP
-
-simpleComment :: Stream s m Char
-              => ParsecT s u m a -> ParsecT s u m end -> ParsecT s u m [Char]
-simpleComment open close = open >> manyTill anyChar (try close)
-
-newlineP :: Stream s m Char => ParsecT s u m String
-newlineP = try (string "\r\n") <|> string "\n" <|> string "\r"
-
+hsSpecificationP modName specComments =
+  case partitionEithers $ parseComment <$> specComments of
+    ([], specs) -> Right $ mkSpec (ModName SrcImport modName) specs
+    (errs, _)   -> Left errs
+  where
+    parseComment (pos, specComment) =
+      parseWithError specP pos specComment
 
 -- | Used to parse .spec files
 
 --------------------------------------------------------------------------
 specSpecificationP  :: SourceName -> String -> Either Error (ModName, Measure.BareSpec)
 --------------------------------------------------------------------------
-specSpecificationP  = parseWithError specificationP
+specSpecificationP f s = parseWithError specificationP (newPos f 1 1) s
 
 specificationP :: Parser (ModName, Measure.BareSpec)
 specificationP
@@ -92,43 +81,47 @@ specificationP
        return $ mkSpec (ModName SpecImport $ mkModuleName $ symbolString name) xs
 
 ---------------------------------------------------------------------------
-parseWithError :: Parser a -> SourceName -> String -> Either Error a
+parseWithError :: Parser a -> SourcePos -> String -> Either Error a
 ---------------------------------------------------------------------------
-parseWithError parser f s
-  = case runParser (remainderP (whiteSpace >> parser)) 0 f s of
-      Left e            -> Left  $ parseErrorError f e
-      Right (r, "", _)  -> Right r
-      Right (_, rem, _) -> Left  $ parseErrorError f $ remParseError f s rem
+parseWithError parser p s =
+  case runParser doParse 0 (sourceName p) s of
+    Left e            -> Left  $ parseErrorError e
+    Right (r, "", _)  -> Right r
+    Right (_, rem, _) -> Left  $ parseErrorError $ remParseError p s rem
+  where
+    doParse = (setPosition p >> remainderP (whiteSpace >> parser))
 
 
 ---------------------------------------------------------------------------
-parseErrorError     :: SourceName -> ParseError -> Error
+parseErrorError     :: ParseError -> Error
 ---------------------------------------------------------------------------
-parseErrorError f e = ErrParse sp msg e
+parseErrorError e = ErrParse sp msg e
   where
     pos             = errorPos e
     sp              = sourcePosSrcSpan pos
-    msg             = text $ "Error Parsing Specification from: " ++ f
+    msg             = text $ "Error Parsing Specification from: " ++ sourceName pos
 
 ---------------------------------------------------------------------------
-remParseError       :: SourceName -> String -> String -> ParseError
+remParseError       :: SourcePos -> String -> String -> ParseError
 ---------------------------------------------------------------------------
-remParseError f s r = newErrorMessage msg $ newPos f line col
+remParseError p s r = newErrorMessage msg $ newPos (sourceName p) line col
   where
     msg             = Message "Leftover while parsing"
-    (line, col)     = remLineCol s r
+    (line, col)     = remLineCol p s r
 
-remLineCol          :: String -> String -> (Int, Int)
-remLineCol src rem = (line, col)
+remLineCol             :: SourcePos -> String -> String -> (Int, Int)
+remLineCol pos src rem = (line + offLine, col + offCol)
   where
-    line           = 1 + srcLine - remLine
-    srcLine        = length srcLines
-    remLine        = length remLines
-    col            = srcCol - remCol
-    srcCol         = length $ srcLines !! (line - 1)
-    remCol         = length $ head remLines
-    srcLines       = lines  src
-    remLines       = lines  rem
+    line               = 1 + srcLine - remLine
+    srcLine            = length srcLines
+    remLine            = length remLines
+    offLine            = sourceLine pos - 1
+    col                = 1 + srcCol - remCol
+    srcCol             = length $ srcLines !! (line - 1)
+    remCol             = length $ head remLines
+    offCol             = if line == 1 then sourceColumn pos - 1 else 0
+    srcLines           = lines  src
+    remLines           = lines  rem
 
 
 
@@ -137,7 +130,7 @@ remLineCol src rem = (line, col)
 ----------------------------------------------------------------------------------
 
 parseSymbolToLogic :: SourceName -> String -> Either Error LogicMap
-parseSymbolToLogic = parseWithError toLogicP
+parseSymbolToLogic f = parseWithError toLogicP (newPos f 1 1)
 
 toLogicP :: Parsec String Integer LogicMap
 toLogicP
@@ -1050,35 +1043,9 @@ fTyConP
   <|> (reserved "bool"    >> return boolFTyCon)
   <|> (symbolFTycon      <$> locUpperIdP)
 
---------------------------------------------------------------------------------
--- | Interacting with Fixpoint -------------------------------------------------
---------------------------------------------------------------------------------
-
-grabUpto :: Parser a -> Parser (Maybe a)
-grabUpto p
-  =  try (Just <$> lookAhead p)
- <|> try (eof   >> return Nothing)
- <|> (anyChar   >> grabUpto p)
-
-betweenMany :: Parser open -> Parser close -> Parser a -> Parser [a]
-betweenMany leftP rightP p
-  = do z <- grabUpto leftP
-       case z of
-         Just _  -> liftM2 (:) (between leftP rightP p) (betweenMany leftP rightP p)
-         Nothing -> return []
-
-specWraps :: Parser a -> Parser [a]
-specWraps = betweenMany (liquidBeginP >> whiteSpace) (whiteSpace >> liquidEndP)
-
-liquidBeginP :: Parser String
-liquidBeginP = string liquidBegin
-
-liquidEndP :: Parser String
-liquidEndP   = string liquidEnd
-
---------------------------------------------------------------------------------
--- | Bundling Parsers into a Typeclass -----------------------------------------
---------------------------------------------------------------------------------
+---------------------------------------------------------------
+-- | Bundling Parsers into a Typeclass ------------------------
+---------------------------------------------------------------
 
 instance Inputable BareType where
   rr' = doParse' bareTypeP

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -89,7 +89,8 @@ parseWithError parser p s =
     Right (r, "", _)  -> Right r
     Right (_, rem, _) -> Left  $ parseErrorError $ remParseError p s rem
   where
-    doParse = (setPosition p >> remainderP (whiteSpace >> parser))
+    doParse =
+      setPosition p >> remainderP (whiteSpace *> parser <* whiteSpace)
 
 
 ---------------------------------------------------------------------------

--- a/src/Language/Haskell/Liquid/Types/Errors.hs
+++ b/src/Language/Haskell/Liquid/Types/Errors.hs
@@ -329,6 +329,9 @@ data TError t =
                 , msg :: !Doc
                 } -- ^ Previously saved error, that carries over after DiffCheck
 
+  | ErrFilePragma { pos :: !SrcSpan
+                  }
+
   | ErrOther    { pos   :: SrcSpan
                 , msg   :: !Doc
                 } -- ^ Sigh. Other.
@@ -722,6 +725,10 @@ ppError' _ dSp dCtx (ErrSaved _ name s)
   = dSp <+> name -- <+> "(saved)"
         $+$ dCtx
         $+$ {- nest 4 -} s
+
+ppError' _ dSp dCtx (ErrFilePragma _)
+  = dSp <+> text "--idirs, --c-files, and --ghc-option cannot be used in file-level pragmas"
+        $+$ dCtx
 
 ppError' _ dSp dCtx (ErrOther _ s)
   = dSp <+> text "Uh oh."

--- a/src/Language/Haskell/Liquid/Types/Errors.hs
+++ b/src/Language/Haskell/Liquid/Types/Errors.hs
@@ -134,7 +134,7 @@ makeContext l c c' s = vcat [ text ""
                             ]
   where
     lnum n           = text (show n) <+> text "|"
-    cursor           = blanks (c - 1) <> pointer (c' - c)
+    cursor           = blanks (c - 1) <> pointer (max 1 (c' - c))
     blanks n         = text $ replicate n ' '
     pointer n        = text $ replicate n '^'
 

--- a/src/Language/Haskell/Liquid/UX/Annotate.hs
+++ b/src/Language/Haskell/Liquid/UX/Annotate.hs
@@ -84,14 +84,11 @@ mkOutput cfg res sol anna
 
 -- | @annotate@ actually renders the output to files
 -------------------------------------------------------------------
-annotate :: Config -> FilePath -> Output Doc -> IO ACSS.AnnMap
+annotate :: Config -> [FilePath] -> Output Doc -> IO ACSS.AnnMap
 -------------------------------------------------------------------
-annotate cfg srcF out
-  = do generateHtml srcF tpHtmlF tplAnnMap
-       generateHtml srcF tyHtmlF typAnnMap
-       writeFile         vimF  $ vimAnnot cfg annTyp
-       B.writeFile       jsonF $ encode typAnnMap
-       when showWarns $ forM_ bots (printf "WARNING: Found false in %s\n" . showPpr)
+annotate cfg srcFs out
+  = do when showWarns $ forM_ bots (printf "WARNING: Found false in %s\n" . showPpr)
+       mapM_ (doGenerate cfg tplAnnMap typAnnMap annTyp) srcFs
        return typAnnMap
     where
        tplAnnMap  = mkAnnMap cfg res annTpl
@@ -100,12 +97,20 @@ annotate cfg srcF out
        annTyp     = o_types  out
        res        = o_result out
        bots       = o_bots   out
+       showWarns  = not $ nowarnings cfg
+
+doGenerate :: Config -> ACSS.AnnMap -> ACSS.AnnMap -> AnnInfo Doc -> FilePath -> IO ()
+doGenerate cfg tplAnnMap typAnnMap annTyp srcF
+  = do generateHtml srcF tpHtmlF tplAnnMap
+       generateHtml srcF tyHtmlF typAnnMap
+       writeFile         vimF  $ vimAnnot cfg annTyp
+       B.writeFile       jsonF $ encode typAnnMap
+    where
        tyHtmlF    = extFileName Html                   srcF
        tpHtmlF    = extFileName Html $ extFileName Cst srcF
        _annF      = extFileName Annot srcF
        jsonF      = extFileName Json  srcF
        vimF       = extFileName Vim   srcF
-       showWarns  = not $ nowarnings cfg
 
 mkBots :: Reftable r => AnnInfo (RType c tv r) -> [GHC.SrcSpan]
 mkBots (AI m) = [ src | (src, (Just _, t) : _) <- sortBy (compare `on` fst) $ M.toList m

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -400,10 +400,10 @@ defConfig = Config { files             = def
 ------------------------------------------------------------------------
 
 ------------------------------------------------------------------------
-exitWithResult :: Config -> FilePath -> Output Doc -> IO (Output Doc)
+exitWithResult :: Config -> [FilePath] -> Output Doc -> IO (Output Doc)
 ------------------------------------------------------------------------
-exitWithResult cfg target out = do
-  annm <- {-# SCC "annotate" #-} annotate cfg target out
+exitWithResult cfg targets out = do
+  annm <- {-# SCC "annotate" #-} annotate cfg targets out
   whenNormal $ donePhase Loud "annotate"
   let r = o_result out `addErrors` o_errors out
   consoleResult cfg out r annm

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -19,7 +19,6 @@ module Language.Haskell.Liquid.UX.CmdLine (
 
    -- * Update Configuration With Pragma
    , withPragmas
-   , withPragma
 
    -- * Canonicalize Paths in Config
    , canonicalizePaths

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -19,6 +19,10 @@ module Language.Haskell.Liquid.UX.CmdLine (
 
    -- * Update Configuration With Pragma
    , withPragmas
+   , withPragma
+
+   -- * Canonicalize Paths in Config
+   , canonicalizePaths
 
    -- * Exit Function
    , exitWithResult

--- a/src/Test/Target/Util.hs
+++ b/src/Test/Target/Util.hs
@@ -149,7 +149,7 @@ fourth4 (_,_,_,d) = d
 getSpec :: [String] -> FilePath -> IO GhcSpec
 getSpec opts target
   = do cfg  <- getOpts ["--quiet"]
-       spec.fst <$> getGhcInfo Nothing (cfg {ghcOptions = opts}) target
+       spec.head.fst <$> getGhcInfo Nothing (cfg {ghcOptions = opts}) [target]
        -- case info of
        --   Left err -> error $ show err
        --   Right i  -> return $ spec i

--- a/tests/crash/BadPragma0.hs
+++ b/tests/crash/BadPragma0.hs
@@ -1,0 +1,7 @@
+{-@ LIQUID "--idirs=.." @-}
+
+module Bad where 
+
+i :: Int
+i = 1
+

--- a/tests/crash/BadPragma1.hs
+++ b/tests/crash/BadPragma1.hs
@@ -1,0 +1,7 @@
+{-@ LIQUID "--c-files=./wow.c" @-}
+
+module Bad where 
+
+i :: Int
+i = 1
+

--- a/tests/crash/BadPragma2.hs
+++ b/tests/crash/BadPragma2.hs
@@ -1,0 +1,7 @@
+{-@ LIQUID "--ghc-option=-O0" @-}
+
+module Bad where 
+
+i :: Int
+i = 1
+

--- a/tests/pos/Class2.hs
+++ b/tests/pos/Class2.hs
@@ -1,6 +1,5 @@
 module Class2 where
 
-{-@ LIQUID "--idirs=../neg" @-}
 import Class5
 
 instance Foo ()

--- a/tests/pos/CommentedOut.hs
+++ b/tests/pos/CommentedOut.hs
@@ -1,0 +1,6 @@
+module Nats where 
+
+{- {-@ nats :: [Nat] @-} -}
+nats :: [Int]
+nats = [-1,0,1,2,3,4,5,6,7,8,9,10]
+

--- a/tests/pos/FFI.hs
+++ b/tests/pos/FFI.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
-{-@ LIQUID "--c-files=../ffi-include/foo.c" @-}
-{-@ LIQUID "-i../ffi-include" @-}
 module Main where
 
 import Foreign.C.Types

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -184,7 +184,7 @@ extraOptions dir test = mappend (dirOpts dir) (testOpts test)
         , "-iinclude --c-files=cbits/fpstring.c"
         )
       , ( "benchmarks/text-0.11.2.3"
-        , "-i../bytestring-0.9.2.1 -iinclude --c-files=cbits/cbits.c"
+        , "-i../bytestring-0.9.2.1 -i../../include --c-files=cbits/cbits.c"
         )
       , ( "benchmarks/vector-0.10.0.1"
         , "-i."

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -184,7 +184,7 @@ extraOptions dir test = mappend (dirOpts dir) (testOpts test)
         , "-iinclude --c-files=cbits/fpstring.c"
         )
       , ( "benchmarks/text-0.11.2.3"
-        , "-i../bytestring-0.9.2.1 -i../../include --c-files=cbits/cbits.c"
+        , "-i../bytestring-0.9.2.1 -i../bytestring-0.9.2.1/include --c-files=../bytestring-0.9.2.1/cbits/fpstring.c -i../../include --c-files=cbits/cbits.c"
         )
       , ( "benchmarks/vector-0.10.0.1"
         , "-i."

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -142,7 +142,7 @@ mkTest code dir file
         createDirectoryIfMissing True $ takeDirectory log
         bin <- binPath "liquid"
         withFile log WriteMode $ \h -> do
-          let cmd     = testCmd bin dir file smt $ mappend (extraOptions file) opts
+          let cmd     = testCmd bin dir file smt $ mappend (extraOptions test) opts
           (_,_,_,ph) <- createProcess $ (shell cmd) {std_out = UseHandle h, std_err = UseHandle h}
           c          <- waitForProcess ph
           renameFile log $ log <.> (if code == c then "pass" else "fail")

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE DoAndIfThenElse     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Main where
 
 import Control.Applicative
@@ -12,9 +14,11 @@ import Control.Monad.Trans.Class (lift)
 import Data.Char
 import qualified Data.Functor.Compose as Functor
 import qualified Data.IntMap as IntMap
+import qualified Data.Map as Map
 import Data.Maybe (fromMaybe)
 import Data.Monoid (Sum(..))
 import Data.Proxy
+import Data.String
 import Data.Tagged
 import Data.Typeable
 import Options.Applicative
@@ -68,7 +72,12 @@ instance IsOption SmtSolver where
       <> help (untag (optionHelp :: Tagged SmtSolver String))
       )
 
-newtype LiquidOpts = LO String deriving (Show, Read, Eq, Ord, Typeable)
+newtype LiquidOpts = LO String deriving (Show, Read, Eq, Ord, Typeable, IsString)
+instance Monoid LiquidOpts where
+  mempty = LO ""
+  mappend (LO "") y = y
+  mappend x (LO "") = x
+  mappend (LO x) (LO y) = LO $ x ++ (' ' : y)
 instance IsOption LiquidOpts where
   defaultValue = LO ""
   parseValue = Just . LO
@@ -133,7 +142,7 @@ mkTest code dir file
         createDirectoryIfMissing True $ takeDirectory log
         bin <- binPath "liquid"
         withFile log WriteMode $ \h -> do
-          let cmd     = testCmd bin dir file smt opts
+          let cmd     = testCmd bin dir file smt $ mappend (extraOptions file) opts
           (_,_,_,ph) <- createProcess $ (shell cmd) {std_out = UseHandle h, std_err = UseHandle h}
           c          <- waitForProcess ph
           renameFile log $ log <.> (if code == c then "pass" else "fail")
@@ -164,6 +173,36 @@ knownToFail Z3   = [ "tests/pos/linspace.hs"
                    , "tests/pos/Gradual.hs"
                    , "tests/equationalproofs/pos/MapAppend.hs"
                    ]
+
+--------------------------------------------------------------------------------
+extraOptions :: FilePath -> LiquidOpts
+--------------------------------------------------------------------------------
+extraOptions = flip (Map.findWithDefault mempty) $ Map.fromList
+  [ ( "tests/pos/Class2.hs"
+    , "-i../neg"
+    )
+  , ( "tests/pos/FFI.hs"
+    , "-i../ffi-include --c-files=../ffi-include/foo.c"
+    )
+  , ( "benchmarks/bytestring-0.9.2.1/Data/ByteString/Internal.hs"
+    , "-i../../include --c-files=../../cbits/fpstring.c"
+    )
+  , ( "benchmarks/text-0.11.2.3/Data/Text/Array.hs"
+    , "--c-files=../../cbits/cbits.c"
+    )
+  , ( "benchmarks/text-0.11.2.3/Data/Text/Encoding.hs"
+    , "-i../../../bytestring-0.9.2.1/ -i../../../../include/ --c-files=../../cbits/cbits.c"
+    )
+  , ( "benchmarks/text-0.11.2.3/Data/Text/Lazy/Encoding.hs"
+    , "-i../../../../bytestring-0.9.2.1/ -i../../../../../include/"
+    )
+  , ( "benchmarks/vector-0.10.0.1/Data/Vector/Fusion/Stream/Monadic.hs"
+    , "-i../../../../"
+    )
+  , ( "benchmarks/vector-0.10.0.1/Data/Vector/Fusion/Stream/Monadic.nocpp.hs"
+    , "-i../../../../"
+    )
+  ]
 
 ---------------------------------------------------------------------------
 testCmd :: FilePath -> FilePath -> FilePath -> SmtSolver -> LiquidOpts -> String

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -142,7 +142,7 @@ mkTest code dir file
         createDirectoryIfMissing True $ takeDirectory log
         bin <- binPath "liquid"
         withFile log WriteMode $ \h -> do
-          let cmd     = testCmd bin dir file smt $ mappend (extraOptions test) opts
+          let cmd     = testCmd bin dir file smt $ mappend (extraOptions dir test) opts
           (_,_,_,ph) <- createProcess $ (shell cmd) {std_out = UseHandle h, std_err = UseHandle h}
           c          <- waitForProcess ph
           renameFile log $ log <.> (if code == c then "pass" else "fail")
@@ -175,34 +175,29 @@ knownToFail Z3   = [ "tests/pos/linspace.hs"
                    ]
 
 --------------------------------------------------------------------------------
-extraOptions :: FilePath -> LiquidOpts
+extraOptions :: FilePath -> FilePath -> LiquidOpts
 --------------------------------------------------------------------------------
-extraOptions = flip (Map.findWithDefault mempty) $ Map.fromList
-  [ ( "tests/pos/Class2.hs"
-    , "-i../neg"
-    )
-  , ( "tests/pos/FFI.hs"
-    , "-i../ffi-include --c-files=../ffi-include/foo.c"
-    )
-  , ( "benchmarks/bytestring-0.9.2.1/Data/ByteString/Internal.hs"
-    , "-i../../include --c-files=../../cbits/fpstring.c"
-    )
-  , ( "benchmarks/text-0.11.2.3/Data/Text/Array.hs"
-    , "--c-files=../../cbits/cbits.c"
-    )
-  , ( "benchmarks/text-0.11.2.3/Data/Text/Encoding.hs"
-    , "-i../../../bytestring-0.9.2.1/ -i../../../../include/ --c-files=../../cbits/cbits.c"
-    )
-  , ( "benchmarks/text-0.11.2.3/Data/Text/Lazy/Encoding.hs"
-    , "-i../../../../bytestring-0.9.2.1/ -i../../../../../include/"
-    )
-  , ( "benchmarks/vector-0.10.0.1/Data/Vector/Fusion/Stream/Monadic.hs"
-    , "-i../../../../"
-    )
-  , ( "benchmarks/vector-0.10.0.1/Data/Vector/Fusion/Stream/Monadic.nocpp.hs"
-    , "-i../../../../"
-    )
-  ]
+extraOptions dir test = mappend (dirOpts dir) (testOpts test)
+  where
+    dirOpts = flip (Map.findWithDefault mempty) $ Map.fromList
+      [ ( "benchmarks/bytestring-0.9.2.1"
+        , "-iinclude --c-files=cbits/fpstring.c"
+        )
+      , ( "benchmarks/text-0.11.2.3"
+        , "-i../bytestring-0.9.2.1 -iinclude --c-files=cbits/cbits.c"
+        )
+      , ( "benchmarks/vector-0.10.0.1"
+        , "-i."
+        )
+      ]
+    testOpts = flip (Map.findWithDefault mempty) $ Map.fromList
+      [ ( "tests/pos/Class2.hs"
+        , "-i../neg"
+        )
+      , ( "tests/pos/FFI.hs"
+        , "-i../ffi-include --c-files=../ffi-include/foo.c"
+        )
+      ]
 
 ---------------------------------------------------------------------------
 testCmd :: FilePath -> FilePath -> FilePath -> SmtSolver -> LiquidOpts -> String


### PR DESCRIPTION
This (a) reworks the GHC Interface pipeline to handle multiple target files at once and parse/load each module one-by-one with a dependency graph, and (b) uses that infrastructure to pull comments out of GHC's ApiAnnotations interface instead of using our own parsing for that (fixes #617).

(a) lays the groundwork for the addition of quasiquoters (coming very soon!), .lqhi files, and the GHC plugin interface. It also means LH compiles each module exactly once, which helps a lot with `liquidhaskell-cabal`.

One caveat: this isn't compatible with using `--idirs` inside `{-@ LIQUID @-}` file pragmas. I think the test suite is the only user of this functionality; to make it work, I moved those flags into an `extraOptions` map in the test runner itself.