### PR TITLE
Fixes to ByteString specs

### DIFF
--- a/include/Data/ByteString.spec
+++ b/include/Data/ByteString.spec
@@ -34,10 +34,6 @@ append
 
 head :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Data.Word.Word8
 
-uncons
-    :: i : Data.ByteString.ByteString
-    -> Maybe (Data.Word.Word8, { o : Data.ByteString.ByteString | bslen o == bslen i - 1 })
-
 unsnoc
     :: i : Data.ByteString.ByteString
     -> Maybe ({ o : Data.ByteString.ByteString | bslen o == bslen i - 1 }, Data.Word.Word8)
@@ -378,3 +374,7 @@ hGetNonBlocking
     :: System.IO.Handle
     -> n : { n : Int | 0 <= n }
     -> IO { bs : Data.ByteString.ByteString | bslen bs <= n }
+
+uncons
+    :: i : Data.ByteString.ByteString
+    -> Maybe (Data.Word.Word8, { o : Data.ByteString.ByteString | bslen o == bslen i - 1 })

--- a/include/Data/ByteString/Unsafe.spec
+++ b/include/Data/ByteString/Unsafe.spec
@@ -4,7 +4,8 @@ unsafeHead
     :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Data.Word.Word8
 
 unsafeTail
-    :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Data.ByteString.ByteString
+    :: bs : { v : Data.ByteString.ByteString | bslen v > 0 }
+    -> { v : Data.ByteString.ByteString | bslen v = bslen bs - 1 }
 
 unsafeInit
     :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Data.Word.Word8

--- a/include/Data/ByteString/Unsafe.spec
+++ b/include/Data/ByteString/Unsafe.spec
@@ -4,7 +4,7 @@ unsafeHead
     :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Data.Word.Word8
 
 unsafeTail
-    :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Data.Word.Word8
+    :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Data.ByteString.ByteString
 
 unsafeInit
     :: { bs : Data.ByteString.ByteString | 1 <= bslen bs } -> Data.Word.Word8


### PR DESCRIPTION
The first one is obvious, but I'm particularly unsure about 31733db.

This was found in the process of using `liquidhaskell` on `binary-serialise-cbor`.