### PR TITLE
Fix743

### DIFF
--- a/README.md
+++ b/README.md
@@ -913,8 +913,7 @@ list is treated as a Stream. To establish this local invariant one can use the
 
 denoting that each list is not empty.
 Then, LiquidHaskell will prove that this invariant holds, by proving that *all
-calls* to List's
-constractos (ie., `:` and `[]`) satisfy it, and
+calls* to List's constructors (ie., `:` and `[]`) satisfy it, and
 will assume that each list element that is created satisfies
 this invariant.
 

--- a/include/GHC/Base.spec
+++ b/include/GHC/Base.spec
@@ -26,7 +26,7 @@ fst (a,b) = a
 measure snd :: (a,b) -> b
 snd (a,b) = b
 
-qualif Fst(v:a, y:b): (v = (fst y)) 
+qualif Fst(v:a, y:b): (v = (fst y))
 qualif Snd(v:a, y:b): (v = (snd y))
 
 
@@ -36,3 +36,5 @@ map       :: (a -> b) -> xs:[a] -> {v: [b] | len(v) = len(xs)}
 
 ($)       :: (a -> b) -> a -> b
 id        :: x:a -> {v:a | v = x}
+
+data variance Text.ParserCombinators.ReadPrec.ReadPrec contravariant

--- a/include/Text/ParserCombinators/ReadPrec.spec
+++ b/include/Text/ParserCombinators/ReadPrec.spec
@@ -1,0 +1,3 @@
+module spec Text.ParserCombinators.ReadPrec where
+
+data variance Text.ParserCombinators.ReadPrec.ReadPrec contravariantzzz

--- a/include/Text/ParserCombinators/ReadPrec.spec
+++ b/include/Text/ParserCombinators/ReadPrec.spec
@@ -1,3 +1,0 @@
-module spec Text.ParserCombinators.ReadPrec where
-
-data variance Text.ParserCombinators.ReadPrec.ReadPrec contravariantzzz

--- a/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -92,7 +92,7 @@ checkGhcSpec specs env sp =  applyNonNull (Right sp) Left errors
     ms               = measures sp
     clsSigs sp       = [ (v, t) | (v, t) <- tySigs sp, isJust (isClassOpId_maybe v) ]
     sigs             = tySigs sp ++ asmSigs sp
-    allowHO          = higherorder $ config sp 
+    allowHO          = higherOrderFlag sp
 
 
 checkQualifiers :: SEnv SortedReft -> [Qualifier] -> [Error]
@@ -147,7 +147,7 @@ checkInv allowHO emb tcEnv env (_, t)   = checkTy allowHO err emb tcEnv env t
 checkIAl :: Bool -> TCEmb TyCon -> TCEnv -> SEnv SortedReft -> [(Located SpecType, Located SpecType)] -> [Error]
 checkIAl allowHO emb tcEnv env ials = catMaybes $ concatMap (checkIAlOne allowHO emb tcEnv env) ials
 
-checkIAlOne :: Bool 
+checkIAlOne :: Bool
             -> TCEmb TyCon
             -> TCEnv
             -> SEnv SortedReft
@@ -254,7 +254,7 @@ errTypeMismatch x t = ErrMismatch lqSp (pprint x) d1 d2 hsSp
 checkRType :: (PPrint r, Reftable r, SubsTy RTyVar (RType RTyCon RTyVar ()) r) => Bool -> TCEmb TyCon -> SEnv SortedReft -> RRType (UReft r) -> Maybe Doc
 ------------------------------------------------------------------------------------------------
 
-checkRType allowHO emb env t   
+checkRType allowHO emb env t
   =   checkAppTys t
   <|> checkAbstractRefs t
   <|> efoldReft farg cb (rTypeSortedReft emb) f insertPEnv env Nothing t

--- a/src/Language/Haskell/Liquid/Constraint/Axioms.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Axioms.hs
@@ -574,7 +574,7 @@ initAEEnv info sigs
                      , ae_recs    = []
                      , ae_assert  = []
                      , ae_cmb     = \x y -> (App (App (Var by) x) y)
-                     , ae_isHO    = higherorder $ config spc
+                     , ae_isHO    = higherOrderFlag spc
                      }
     where
       spc        = spec info

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -119,10 +119,10 @@ consAct :: GhcInfo -> CG ()
 consAct info = do
   γ'    <- initEnv      info
   sflag <- scheck   <$> get
-  -- tflag <- trustghc <$> get
+  tflag <- trustghc <$> get
   γ     <- if expandProofsMode then addCombine τProof γ' else return γ'
   cbs'  <- if expandProofsMode then mapM (expandProofs info (mkSigs γ)) $ cbs info else return $ cbs info
-  let trustBinding x = {- tflag && -} (x `elem` derVars info || isInternal x)
+  let trustBinding x = tflag && (x `elem` derVars info || isInternal x)
   foldM_ (consCBTop trustBinding) γ cbs'
   hcs   <- hsCs  <$> get
   hws   <- hsWfs <$> get
@@ -365,7 +365,7 @@ initCGI cfg info = CGInfo {
   , specLazy   = dictionaryVar `S.insert` lazy spc
   , tcheck     = not $ notermination cfg
   , scheck     = strata cfg
-  -- , trustghc   = trustinternals cfg
+  , trustghc   = not $ noTrustInterns cfg
   , pruneRefs  = pruneUnsorted cfg
   , logErrors  = []
   , kvProf     = emptyKVProf

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -119,10 +119,10 @@ consAct :: GhcInfo -> CG ()
 consAct info = do
   γ'    <- initEnv      info
   sflag <- scheck   <$> get
-  tflag <- trustghc <$> get
+  -- tflag <- trustghc <$> get
   γ     <- if expandProofsMode then addCombine τProof γ' else return γ'
   cbs'  <- if expandProofsMode then mapM (expandProofs info (mkSigs γ)) $ cbs info else return $ cbs info
-  let trustBinding x = tflag && (x `elem` derVars info || isInternal x)
+  let trustBinding x = {- tflag && -} (x `elem` derVars info || isInternal x)
   foldM_ (consCBTop trustBinding) γ cbs'
   hcs   <- hsCs  <$> get
   hws   <- hsWfs <$> get
@@ -365,7 +365,7 @@ initCGI cfg info = CGInfo {
   , specLazy   = dictionaryVar `S.insert` lazy spc
   , tcheck     = not $ notermination cfg
   , scheck     = strata cfg
-  , trustghc   = trustinternals cfg
+  -- , trustghc   = trustinternals cfg
   , pruneRefs  = pruneUnsorted cfg
   , logErrors  = []
   , kvProf     = emptyKVProf

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -952,11 +952,7 @@ safeFromAsserted msg _ = panic Nothing $ "safeFromAsserted:" ++ msg
 -- | @varTemplate@ is only called with a `Just e` argument when the `e`
 -- corresponds to the body of a @Rec@ binder.
 varTemplate :: CGEnv -> (Var, Maybe CoreExpr) -> CG (Template SpecType)
-varTemplate γ (x, eo) = do
-  t     <- varTemplate' γ (x, eo)
-  t'    <- mapM (topSpecType x) t
-  return {- $ traceShow ("VAR-TEMPLATE: " ++ show x) -} t'
-
+varTemplate γ (x, eo) = varTemplate' γ (x, eo) >>= mapM (topSpecType x)
 
 -- | @lazVarTemplate@ is like `varTemplate` but for binders that are *not*
 --   termination checked and hence, the top-level refinement / KVar is

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -405,7 +405,7 @@ freshTy_expr k e _  = freshTy_reftype k $ exprRefType e
 freshTy_reftype     :: KVKind -> SpecType -> CG SpecType
 freshTy_reftype k _t = (fixTy t >>= refresh) =>> addKVars k
   where
-    t                = F.tracepp ("freshTy_reftype:" ++ show k)  _t
+    t                = {- F.tracepp ("freshTy_reftype:" ++ show k) -} _t
 
 -- | Used to generate "cut" kvars for fixpoint. Typically, KVars for recursive
 --   definitions, and also to update the KVar profile.
@@ -955,13 +955,8 @@ varTemplate :: CGEnv -> (Var, Maybe CoreExpr) -> CG (Template SpecType)
 varTemplate γ (x, eo) = do
   t     <- varTemplate' γ (x, eo)
   t'    <- mapM (topSpecType x) t
-  return $ traceShow ("VAR-TEMPLATE: " ++ show x) t'
+  return {- $ traceShow ("VAR-TEMPLATE: " ++ show x) -} t'
 
--- | @topSpecType@ strips out the top-level refinement of a derived var
-topSpecType :: Var -> SpecType -> CG SpecType
-topSpecType x t = do
-  info  <- ghcI <$> get
-  return $ if derivedVar info x then topRTypeBase t else t
 
 -- | @lazVarTemplate@ is like `varTemplate` but for binders that are *not*
 --   termination checked and hence, the top-level refinement / KVar is
@@ -981,6 +976,12 @@ varTemplate' γ (x, eo)
                               addW (WfC γ t)
                               Asserted <$> refreshArgsTop (x, t)
       (_,      _, _, _) -> return Unknown
+
+-- | @topSpecType@ strips out the top-level refinement of "derived var"
+topSpecType :: Var -> SpecType -> CG SpecType
+topSpecType x t = do
+  info  <- ghcI <$> get
+  return $ if derivedVar info x then topRTypeBase t else t
 
 --------------------------------------------------------------------------------
 -- | Constraint Generation: Checking -------------------------------------------

--- a/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
+++ b/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
@@ -30,7 +30,7 @@ targetFInfo info cgi fn = F.fi cs ws bs ls ks packs qs bi fn aHO aHOqs
     qs                  = targetQuals info cgi
     bi                  = (`Ci` Nothing) <$> bindSpans cgi
     aHO                 = allowHO cgi
-    aHOqs               = higherorderqs  $ config $ spec info
+    aHOqs               = higherOrderFlag info
 
 targetQuals :: GhcInfo -> CGInfo -> [F.Qualifier]
 targetQuals info cgi = spcQs ++ genQs

--- a/src/Language/Haskell/Liquid/Constraint/Types.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Types.hs
@@ -185,7 +185,7 @@ data CGInfo = CGInfo {
   , lits       :: !(F.SEnv F.Sort)             -- ^ Literals to be embedded as constants in refinement logic
   , tcheck     :: !Bool                        -- ^ Check Termination (?)
   , scheck     :: !Bool                        -- ^ Check Strata (?)
-  , trustghc   :: !Bool                        -- ^ Trust ghc auto generated bindings
+  -- , trustghc   :: !Bool                        -- ^ Trust ghc auto generated bindings
   , pruneRefs  :: !Bool                        -- ^ prune unsorted refinements
   , logErrors  :: ![Error]                     -- ^ Errors during constraint generation
   , kvProf     :: !KVProf                      -- ^ Profiling distribution of KVars

--- a/src/Language/Haskell/Liquid/Constraint/Types.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Types.hs
@@ -194,6 +194,7 @@ data CGInfo = CGInfo {
   , recCount   :: !Int                         -- ^ number of recursive functions seen (for benchmarks)
   , bindSpans  :: M.HashMap F.BindId SrcSpan   -- ^ Source Span associated with Fixpoint Binder
   , allowHO    :: !Bool
+  , ghcI       :: !GhcInfo
   }
 
 instance PPrint CGInfo where

--- a/src/Language/Haskell/Liquid/Constraint/Types.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Types.hs
@@ -185,7 +185,7 @@ data CGInfo = CGInfo {
   , lits       :: !(F.SEnv F.Sort)             -- ^ Literals to be embedded as constants in refinement logic
   , tcheck     :: !Bool                        -- ^ Check Termination (?)
   , scheck     :: !Bool                        -- ^ Check Strata (?)
-  -- , trustghc   :: !Bool                        -- ^ Trust ghc auto generated bindings
+  , trustghc   :: !Bool                        -- ^ Trust ghc auto generated bindings
   , pruneRefs  :: !Bool                        -- ^ prune unsorted refinements
   , logErrors  :: ![Error]                     -- ^ Errors during constraint generation
   , kvProf     :: !KVProf                      -- ^ Profiling distribution of KVars

--- a/src/Language/Haskell/Liquid/GHC/Interface.hs
+++ b/src/Language/Haskell/Liquid/GHC/Interface.hs
@@ -360,7 +360,18 @@ processTargetModule cfg0 logicMap depGraph specEnv file typechecked bareSpec = d
   (spc, imps, incs) <- toGhcSpec cfg coreBinds (impVs ++ defVs) letVs modName modGuts bareSpec logicMap impSpecs
   _                 <- liftIO $ whenLoud $ putStrLn $ "Module Imports: " ++ show imps
   hqualsFiles       <- moduleHquals modGuts paths file imps incs
-  return $ GI file (moduleName mod) hscEnv coreBinds derVs impVs (letVs ++ dataCons) useVs hqualsFiles imps incs spc
+  return GI { target    = file
+            , targetMod = moduleName mod
+            , env       = hscEnv
+            , cbs       = coreBinds
+            , derVars   = traceShow "DERIVED VARS" derVs
+            , impVars   = impVs
+            , defVars   = letVs ++ dataCons
+            , useVars   = useVs
+            , hqFiles   = hqualsFiles
+            , imports   = imps
+            , includes  = incs
+            , spec      = spc                }
 
 toGhcSpec :: GhcMonad m
           => Config

--- a/src/Language/Haskell/Liquid/GHC/Interface.hs
+++ b/src/Language/Haskell/Liquid/GHC/Interface.hs
@@ -250,7 +250,7 @@ derivedVars cbs (Just fds) = concatMap (derivedVs cbs) fds
 derivedVars _   Nothing    = []
 
 derivedVs :: CoreProgram -> DFunId -> [Id]
-derivedVs cbs fd = concatMap bindersOf cbs' ++ deps
+derivedVs cbs fd   = concatMap bindersOf cbs' ++ deps
   where
     cbs'           = filter f cbs
     f (NonRec x _) = eqFd x

--- a/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -79,7 +79,6 @@ import           Language.Haskell.Liquid.Types.Errors
 --------------------------------------------------------------------------------
 -- | Datatype For Holding GHC ModGuts ------------------------------------------
 --------------------------------------------------------------------------------
-
 data MGIModGuts = MI {
     mgi_binds     :: !CoreProgram
   , mgi_module    :: !Module

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -202,7 +202,7 @@ fixConfig tgt cfg = def
   , FC.maxPartSize = maxPartSize       cfg
   , FC.elimStats   = elimStats         cfg
   , FC.elimBound   = elimBound         cfg
-  , FC.allowHO     = higherorder       cfg
+  , FC.allowHO     = higherOrderFlag   cfg
   , FC.allowHOqs   = higherorderqs     cfg
   , FC.extensionality = extensionality cfg
   }

--- a/src/Language/Haskell/Liquid/Model.hs
+++ b/src/Language/Haskell/Liquid/Model.hs
@@ -29,7 +29,7 @@ import           Unsafe.Coerce
 import           Language.Fixpoint.Types (FixResult(..), mapPredReft, Symbol, symbol, Expr(..),
                                           mkSubst, subst)
 import           Language.Fixpoint.Smt.Interface
-import qualified Language.Fixpoint.Types.Config as FC  
+import qualified Language.Fixpoint.Types.Config as FC
 import           Language.Haskell.Liquid.GHC.Interface
 import           Language.Haskell.Liquid.GHC.Misc
 import           Language.Haskell.Liquid.Types         hiding (var)
@@ -170,11 +170,11 @@ withContext cfg s t act = do
 
 
 toFixCfg :: Config -> FC.Config
-toFixCfg cfg 
+toFixCfg cfg
   = FC.defConfig
      { FC.solver    = fromMaybe FC.Z3 $ smtsolver cfg
-     , FC.allowHO   = higherorder cfg
-     , FC.allowHOqs = higherorderqs cfg 
+     , FC.allowHO   = higherOrderFlag cfg
+     , FC.allowHOqs = higherorderqs   cfg 
      }
 
 dictProxy :: forall t. Dict (Targetable t) -> Proxy t

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -131,6 +131,7 @@ module Language.Haskell.Liquid.Types (
   , rTypeValueVar
   , rTypeReft
   , stripRTypeBase
+  , topRTypeBase
 
   -- * Class for values that can be pretty printed
   , PPrint (..), pprint
@@ -1451,6 +1452,9 @@ stripRTypeBase (RAppTy _ _ x)
   = Just x
 stripRTypeBase _
   = Nothing
+
+topRTypeBase :: (Reftable r) => RType c tv r -> RType c tv r
+topRTypeBase = mapRBase top
 
 mapRBase :: (r -> r) -> RType c tv r -> RType c tv r
 mapRBase f (RApp c ts rs r) = RApp c ts rs $ f r

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -293,8 +293,8 @@ data GhcInfo = GI {
     target   :: !FilePath
   , targetMod:: !ModuleName
   , env      :: !HscEnv
-  , cbs      :: ![CoreBind]
-  , derVars  :: ![Var]
+  , cbs      :: ![CoreBind]     
+  , derVars  :: ![Var]          -- ^ ?
   , impVars  :: ![Var]
   , defVars  :: ![Var]
   , useVars  :: ![Var]
@@ -532,7 +532,7 @@ instance Symbolic RTyVar where
 data BTyCon = BTyCon
   { btc_tc    :: !LocSymbol    -- ^ TyCon name with location information
   , btc_class :: !Bool         -- ^ Is this a class type constructor?
-  , btc_prom  :: !Bool         -- ^ Is Promoted Data Con? 
+  , btc_prom  :: !Bool         -- ^ Is Promoted Data Con?
   }
   deriving (Generic, Data, Typeable)
 

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -293,7 +293,7 @@ data GhcInfo = GI {
     target   :: !FilePath
   , targetMod:: !ModuleName
   , env      :: !HscEnv
-  , cbs      :: ![CoreBind]     
+  , cbs      :: ![CoreBind]
   , derVars  :: ![Var]          -- ^ ?
   , impVars  :: ![Var]
   , defVars  :: ![Var]

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -142,9 +142,9 @@ config = cmdArgsMode $ Config {
     = def &= help "Don't display warnings, only show errors"
           &= name "no-warnings"
 
- , trustinternals
-    = def &= help "Trust all ghc auto generated code"
-          &= name "trust-internals"
+ -- , trustinternals
+ --   = def &= help "Trust all ghc auto generated code"
+ --          &= name "trust-internals"
 
  , nocaseexpand
     = def &= help "Don't expand the default case in a case-expression"
@@ -412,7 +412,7 @@ defConfig = Config { files             = def
                    , notermination     = def
                    , autoproofs        = def
                    , nowarnings        = def
-                   , trustinternals    = def
+                   -- , trustinternals    = def
                    , nocaseexpand      = def
                    , strata            = def
                    , notruetypes       = def

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -142,9 +142,9 @@ config = cmdArgsMode $ Config {
     = def &= help "Don't display warnings, only show errors"
           &= name "no-warnings"
 
- -- , trustinternals
- --   = def &= help "Trust all ghc auto generated code"
- --          &= name "trust-internals"
+ , noTrustInterns
+    = False &= help "Verify (don't trust) ghc generated code"
+            &= name "no-trust-internals"
 
  , nocaseexpand
     = def &= help "Don't expand the default case in a case-expression"
@@ -412,7 +412,7 @@ defConfig = Config { files             = def
                    , notermination     = def
                    , autoproofs        = def
                    , nowarnings        = def
-                   -- , trustinternals    = def
+                   , noTrustInterns    = False
                    , nocaseexpand      = def
                    , strata            = def
                    , notruetypes       = def

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -142,9 +142,9 @@ config = cmdArgsMode $ Config {
     = def &= help "Don't display warnings, only show errors"
           &= name "no-warnings"
 
- , noTrustInterns
-    = False &= help "Verify (don't trust) ghc generated code"
-            &= name "no-trust-internals"
+ , trustInternals
+    = False &= help "Trust GHC generated code"
+            &= name "trust-internals"
 
  , nocaseexpand
     = def &= help "Don't expand the default case in a case-expression"
@@ -412,7 +412,7 @@ defConfig = Config { files             = def
                    , notermination     = def
                    , autoproofs        = def
                    , nowarnings        = def
-                   , noTrustInterns    = False
+                   , trustInternals    = False
                    , nocaseexpand      = def
                    , strata            = def
                    , notruetypes       = def

--- a/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/src/Language/Haskell/Liquid/UX/Config.hs
@@ -37,7 +37,7 @@ data Config = Config {
   , notermination  :: Bool       -- ^ disable termination check
   , autoproofs     :: Bool       -- ^ automatically construct proofs from axioms
   , nowarnings     :: Bool       -- ^ disable warnings output (only show errors)
-  -- , trustinternals :: Bool       -- ^ type all internal variables with true
+  , noTrustInterns :: Bool       -- ^ type all internal variables with true
   , nocaseexpand   :: Bool       -- ^ disable case expand
   , strata         :: Bool       -- ^ enable strata analysis
   , notruetypes    :: Bool       -- ^ disable truing top level types

--- a/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/src/Language/Haskell/Liquid/UX/Config.hs
@@ -37,7 +37,7 @@ data Config = Config {
   , notermination  :: Bool       -- ^ disable termination check
   , autoproofs     :: Bool       -- ^ automatically construct proofs from axioms
   , nowarnings     :: Bool       -- ^ disable warnings output (only show errors)
-  , noTrustInterns :: Bool       -- ^ type all internal variables with true
+  , trustInternals :: Bool       -- ^ type all internal variables with true
   , nocaseexpand   :: Bool       -- ^ disable case expand
   , strata         :: Bool       -- ^ enable strata analysis
   , notruetypes    :: Bool       -- ^ disable truing top level types
@@ -78,6 +78,15 @@ instance Serialize Config
 
 class HasConfig t where
   getConfig :: t -> Config
+
+  patternFlag :: t -> Bool
+  patternFlag = not . noPatternInline . getConfig
+
+  higherOrderFlag :: t -> Bool
+  higherOrderFlag = higherorder . getConfig
+
+
+
 
 hasOpt :: HasConfig t => t -> (Config -> Bool) -> Bool
 hasOpt t f = f (getConfig t)

--- a/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/src/Language/Haskell/Liquid/UX/Config.hs
@@ -37,7 +37,7 @@ data Config = Config {
   , notermination  :: Bool       -- ^ disable termination check
   , autoproofs     :: Bool       -- ^ automatically construct proofs from axioms
   , nowarnings     :: Bool       -- ^ disable warnings output (only show errors)
-  , trustinternals :: Bool       -- ^ type all internal variables with true
+  -- , trustinternals :: Bool       -- ^ type all internal variables with true
   , nocaseexpand   :: Bool       -- ^ disable case expand
   , strata         :: Bool       -- ^ enable strata analysis
   , notruetypes    :: Bool       -- ^ disable truing top level types

--- a/tests/neg/Class2.hs
+++ b/tests/neg/Class2.hs
@@ -17,8 +17,12 @@ instance Sized [] where
       sz ([])   = 0
       sz (x:xs) = 1 + (sz xs)
     @-}
+
   size []     = 0
   size (x:xs) = 1 + size xs
+
+-- The following is needed to make this work (but are invariants checked?) 
+{- invariant {v:[a] | sz v == len v} @-}
 
 {-@ class (Sized s) => Indexable s where
       index :: forall a. x:s a -> {v:Nat | v < sz x} -> a
@@ -29,6 +33,4 @@ class (Sized s) => Indexable s where
 
 instance Indexable [] where
   index = (!!)
-
-
 

--- a/tests/neg/Class2.hs
+++ b/tests/neg/Class2.hs
@@ -5,8 +5,9 @@ module Class () where
 import Language.Haskell.Liquid.Prelude
 
 {-@ class measure sz :: forall a. a -> Int @-}
+
 {-@ class Sized s where
-      size :: forall a. x:s a -> {v:Nat | v = (sz x)}
+      size :: forall a. x:s a -> {v:Nat | v = sz x}
   @-}
 class Sized s where
   size :: s a -> Int
@@ -20,7 +21,7 @@ instance Sized [] where
   size (x:xs) = 1 + size xs
 
 {-@ class (Sized s) => Indexable s where
-      index :: forall a. x:s a -> {v:Nat | v < (sz x)} -> a
+      index :: forall a. x:s a -> {v:Nat | v < sz x} -> a
   @-}
 class (Sized s) => Indexable s where
   index :: s a -> Int -> a

--- a/tests/neg/T743-mini.hs
+++ b/tests/neg/T743-mini.hs
@@ -1,0 +1,22 @@
+module Bob (bar) where
+
+data Foo a = FooCon a
+data Dict = DictCon
+
+{-@ foo :: {v:Foo Int | false} @-}
+foo = undefined :: Foo Int
+
+{-@ mkDict :: Foo Int -> Dict @-}
+mkDict :: Foo Int -> Dict
+mkDict _ = DictCon
+
+dict      = mkDict dictList
+dictList  = readListPrecDefault dict
+
+{-@ readListPrecDefault :: Dict -> Foo Int @-}
+readListPrecDefault :: Dict -> Foo Int
+readListPrecDefault = undefined
+
+{-@ bar :: Nat @-}
+bar :: Int
+bar = 2 - 10

--- a/tests/neg/T743.hs
+++ b/tests/neg/T743.hs
@@ -1,0 +1,9 @@
+{-@ checkNat :: Nat -> Int @-} 
+checkNat :: Int -> Int 
+checkNat x = x
+
+unsound :: Int
+unsound = checkNat (-1)
+
+
+data TestBS = TestBS Int deriving (Read)

--- a/tests/neg/T743.hs
+++ b/tests/neg/T743.hs
@@ -1,9 +1,10 @@
-{-@ checkNat :: Nat -> Int @-} 
-checkNat :: Int -> Int 
+module Bob where
+
+{-@ checkNat :: Nat -> Int @-}
+checkNat :: Int -> Int
 checkNat x = x
 
 unsound :: Int
 unsound = checkNat (-1)
-
 
 data TestBS = TestBS Int deriving (Read)


### PR DESCRIPTION
Fix for issue #743.

We **cannot** make `--trust-internals` default because it means skipping all instance methods, which breaks the whole class measure thing.

Instead, this fix ensures that all derived/generated binders have "True" as their "top-level" refinement,
i.e. do not contaminate the top-level environment with some bogus inferred refinement. (This is needed
for things like, e.g. `Read` where there is some oddness involving the generated binders and dictionaries, and which, since they are auto-generated, cannot be annotated as `Lazy` by the programmer.)