### PR TITLE
Patterns

### DIFF
--- a/benchmarks/text-0.11.2.3/Data/Text/Fusion.hs
+++ b/benchmarks/text-0.11.2.3/Data/Text/Fusion.hs
@@ -339,4 +339,4 @@ mapAccumL f z0 (Stream next0 s0 len) =
                 where (z',c) = f z x
                       j | ord c < 0x10000 = i
                         | otherwise       = i + 1
-{- INLINE [0] mapAccumL -}
+{-# INLINE [0] mapAccumL #-}

--- a/benchmarks/text-0.11.2.3/Data/Text/Fusion.hs
+++ b/benchmarks/text-0.11.2.3/Data/Text/Fusion.hs
@@ -308,7 +308,7 @@ countChar = S.countCharI
 {-@ Lazy mapAccumL @-}
 mapAccumL :: (a -> Char -> (a,Char)) -> a -> Stream Char -> (a, Text)
 mapAccumL f z0 (Stream next0 s0 len) =
-    (nz,I.textP na 0 nl)
+    (nz, I.textP na 0 nl)
   where
     --LIQUID INLINE (na,(nz,nl)) = A.run2 (A.new mlen >>= \arr -> outer arr mlen z0 s0 0)
     (na,(nz,nl)) = runST $ do (marr,x) <- (A.new mlen >>= \arr -> outer arr mlen z0 s0 0)
@@ -339,4 +339,4 @@ mapAccumL f z0 (Stream next0 s0 len) =
                 where (z',c) = f z x
                       j | ord c < 0x10000 = i
                         | otherwise       = i + 1
-{-# INLINE [0] mapAccumL #-}
+{- INLINE [0] mapAccumL -}

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -1196,11 +1196,21 @@ consPattern :: CGEnv -> Rs.Pattern -> CG SpecType
     -----------------------------------------
           G |- (e1 >>= \x -> e2) ~> m t
  -}
-consPattern γ (Rs.PatBindApp e1 x e2 _ _ _ _ _) = do
+consPattern γ (Rs.PatBind e1 x e2 _ _ _ _ _) = do
   tx    <- monadArg γ <$> consE γ e1
   γ'    <- ((γ, "consPattern") += (F.symbol x, tx))
   mt    <- consE γ' e2
   return mt
+
+{-
+           G |- e ~> t
+    ------------------------
+      G |- return e ~ m t
+ -}
+consPattern γ (Rs.PatReturn e m _ _ _) = do
+  t     <- consE γ e
+  mt    <- trueTy  m
+  return $ RAppTy mt t mempty
 
 
 monadArg :: CGEnv -> SpecType -> SpecType

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -1222,7 +1222,8 @@ consPattern γ (Rs.PatReturn e m _ _ _) = do
   return $ RAppTy mt t mempty
 
 checkMonad :: (Outputable a) => (String, a) -> CGEnv -> SpecType -> SpecType
-checkMonad _ _ (RApp _ [t] _ _) = t
+checkMonad _ _ (RApp _ ts _ _) 
+  | length ts > 0               = last ts
 checkMonad _ _ (RAppTy _ t _)   = t
 checkMonad x g t                = checkErr x g t
 

--- a/src/Language/Haskell/Liquid/Constraint/Types.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Types.hs
@@ -242,8 +242,8 @@ elemHEnv x (HEnv s) = x `S.member` s
 data RInv = RInv { _rinv_args :: [RSort]   -- empty list means that the invariant is generic
                                            -- for all type arguments
                  , _rinv_type :: SpecType
-                 , _rinv_name :: Maybe Var 
-                 } deriving Show 
+                 , _rinv_name :: Maybe Var
+                 } deriving Show
 
 type RTyConInv = M.HashMap RTyCon [RInv]
 type RTyConIAl = M.HashMap RTyCon [RInv]
@@ -255,10 +255,10 @@ mkRTyConInv ts = group [ (c, RInv (go ts) t v) | (v, t@(RApp c ts _ _)) <- strip
   where
     strip = mapSnd (fourth4 . bkUniv . val)
     go ts | generic (toRSort <$> ts) = []
-          | otherwise                = toRSort <$> ts 
+          | otherwise                = toRSort <$> ts
 
     generic ts = let ts' = L.nub ts in
-                 all isRVar ts' && length ts' == length ts 
+                 all isRVar ts' && length ts' == length ts
 
 mkRTyConIAl :: [(a, F.Located SpecType)] -> RTyConInv
 mkRTyConIAl    = mkRTyConInv . fmap ((Nothing,) . snd)
@@ -270,16 +270,16 @@ addRTyConInv m t
       Just ts -> L.foldl' conjoinInvariantShift t ts
 
 lookupRInv :: SpecType -> RTyConInv -> Maybe [SpecType]
-lookupRInv (RApp c ts _ _) m 
+lookupRInv (RApp c ts _ _) m
   = case M.lookup c m of
       Nothing   -> Nothing
       Just invs -> Just (catMaybes $ goodInvs ts <$> invs)
 lookupRInv _ _
-  = Nothing 
+  = Nothing
 
 goodInvs :: [SpecType] -> RInv -> Maybe SpecType
-goodInvs _ (RInv []  t _) 
-  = Just t 
+goodInvs _ (RInv []  t _)
+  = Just t
 goodInvs ts (RInv ts' t _)
   | and (zipWith unifiable ts' (toRSort <$> ts))
   = Just t
@@ -287,7 +287,7 @@ goodInvs ts (RInv ts' t _)
   = Nothing
 
 
-unifiable :: RSort -> RSort -> Bool 
+unifiable :: RSort -> RSort -> Bool
 unifiable t1 t2 = isJust $ tcUnifyTy (toType t1) (toType t2)
 
 addRInv :: RTyConInv -> (Var, SpecType) -> (Var, SpecType)
@@ -322,14 +322,14 @@ conjoinInvariant t _
 
 
 removeInvariant  :: CGEnv -> CoreBind -> (CGEnv, RTyConInv)
-removeInvariant γ cbs 
+removeInvariant γ cbs
   = (γ{ invs  = M.map (filter f) (invs γ)
       , rinvs = M.map (filter (\x -> not $ f x)) (invs γ)}, invs γ)
   where
-    f i | Just v  <- _rinv_name i, v `elem` binds cbs 
-        = False 
+    f i | Just v  <- _rinv_name i, v `elem` binds cbs
+        = False
         | otherwise
-        = True          
+        = True
 
     binds (NonRec x _) = [x]
     binds (Rec xes)    = fst $ unzip xes
@@ -339,19 +339,19 @@ restoreInvariant γ is = γ {invs = is}
 
 
 
-makeRecInvariants :: CGEnv -> [Var] -> CGEnv 
+makeRecInvariants :: CGEnv -> [Var] -> CGEnv
 makeRecInvariants γ [x] = γ {invs = M.unionWith (++) (invs γ) is}
   where
     is  =  M.map (map f . filter (isJust . ((varType x) `tcUnifyTy`) . toType . _rinv_type)) (rinvs γ)
     f i = i{_rinv_type = guard $ _rinv_type i}
 
     guard (RApp c ts rs r)
-      | Just f <- sizeFunction $ rtc_info c 
+      | Just f <- sizeFunction $ rtc_info c
       = RApp c ts rs (MkUReft (ref f $ F.toReft r) mempty mempty)
-      | otherwise 
-      = RApp c ts rs mempty 
+      | otherwise
+      = RApp c ts rs mempty
     guard t
-      = t   
+      = t
 
     ref f (F.Reft(v, rr)) = F.Reft (v, F.PImp (F.PAtom F.Lt (f v) (f $ F.symbol x)) rr)
 
@@ -381,7 +381,7 @@ initFEnv xts = FE F.emptyIBindEnv $ F.fromListSEnv (wiredSortedSyms ++ xts)
 --------------------------------------------------------------------------------
 
 instance NFData RInv where
-  rnf (RInv x y z) = rnf x `seq` rnf y `seq` rnf z  
+  rnf (RInv x y z) = rnf x `seq` rnf y `seq` rnf z
 
 instance NFData CGEnv where
   rnf (CGE x1 _ x3 _ x5 x6 x7 x8 x9 _ _ _ x10 _ _ _ _ _ _ _ _)

--- a/src/Language/Haskell/Liquid/GHC/Interface.hs
+++ b/src/Language/Haskell/Liquid/GHC/Interface.hs
@@ -8,11 +8,15 @@
 module Language.Haskell.Liquid.GHC.Interface (
 
   -- * extract all information needed for verification
-    getGhcInfo,
-    runLiquidGhc,
+    getGhcInfo
+  , runLiquidGhc
 
   -- * printer
-    pprintCBs
+  , pprintCBs
+
+  -- * predicates
+  , isExportedVar
+  , exportedVars
   ) where
 
 import Prelude hiding (error)
@@ -35,6 +39,7 @@ import HscTypes hiding (Target)
 import IdInfo
 import InstEnv
 import Var
+import NameSet
 
 import Control.Exception
 import Control.Monad
@@ -206,8 +211,18 @@ makeLogicMap = do
   return $ parseSymbolToLogic lg lspec
 
 --------------------------------------------------------------------------------
--- Extract Ids -----------------------------------------------------------------
+-- | Extract Ids ---------------------------------------------------------------
 --------------------------------------------------------------------------------
+
+exportedVars :: GhcInfo -> [Var]
+exportedVars info = filter (isExportedVar info) (defVars info)
+
+isExportedVar :: GhcInfo -> Var -> Bool
+isExportedVar info v = n `elemNameSet` ns
+  where
+    n                = getName v
+    ns               = exports (spec info)
+
 
 classCons :: Maybe [ClsInst] -> [Id]
 classCons Nothing   = []

--- a/src/Language/Haskell/Liquid/GHC/Interface.hs
+++ b/src/Language/Haskell/Liquid/GHC/Interface.hs
@@ -430,8 +430,8 @@ instance PPrint GhcInfo where
 
 pprintCBs :: [CoreBind] -> Doc
 pprintCBs
-  | otherwise = pprintCBsVerbose
   | True      = pprintCBsTidy
+  | otherwise = pprintCBsVerbose
   where
     pprintCBsTidy    = pprDoc . tidyCBs
     pprintCBsVerbose = text . O.showSDocDebug unsafeGlobalDynFlags . O.ppr . tidyCBs

--- a/src/Language/Haskell/Liquid/GHC/Interface.hs
+++ b/src/Language/Haskell/Liquid/GHC/Interface.hs
@@ -86,7 +86,7 @@ getGhcInfo' cfg target name tgtSpec = do
   impSpecs  <- findAndLoadTargets cfg paths target
   modGuts   <- makeMGIModGuts target
   hscEnv    <- getSession
-  coreBinds <- liftIO $ anormalize (not $ nocaseexpand cfg) hscEnv modGuts
+  coreBinds <- liftIO $ anormalize cfg hscEnv modGuts
   logicMap  <- liftIO makeLogicMap
   let dataCons = concatMap (map dataConWorkId . tyConDataCons) (mgi_tcs modGuts)
   let impVs = importVars coreBinds ++ classCons (mgi_cls_inst modGuts)

--- a/src/Language/Haskell/Liquid/GHC/Resugar.hs
+++ b/src/Language/Haskell/Liquid/GHC/Resugar.hs
@@ -23,12 +23,13 @@ module Language.Haskell.Liquid.GHC.Resugar (
   , lower
   ) where
 
+import           MkCore                           (mkCoreApps)
 import           CoreSyn
 import           Type
 import qualified PrelNames as PN -- (bindMName)
 import           Name       (Name, getName)
-import qualified Data.List as L
 
+-- import qualified Data.List as L
 -- import           Debug.Trace
 -- import           Var
 -- import           Data.Maybe                                 (fromMaybe)
@@ -39,22 +40,22 @@ import qualified Data.List as L
 
 data Pattern
   = PatBind
-      { patE1  :: CoreExpr
-      , patX   :: Var
-      , patE2  :: CoreExpr
-      , patM   :: Type
-      , patDct :: CoreExpr
-      , patTyA :: Type
-      , patTyB :: Type
-      , patFF  :: Var
+      { patE1  :: !CoreExpr
+      , patX   :: !Var
+      , patE2  :: !CoreExpr
+      , patM   :: !Type
+      , patDct :: !CoreExpr
+      , patTyA :: !Type
+      , patTyB :: !Type
+      , patFF  :: !Var
       }                      -- ^ e1 >>= \x -> e2
 
   | PatReturn
-     { patE    :: CoreExpr
-     , patM    :: Type
-     , patDct  :: CoreExpr
-     , patTy   :: Type
-     , patRet  :: Var
+     { patE    :: !CoreExpr
+     , patM    :: !Type
+     , patDct  :: !CoreExpr
+     , patTy   :: !Type
+     , patRet  :: !Var
      }                       -- ^ return e
 
 --------------------------------------------------------------------------------
@@ -84,12 +85,12 @@ is v n = n == getName v
 --------------------------------------------------------------------------------
 lower :: Pattern -> CoreExpr
 --------------------------------------------------------------------------------
-
 lower (PatBind e1 x e2 m d a b op)
-  = argsExpr (Var op) [Type m, d, Type a, Type b, e1, Lam x e2]
+  = mkCoreApps (Var op) [Type m, d, Type a, Type b, e1, Lam x e2]
 
 lower (PatReturn e m d t op)
-  = argsExpr (Var op) [Type m, d, Type t, e]
+  = mkCoreApps (Var op) [Type m, d, Type t, e]
 
-argsExpr :: CoreExpr -> [CoreExpr] -> CoreExpr
-argsExpr = L.foldl' App
+-- argsExpr :: CoreExpr -> [CoreExpr] -> CoreExpr
+-- argsExpr = L.foldl' App
+-- mkCoreApps (Var bindMVar)

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -192,12 +192,13 @@ solveCs cfg tgt cgi info names
                        , FC.linear      = linear      cfg
                        , FC.newcheck    = newcheck    cfg
                        , FC.eliminate   = eliminate   cfg
-                       , FC.save        = saveQuery cfg
+                       , FC.save        = saveQuery   cfg
                        , FC.srcFile     = tgt
                        , FC.cores       = cores       cfg
                        , FC.minPartSize = minPartSize cfg
                        , FC.maxPartSize = maxPartSize cfg
                        , FC.elimStats   = elimStats   cfg
+                       , FC.elimBound   = elimBound   cfg
                        }
 
 

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -37,6 +37,7 @@ import           Language.Haskell.Liquid.Types.RefType (applySolution)
 import           Language.Haskell.Liquid.UX.Errors
 import           Language.Haskell.Liquid.UX.CmdLine
 import           Language.Haskell.Liquid.UX.Tidy
+import           Language.Haskell.Liquid.GHC.Misc (showPpr)
 import           Language.Haskell.Liquid.GHC.Interface
 import           Language.Haskell.Liquid.Constraint.Generate
 import           Language.Haskell.Liquid.Constraint.ToFixpoint
@@ -116,7 +117,8 @@ liquidOne tgt info = do
   let cbs' = transformScope (cbs info)
   whenLoud  $ do donePhase Loud "transformRecExpr"
                  putStrLn "*************** Transform Rec Expr CoreBinds *****************"
-                 putStrLn $ render $ pprintCBs cbs'
+                 --  putStrLn $ render $ pprintCBs cbs'
+                 putStrLn $ showPpr cbs'
   edcs <- newPrune      cfg cbs' tgt info
   out' <- liquidQueries cfg      tgt info edcs
   DC.saveResult      tgt out'

--- a/src/Language/Haskell/Liquid/Transforms/ANF.hs
+++ b/src/Language/Haskell/Liquid/Transforms/ANF.hs
@@ -192,7 +192,7 @@ normalizeLiteral γ e =
 normalize :: AnfEnv -> CoreExpr -> DsMW CoreExpr
 --------------------------------------------------------------------------------
 normalize γ e
-  | Just p <- Rs.resugar e
+  | Just p <- Rs.lift e
   = normalizePattern γ p
 
 normalize γ (Lam x e)
@@ -254,7 +254,10 @@ stitch γ e
 --------------------------------------------------------------------------------
 normalizePattern :: AnfEnv -> Rs.Pattern -> DsMW CoreExpr
 --------------------------------------------------------------------------------
-normalizePattern _γ _ = panic Nothing "TODO:PATTERN"
+normalizePattern γ p@(Rs.PatBindApp {}) = do
+  e1'   <- normalize γ (Rs.patE1 p)
+  e2'   <- normalize γ (Rs.patE2 p)
+  return $ Rs.lower p { Rs.patE1 = e1', Rs.patE2 = e2' }
 
 --------------------------------------------------------------------------------
 expandDefaultCase :: AnfEnv
@@ -310,7 +313,6 @@ freshNormalVar γ t = mkUserLocalM anfOcc t sp
   where
     anfOcc         = mkVarOccFS $ symbolFastString anfPrefix
     sp             = Sp.srcSpan (aeSrcSpan γ)
-
 
 data AnfEnv = AnfEnv
   { aeVarEnv  :: VarEnv Id

--- a/src/Language/Haskell/Liquid/Transforms/ANF.hs
+++ b/src/Language/Haskell/Liquid/Transforms/ANF.hs
@@ -254,10 +254,14 @@ stitch γ e
 --------------------------------------------------------------------------------
 normalizePattern :: AnfEnv -> Rs.Pattern -> DsMW CoreExpr
 --------------------------------------------------------------------------------
-normalizePattern γ p@(Rs.PatBindApp {}) = do
+normalizePattern γ p@(Rs.PatBind {}) = do
   e1'   <- normalize γ (Rs.patE1 p)
   e2'   <- normalize γ (Rs.patE2 p)
   return $ Rs.lower p { Rs.patE1 = e1', Rs.patE2 = e2' }
+
+normalizePattern γ p@(Rs.PatReturn {}) = do
+  e'    <- normalize γ (Rs.patE p)
+  return $ Rs.lower p { Rs.patE = e' }
 
 --------------------------------------------------------------------------------
 expandDefaultCase :: AnfEnv

--- a/src/Language/Haskell/Liquid/Transforms/ANF.hs
+++ b/src/Language/Haskell/Liquid/Transforms/ANF.hs
@@ -199,8 +199,8 @@ normalizeLiteral γ e =
 normalize :: AnfEnv -> CoreExpr -> DsMW CoreExpr
 --------------------------------------------------------------------------------
 normalize γ e
-  | Just p <- Rs.lift e
-  , patternFlag γ
+  | patternFlag γ
+  , Just p <- Rs.lift e
   = normalizePattern γ p
 
 normalize γ (Lam x e)

--- a/src/Language/Haskell/Liquid/Transforms/ANF.hs
+++ b/src/Language/Haskell/Liquid/Transforms/ANF.hs
@@ -37,6 +37,8 @@ import           Control.Monad.State.Lazy
 import           System.Console.CmdArgs.Verbosity (whenLoud)
 import           Language.Fixpoint.Misc             (fst3)
 import           Language.Fixpoint.Types            (anfPrefix)
+
+import           Language.Haskell.Liquid.UX.Config  (Config, nocaseexpand, patternInline)
 import           Language.Haskell.Liquid.Misc       (concatMapM)
 import           Language.Haskell.Liquid.GHC.Misc   (MGIModGuts(..), showPpr, symbolFastString)
 import           Language.Haskell.Liquid.Transforms.Rec
@@ -50,9 +52,9 @@ import           Data.List                        (sortBy, (\\))
 --------------------------------------------------------------------------------
 -- | A-Normalize a module ------------------------------------------------------
 --------------------------------------------------------------------------------
-anormalize :: Bool -> HscEnv -> MGIModGuts -> IO [CoreBind]
+anormalize :: Config -> HscEnv -> MGIModGuts -> IO [CoreBind]
 --------------------------------------------------------------------------------
-anormalize expandFlag hscEnv modGuts
+anormalize cfg hscEnv modGuts
   = do whenLoud $ do putStrLn "***************************** GHC CoreBinds ***************************"
                      putStrLn $ showPpr orig_cbs
        (fromMaybe err . snd) <$> initDs hscEnv m grEnv tEnv emptyFamInstEnv act
@@ -60,9 +62,16 @@ anormalize expandFlag hscEnv modGuts
       m        = mgi_module modGuts
       grEnv    = mgi_rdr_env modGuts
       tEnv     = modGutsTypeEnv modGuts
-      act      = concatMapM (normalizeTopBind expandFlag emptyAnfEnv) orig_cbs
+      act      = concatMapM (normalizeTopBind γ0) orig_cbs
       orig_cbs = transformRecExpr $ mgi_binds modGuts
       err      = panic Nothing "Oops, cannot A-Normalize GHC Core!"
+      γ0       = emptyAnfEnv cfg
+
+expandFlag :: AnfEnv -> Bool
+expandFlag = not . nocaseexpand . aeCfg
+
+patternFlag :: AnfEnv -> Bool
+patternFlag = patternInline . aeCfg
 
 modGutsTypeEnv :: MGIModGuts -> TypeEnv
 modGutsTypeEnv mg  = typeEnvFromEntities ids tcs fis
@@ -78,13 +87,13 @@ modGutsTypeEnv mg  = typeEnvFromEntities ids tcs fis
 -- Can't make the below default for normalizeBind as it
 -- fails tests/pos/lets.hs due to GHCs odd let-bindings
 
-normalizeTopBind :: Bool -> AnfEnv -> Bind CoreBndr -> DsMonad.DsM [CoreBind]
-normalizeTopBind expandFlag γ (NonRec x e)
-  = do e' <- runDsM $ evalStateT (stitch γ e) (DsST expandFlag  [])
+normalizeTopBind :: AnfEnv -> Bind CoreBndr -> DsMonad.DsM [CoreBind]
+normalizeTopBind γ (NonRec x e)
+  = do e' <- runDsM $ evalStateT (stitch γ e) (DsST [])
        return [normalizeTyVars $ NonRec x e']
 
-normalizeTopBind expandFlag γ (Rec xes)
-  = do xes' <- runDsM $ execStateT (normalizeBind γ (Rec xes)) (DsST expandFlag [])
+normalizeTopBind γ (Rec xes)
+  = do xes' <- runDsM $ execStateT (normalizeBind γ (Rec xes)) (DsST [])
        return $ map normalizeTyVars (st_binds xes')
 
 normalizeTyVars :: Bind Id -> Bind Id
@@ -118,9 +127,7 @@ normalizeForAllTys e = case e of
 newtype DsM a = DsM {runDsM :: DsMonad.DsM a}
    deriving (Functor, Monad, MonadUnique, Applicative)
 
-data DsST = DsST { st_expandflag :: Bool
-                 , st_binds      :: [CoreBind]
-                 }
+data DsST = DsST { st_binds :: [CoreBind] }
 
 type DsMW = StateT DsST DsM
 
@@ -178,7 +185,7 @@ shouldNormalize l = case l of
   _ -> False
 
 add :: [CoreBind] -> DsMW ()
-add w = modify $ \s -> s{st_binds = st_binds s++w}
+add w = modify $ \s -> s { st_binds = st_binds s ++ w}
 
 --------------------------------------------------------------------------------
 normalizeLiteral :: AnfEnv -> CoreExpr -> DsMW CoreExpr
@@ -193,6 +200,7 @@ normalize :: AnfEnv -> CoreExpr -> DsMW CoreExpr
 --------------------------------------------------------------------------------
 normalize γ e
   | Just p <- Rs.lift e
+  , patternFlag γ
   = normalizePattern γ p
 
 normalize γ (Lam x e)
@@ -210,8 +218,7 @@ normalize γ (Case e x t as)
        x'    <- lift $ freshNormalVar γ τx -- rename "wild" to avoid shadowing
        let γ' = extendAnfEnv γ x x'
        as'   <- forM as $ \(c, xs, e') -> liftM (c, xs,) (stitch γ' e')
-       flag  <- st_expandflag <$> get
-       as''  <- lift $ expandDefaultCase γ flag τx as'
+       as''  <- lift $ expandDefaultCase γ τx as'
        return $ Case n x' t as''
     where τx = varType x
 
@@ -245,7 +252,7 @@ stitch :: AnfEnv -> CoreExpr -> DsMW CoreExpr
 --------------------------------------------------------------------------------
 stitch γ e
   = do bs'   <- get
-       modify $ \s -> s {st_binds = []}
+       modify $ \s -> s { st_binds = [] }
        e'    <- normalize γ e
        bs    <- st_binds <$> get
        put bs'
@@ -255,8 +262,9 @@ stitch γ e
 normalizePattern :: AnfEnv -> Rs.Pattern -> DsMW CoreExpr
 --------------------------------------------------------------------------------
 normalizePattern γ p@(Rs.PatBind {}) = do
+  -- don't normalize the >>= itself, we have a special typing rule for it
   e1'   <- normalize γ (Rs.patE1 p)
-  e2'   <- normalize γ (Rs.patE2 p)
+  e2'   <- stitch    γ (Rs.patE2 p)
   return $ Rs.lower p { Rs.patE1 = e1', Rs.patE2 = e2' }
 
 normalizePattern γ p@(Rs.PatReturn {}) = do
@@ -265,16 +273,14 @@ normalizePattern γ p@(Rs.PatReturn {}) = do
 
 --------------------------------------------------------------------------------
 expandDefaultCase :: AnfEnv
-                  -> Bool
                   -> Type
                   -> [(AltCon, [Id], CoreExpr)]
                   -> DsM [(AltCon, [Id], CoreExpr)]
 --------------------------------------------------------------------------------
-
-expandDefaultCase γ flag tyapp zs@((DEFAULT, _ ,_) : _) | flag
+expandDefaultCase γ tyapp zs@((DEFAULT, _ ,_) : _) | expandFlag γ
   = expandDefaultCase' γ tyapp zs
 
-expandDefaultCase γ _    tyapp@(TyConApp tc _) z@((DEFAULT, _ ,_):dcs)
+expandDefaultCase γ tyapp@(TyConApp tc _) z@((DEFAULT, _ ,_):dcs)
   = case tyConDataCons_maybe tc of
        Just ds -> do let ds' = ds \\ [ d | (DataAlt d, _ , _) <- dcs]
                      if (length ds') == 1
@@ -282,7 +288,7 @@ expandDefaultCase γ _    tyapp@(TyConApp tc _) z@((DEFAULT, _ ,_):dcs)
                       else return z
        Nothing -> return z --
 
-expandDefaultCase _ _ _ z
+expandDefaultCase _ _ z
    = return z
 
 expandDefaultCase' :: AnfEnv -> Type -> [(AltCon, [Id], c)] -> DsM [(AltCon, [Id], c)]
@@ -321,9 +327,10 @@ freshNormalVar γ t = mkUserLocalM anfOcc t sp
 data AnfEnv = AnfEnv
   { aeVarEnv  :: VarEnv Id
   , aeSrcSpan :: Sp.SpanStack
+  , aeCfg     :: Config
   }
 
-emptyAnfEnv :: AnfEnv
+emptyAnfEnv :: Config -> AnfEnv
 emptyAnfEnv = AnfEnv emptyVarEnv Sp.empty
 
 lookupAnfEnv :: AnfEnv -> Id -> Id -> Id

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -522,9 +522,9 @@ isBool :: RType RTyCon t t1 -> Bool
 isBool (RApp (RTyCon{rtc_tc = c}) _ _ _) = c == boolTyCon
 isBool _                                 = False
 
-isRVar :: RType c tv r -> Bool 
-isRVar (RVar _ _) = True 
-isRVar _          = False 
+isRVar :: RType c tv r -> Bool
+isRVar (RVar _ _) = True
+isRVar _          = False
 
 isClassRTyCon :: RTyCon -> Bool
 isClassRTyCon = isClassTyCon . rtc_tc

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -49,7 +49,7 @@ import Data.List                           (nub)
 import System.FilePath                     (dropFileName, isAbsolute,
                                             takeDirectory, (</>))
 
-import Language.Fixpoint.Types.Config      hiding (Config, linear, elimStats,
+import Language.Fixpoint.Types.Config      hiding (Config, linear, elimBound, elimStats,
                                               getOpts, cores, minPartSize,
                                               maxPartSize, newcheck, eliminate)
 -- import Language.Fixpoint.Utils.Files
@@ -221,6 +221,11 @@ config = cmdArgsMode $ Config {
     = False &= name "elimStats"
             &= help "Print eliminate stats"
 
+ , elimBound
+    = Nothing
+            &= name "elimBound"
+            &= help "Maximum chain length for eliminating KVars"
+
  , json
     = False &= name "json"
             &= help "Print results in JSON (for editor integration)"
@@ -389,6 +394,7 @@ defConfig = Config { files             = def
                    , scrapeImports     = False
                    , scrapeUsedImports = False
                    , elimStats         = False
+                   , elimBound         = Nothing
                    , json              = False
                    , counterExamples   = False
                    , timeBinds         = False

--- a/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/src/Language/Haskell/Liquid/UX/Config.hs
@@ -51,12 +51,13 @@ data Config = Config {
   , cabalDir       :: Bool       -- ^ find and use .cabal file to include paths to sources for imported modules
   , ghcOptions     :: [String]   -- ^ command-line options to pass to GHC
   , cFiles         :: [String]   -- ^ .c files to compile and link against (for GHC)
-  , eliminate      :: Bool
+  , eliminate      :: Bool       -- ^ eliminate non-top-level and non-recursive KVars
   , port           :: Int        -- ^ port at which lhi should listen
   , exactDC        :: Bool       -- ^ Automatically generate singleton types for data constructors
   , scrapeImports  :: Bool       -- ^ scrape qualifiers from imported specifications
   , scrapeUsedImports  :: Bool   -- ^ scrape qualifiers from used, imported specifications
   , elimStats      :: Bool       -- ^ print eliminate stats
+  , elimBound      :: Maybe Int  -- ^ eliminate upto given depth of KVar chains
   , json           :: Bool       -- ^ print results (safe/errors) as JSON
   , counterExamples:: Bool       -- ^ attempt to generate counter-examples to type errors
   , timeBinds      :: Bool       -- ^ check and time each (asserted) type-sig separately

--- a/tests/elim/ElimMonad.hs
+++ b/tests/elim/ElimMonad.hs
@@ -2,28 +2,28 @@
 --   about 2x the number of calls to `incr`.
 module ElimMonad (prop) where
 
-{-@ prop :: x:Nat -> IO {v:Int | v = x + 3} @-}
+{-@ prop :: x:Nat -> IO {v:Int | v = x + 22} @-}
 prop :: Int -> IO Int
 prop x = do
-  -- x <- incr x
-  -- x <- incr x
-  -- x <- incr x
-  -- x <- incr x
-  -- x <- incr x
-  -- x <- incr x
-  -- x <- incr x
-  -- x <- incr x
-  -- x <- incr x
-  -- x <- incr x
-  -- x <- incr x
-  -- x <- incr x
-  -- x <- incr x
-  -- x <- incr x
-  -- x <- incr x
-  -- x <- incr x
-  -- x <- incr x
-  -- x <- incr x
-  -- x <- incr x
+  x <- incr x
+  x <- incr x
+  x <- incr x
+  x <- incr x
+  x <- incr x
+  x <- incr x
+  x <- incr x
+  x <- incr x
+  x <- incr x
+  x <- incr x
+  x <- incr x
+  x <- incr x
+  x <- incr x
+  x <- incr x
+  x <- incr x
+  x <- incr x
+  x <- incr x
+  x <- incr x
+  x <- incr x
   x <- incr x
   x <- incr x
   x <- incr x

--- a/tests/elim/ElimMonad00.hs
+++ b/tests/elim/ElimMonad00.hs
@@ -13,3 +13,8 @@ prop apple = do
 {-@ incr :: dog:Int -> IO {v:Int | v == dog + 1} @-}
 incr :: Int -> IO Int
 incr cat = return (cat + 1)
+
+
+{-@ zonk :: (Monad m) => Nat -> m Nat @-}
+zonk :: (Monad m) => Int -> m Int
+zonk mouse = return (mouse + 1)


### PR DESCRIPTION
Add a `--pattern-inline` flag that special cases the handling of `e1 >>= \x -> e2` to avoid KVars. 

Would be nice to generalize / make this user extensible...