### PR TITLE
Check unbound variables in user specified signatures 

### DIFF
--- a/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -64,6 +64,7 @@ checkGhcSpec specs env sp =  applyNonNull (Right sp) Left errors
   where
     errors           =  mapMaybe (checkBind allowHO "constructor"  emb tcEnv env) (dcons      sp)
                      ++ mapMaybe (checkBind allowHO "measure"      emb tcEnv env) (meas       sp)
+                     ++ mapMaybe (checkBind allowHO "assumed type" emb tcEnv env) (tySigs     sp)
                      ++ mapMaybe (checkBind allowHO "assumed type" emb tcEnv env) (asmSigs    sp)
                      ++ mapMaybe (checkBind allowHO "class method" emb tcEnv env) (clsSigs    sp)
                      ++ mapMaybe (checkInv allowHO emb tcEnv env)               (invariants sp)

--- a/tests/crash/UnboundSigs.hs
+++ b/tests/crash/UnboundSigs.hs
@@ -1,0 +1,9 @@
+module DependeTypes where
+
+
+
+data MI s
+  = Small { mi_input :: String  }
+
+
+{-@ Small :: forall s. {v:String | s == v } -> MI s @-}

--- a/tests/todo/DependentTypes.hs
+++ b/tests/todo/DependentTypes.hs
@@ -26,7 +26,7 @@ data MI (s :: Symbol)
   = Small { mi_input :: String  }
 
 
-{- Small :: forall (s :: Symbol). {v:String | s == v } -> MI s @-}
+{-@ Small :: forall s. {v:String | s == v } -> MI s @-}
 
 -- OR 
 

--- a/tests/todo/DependentTypes.hs
+++ b/tests/todo/DependentTypes.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module DependeTypes where
+
+import GHC.TypeLits
+
+
+-- THIS SHOULD BE SAFE 
+misafe   :: MI "blaa" 
+misafe   = Small "blaa"
+
+-- THIS SHOULD BE UNSAFE
+miunsafe1 :: forall s. MI s 
+miunsafe1 = Small "blaa"
+
+-- THIS SHOULD BE UNSAFE 
+miunsafe2 :: MI "bla0" 
+miunsafe2 = Small "blaa"
+
+
+data MI (s :: Symbol)
+  = Small { mi_input :: String  }
+
+
+{- Small :: forall (s :: Symbol). {v:String | s == v } -> MI s @-}
+
+-- OR 
+
+{- data MI (s :: Symbol)
+    = Small { mi_input :: {v:String | v == s } } @-}


### PR DESCRIPTION
The following used to be safe (not crashes).

```
data MI s  = Small { mi_input :: String  }
{-@ Small :: forall s. {v:String | s == v } -> MI s @-}
```

http://goto.ucsd.edu:8090/index.html#?demo=permalink%2F1468258362_14141.hs