### PR TITLE
Refactor fields

### DIFF
--- a/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -18,7 +18,6 @@ import TypeRep
 
 import Prelude hiding (mapM)
 
-
 import Control.Monad hiding (forM, mapM)
 import Control.Monad.Except hiding (forM, mapM)
 import Control.Monad.State hiding (forM, mapM)
@@ -27,36 +26,45 @@ import Text.PrettyPrint.HughesPJ (text)
 
 
 import qualified Data.List as L
-import Data.Maybe (fromMaybe)
+import           Data.Maybe (fromMaybe)
 
 import Language.Fixpoint.Misc
 import Language.Fixpoint.Types (Symbol, symbol, symbolString)
 
-import qualified Language.Fixpoint.Types as F
-import Language.Haskell.Liquid.Types.RefType
-import Language.Haskell.Liquid.Transforms.CoreToLogic
-import Language.Haskell.Liquid.GHC.Misc (showPpr, sourcePosSrcSpan, dropModuleNames)
-import Language.Haskell.Liquid.Types
-
-
 import qualified Language.Haskell.Liquid.Measure as Ms
+import qualified Language.Fixpoint.Types as F
+import           Language.Haskell.Liquid.Types.RefType
+import           Language.Haskell.Liquid.Transforms.CoreToLogic
+import           Language.Haskell.Liquid.GHC.Misc (showPpr, sourcePosSrcSpan, dropModuleNames)
+import           Language.Haskell.Liquid.Types
+import           Language.Haskell.Liquid.Bare.Env
+import           Language.Haskell.Liquid.Misc (mapSnd)
 
-import Language.Haskell.Liquid.Bare.Env
-import Language.Haskell.Liquid.Misc (mapSnd)
-
-
-makeAxiom :: F.TCEmb TyCon -> LogicMap -> [CoreBind] -> GhcSpec -> Ms.BareSpec
+--------------------------------------------------------------------------------
+makeAxiom :: F.TCEmb TyCon
+          -> LogicMap
+          -> [CoreBind]
+          -> GhcSpec
+          -> Ms.BareSpec
           -> LocSymbol
           -> BareM ((Symbol, LocSpecType), [(Var, LocSpecType)], [HAxiom])
+--------------------------------------------------------------------------------
 makeAxiom tce lmap cbs spec _ x
   = case filter ((val x `elem`) . map (dropModuleNames . simplesymbol) . binders) cbs of
         (NonRec v def:_)   -> makeAxiom' tce lmap cbs spec x v def
         (Rec [(v, def)]:_) -> makeAxiom' tce lmap cbs spec x v def
         _                  -> throwError $ mkError x "Cannot extract measure from haskell function"
 
-makeAxiom' :: F.TCEmb TyCon -> LogicMap -> [CoreBind] -> GhcSpec
-           -> LocSymbol -> Var -> CoreExpr
+--------------------------------------------------------------------------------
+makeAxiom' :: F.TCEmb TyCon
+           -> LogicMap
+           -> [CoreBind]
+           -> GhcSpec
+           -> LocSymbol
+           -> Var
+           -> CoreExpr
            -> BareM ((Symbol, LocSpecType), [(Var, LocSpecType)], [HAxiom])
+--------------------------------------------------------------------------------
 makeAxiom' tce lmap cbs spec x v def = do
   let anames = findAxiomNames x cbs
   vts <- zipWithM (makeAxiomType tce lmap x) (reverse anames) (defAxioms anames v def)
@@ -68,15 +76,11 @@ makeAxiom' tce lmap cbs spec x v def = do
          , (v, t) : vts
          , defAxioms anames v def )
 
-
-
 mkError :: LocSymbol -> String -> Error
 mkError x str = ErrHMeas (sourcePosSrcSpan $ loc x) (pprint $ val x) (text str)
 
 mkType :: LocSymbol -> Var -> Located SpecType
 mkType x v = x {val = ufType $ varType v}
-
-
 
 makeAssumeType :: F.TCEmb TyCon -> LogicMap -> LocSymbol ->  Var -> [(Var, Located SpecType)] -> [a] -> CoreExpr -> Located SpecType
 makeAssumeType tce lmap x v xts ams def
@@ -202,7 +206,7 @@ defAxioms vs v e = go [] $ normalize e
      goalt _ _  (LitAlt _,  _,  _) = todo Nothing "defAxioms: goalt Lit"
      goalt _ _  (DEFAULT,   _,  _) = todo Nothing "defAxioms: goalt Def"
 
-     mkApp bs x c ys = foldl App (Var v) ((\y -> if y == x then (mkConApp c (Var <$> ys)) else Var y)<$> bs)
+     mkApp bs x c ys = foldl App (Var v) ((\y -> if y == x then mkConApp c (Var <$> ys) else Var y) <$> bs)
 
 
      getSimpleName v = case filter (\n -> (symbolString $ dropModuleNames $ simplesymbol n) == ("axiom_" ++ (symbolString $ dropModuleNames $ simplesymbol v))) vs of

--- a/src/Language/Haskell/Liquid/Bare/GhcSpec.hs
+++ b/src/Language/Haskell/Liquid/Bare/GhcSpec.hs
@@ -19,7 +19,6 @@ import           Name
 import           TyCon
 import           Var
 import           TysWiredIn
-
 import           DataCon                                    (DataCon)
 import           InstEnv
 
@@ -100,31 +99,31 @@ listLMap  = toLogicMap [ (nilName , []     , hNil)
 
 postProcess :: [CoreBind] -> SEnv SortedReft -> GhcSpec -> GhcSpec
 postProcess cbs specEnv sp@(SP {..})
-  = sp { tySigs     = mapSnd addTCI <$> sigs
-       , inSigs     = mapSnd addTCI <$> insigs
-       , asmSigs    = mapSnd addTCI <$> assms
-       , invariants = mapSnd addTCI <$> invariants
-       , spLits     = txSort        <$> spLits
-       , meas       = txSort        <$> meas
-       , dicts      = dmapty addTCI'    dicts
-       , texprs     = ts
+  = sp { gsTySigs     = mapSnd addTCI <$> sigs
+       , gsInSigs     = mapSnd addTCI <$> insigs
+       , gsAsmSigs    = mapSnd addTCI <$> assms
+       , gsInvariants = mapSnd addTCI <$> gsInvariants
+       , gsLits       = txSort        <$> gsLits
+       , gsMeas       = txSort        <$> gsMeas
+       , gsDicts      = dmapty addTCI'    gsDicts
+       , gsTexprs     = ts
        }
   where
-    (sigs, ts')     = replaceLocalBinds allowHO tcEmbeds tyconEnv tySigs texprs specEnv cbs
-    (assms, ts'')   = replaceLocalBinds allowHO tcEmbeds tyconEnv asmSigs ts'   specEnv cbs
-    (insigs, ts)    = replaceLocalBinds allowHO tcEmbeds tyconEnv inSigs  ts''  specEnv cbs
-    txSort          = mapSnd (addTCI . txRefSort tyconEnv tcEmbeds)
+    (sigs, ts')     = replaceLocalBinds allowHO gsTcEmbeds gsTyconEnv gsTySigs  gsTexprs specEnv cbs
+    (assms, ts'')   = replaceLocalBinds allowHO gsTcEmbeds gsTyconEnv gsAsmSigs ts'   specEnv cbs
+    (insigs, ts)    = replaceLocalBinds allowHO gsTcEmbeds gsTyconEnv gsInSigs  ts''  specEnv cbs
+    txSort          = mapSnd (addTCI . txRefSort gsTyconEnv gsTcEmbeds)
     addTCI          = (addTCI' <$>)
-    addTCI'         = addTyConInfo tcEmbeds tyconEnv
-    allowHO         = higherOrderFlag config
+    addTCI'         = addTyConInfo gsTcEmbeds gsTyconEnv
+    allowHO         = higherOrderFlag gsConfig
 
 ghcSpecEnv :: GhcSpec -> SEnv SortedReft
 ghcSpecEnv sp        = fromListSEnv binds
   where
-    emb              = tcEmbeds sp
-    binds            =  [(x,        rSort t) | (x, Loc _ _ t) <- meas sp]
-                     ++ [(symbol v, rSort t) | (v, Loc _ _ t) <- ctors sp]
-                     ++ [(x,        vSort v) | (x, v) <- freeSyms sp, isConLikeId v]
+    emb              = gsTcEmbeds sp
+    binds            =  [(x,        rSort t) | (x, Loc _ _ t) <- gsMeas sp]
+                     ++ [(symbol v, rSort t) | (v, Loc _ _ t) <- gsCtors sp]
+                     ++ [(x,        vSort v) | (x, v) <- gsFreeSyms sp, isConLikeId v]
     rSort            = rTypeSortedReft emb
     vSort            = rSort . varRSort
     varRSort         :: Var -> RSort
@@ -160,12 +159,12 @@ makeGhcSpec' cfg cbs instenv vars defVars exports specs
 addProofType :: GhcSpec -> BareM GhcSpec
 addProofType spec = do
   tycon <- (Just <$> lookupGhcTyCon (dummyLoc proofTyConName)) `catchError` (\_ -> return Nothing)
-  return $ spec { proofType = (`TyConApp` []) <$> tycon }
+  return $ spec { gsProofType = (`TyConApp` []) <$> tycon }
 
 
 makeExactDataCons :: ModName -> Bool -> [Var] -> GhcSpec -> BareM GhcSpec
 makeExactDataCons n flag vs spec
-  | flag      = return $ spec {tySigs = tySigs spec ++ xts}
+  | flag      = return $ spec { gsTySigs = gsTySigs spec ++ xts}
   | otherwise = return spec
   where
     xts       = makeExact <$> filter f vs
@@ -200,41 +199,41 @@ makeAxioms tce cbs spec sp
   = do lmap          <- logicEnv <$> get
        (ms, tys, as) <- unzip3 <$> mapM (makeAxiom tce lmap cbs spec sp) (S.toList $ Ms.axioms sp)
        lmap'         <- logicEnv <$> get
-       return $ spec { meas     = ms         ++ meas spec
-                     , asmSigs  = concat tys ++ asmSigs spec
-                     , axioms   = concat as  ++ axioms  spec
-                     , logicMap = lmap' }
+       return $ spec { gsMeas     = ms         ++ gsMeas     spec
+                     , gsAsmSigs  = concat tys ++ gsAsmSigs  spec
+                     , gsAxioms   = concat as  ++ gsAxioms spec
+                     , gsLogicMap = lmap' }
 
 emptySpec     :: Config -> GhcSpec
 -- emptySpec cfg = SP [] [] [] [] [] [] [] [] [] [] [] mempty [] [] [] [] mempty mempty mempty cfg mempty [] mempty mempty [] mempty Nothing
 emptySpec cfg = SP
-  { tySigs     = mempty
-  , asmSigs    = mempty
-  , inSigs     = mempty
-  , ctors      = mempty
-  , spLits     = mempty
-  , meas       = mempty
-  , invariants = mempty
-  , ialiases   = mempty
-  , dconsP     = mempty
-  , tconsP     = mempty
-  , freeSyms   = mempty
-  , tcEmbeds   = mempty
-  , qualifiers = mempty
-  , tgtVars    = mempty
-  , decr       = mempty
-  , texprs     = mempty
-  , lvars      = mempty
-  , lazy       = mempty
-  , autosize   = mempty
-  , config     = cfg
-  , exports    = mempty
-  , measures   = mempty
-  , tyconEnv   = mempty
-  , dicts      = mempty
-  , axioms     = mempty
-  , logicMap   = mempty
-  , proofType  = Nothing
+  { gsTySigs     = mempty
+  , gsAsmSigs    = mempty
+  , gsInSigs     = mempty
+  , gsCtors      = mempty
+  , gsLits     = mempty
+  , gsMeas       = mempty
+  , gsInvariants = mempty
+  , gsIaliases   = mempty
+  , gsDconsP     = mempty
+  , gsTconsP     = mempty
+  , gsFreeSyms   = mempty
+  , gsTcEmbeds   = mempty
+  , gsQualifiers = mempty
+  , gsTgtVars    = mempty
+  , gsDecr       = mempty
+  , gsTexprs     = mempty
+  , gsLvars      = mempty
+  , gsLazy       = mempty
+  , gsAutosize   = mempty
+  , gsConfig     = cfg
+  , gsExports    = mempty
+  , gsMeasures   = mempty
+  , gsTyconEnv   = mempty
+  , gsDicts      = mempty
+  , gsAxioms     = mempty
+  , gsLogicMap   = mempty
+  , gsProofType  = Nothing
   }
 
 
@@ -250,9 +249,9 @@ makeGhcSpec0 :: Config
              -> BareM GhcSpec
 makeGhcSpec0 cfg defVars exports name sp
   = do targetVars <- makeTargetVars name defVars $ checks cfg
-       return      $ sp { config = cfg
-                        , exports = exports
-                        , tgtVars = targetVars }
+       return      $ sp { gsConfig  = cfg
+                        , gsExports = exports
+                        , gsTgtVars = targetVars }
 
 makeGhcSpec1 :: [Var]
              -> [Var]
@@ -272,11 +271,11 @@ makeGhcSpec1 vars defVars embs tyi exports name sigs asms cs' ms' cms' su sp
   = do tySigs      <- makePluggedSigs name embs tyi exports $ tx sigs
        asmSigs     <- makePluggedAsmSigs embs tyi $ tx asms
        ctors       <- makePluggedAsmSigs embs tyi $ tx cs'
-       return $ sp { tySigs     = filter (\(v,_) -> v `elem` vs) tySigs
-                   , asmSigs    = filter (\(v,_) -> v `elem` vs) asmSigs
-                   , ctors      = filter (\(v,_) -> v `elem` vs) ctors
-                   , meas       = measSyms
-                   , spLits     = measSyms -- RJ: we will be adding *more* things to `meas` but not `lits`
+       return $ sp { gsTySigs   = filter (\(v,_) -> v `elem` vs) tySigs
+                   , gsAsmSigs  = filter (\(v,_) -> v `elem` vs) asmSigs
+                   , gsCtors    = filter (\(v,_) -> v `elem` vs) ctors
+                   , gsMeas     = measSyms
+                   , gsLits     = measSyms -- RJ: we will be adding *more* things to `meas` but not `lits`
                    }
     where
       tx       = fmap . mapSnd . subst $ su
@@ -292,9 +291,9 @@ makeGhcSpec2 :: Monad m
              -> GhcSpec
              -> m GhcSpec
 makeGhcSpec2 invs ialias measures su sp
-  = return $ sp { invariants = mapSnd (subst su) <$> invs
-                , ialiases   = subst su ialias
-                , measures   = subst su
+  = return $ sp { gsInvariants = mapSnd (subst su) <$> invs
+                , gsIaliases   = subst su ialias
+                , gsMeasures   = subst su
                                  <$> M.elems (Ms.measMap measures)
                                   ++ Ms.imeas measures
                 }
@@ -305,11 +304,11 @@ makeGhcSpec3 datacons tycons embs syms sp
        lmap        <- logicEnv <$> get
        inlmap      <- inlines  <$> get
        let dcons'   = mapSnd (txRefToLogic lmap inlmap) <$> datacons
-       return  $ sp { tyconEnv   = tcEnv
-                    , dconsP     = dcons'
-                    , tconsP     = tycons
-                    , tcEmbeds   = embs
-                    , freeSyms   = [(symbol v, v) | (_, v) <- syms] }
+       return  $ sp { gsTyconEnv = tcEnv
+                    , gsDconsP   = dcons'
+                    , gsTconsP   = tycons
+                    , gsTcEmbeds = embs
+                    , gsFreeSyms = [(symbol v, v) | (_, v) <- syms] }
 
 makeGhcSpec4 :: [Qualifier]
              -> [Var]
@@ -331,7 +330,7 @@ makeGhcSpec4 quals defVars specs name su sp
        mapM_ insertHMeasLogicEnv $ S.toList hmeas
        mapM_ insertHMeasLogicEnv $ S.toList hinls
        lmap'   <- logicEnv <$> get
-       let isgs = strengthenHaskellInlines  (S.map fst hinls) (tySigs sp)
+       let isgs = strengthenHaskellInlines  (S.map fst hinls) (gsTySigs sp)
        let msgs = strengthenHaskellMeasures (S.map fst hmeas) isgs
        lmap    <- logicEnv <$> get
        inlmap  <- inlines  <$> get
@@ -339,21 +338,21 @@ makeGhcSpec4 quals defVars specs name su sp
        let tx   = mapSnd f
        let mtx  = txRefToLogic lmap inlmap
        let txdcons d = d{tyRes = f $ tyRes d, tyConsts = f <$> tyConsts d, tyArgs = tx <$> tyArgs d}
-       return   $ sp { qualifiers = subst su quals
-                     , decr       = decr'
-                     , lvars      = lvars'
-                     , autosize   = asize'
-                     , lazy       = S.insert dictionaryVar lazies
-                     , tySigs     = tx  <$> msgs
-                     , asmSigs    = tx  <$> asmSigs  sp
-                     , inSigs     = tx  <$> inSigs   sp
-                     , measures   = mtx <$> measures sp
-                     , logicMap   = lmap'
-                     , invariants = tx <$> invariants sp
-                     , ctors      = tx <$> ctors      sp
-                     , ialiases   = tx <$> ialiases   sp
-                     , dconsP     = mapSnd txdcons <$> dconsP sp
-                     , texprs     = mapSnd f <$> texprs'
+       return   $ sp { gsQualifiers = subst su quals
+                     , gsDecr       = decr'
+                     , gsLvars      = lvars'
+                     , gsAutosize   = asize'
+                     , gsLazy       = S.insert dictionaryVar lazies
+                     , gsTySigs     = tx  <$> msgs
+                     , gsAsmSigs    = tx  <$> gsAsmSigs  sp
+                     , gsInSigs     = tx  <$> gsInSigs   sp
+                     , gsMeasures = mtx <$> gsMeasures sp
+                     , gsLogicMap = lmap'
+                     , gsInvariants = tx <$> gsInvariants sp
+                     , gsCtors      = tx <$> gsCtors      sp
+                     , gsIaliases   = tx <$> gsIaliases   sp
+                     , gsDconsP     = mapSnd txdcons <$> gsDconsP sp
+                     , gsTexprs     = mapSnd f <$> texprs'
                      }
     where
        mkThing mk = S.fromList . mconcat <$> sequence [ mk defVars s | (m, s) <- specs, m == name ]
@@ -504,8 +503,7 @@ replaceLocalBinds allowHO emb tyi sigs texprs senv cbs
                                    (RE M.empty senv emb tyi))
                        (M.fromList sigs, M.fromList texprs)
 
-traverseExprs
-  :: Bool -> CoreSyn.Expr Var -> ReaderT ReplaceEnv (State ReplaceState) ()
+traverseExprs :: Bool -> CoreSyn.Expr Var -> ReplaceM ()
 traverseExprs allowHO (Let b e)
   = traverseBinds allowHO b (traverseExprs allowHO e)
 traverseExprs allowHO (Lam b e)
@@ -521,22 +519,13 @@ traverseExprs allowHO (Tick _ e)
 traverseExprs _ _
   = return ()
 
-traverseBinds
-  :: Bool
-  -> Bind Var
-  -> ReaderT ReplaceEnv (State ReplaceState) b
-  -> ReaderT ReplaceEnv (State ReplaceState) b
+traverseBinds :: Bool -> Bind Var -> ReplaceM b -> ReplaceM b
 traverseBinds allowHO b k = withExtendedEnv allowHO (bindersOf b) $ do
   mapM_ (traverseExprs allowHO) (rhssOfBind b)
   k
 
 -- RJ: this function is incomprehensible, what does it do?!
-withExtendedEnv
-  :: Foldable t
-  => Bool
-  -> t Var
-  -> ReaderT ReplaceEnv (State ReplaceState) b
-  -> ReaderT ReplaceEnv (State ReplaceState) b
+withExtendedEnv :: Bool -> [Var] -> ReplaceM b -> ReplaceM b
 withExtendedEnv allowHO vs k
   = do RE env' fenv' emb tyi <- ask
        let env  = L.foldl' (\m v -> M.insert (varShortSymbol v) (symbol v) m) env' vs

--- a/src/Language/Haskell/Liquid/Bare/Spec.hs
+++ b/src/Language/Haskell/Liquid/Bare/Spec.hs
@@ -128,7 +128,7 @@ makeHIMeas :: (Ms.Spec ty bndr -> S.HashSet LocSymbol)
            -> [Var]
            -> Ms.Spec ty bndr
            -> BareM [(Located Var, LocSymbol)]
-makeHIMeas f vs spec 
+makeHIMeas f vs spec
   = fmap tx <$> varSymbols id vs [(v, (loc v, locE v, v)) | v <- S.toList (f spec)]
   where
     tx (x,(l, l', s))  = (Loc l l' x, s)
@@ -274,7 +274,7 @@ makeSpecDictionaries :: F.TCEmb TyCon -> [Var] -> [(a, Ms.BareSpec)] -> GhcSpec
                      -> BareM GhcSpec
 makeSpecDictionaries embs vars specs sp
   = do ds <- (dfromList . concat)  <$>  mapM (makeSpecDictionary embs vars) specs
-       return $ sp { dicts = ds }
+       return $ sp { gsDicts = ds }
 
 
 
@@ -284,7 +284,7 @@ makeSpecDictionary embs vars (_, spec)
   = (catMaybes . resolveDictionaries vars) <$> mapM (makeSpecDictionaryOne embs) (Ms.rinstance spec)
 
 
-makeSpecDictionaryOne :: F.TCEmb TyCon -> (RInstance (Located BareType))
+makeSpecDictionaryOne :: F.TCEmb TyCon -> RInstance (Located BareType)
                       -> BareM (F.Symbol, M.HashMap F.Symbol SpecType)
 makeSpecDictionaryOne embs (RI x t xts)
   = do t'  <- mapM mkLSpecType t
@@ -298,7 +298,7 @@ makeSpecDictionaryOne embs (RI x t xts)
 
 resolveDictionaries :: [Var] -> [(F.Symbol, M.HashMap F.Symbol SpecType)] -> [Maybe (Var, M.HashMap F.Symbol SpecType)]
 resolveDictionaries vars ds  = lookupVar <$> concat (go <$> groupList ds)
- where 
+ where
     go (x,is)           = addIndex 0 x $ reverse is
 
     -- GHC internal postfixed same name dictionaries with ints
@@ -306,7 +306,7 @@ resolveDictionaries vars ds  = lookupVar <$> concat (go <$> groupList ds)
     addIndex _ x [i]    = [(x,i)]
     addIndex j x (i:is) = (F.symbol (F.symbolString x ++ show j),i):addIndex (j+1) x is
 
-    lookupVar (s, i)    = ((,i) <$> lookupName s) 
+    lookupVar (s, i)    = ((,i) <$> lookupName s)
     lookupName x
              = case filter ((==x) . fst) ((\x -> (dropModuleNames $ F.symbol $ show x, x)) <$> vars) of
                 [(_, x)] -> Just x

--- a/src/Language/Haskell/Liquid/Constraint/Axioms.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Axioms.hs
@@ -578,10 +578,10 @@ initAEEnv info sigs
                      }
     where
       spc        = spec info
-      vs         = filter validVar (snd <$> freeSyms spc)
+      vs         = filter validVar (snd <$> gsFreeSyms spc)
       tp         = filter validExp (defVars info)
 
-      isExported = flip elemNameSet (exports $ spec info) . getName
+      isExported = flip elemNameSet (gsExports $ spec info) . getName
       validVar   = not . canIgnore
       validExp x = validVar x && isExported x
       by         = makeCombineVar $ makeCombineType τProof

--- a/src/Language/Haskell/Liquid/Constraint/Axioms.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Axioms.hs
@@ -560,9 +560,9 @@ initAEEnv info sigs
          lts   <- cgLits      <$> get
          i     <- freshIndex  <$> get
          modify $ \s -> s{freshIndex = i + 1}
-         return $ AE { ae_axioms  = axioms spc
+         return $ AE { ae_axioms  = gsAxioms spc
                      , ae_binds   = []
-                     , ae_lmap    = logicMap spc
+                     , ae_lmap    = gsLogicMap spc
                      , ae_consts  = L.nub vs
                      , ae_globals = L.nub tp
                      , ae_vars    = []
@@ -585,7 +585,7 @@ initAEEnv info sigs
       validVar   = not . canIgnore
       validExp x = validVar x && isExported x
       by         = makeCombineVar $ makeCombineType τProof
-      τProof     = proofType $ spec info
+      τProof     = gsProofType $ spec info
 
 
 

--- a/src/Language/Haskell/Liquid/Constraint/Env.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Env.hs
@@ -83,13 +83,6 @@ import           Language.Haskell.Liquid.Transforms.RefSplit
 import qualified Language.Haskell.Liquid.UX.CTags       as Tg
 
 -- import Debug.Trace (trace)
-
-instance Freshable CG Integer where
-  fresh = do s <- get
-             let n = freshIndex s
-             put $ s { freshIndex = n + 1 }
-             return n
-
 --------------------------------------------------------------------------------
 -- | Refinement Type Environments ----------------------------------------------
 --------------------------------------------------------------------------------

--- a/src/Language/Haskell/Liquid/Constraint/Fresh.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Fresh.hs
@@ -7,14 +7,26 @@
 {-# LANGUAGE TypeSynonymInstances  #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
-module Language.Haskell.Liquid.Constraint.Fresh (Freshable(..)) where
+module Language.Haskell.Liquid.Constraint.Fresh
+  (
+  -- * Types that can be refreshed
+    Freshable(..)
 
-import           Prelude                hiding (error)
+  )
+  where
 
+import qualified Data.List                      as L
+import qualified Data.HashMap.Strict            as M
+import           Control.Monad.State            (get, put, modify)
+import           Prelude                        hiding (error)
 
-import           Language.Fixpoint.Types
+import           Var      (Var)
+-- import           Language.Fixpoint.Types
+import qualified Language.Fixpoint.Types as F
 import           Language.Haskell.Liquid.Misc  (single)
 import           Language.Haskell.Liquid.Types
+import           Language.Haskell.Liquid.Types.RefType
+import           Language.Haskell.Liquid.Constraint.Types
 
 class (Applicative m, Monad m) => Freshable m a where
   fresh   :: m a
@@ -23,23 +35,29 @@ class (Applicative m, Monad m) => Freshable m a where
   refresh :: a -> m a
   refresh = return
 
-instance Freshable m Integer => Freshable m Symbol where
-  fresh = tempSymbol "x" <$> fresh
+instance Freshable CG Integer where
+  fresh = do s <- get
+             let n = freshIndex s
+             put $ s { freshIndex = n + 1 }
+             return n
 
-instance Freshable m Integer => Freshable m Expr where
+instance Freshable m Integer => Freshable m F.Symbol where
+  fresh = F.tempSymbol "x" <$> fresh
+
+instance Freshable m Integer => Freshable m F.Expr where
   fresh  = kv <$> fresh
     where
-      kv = (`PKVar` mempty) . intKvar
+      kv = (`F.PKVar` mempty) . F.intKvar
 
-instance Freshable m Integer => Freshable m [Expr] where
+instance Freshable m Integer => Freshable m [F.Expr] where
   fresh = single <$> fresh
 
-instance Freshable m Integer => Freshable m Reft where
-  fresh                = panic Nothing "fresh Reft"
-  true    (Reft (v,_)) = return $ Reft (v, mempty)
-  refresh (Reft (_,_)) = (Reft .) . (,) <$> freshVV <*> fresh
+instance Freshable m Integer => Freshable m F.Reft where
+  fresh                  = panic Nothing "fresh Reft"
+  true    (F.Reft (v,_)) = return $ F.Reft (v, mempty)
+  refresh (F.Reft (_,_)) = (F.Reft .) . (,) <$> freshVV <*> fresh
     where
-      freshVV          = vv . Just <$> fresh
+      freshVV            = F.vv . Just <$> fresh
 
 instance Freshable m Integer => Freshable m RReft where
   fresh             = panic Nothing "fresh RReft"
@@ -53,13 +71,13 @@ instance Freshable m Integer => Freshable m Strata where
   refresh [] = fresh
   refresh s  = return s
 
-instance (Freshable m Integer, Freshable m r, Reftable r ) => Freshable m (RRType r) where
+instance (Freshable m Integer, Freshable m r, F.Reftable r ) => Freshable m (RRType r) where
   fresh   = panic Nothing "fresh RefType"
   refresh = refreshRefType
   true    = trueRefType
 
 -----------------------------------------------------------------------------------------------
-trueRefType :: (Freshable m Integer, Freshable m r, Reftable r) => RRType r -> m (RRType r)
+trueRefType :: (Freshable m Integer, Freshable m r, F.Reftable r) => RRType r -> m (RRType r)
 -----------------------------------------------------------------------------------------------
 trueRefType (RAllT α t)
   = RAllT α <$> true t
@@ -86,7 +104,7 @@ trueRefType (RAllE y ty tx)
   = do y'  <- fresh
        ty' <- true ty
        tx' <- true tx
-       return $ RAllE y' ty' (tx' `subst1` (y, EVar y'))
+       return $ RAllE y' ty' (tx' `F.subst1` (y, F.EVar y'))
 
 trueRefType (RRTy e o r t)
   = RRTy e o r <$> trueRefType t
@@ -94,15 +112,14 @@ trueRefType (RRTy e o r t)
 trueRefType t
   = return t
 
-trueRef :: (Reftable r, Freshable f r, Freshable f Integer)
+trueRef :: (F.Reftable r, Freshable f r, Freshable f Integer)
         => Ref τ (RType RTyCon RTyVar r) -> f (Ref τ (RRType r))
 trueRef (RProp _ (RHole _)) = panic Nothing "trueRef: unexpected RProp _ (RHole _))"
 trueRef (RProp s t) = RProp s <$> trueRefType t
 
 
-
 -----------------------------------------------------------------------------------------------
-refreshRefType :: (Freshable m Integer, Freshable m r, Reftable r) => RRType r -> m (RRType r)
+refreshRefType :: (Freshable m Integer, Freshable m r, F.Reftable r) => RRType r -> m (RRType r)
 -----------------------------------------------------------------------------------------------
 refreshRefType (RAllT α t)
   = RAllT α <$> refresh t
@@ -111,8 +128,8 @@ refreshRefType (RAllP π t)
   = RAllP π <$> refresh t
 
 refreshRefType (RFun b t t' _)
-  | b == dummySymbol = rFun <$> fresh <*> refresh t <*> refresh t'
-  | otherwise        = rFun     b     <$> refresh t <*> refresh t'
+  | b == F.dummySymbol = rFun <$> fresh <*> refresh t <*> refresh t'
+  | otherwise          = rFun     b     <$> refresh t <*> refresh t'
 
 refreshRefType (RApp rc ts _ _) | isClass rc
   = return $ rRCls rc ts
@@ -130,7 +147,7 @@ refreshRefType (RAllE y ty tx)
   = do y'  <- fresh
        ty' <- refresh ty
        tx' <- refresh tx
-       return $ RAllE y' ty' (tx' `subst1` (y, EVar y'))
+       return $ RAllE y' ty' (tx' `F.subst1` (y, F.EVar y'))
 
 refreshRefType (RRTy e o r t)
   = RRTy e o r <$> refreshRefType t
@@ -138,10 +155,89 @@ refreshRefType (RRTy e o r t)
 refreshRefType t
   = return t
 
-refreshRef :: (Reftable r, Freshable f r, Freshable f Integer)
+refreshRef :: (F.Reftable r, Freshable f r, Freshable f Integer)
            => Ref τ (RType RTyCon RTyVar r) -> f (Ref τ (RRType r))
 refreshRef (RProp _ (RHole _)) = panic Nothing "refreshRef: unexpected (RProp _ (RHole _))"
 refreshRef (RProp s t) = RProp <$> mapM freshSym s <*> refreshRefType t
 
 freshSym :: Freshable f a => (t, t1) -> f (a, t1)
 freshSym (_, t)        = (, t) <$> fresh
+
+
+--------------------------------------------------------------------------------
+refreshTy :: SpecType -> CG SpecType
+--------------------------------------------------------------------------------
+refreshTy t = refreshVV t >>= refreshArgs
+
+refreshVV :: Freshable m Integer => SpecType -> m SpecType
+refreshVV (RAllT a t) = RAllT a <$> refreshVV t
+refreshVV (RAllP p t) = RAllP p <$> refreshVV t
+
+refreshVV (REx x t1 t2)
+  = do [t1', t2'] <- mapM refreshVV [t1, t2]
+       shiftVV (REx x t1' t2') <$> fresh
+
+refreshVV (RFun x t1 t2 r)
+  = do [t1', t2'] <- mapM refreshVV [t1, t2]
+       shiftVV (RFun x t1' t2' r) <$> fresh
+
+refreshVV (RAppTy t1 t2 r)
+  = do [t1', t2'] <- mapM refreshVV [t1, t2]
+       shiftVV (RAppTy t1' t2' r) <$> fresh
+
+refreshVV (RApp c ts rs r)
+  = do ts' <- mapM refreshVV ts
+       rs' <- mapM refreshVVRef rs
+       shiftVV (RApp c ts' rs' r) <$> fresh
+
+refreshVV t
+  = return t
+
+refreshVVRef :: Freshable m Integer
+             => Ref b (RType RTyCon RTyVar RReft)
+             -> m (Ref b (RType RTyCon RTyVar RReft))
+refreshVVRef (RProp ss (RHole r))
+  = return $ RProp ss (RHole r)
+
+refreshVVRef (RProp ss t)
+  = do xs    <- mapM (const fresh) (fst <$> ss)
+       let su = F.mkSubst $ zip (fst <$> ss) (F.EVar <$> xs)
+       (RProp (zip xs (snd <$> ss)) . F.subst su) <$> refreshVV t
+
+refreshArgsTop :: (Var, SpecType) -> CG SpecType
+refreshArgsTop (x, t)
+  = do (t', su) <- refreshArgsSub t
+       modify $ \s -> s {termExprs = M.adjust (F.subst su <$>) x $ termExprs s}
+       return t'
+
+refreshArgs :: SpecType -> CG SpecType
+refreshArgs t
+  = fst <$> refreshArgsSub t
+
+
+-- NV TODO: this does not refresh args if they are wrapped in an RRTy
+refreshArgsSub :: SpecType -> CG (SpecType, F.Subst)
+refreshArgsSub t
+  = do ts     <- mapM refreshArgs ts_u
+       xs'    <- mapM (const fresh) xs
+       let sus = F.mkSubst <$> L.inits (zip xs (F.EVar <$> xs'))
+       let su  = last sus
+       ts'    <- mapM refreshPs $ zipWith F.subst sus ts
+       let rs' = zipWith F.subst sus rs
+       tr     <- refreshPs $ F.subst su tbd
+       let t'  = fromRTypeRep $ trep {ty_binds = xs', ty_args = ts', ty_res = tr, ty_refts = rs'}
+       return (t', su)
+    where
+       trep    = toRTypeRep t
+       xs      = ty_binds trep
+       ts_u    = ty_args  trep
+       tbd     = ty_res   trep
+       rs      = ty_refts trep
+
+refreshPs :: SpecType -> CG SpecType
+refreshPs = mapPropM go
+  where
+    go (RProp s t) = do t'    <- refreshPs t
+                        xs    <- mapM (const fresh) s
+                        let su = F.mkSubst [(y, F.EVar x) | (x, (y, _)) <- zip xs s]
+                        return $ RProp [(x, t) | (x, (_, t)) <- zip xs s] $ F.subst su t'

--- a/src/Language/Haskell/Liquid/Constraint/Fresh.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Fresh.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE TupleSections         #-}
 {-# LANGUAGE TypeSynonymInstances  #-}
 {-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE BangPatterns          #-}
 
 module Language.Haskell.Liquid.Constraint.Fresh
   ( Freshable(..)
@@ -14,6 +15,10 @@ module Language.Haskell.Liquid.Constraint.Fresh
   , refreshArgs
   , refreshArgsTop
   , refreshHoles
+  , freshTy_type
+  , freshTy_expr
+  , trueTy
+  , addKuts  
   )
   where
 
@@ -21,13 +26,20 @@ import           Data.Maybe                    (catMaybes) -- , fromJust, isJust
 import           Data.Bifunctor
 import qualified Data.List                      as L
 import qualified Data.HashMap.Strict            as M
+import qualified Data.HashSet                   as S
+import           Data.Hashable
 import           Control.Monad.State            (get, put, modify)
+import           Control.Monad                  (when, (>=>))
 import           Prelude                        hiding (error)
 
-import           Var      (Var)
--- import           Language.Fixpoint.Types
+import           CoreUtils  (exprType)
+import           Type       (Type)
+import           CoreSyn
+import           Var        (varType, isTyVar, Var)
+
 import qualified Language.Fixpoint.Types as F
-import           Language.Haskell.Liquid.Misc  (single)
+import           Language.Fixpoint.Types.Visitor (kvars)
+import           Language.Haskell.Liquid.Misc  (single, (=>>))
 import           Language.Haskell.Liquid.Types
 import           Language.Haskell.Liquid.Types.RefType
 import           Language.Haskell.Liquid.Constraint.Types
@@ -269,3 +281,102 @@ refreshHoles' (x,t)
 
 noHoles :: (F.Reftable r, TyConable c) => RType c tv r -> Bool
 noHoles = and . foldReft (\_ r bs -> not (hasHole r) : bs) []
+
+--------------------------------------------------------------------------------
+-- | Generation: Freshness -----------------------------------------------------
+--------------------------------------------------------------------------------
+
+-- | Right now, we generate NO new pvars. Rather than clutter code
+--   with `uRType` calls, put it in one place where the above
+--   invariant is /obviously/ enforced.
+--   Constraint generation should ONLY use @freshTy_type@ and @freshTy_expr@
+
+freshTy_type        :: KVKind -> CoreExpr -> Type -> CG SpecType
+freshTy_type k _ τ  = freshTy_reftype k $ ofType τ
+
+freshTy_expr        :: KVKind -> CoreExpr -> Type -> CG SpecType
+freshTy_expr k e _  = freshTy_reftype k $ exprRefType e
+
+freshTy_reftype     :: KVKind -> SpecType -> CG SpecType
+freshTy_reftype k _t = (fixTy t >>= refresh) =>> addKVars k
+  where
+    t                = {- F.tracepp ("freshTy_reftype:" ++ show k) -} _t
+
+-- | Used to generate "cut" kvars for fixpoint. Typically, KVars for recursive
+--   definitions, and also to update the KVar profile.
+addKVars        :: KVKind -> SpecType -> CG ()
+addKVars !k !t  = do when (True)    $ modify $ \s -> s { kvProf = updKVProf k ks (kvProf s) }
+                     when (isKut k) $ addKuts k t
+                     -- when (True)    $ addKvPack t
+  where
+     ks         = F.KS $ S.fromList $ specTypeKVars t
+
+isKut              :: KVKind -> Bool
+isKut (RecBindE _) = True
+isKut ProjectE     = True
+isKut _            = False
+
+addKuts :: (PPrint a) => a -> SpecType -> CG ()
+addKuts _x t = modify $ \s -> s { kuts = mappend (F.KS ks) (kuts s)   }
+  where
+     ks'     = S.fromList $ specTypeKVars t
+     ks
+       | S.null ks' = ks'
+       | otherwise  = {- F.tracepp ("addKuts: " ++ showpp _x) -} ks'
+
+-- addKvPack :: SpecType -> CG ()
+-- addKvPack t = modify $ \s -> s { kvPacks = ks : kvPacks s}
+  -- where
+    -- ks      = S.fromList $ specTypeKVars t
+
+specTypeKVars :: SpecType -> [F.KVar]
+specTypeKVars = foldReft (\ _ r ks -> (kvars $ ur_reft r) ++ ks) []
+
+--------------------------------------------------------------------------------
+trueTy  :: Type -> CG SpecType
+--------------------------------------------------------------------------------
+trueTy = ofType' >=> true
+
+ofType' :: Type -> CG SpecType
+ofType' = fixTy . ofType
+
+fixTy :: SpecType -> CG SpecType
+fixTy t = do tyi   <- tyConInfo  <$> get
+             tce   <- tyConEmbed <$> get
+             return $ addTyConInfo tce tyi t
+
+exprRefType :: CoreExpr -> SpecType
+exprRefType = exprRefType_ M.empty
+
+exprRefType_ :: M.HashMap Var SpecType -> CoreExpr -> SpecType
+exprRefType_ γ (Let b e)
+  = exprRefType_ (bindRefType_ γ b) e
+
+exprRefType_ γ (Lam α e) | isTyVar α
+  = RAllT (makeRTVar $ rTyVar α) (exprRefType_ γ e)
+
+exprRefType_ γ (Lam x e)
+  = rFun (F.symbol x) (ofType $ varType x) (exprRefType_ γ e)
+
+exprRefType_ γ (Tick _ e)
+  = exprRefType_ γ e
+
+exprRefType_ γ (Var x)
+  = M.lookupDefault (ofType $ varType x) x γ
+
+exprRefType_ _ e
+  = ofType $ exprType e
+
+bindRefType_ :: M.HashMap Var SpecType -> Bind Var -> M.HashMap Var SpecType
+bindRefType_ γ (Rec xes)
+  = extendγ γ [(x, exprRefType_ γ e) | (x,e) <- xes]
+
+bindRefType_ γ (NonRec x e)
+  = extendγ γ [(x, exprRefType_ γ e)]
+
+extendγ :: (Eq k, Foldable t, Hashable k)
+        => M.HashMap k v
+        -> t (k, v)
+        -> M.HashMap k v
+extendγ γ xts
+  = foldr (\(x,t) m -> M.insert x t m) γ xts

--- a/src/Language/Haskell/Liquid/Constraint/Fresh.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Fresh.hs
@@ -8,10 +8,11 @@
 {-# LANGUAGE UndecidableInstances  #-}
 
 module Language.Haskell.Liquid.Constraint.Fresh
-  (
-  -- * Types that can be refreshed
-    Freshable(..)
-
+  ( Freshable(..)
+  , refreshTy
+  , refreshVV
+  , refreshArgs
+  , refreshArgsTop
   )
   where
 
@@ -211,8 +212,7 @@ refreshArgsTop (x, t)
        return t'
 
 refreshArgs :: SpecType -> CG SpecType
-refreshArgs t
-  = fst <$> refreshArgsSub t
+refreshArgs t = fst <$> refreshArgsSub t
 
 
 -- NV TODO: this does not refresh args if they are wrapped in an RRTy

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -22,7 +22,6 @@ module Language.Haskell.Liquid.Constraint.Generate ( generateConstraints ) where
 
 import           Outputable                                    (Outputable)
 import           Prelude                                       hiding (error, undefined)
-
 import           GHC.Stack
 import           CoreUtils                                     (exprType)
 import           MkCore
@@ -41,12 +40,8 @@ import           Id                                           -- hiding (isExpor
 import           IdInfo
 import           Name        hiding (varName)
 import           FastString (fastStringToByteString)
--- import           NameSet
 import           Unify
 import           VarSet
--- import Unique
-
-
 import           Text.PrettyPrint.HughesPJ                     hiding (first)
 import           Control.Monad.State
 import           Data.Maybe                                    (fromMaybe, catMaybes, fromJust, isJust)
@@ -57,17 +52,8 @@ import qualified Data.List                                     as L
 import           Data.Bifunctor
 import qualified Data.Foldable                                 as F
 import qualified Data.Traversable                              as T
-
-
-
-
-
 import qualified Language.Haskell.Liquid.UX.CTags              as Tg
-
-
-
 import           Language.Fixpoint.Types.Visitor
-
 import           Language.Haskell.Liquid.Constraint.Fresh
 import           Language.Haskell.Liquid.Constraint.Env
 import           Language.Haskell.Liquid.Constraint.Monad
@@ -153,243 +139,7 @@ addCombine τ γ
        combineType   = makeCombineType τ
        combineVar    = makeCombineVar  combineType
        combineSymbol = F.symbol combineVar
-
---------------------------------------------------------------------------------
-initEnv :: GhcInfo -> CG CGEnv
---------------------------------------------------------------------------------
-initEnv info
-  = do let tce   = gsTcEmbeds sp
-       let fVars = impVars info
-       let dcs   = filter isConLikeId ((snd <$> gsFreeSyms sp))
-       let dcs'  = filter isConLikeId fVars
-       defaults <- forM fVars $ \x -> liftM (x,) (trueTy $ varType x)
-       dcsty    <- forM dcs   $ makeDataConTypes
-       dcsty'   <- forM dcs'  $ makeDataConTypes
-       (hs,f0)  <- refreshHoles $ grty info                  -- asserted refinements     (for defined vars)
-       f0''     <- refreshArgs' =<< grtyTop info             -- default TOP reftype      (for exported vars without spec)
-       let f0'   = if notruetypes $ getConfig sp then [] else f0''
-       f1       <- refreshArgs'   defaults                   -- default TOP reftype      (for all vars)
-       f1'      <- refreshArgs' $ makedcs dcsty              -- data constructors
-       f2       <- refreshArgs' $ assm info                  -- assumed refinements      (for imported vars)
-       f3       <- refreshArgs' $ vals gsAsmSigs sp            -- assumed refinedments     (with `assume`)
-       f40      <- refreshArgs' $ vals gsCtors sp              -- constructor refinements  (for measures)
-       f5       <- refreshArgs' $ vals gsInSigs sp             -- internal refinements     (from Haskell measures)
-       (invs1, f41) <- mapSndM refreshArgs' $ makeAutoDecrDataCons dcsty  (gsAutosize sp) dcs
-       (invs2, f42) <- mapSndM refreshArgs' $ makeAutoDecrDataCons dcsty' (gsAutosize sp) dcs'
-       let f4    = mergeDataConTypes (mergeDataConTypes f40 (f41 ++ f42)) (filter (isDataConId . fst) f2)
-       sflag    <- scheck <$> get
-       let senv  = if sflag then f2 else []
-       let tx    = mapFst F.symbol . addRInv ialias . strataUnify senv . predsUnify sp
-       let bs    = (tx <$> ) <$> [f0 ++ f0', f1 ++ f1', f2, f3, f4, f5]
-       lt1s     <- F.toListSEnv . cgLits <$> get
-       let lt2s  = [ (F.symbol x, rTypeSort tce t) | (x, t) <- f1' ]
-       let tcb   = mapSnd (rTypeSort tce) <$> concat bs
-       let γ0    = measEnv sp (head bs) (cbs info) tcb lt1s lt2s (bs!!3) (bs!!5) hs info
-       γ  <- globalize <$> foldM (+=) γ0 [("initEnv", x, y) | (x, y) <- concat $ tail bs]
-       return γ {invs = is (invs1 ++ invs2)}
-  where
-    sp           = spec info
-    ialias       = mkRTyConIAl $ gsIaliases sp
-    vals f       = map (mapSnd val) . f
-    mapSndM f    = \(x,y) -> ((x,) <$> f y)
-    makedcs      = map strengthenDataConType
-    is autoinv   = mkRTyConInv    $ (gsInvariants sp ++ ((Nothing,) <$> autoinv))
-
-makeDataConTypes :: Var -> CG (Var, SpecType)
-makeDataConTypes x = (x,) <$> (trueTy $ varType x)
-
-makeAutoDecrDataCons :: [(Id, SpecType)] -> S.HashSet TyCon -> [Id] -> ([LocSpecType], [(Id, SpecType)])
-
-makeAutoDecrDataCons dcts specenv dcs
-  = (simplify invs, tys)
-  where
-    (invs, tys) = unzip $ concatMap go tycons
-    tycons      = L.nub $ catMaybes $ map idTyCon dcs
-
-    go tycon
-      | S.member tycon specenv =  zipWith (makeSizedDataCons dcts) (tyConDataCons tycon) [0..]
-    go _
-      = []
-    idTyCon x = dataConTyCon <$> case idDetails x of {DataConWorkId d -> Just d; DataConWrapId d -> Just d; _ -> Nothing}
-
-    simplify invs = dummyLoc . (`strengthen` invariant) .  fmap (\_ -> mempty) <$> L.nub invs
-    invariant = MkUReft (F.Reft (F.vv_, F.PAtom F.Ge (lenOf F.vv_) (F.ECon $ F.I 0)) ) mempty mempty
-
-lenOf :: F.Symbol -> F.Expr
-lenOf x = F.mkEApp lenLocSymbol [F.EVar x]
-
-makeSizedDataCons :: [(Id, SpecType)] -> DataCon -> Integer -> (RSort, (Id, SpecType))
-makeSizedDataCons dcts x' n = (toRSort $ ty_res trep, (x, fromRTypeRep trep{ty_res = tres}))
-    where
-      x      = dataConWorkId x'
-      t      = fromMaybe (impossible Nothing "makeSizedDataCons: this should never happen") $ L.lookup x dcts
-      trep   = toRTypeRep t
-      tres   = ty_res trep `strengthen` MkUReft (F.Reft (F.vv_, F.PAtom F.Eq (lenOf F.vv_) computelen)) mempty mempty
-
-      recarguments = filter (\(t,_) -> (toRSort t == toRSort tres)) (zip (ty_args trep) (ty_binds trep))
-      computelen   = foldr (F.EBin F.Plus) (F.ECon $ F.I n) (lenOf .  snd <$> recarguments)
-
-mergeDataConTypes ::  [(Var, SpecType)] -> [(Var, SpecType)] -> [(Var, SpecType)]
-mergeDataConTypes xts yts = merge (L.sortBy f xts) (L.sortBy f yts)
-  where
-    f (x,_) (y,_) = compare x y
-    merge [] ys = ys
-    merge xs [] = xs
-    merge (xt@(x, tx):xs) (yt@(y, ty):ys)
-      | x == y    = (x, mXY x tx y ty) : merge xs ys
-      | x <  y    = xt : merge xs (yt : ys)
-      | otherwise = yt : merge (xt : xs) ys
-    mXY x tx y ty = meetVarTypes (F.pprint x) (getSrcSpan x, tx) (getSrcSpan y, ty)
-
-----
-
-
-refreshArgs' :: [(a, SpecType)] -> CG [(a, SpecType)]
-refreshArgs' = mapM (mapSndM refreshArgs)
-
-strataUnify :: [(Var, SpecType)] -> (Var, SpecType) -> (Var, SpecType)
-strataUnify senv (x, t) = (x, maybe t (mappend t) pt)
-  where
-    pt                  = fmap (\(MkUReft _ _ l) -> MkUReft mempty mempty l) <$> L.lookup x senv
-
-
--- | TODO: All this *should* happen inside @Bare@ but appears
---   to happen after certain are signatures are @fresh@-ed,
---   which is why they are here.
-
--- NV : still some sigs do not get TyConInfo
-
-predsUnify :: GhcSpec -> (Var, RRType RReft) -> (Var, RRType RReft)
-predsUnify sp = second (addTyConInfo tce tyi) -- needed to eliminate some @RPropH@
-  where
-    tce            = gsTcEmbeds sp
-    tyi            = gsTyconEnv sp
-
---------------------------------------------------------------------------------
-measEnv :: GhcSpec
-        -> [(F.Symbol, SpecType)]
-        -> [CoreBind]
-        -> [(F.Symbol, F.Sort)]
-        -> [(F.Symbol, F.Sort)]
-        -> [(F.Symbol, F.Sort)]
-        -> [(F.Symbol, SpecType)]
-        -> [(F.Symbol, SpecType)]
-        -> [F.Symbol]
-        -> GhcInfo
-        -> CGEnv
---------------------------------------------------------------------------------
-measEnv sp xts cbs tcb lt1s lt2s asms itys hs info = CGE
-  { cgLoc    = Sp.empty
-  , renv     = fromListREnv (second val <$> gsMeas sp) []
-  , syenv    = F.fromListSEnv $ gsFreeSyms sp
-  , litEnv   = F.fromListSEnv lts
-  , constEnv = F.fromListSEnv lt2s
-  , fenv     = initFEnv $ tcb ++ lts ++ (second (rTypeSort tce . val) <$> gsMeas sp)
-  , denv     = gsDicts sp
-  , recs     = S.empty
-  , fargs    = S.empty
-  , invs     = mempty
-  , rinvs    = mempty
-  , ial      = mkRTyConIAl    $ gsIaliases   sp
-  , grtys    = fromListREnv xts  []
-  , assms    = fromListREnv asms []
-  , intys    = fromListREnv itys []
-  , emb      = tce
-  , tgEnv    = Tg.makeTagEnv cbs
-  , tgKey    = Nothing
-  , trec     = Nothing
-  , lcb      = M.empty
-  , holes    = fromListHEnv hs
-  , lcs      = mempty
-  , aenv     = axiom_map $ gsLogicMap sp
-  , cerr     = Nothing
-  , cgInfo   = info
-  }
-  where
-      tce = gsTcEmbeds sp
-      lts = lt1s ++ lt2s
-
-assm :: GhcInfo -> [(Var, SpecType)]
-assm = assmGrty impVars
-
-grty :: GhcInfo -> [(Var, SpecType)]
-grty = assmGrty defVars
-
-assmGrty :: (GhcInfo -> [Var]) -> GhcInfo -> [(Var, SpecType)]
-assmGrty f info = [ (x, val t) | (x, t) <- sigs, x `S.member` xs ]
-  where
-    xs          = S.fromList $ f info
-    sigs        = gsTySigs     $ spec info
-
-grtyTop :: GhcInfo -> CG [(Var, SpecType)]
-grtyTop info     = forM topVs $ \v -> (v,) <$> trueTy (varType v)
-  where
-    topVs        = filter isTop $ defVars info
-    isTop v      = isExportedVar info v && not (v `S.member` sigVs)
-    sigVs        = S.fromList [v | (v,_) <- gsTySigs (spec info) ++ gsAsmSigs (spec info) ++ gsInSigs (spec info)]
-
-
-infoLits :: (GhcSpec -> [(F.Symbol, LocSpecType)]) -> (F.Sort -> Bool) -> GhcInfo -> F.SEnv F.Sort
-infoLits litF selF info = F.fromListSEnv $ cbLits ++ measLits
-  where
-    cbLits    = filter (selF . snd) $ coreBindLits tce info
-    measLits  = filter (selF . snd) $ mkSort <$> litF spc
-    spc       = spec info
-    tce       = gsTcEmbeds spc
-    mkSort    = mapSnd (F.sr_sort . rTypeSortedReft tce . val)
-
-initCGI :: Config -> GhcInfo -> CGInfo
-initCGI cfg info = CGInfo {
-    fEnv       = F.emptySEnv
-  , hsCs       = []
-  , sCs        = []
-  , hsWfs      = []
-  , fixCs      = []
-  , isBind     = []
-  , fixWfs     = []
-  , freshIndex = 0
-  , binds      = F.emptyBindEnv
-  , annotMap   = AI M.empty
-  , tyConInfo  = tyi
-  , tyConEmbed = tce
-  , kuts       = mempty
-  , kvPacks    = mempty
-  , cgLits     = infoLits gsMeas   (const True) info
-  , cgConsts   = infoLits gsLits notFn info
-  , termExprs  = M.fromList $ gsTexprs spc
-  , specDecr   = gsDecr spc
-  , specLVars  = gsLvars spc
-  , specLazy   = dictionaryVar `S.insert` gsLazy spc
-  , tcheck     = not $ notermination cfg
-  , scheck     = strata cfg
-  , pruneRefs  = pruneUnsorted cfg
-  , logErrors  = []
-  , kvProf     = emptyKVProf
-  , recCount   = 0
-  , bindSpans  = M.empty
-  , autoSize   = gsAutosize spc
-  , allowHO    = higherOrderFlag cfg
-  , ghcI       = info
-  }
-  where
-    tce        = gsTcEmbeds spc
-    spc        = spec info
-    tyi        = gsTyconEnv spc
-    notFn      = not . isJust . F.functionSort
-
-coreBindLits :: F.TCEmb TyCon -> GhcInfo -> [(F.Symbol, F.Sort)]
-coreBindLits tce info
-  = sortNub      $ [ (F.symbol x, F.strSort) | (_, Just (F.ESym x)) <- lconsts ]    -- strings
-                ++ [ (dconToSym dc, dconToSort dc) | dc <- dcons ]                  -- data constructors
-  where
-    lconsts      = literalConst tce <$> literals (cbs info)
-    dcons        = filter isDCon freeVs
-    freeVs       = impVars info ++ (snd <$> gsFreeSyms (spec info))
-    dconToSort   = typeSort tce . expandTypeSynonyms . varType
-    dconToSym    = F.symbol . idDataCon
-    isDCon x     = isDataConId x && not (hasBaseTypeVar x)
-
-
+       
 --------------------------------------------------------------------------------
 -- | TERMINATION TYPE ----------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -471,7 +221,6 @@ unOCons (RAllP p t)        = RAllP p $ unOCons t
 unOCons (RFun x tx t r)    = RFun x (unOCons tx) (unOCons t) r
 unOCons (RRTy _ _ OCons t) = unOCons t
 unOCons t                  = t
-
 
 mergecondition :: RType c tv r -> RType c tv r -> RType c tv r
 mergecondition (RAllT _ t1) (RAllT v t2)

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -242,21 +242,8 @@ mergeDataConTypes xts yts = merge (L.sortBy f xts) (L.sortBy f yts)
       | otherwise = yt : merge (xt : xs) ys
     mXY x tx y ty = meetVarTypes (F.pprint x) (getSrcSpan x, tx) (getSrcSpan y, ty)
 
-refreshHoles :: (F.Symbolic t, F.Reftable r, TyConable c, Freshable f r)
-             => [(t, RType c tv r)] -> f ([F.Symbol], [(t, RType c tv r)])
-refreshHoles vts = first catMaybes . unzip . map extract <$> mapM refreshHoles' vts
+----
 
-refreshHoles' :: (F.Symbolic a, F.Reftable r, TyConable c, Freshable m r)
-              => (a, RType c tv r) -> m (Maybe F.Symbol, a, RType c tv r)
-refreshHoles' (x,t)
-  | noHoles t = return (Nothing, x, t)
-  | otherwise = (Just $ F.symbol x,x,) <$> mapReftM tx t
-  where
-    tx r | hasHole r = refresh r
-         | otherwise = return r
-
-extract :: (t, t1, t2) -> (t, (t1, t2))
-extract (a,b,c) = (a,(b,c))
 
 refreshArgs' :: [(a, SpecType)] -> CG [(a, SpecType)]
 refreshArgs' = mapM (mapSndM refreshArgs)
@@ -865,9 +852,6 @@ consBind isRec γ (x, e, Unknown)
        addIdA x (defAnn isRec t)
        when (isExportedId x) (addKuts x t)
        return $ Asserted t
-
-noHoles :: (F.Reftable r, TyConable c) => RType c tv r -> Bool
-noHoles = and . foldReft (\_ r bs -> not (hasHole r) : bs) []
 
 killSubst :: RReft -> RReft
 killSubst = fmap killSubstReft

--- a/src/Language/Haskell/Liquid/Constraint/Init.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Init.hs
@@ -1,0 +1,312 @@
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE TypeSynonymInstances      #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE FlexibleInstances         #-}
+{-# LANGUAGE TupleSections             #-}
+{-# LANGUAGE MultiParamTypeClasses     #-}
+{-# LANGUAGE OverloadedStrings         #-}
+
+-- | This module defines the representation of Subtyping and WF Constraints,
+--   and the code for syntax-directed constraint generation.
+
+module Language.Haskell.Liquid.Constraint.Init ( initEnv , initCGI ) where
+
+import           Outputable                                    (Outputable)
+import           Prelude                                       hiding (error, undefined)
+import           GHC.Stack
+import           CoreUtils                                     (exprType)
+import           MkCore
+import           Coercion
+import           DataCon
+import           Pair
+import           CoreSyn
+import           SrcLoc                                 hiding (Located)
+import           Type
+import           TyCon
+import           PrelNames
+import           TypeRep
+import           Class                                         (className)
+import           Var
+import           Id                                           -- hiding (isExportedId)
+import           IdInfo
+import           Name        hiding (varName)
+import           FastString (fastStringToByteString)
+import           Unify
+import           VarSet
+import           Text.PrettyPrint.HughesPJ                     hiding (first)
+import           Control.Monad.State
+import           Data.Maybe                                    (isNothing, fromMaybe, catMaybes, fromJust, isJust)
+import qualified Data.HashMap.Strict                           as M
+import qualified Data.HashSet                                  as S
+import qualified Data.List                                     as L
+
+import           Data.Bifunctor
+import qualified Data.Foldable                                 as F
+import qualified Data.Traversable                              as T
+import qualified Language.Haskell.Liquid.UX.CTags              as Tg
+import           Language.Fixpoint.Types.Visitor
+import           Language.Haskell.Liquid.Constraint.Fresh
+import           Language.Haskell.Liquid.Constraint.Env
+import           Language.Haskell.Liquid.Constraint.Monad
+import           Language.Haskell.Liquid.Constraint.Split
+
+import qualified Language.Fixpoint.Types                       as F
+
+import           Language.Haskell.Liquid.WiredIn               (dictionaryVar)
+import           Language.Haskell.Liquid.Types.Dictionaries
+
+import qualified Language.Haskell.Liquid.GHC.Resugar           as Rs
+import qualified Language.Haskell.Liquid.GHC.SpanStack         as Sp
+import           Language.Haskell.Liquid.GHC.Interface         (isExportedVar)
+import           Language.Haskell.Liquid.Types                 hiding (binds, Loc, loc, freeTyVars, Def)
+import           Language.Haskell.Liquid.Types.Strata
+import           Language.Haskell.Liquid.Types.Names
+
+import           Language.Haskell.Liquid.Types.RefType
+import           Language.Haskell.Liquid.Types.Visitors        hiding (freeVars)
+import           Language.Haskell.Liquid.Types.PredType        hiding (freeTyVars)
+import           Language.Haskell.Liquid.Types.Meet
+import           Language.Haskell.Liquid.GHC.Misc          ( isInternal, collectArguments, tickSrcSpan
+                                                           , hasBaseTypeVar, showPpr, isDataConId
+                                                           )
+import           Language.Haskell.Liquid.Misc
+import           Language.Fixpoint.Misc
+import           Language.Haskell.Liquid.Types.Literals
+
+import           Language.Haskell.Liquid.Constraint.Axioms
+import           Language.Haskell.Liquid.Constraint.Types
+import           Language.Haskell.Liquid.Constraint.Constraint
+
+-- import Debug.Trace (trace)
+
+--------------------------------------------------------------------------------
+initEnv :: GhcInfo -> CG CGEnv
+--------------------------------------------------------------------------------
+initEnv info
+  = do let tce   = gsTcEmbeds sp
+       let fVars = impVars info
+       let dcs   = filter isConLikeId (snd <$> gsFreeSyms sp)
+       let dcs'  = filter isConLikeId fVars
+       defaults <- forM fVars $ \x -> liftM (x,) (trueTy $ varType x)
+       dcsty    <- forM dcs   makeDataConTypes
+       dcsty'   <- forM dcs'  makeDataConTypes
+       (hs,f0)  <- refreshHoles $ grty info                  -- asserted refinements     (for defined vars)
+       f0''     <- refreshArgs' =<< grtyTop info             -- default TOP reftype      (for exported vars without spec)
+       let f0'   = if notruetypes $ getConfig sp then [] else f0''
+       f1       <- refreshArgs'   defaults                   -- default TOP reftype      (for all vars)
+       f1'      <- refreshArgs' $ makedcs dcsty              -- data constructors
+       f2       <- refreshArgs' $ assm info                  -- assumed refinements      (for imported vars)
+       f3       <- refreshArgs' $ vals gsAsmSigs sp            -- assumed refinedments     (with `assume`)
+       f40      <- refreshArgs' $ vals gsCtors sp              -- constructor refinements  (for measures)
+       f5       <- refreshArgs' $ vals gsInSigs sp             -- internal refinements     (from Haskell measures)
+       (invs1, f41) <- mapSndM refreshArgs' $ makeAutoDecrDataCons dcsty  (gsAutosize sp) dcs
+       (invs2, f42) <- mapSndM refreshArgs' $ makeAutoDecrDataCons dcsty' (gsAutosize sp) dcs'
+       let f4    = mergeDataConTypes (mergeDataConTypes f40 (f41 ++ f42)) (filter (isDataConId . fst) f2)
+       sflag    <- scheck <$> get
+       let senv  = if sflag then f2 else []
+       let tx    = mapFst F.symbol . addRInv ialias . strataUnify senv . predsUnify sp
+       let bs    = (tx <$> ) <$> [f0 ++ f0', f1 ++ f1', f2, f3, f4, f5]
+       lt1s     <- F.toListSEnv . cgLits <$> get
+       let lt2s  = [ (F.symbol x, rTypeSort tce t) | (x, t) <- f1' ]
+       let tcb   = mapSnd (rTypeSort tce) <$> concat bs
+       let γ0    = measEnv sp (head bs) (cbs info) tcb lt1s lt2s (bs!!3) (bs!!5) hs info
+       γ  <- globalize <$> foldM (+=) γ0 [("initEnv", x, y) | (x, y) <- concat $ tail bs]
+       return γ {invs = is (invs1 ++ invs2)}
+  where
+    sp           = spec info
+    ialias       = mkRTyConIAl $ gsIaliases sp
+    vals f       = map (mapSnd val) . f
+    mapSndM f    = \(x,y) -> ((x,) <$> f y)
+    makedcs      = map strengthenDataConType
+    is autoinv   = mkRTyConInv    $ (gsInvariants sp ++ ((Nothing,) <$> autoinv))
+
+makeDataConTypes :: Var -> CG (Var, SpecType)
+makeDataConTypes x = (x,) <$> (trueTy $ varType x)
+
+makeAutoDecrDataCons :: [(Id, SpecType)] -> S.HashSet TyCon -> [Id] -> ([LocSpecType], [(Id, SpecType)])
+makeAutoDecrDataCons dcts specenv dcs
+  = (simplify invs, tys)
+  where
+    (invs, tys) = unzip $ concatMap go tycons
+    tycons      = L.nub $ catMaybes $ map idTyCon dcs
+
+    go tycon
+      | S.member tycon specenv =  zipWith (makeSizedDataCons dcts) (tyConDataCons tycon) [0..]
+    go _
+      = []
+    idTyCon x = dataConTyCon <$> case idDetails x of {DataConWorkId d -> Just d; DataConWrapId d -> Just d; _ -> Nothing}
+
+    simplify invs = dummyLoc . (`strengthen` invariant) .  fmap (\_ -> mempty) <$> L.nub invs
+    invariant = MkUReft (F.Reft (F.vv_, F.PAtom F.Ge (lenOf F.vv_) (F.ECon $ F.I 0)) ) mempty mempty
+
+lenOf :: F.Symbol -> F.Expr
+lenOf x = F.mkEApp lenLocSymbol [F.EVar x]
+
+makeSizedDataCons :: [(Id, SpecType)] -> DataCon -> Integer -> (RSort, (Id, SpecType))
+makeSizedDataCons dcts x' n = (toRSort $ ty_res trep, (x, fromRTypeRep trep{ty_res = tres}))
+    where
+      x      = dataConWorkId x'
+      t      = fromMaybe (impossible Nothing "makeSizedDataCons: this should never happen") $ L.lookup x dcts
+      trep   = toRTypeRep t
+      tres   = ty_res trep `strengthen` MkUReft (F.Reft (F.vv_, F.PAtom F.Eq (lenOf F.vv_) computelen)) mempty mempty
+
+      recarguments = filter (\(t,_) -> (toRSort t == toRSort tres)) (zip (ty_args trep) (ty_binds trep))
+      computelen   = foldr (F.EBin F.Plus) (F.ECon $ F.I n) (lenOf .  snd <$> recarguments)
+
+mergeDataConTypes ::  [(Var, SpecType)] -> [(Var, SpecType)] -> [(Var, SpecType)]
+mergeDataConTypes xts yts = merge (L.sortBy f xts) (L.sortBy f yts)
+  where
+    f (x,_) (y,_) = compare x y
+    merge [] ys = ys
+    merge xs [] = xs
+    merge (xt@(x, tx):xs) (yt@(y, ty):ys)
+      | x == y    = (x, mXY x tx y ty) : merge xs ys
+      | x <  y    = xt : merge xs (yt : ys)
+      | otherwise = yt : merge (xt : xs) ys
+    mXY x tx y ty = meetVarTypes (F.pprint x) (getSrcSpan x, tx) (getSrcSpan y, ty)
+
+refreshArgs' :: [(a, SpecType)] -> CG [(a, SpecType)]
+refreshArgs' = mapM (mapSndM refreshArgs)
+
+strataUnify :: [(Var, SpecType)] -> (Var, SpecType) -> (Var, SpecType)
+strataUnify senv (x, t) = (x, maybe t (mappend t) pt)
+  where
+    pt                  = fmap (\(MkUReft _ _ l) -> MkUReft mempty mempty l) <$> L.lookup x senv
+
+
+-- | TODO: All this *should* happen inside @Bare@ but appears
+--   to happen after certain are signatures are @fresh@-ed,
+--   which is why they are here.
+
+-- NV : still some sigs do not get TyConInfo
+
+predsUnify :: GhcSpec -> (Var, RRType RReft) -> (Var, RRType RReft)
+predsUnify sp = second (addTyConInfo tce tyi) -- needed to eliminate some @RPropH@
+  where
+    tce            = gsTcEmbeds sp
+    tyi            = gsTyconEnv sp
+
+--------------------------------------------------------------------------------
+measEnv :: GhcSpec
+        -> [(F.Symbol, SpecType)]
+        -> [CoreBind]
+        -> [(F.Symbol, F.Sort)]
+        -> [(F.Symbol, F.Sort)]
+        -> [(F.Symbol, F.Sort)]
+        -> [(F.Symbol, SpecType)]
+        -> [(F.Symbol, SpecType)]
+        -> [F.Symbol]
+        -> GhcInfo
+        -> CGEnv
+--------------------------------------------------------------------------------
+measEnv sp xts cbs tcb lt1s lt2s asms itys hs info = CGE
+  { cgLoc    = Sp.empty
+  , renv     = fromListREnv (second val <$> gsMeas sp) []
+  , syenv    = F.fromListSEnv $ gsFreeSyms sp
+  , litEnv   = F.fromListSEnv lts
+  , constEnv = F.fromListSEnv lt2s
+  , fenv     = initFEnv $ tcb ++ lts ++ (second (rTypeSort tce . val) <$> gsMeas sp)
+  , denv     = gsDicts sp
+  , recs     = S.empty
+  , fargs    = S.empty
+  , invs     = mempty
+  , rinvs    = mempty
+  , ial      = mkRTyConIAl    $ gsIaliases   sp
+  , grtys    = fromListREnv xts  []
+  , assms    = fromListREnv asms []
+  , intys    = fromListREnv itys []
+  , emb      = tce
+  , tgEnv    = Tg.makeTagEnv cbs
+  , tgKey    = Nothing
+  , trec     = Nothing
+  , lcb      = M.empty
+  , holes    = fromListHEnv hs
+  , lcs      = mempty
+  , aenv     = axiom_map $ gsLogicMap sp
+  , cerr     = Nothing
+  , cgInfo   = info
+  }
+  where
+      tce = gsTcEmbeds sp
+      lts = lt1s ++ lt2s
+
+assm :: GhcInfo -> [(Var, SpecType)]
+assm = assmGrty impVars
+
+grty :: GhcInfo -> [(Var, SpecType)]
+grty = assmGrty defVars
+
+assmGrty :: (GhcInfo -> [Var]) -> GhcInfo -> [(Var, SpecType)]
+assmGrty f info = [ (x, val t) | (x, t) <- sigs, x `S.member` xs ]
+  where
+    xs          = S.fromList $ f info
+    sigs        = gsTySigs     $ spec info
+
+grtyTop :: GhcInfo -> CG [(Var, SpecType)]
+grtyTop info     = forM topVs $ \v -> (v,) <$> trueTy (varType v)
+  where
+    topVs        = filter isTop $ defVars info
+    isTop v      = isExportedVar info v && not (v `S.member` sigVs)
+    sigVs        = S.fromList [v | (v,_) <- gsTySigs (spec info) ++ gsAsmSigs (spec info) ++ gsInSigs (spec info)]
+
+
+infoLits :: (GhcSpec -> [(F.Symbol, LocSpecType)]) -> (F.Sort -> Bool) -> GhcInfo -> F.SEnv F.Sort
+infoLits litF selF info = F.fromListSEnv $ cbLits ++ measLits
+  where
+    cbLits    = filter (selF . snd) $ coreBindLits tce info
+    measLits  = filter (selF . snd) $ mkSort <$> litF spc
+    spc       = spec info
+    tce       = gsTcEmbeds spc
+    mkSort    = mapSnd (F.sr_sort . rTypeSortedReft tce . val)
+
+initCGI :: Config -> GhcInfo -> CGInfo
+initCGI cfg info = CGInfo {
+    fEnv       = F.emptySEnv
+  , hsCs       = []
+  , sCs        = []
+  , hsWfs      = []
+  , fixCs      = []
+  , isBind     = []
+  , fixWfs     = []
+  , freshIndex = 0
+  , binds      = F.emptyBindEnv
+  , annotMap   = AI M.empty
+  , tyConInfo  = tyi
+  , tyConEmbed = tce
+  , kuts       = mempty
+  , kvPacks    = mempty
+  , cgLits     = infoLits gsMeas   (const True) info
+  , cgConsts   = infoLits gsLits notFn info
+  , termExprs  = M.fromList $ gsTexprs spc
+  , specDecr   = gsDecr spc
+  , specLVars  = gsLvars spc
+  , specLazy   = dictionaryVar `S.insert` gsLazy spc
+  , tcheck     = not $ notermination cfg
+  , scheck     = strata cfg
+  , pruneRefs  = pruneUnsorted cfg
+  , logErrors  = []
+  , kvProf     = emptyKVProf
+  , recCount   = 0
+  , bindSpans  = M.empty
+  , autoSize   = gsAutosize spc
+  , allowHO    = higherOrderFlag cfg
+  , ghcI       = info
+  }
+  where
+    tce        = gsTcEmbeds spc
+    spc        = spec info
+    tyi        = gsTyconEnv spc
+    notFn      = isNothing . F.functionSort
+
+coreBindLits :: F.TCEmb TyCon -> GhcInfo -> [(F.Symbol, F.Sort)]
+coreBindLits tce info
+  = sortNub      $ [ (F.symbol x, F.strSort) | (_, Just (F.ESym x)) <- lconsts ]    -- strings
+                ++ [ (dconToSym dc, dconToSort dc) | dc <- dcons ]                  -- data constructors
+  where
+    lconsts      = literalConst tce <$> literals (cbs info)
+    dcons        = filter isDCon freeVs
+    freeVs       = impVars info ++ (snd <$> gsFreeSyms (spec info))
+    dconToSort   = typeSort tce . expandTypeSynonyms . varType
+    dconToSym    = F.symbol . idDataCon
+    isDCon x     = isDataConId x && not (hasBaseTypeVar x)

--- a/src/Language/Haskell/Liquid/Constraint/Init.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Init.hs
@@ -12,71 +12,40 @@
 
 module Language.Haskell.Liquid.Constraint.Init ( initEnv , initCGI ) where
 
-import           Outputable                                    (Outputable)
 import           Prelude                                       hiding (error, undefined)
-import           GHC.Stack
-import           CoreUtils                                     (exprType)
-import           MkCore
 import           Coercion
 import           DataCon
-import           Pair
 import           CoreSyn
-import           SrcLoc                                 hiding (Located)
 import           Type
 import           TyCon
-import           PrelNames
-import           TypeRep
-import           Class                                         (className)
 import           Var
 import           Id                                           -- hiding (isExportedId)
 import           IdInfo
 import           Name        hiding (varName)
-import           FastString (fastStringToByteString)
-import           Unify
-import           VarSet
-import           Text.PrettyPrint.HughesPJ                     hiding (first)
 import           Control.Monad.State
-import           Data.Maybe                                    (isNothing, fromMaybe, catMaybes, fromJust, isJust)
+import           Data.Maybe                                    (isNothing, fromMaybe, catMaybes)
 import qualified Data.HashMap.Strict                           as M
 import qualified Data.HashSet                                  as S
 import qualified Data.List                                     as L
-
 import           Data.Bifunctor
-import qualified Data.Foldable                                 as F
-import qualified Data.Traversable                              as T
-import qualified Language.Haskell.Liquid.UX.CTags              as Tg
-import           Language.Fixpoint.Types.Visitor
-import           Language.Haskell.Liquid.Constraint.Fresh
-import           Language.Haskell.Liquid.Constraint.Env
-import           Language.Haskell.Liquid.Constraint.Monad
-import           Language.Haskell.Liquid.Constraint.Split
-
 import qualified Language.Fixpoint.Types                       as F
 
+import qualified Language.Haskell.Liquid.UX.CTags              as Tg
+import           Language.Haskell.Liquid.Constraint.Fresh
+import           Language.Haskell.Liquid.Constraint.Env
 import           Language.Haskell.Liquid.WiredIn               (dictionaryVar)
-import           Language.Haskell.Liquid.Types.Dictionaries
-
-import qualified Language.Haskell.Liquid.GHC.Resugar           as Rs
 import qualified Language.Haskell.Liquid.GHC.SpanStack         as Sp
 import           Language.Haskell.Liquid.GHC.Interface         (isExportedVar)
 import           Language.Haskell.Liquid.Types                 hiding (binds, Loc, loc, freeTyVars, Def)
-import           Language.Haskell.Liquid.Types.Strata
 import           Language.Haskell.Liquid.Types.Names
-
 import           Language.Haskell.Liquid.Types.RefType
 import           Language.Haskell.Liquid.Types.Visitors        hiding (freeVars)
-import           Language.Haskell.Liquid.Types.PredType        hiding (freeTyVars)
 import           Language.Haskell.Liquid.Types.Meet
-import           Language.Haskell.Liquid.GHC.Misc          ( isInternal, collectArguments, tickSrcSpan
-                                                           , hasBaseTypeVar, showPpr, isDataConId
-                                                           )
+import           Language.Haskell.Liquid.GHC.Misc          ( hasBaseTypeVar, isDataConId )
 import           Language.Haskell.Liquid.Misc
 import           Language.Fixpoint.Misc
 import           Language.Haskell.Liquid.Types.Literals
-
-import           Language.Haskell.Liquid.Constraint.Axioms
 import           Language.Haskell.Liquid.Constraint.Types
-import           Language.Haskell.Liquid.Constraint.Constraint
 
 -- import Debug.Trace (trace)
 
@@ -119,7 +88,7 @@ initEnv info
     vals f       = map (mapSnd val) . f
     mapSndM f    = \(x,y) -> ((x,) <$> f y)
     makedcs      = map strengthenDataConType
-    is autoinv   = mkRTyConInv    $ (gsInvariants sp ++ ((Nothing,) <$> autoinv))
+    is autoinv   = mkRTyConInv    (gsInvariants sp ++ ((Nothing,) <$> autoinv))
 
 makeDataConTypes :: Var -> CG (Var, SpecType)
 makeDataConTypes x = (x,) <$> (trueTy $ varType x)

--- a/src/Language/Haskell/Liquid/Constraint/Qualifier.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Qualifier.hs
@@ -8,7 +8,7 @@ module Language.Haskell.Liquid.Constraint.Qualifier (
   ) where
 
 import TyCon
-
+import Var (Var)
 import Prelude hiding (error)
 
 import Language.Haskell.Liquid.Bare
@@ -47,7 +47,7 @@ specificationQualifiers k info lEnv
     ]
     -- where lEnv = trace ("Literals: " ++ show lEnv') lEnv'
 
-specBinders :: GhcInfo -> [(_, LocSpecType)]
+specBinders :: GhcInfo -> [(Var, LocSpecType)]
 specBinders info = mconcat
   [ gsTySigs sp
   , gsAsmSigs sp

--- a/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
+++ b/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
@@ -37,8 +37,8 @@ targetFInfo info cgi fn = F.fi cs ws bs ls consts ks {- packs -} qs bi fn aHO aH
 targetQuals :: GhcInfo -> CGInfo -> [F.Qualifier]
 targetQuals info cgi = spcQs ++ genQs
   where
-    spcQs     = qualifiers spc
+    spcQs     = gsQualifiers spc
     genQs     = specificationQualifiers n info (fEnv cgi)
-    n         = maxParams $ config spc
+    n         = maxParams $ getConfig spc
     spc       = spec info
     -- lEnv      = F.fromListSEnv $ lits cgi

--- a/src/Language/Haskell/Liquid/Constraint/Types.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Types.hs
@@ -204,7 +204,7 @@ instance PPrint CGInfo where
 
 pprCGInfo :: F.Tidy -> CGInfo -> Doc
 pprCGInfo _k _cgi
-  =  "*********** Constraint Information ***********"
+  =  "*********** Constraint Information (omitted) *************"
   -- -$$ (text "*********** Haskell SubConstraints ***********")
   -- -$$ (pprintLongList $ hsCs  cgi)
   -- -$$ (text "*********** Haskell WFConstraints ************")
@@ -215,8 +215,8 @@ pprCGInfo _k _cgi
   -- -$$ (F.toFix  $ fixWfs cgi)
   -- -$$ (text "*********** Fixpoint Kut Variables ************")
   -- -$$ (F.toFix  $ kuts cgi)
-      $$ "*********** Literals in Source     ************"
-      $$ F.pprint (cgLits _cgi)
+  -- -$$ "*********** Literals in Source     ************"
+  -- -$$ F.pprint (cgLits _cgi)
   -- -$$ (text "*********** KVar Distribution *****************")
   -- -$$ (pprint $ kvProf cgi)
   -- -$$ (text "Recursive binders:" <+> pprint (recCount cgi))

--- a/src/Language/Haskell/Liquid/GHC/Interface.hs
+++ b/src/Language/Haskell/Liquid/GHC/Interface.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE TupleSections              #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Language.Haskell.Liquid.GHC.Interface (
 
@@ -238,7 +237,7 @@ isExportedVar :: GhcInfo -> Var -> Bool
 isExportedVar info v = n `elemNameSet` ns
   where
     n                = getName v
-    ns               = exports (spec info)
+    ns               = gsExports (spec info)
 
 
 classCons :: Maybe [ClsInst] -> [Id]
@@ -598,15 +597,15 @@ makeLogicMap = do
 instance PPrint GhcSpec where
   pprintTidy k spec = vcat
     [ "******* Target Variables ********************"
-    , pprintTidy k $ tgtVars spec
+    , pprintTidy k $ gsTgtVars spec
     , "******* Type Signatures *********************"
-    , pprintLongList k (tySigs spec)
+    , pprintLongList k (gsTySigs spec)
     , "******* Assumed Type Signatures *************"
-    , pprintLongList k (asmSigs spec)
+    , pprintLongList k (gsAsmSigs spec)
     , "******* DataCon Specifications (Measure) ****"
-    , pprintLongList k (ctors spec)
+    , pprintLongList k (gsCtors spec)
     , "******* Measure Specifications **************"
-    , pprintLongList k (meas spec)                   ]
+    , pprintLongList k (gsMeas spec)                   ]
 
 instance PPrint GhcInfo where
   pprintTidy k info = vcat

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -108,7 +108,7 @@ liquidOne :: GhcInfo -> IO (Output Doc)
 ------------------------------------------------------------------------------
 liquidOne info = do
   whenNormal $ donePhase Loud "Extracted Core using GHC"
-  let cfg   = config $ spec info
+  let cfg   = getConfig info
   let tgt   = target info
   -- whenLoud  $ do putStrLn $ showpp info
                  -- putStrLn "*************** Original CoreBinds ***************************"
@@ -132,7 +132,7 @@ newPrune cfg cbs tgt info
   | diffcheck cfg = maybeEither cbs <$> DC.slice tgt cbs sp
   | otherwise     = return  (Left cbs)
   where
-    vs            = tgtVars sp
+    vs            = gsTgtVars sp
     sp            = spec    info
 
 -- topLevelBinders :: GhcSpec -> [Var]

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -151,9 +151,10 @@ liquidQueries cfg tgt info (Right dcs)
 liquidQuery   :: Config -> FilePath -> GhcInfo -> Either [CoreBind] DC.DiffCheck -> IO (Output Doc)
 liquidQuery cfg tgt info edc = do
   when False (dumpCs cgi)
-  -- when True $ putStrLn $ render (pprint cgi)
+  -- whenLoud $ mapM_ putStrLn [ "****************** CGInfo ********************"
+                            -- , render (pprint cgi)                            ]
   out   <- timedAction names $ solveCs cfg tgt cgi info' names
-  return $ mconcat [oldOut, out]
+  return $  mconcat [oldOut, out]
   where
     cgi    = {-# SCC "generateConstraints" #-} generateConstraints $! info' {cbs = cbs''}
     cbs''  = either id              DC.newBinds                        edc

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -318,35 +318,35 @@ instance HasConfig GhcInfo where
 -- parsing the target source and dependent libraries
 
 data GhcSpec = SP {
-    tySigs     :: ![(Var, LocSpecType)]          -- ^ Asserted Reftypes
-  , asmSigs    :: ![(Var, LocSpecType)]          -- ^ Assumed Reftypes
-  , inSigs     :: ![(Var, LocSpecType)]          -- ^ Auto generated Signatures
-  , ctors      :: ![(Var, LocSpecType)]          -- ^ Data Constructor Measure Sigs
-  , spLits     :: ![(Symbol, LocSpecType)]       -- ^ Literals/Constants
+    gsTySigs   :: ![(Var, LocSpecType)]          -- ^ Asserted Reftypes
+  , gsAsmSigs  :: ![(Var, LocSpecType)]          -- ^ Assumed Reftypes
+  , gsInSigs   :: ![(Var, LocSpecType)]          -- ^ Auto generated Signatures
+  , gsCtors    :: ![(Var, LocSpecType)]          -- ^ Data Constructor Measure Sigs
+  , gsLits     :: ![(Symbol, LocSpecType)]       -- ^ Literals/Constants
                                                  -- e.g. datacons: EQ, GT, string lits: "zombie",...
-  , meas       :: ![(Symbol, LocSpecType)]       -- ^ Measure Types
+  , gsMeas     :: ![(Symbol, LocSpecType)]       -- ^ Measure Types
                                                  -- eg.  len :: [a] -> Int
-  , invariants :: ![(Maybe Var, LocSpecType)]    -- ^ Data Type Invariants that came from the definition of var measure
+  , gsInvariants :: ![(Maybe Var, LocSpecType)]  -- ^ Data Type Invariants that came from the definition of var measure
                                                  -- eg.  forall a. {v: [a] | len(v) >= 0}
-  , ialiases   :: ![(LocSpecType, LocSpecType)]  -- ^ Data Type Invariant Aliases
-  , dconsP     :: ![(DataCon, DataConP)]         -- ^ Predicated Data-Constructors
+  , gsIaliases   :: ![(LocSpecType, LocSpecType)]-- ^ Data Type Invariant Aliases
+  , gsDconsP     :: ![(DataCon, DataConP)]       -- ^ Predicated Data-Constructors
                                                  -- e.g. see tests/pos/Map.hs
-  , tconsP     :: ![(TyCon, TyConP)]             -- ^ Predicated Type-Constructors
+  , gsTconsP     :: ![(TyCon, TyConP)]           -- ^ Predicated Type-Constructors
                                                  -- eg.  see tests/pos/Map.hs
-  , freeSyms   :: ![(Symbol, Var)]               -- ^ List of `Symbol` free in spec and corresponding GHC var
+  , gsFreeSyms   :: ![(Symbol, Var)]             -- ^ List of `Symbol` free in spec and corresponding GHC var
                                                  -- eg. (Cons, Cons#7uz) from tests/pos/ex1.hs
-  , tcEmbeds   :: TCEmb TyCon                    -- ^ How to embed GHC Tycons into fixpoint sorts
+  , gsTcEmbeds   :: TCEmb TyCon                  -- ^ How to embed GHC Tycons into fixpoint sorts
                                                  -- e.g. "embed Set as Set_set" from include/Data/Set.spec
-  , qualifiers :: ![Qualifier]                   -- ^ Qualifiers in Source/Spec files
+  , gsQualifiers :: ![Qualifier]                 -- ^ Qualifiers in Source/Spec files
                                                  -- e.g tests/pos/qualTest.hs
-  , tgtVars    :: ![Var]                         -- ^ Top-level Binders To Verify (empty means ALL binders)
-  , decr       :: ![(Var, [Int])]                -- ^ Lexicographically ordered size witnesses for termination
-  , texprs     :: ![(Var, [Located Expr])]       -- ^ Lexicographically ordered expressions for termination
-  , lvars      :: !(S.HashSet Var)               -- ^ Variables that should be checked in the environment they are used
-  , lazy       :: !(S.HashSet Var)               -- ^ Binders to IGNORE during termination checking
-  , autosize   :: !(S.HashSet TyCon)             -- ^ Binders to IGNORE during termination checking
-  , config     :: !Config                        -- ^ Configuration Options
-  , exports    :: !NameSet                       -- ^ `Name`s exported by the module being verified
+  , gsTgtVars    :: ![Var]                       -- ^ Top-level Binders To Verify (empty means ALL binders)
+  , gsDecr       :: ![(Var, [Int])]              -- ^ Lexicographically ordered size witnesses for termination
+  , gsTexprs     :: ![(Var, [Located Expr])]     -- ^ Lexicographically ordered expressions for termination
+  , gsLvars      :: !(S.HashSet Var)             -- ^ Variables that should be checked in the environment they are used
+  , gsLazy       :: !(S.HashSet Var)               -- ^ Binders to IGNORE during termination checking
+  , gsAutosize   :: !(S.HashSet TyCon)             -- ^ Binders to IGNORE during termination checking
+  , gsConfig     :: !Config                        -- ^ Configuration Options
+  , gsExports    :: !NameSet                       -- ^ `Name`s exported by the module being verified
   , gsMeasures  :: [Measure SpecType DataCon]
   , gsTyconEnv  :: M.HashMap TyCon RTyCon
   , gsDicts     :: DEnv Var SpecType              -- ^ Dictionary Environment
@@ -356,7 +356,7 @@ data GhcSpec = SP {
   }
 
 instance HasConfig GhcSpec where
-  getConfig = config
+  getConfig = gsConfig
 
 data LogicMap = LM { logic_map :: M.HashMap Symbol LMap
                    , axiom_map :: M.HashMap Var Symbol

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -55,7 +55,7 @@ import System.FilePath                     (dropFileName, isAbsolute,
 
 import Language.Fixpoint.Types.Config      hiding (Config, linear, elimBound, elimStats,
                                                    nonLinCuts, getOpts, cores, minPartSize,
-                                                   maxPartSize, eliminate, defConfig, 
+                                                   maxPartSize, eliminate, defConfig,
                                                    extensionality, alphaEquivalence, betaEquivalence, normalForm)
 -- import Language.Fixpoint.Utils.Files
 import Language.Fixpoint.Misc
@@ -66,7 +66,7 @@ import Language.Haskell.Liquid.UX.Annotate
 import Language.Haskell.Liquid.GHC.Misc
 import Language.Haskell.Liquid.Misc
 import Language.Haskell.Liquid.Types.PrettyPrint
-import Language.Haskell.Liquid.Types       hiding (config, name, typ)
+import Language.Haskell.Liquid.Types       hiding (name, typ)
 import qualified Language.Haskell.Liquid.UX.ACSS as ACSS
 
 
@@ -416,7 +416,7 @@ defConfig = Config { files             = def
                    , extensionality    = def
                    , alphaEquivalence  = def
                    , betaEquivalence   = def
-                   , normalForm        = def 
+                   , normalForm        = def
                    , higherorderqs     = def
                    , diffcheck         = def
                    , saveQuery         = def

--- a/src/Language/Haskell/Liquid/UX/DiffCheck.hs
+++ b/src/Language/Haskell/Liquid/UX/DiffCheck.hs
@@ -140,9 +140,9 @@ sliceSaved' srcF is lm (DC coreBinds result spec)
 --   whose bodies have been pruned from [CoreBind] into the "assumes"
 
 assumeSpec :: M.HashMap Var LocSpecType -> GhcSpec -> GhcSpec
-assumeSpec sigm sp = sp { asmSigs = M.toList $ M.union sigm assm }
+assumeSpec sigm sp = sp { gsAsmSigs = M.toList $ M.union sigm assm }
   where
-    assm           = M.fromList $ asmSigs sp
+    assm           = M.fromList $ gsAsmSigs sp
 
 diffVars :: [Int] -> [Def] -> [Var]
 diffVars ls defs'    = tracePpr ("INCCHECK: diffVars lines = " ++ show ls ++ " defs= " ++ show defs) $
@@ -164,9 +164,9 @@ sigVars srcF ls sp = M.fromList $ filter (ok . snd) $ specSigs sp
 globalDiff :: FilePath -> [Int] -> GhcSpec -> Bool
 globalDiff srcF ls spec = measDiff || invsDiff || dconsDiff
   where
-    measDiff  = any (isDiff srcF ls) (snd <$> meas spec)
-    invsDiff  = any (isDiff srcF ls) (snd <$> invariants spec)
-    dconsDiff = any (isDiff srcF ls) (dloc . snd <$> dconsP spec)
+    measDiff  = any (isDiff srcF ls) (snd <$> gsMeas spec)
+    invsDiff  = any (isDiff srcF ls) (snd <$> gsInvariants spec)
+    dconsDiff = any (isDiff srcF ls) (dloc . snd <$> gsDconsP spec)
     dloc dc   = Loc (dc_loc dc) (dc_locE dc) ()
 
 isDiff :: FilePath -> [Int] -> Located a -> Bool
@@ -256,7 +256,7 @@ specDefs srcF  = map def . filter sameFile . specSigs
     sameFile   = (srcF ==) . file . snd
 
 specSigs :: GhcSpec -> [(Var, LocSpecType)]
-specSigs sp = tySigs sp ++ asmSigs sp ++ ctors sp
+specSigs sp = gsTySigs sp ++ gsAsmSigs sp ++ gsCtors sp
 
 --------------------------------------------------------------------------------
 coreDefs     :: [CoreBind] -> [Def]

--- a/src/Test/Target/Monad.hs
+++ b/src/Test/Target/Monad.hs
@@ -149,7 +149,7 @@ initState fp sp ctx = TargetState
   , dconEnv      = dcons
   , ctorEnv      = cts
   , measEnv      = meas
-  , embEnv       = tcEmbeds sp
+  , embEnv       = gsTcEmbeds sp
   , tyconInfo    = tyi
   , freesyms     = free
   , constructors = []
@@ -163,16 +163,16 @@ initState fp sp ctx = TargetState
   }
   where
     -- FIXME: can we NOT tidy???
-    dcons = tidyF $ map (first symbol) (dconsP sp)
+    dcons = tidyF $ map (first symbol) (gsDconsP sp)
 
     -- NOTE: we want to tidy all occurrences of nullary datacons in the signatures
-    cts   = subst su $ tidyF $ map (symbol *** val) (ctors sp)
-    sigs  = subst su $ tidyF $ map (symbol *** val) $ tySigs sp
+    cts   = subst su $ tidyF $ map (symbol *** val) (gsCtors sp)
+    sigs  = subst su $ tidyF $ map (symbol *** val) $ gsTySigs sp
 
-    tyi   = makeTyConInfo (tconsP sp)
+    tyi   = makeTyConInfo (gsTconsP sp)
     free  = tidyS $ map (second symbol)
-          $ freeSyms sp ++ map (\(c,_) -> (symbol c, c)) (ctors sp)
-    meas  = measures sp
+          $ gsFreeSyms sp ++ map (\(c,_) -> (symbol c, c)) (gsCtors sp)
+    meas  = gsMeasures sp
     tidyF = map (first tidySymbol)
     tidyS = map (second tidySymbol)
     su = mkSubst (map (second eVar) free)
@@ -196,8 +196,7 @@ addConstraint p = modify $ \s@(TargetState {..}) -> s { constraints = p:constrai
 
 addConstructor :: Variable -> Target ()
 addConstructor c
-  = do -- modify $ \s@(TargetState {..}) -> s { constructors = S.insert c constructors }
-       modify $ \s@(TargetState {..}) -> s { constructors = nub $ c:constructors }
+  = modify $ \s@(TargetState {..}) -> s { constructors = nub $ c:constructors }
 
 inModule :: Symbol -> Target a -> Target a
 inModule m act
@@ -223,8 +222,7 @@ lookupCtor c (toType -> t)
   = do mt <- find (\(c', _) -> symbolText c == symbolText c')
                <$> gets ctorEnv
        case mt of
-         Just (_, t) -> do
-           return t
+         Just (_, t) -> return t
          Nothing -> do
            -- m  <- gets filePath
            -- o  <- asks ghcOpts

--- a/tests/TestCommits.hs
+++ b/tests/TestCommits.hs
@@ -26,15 +26,13 @@ import Data.Maybe           (fromMaybe)
 
 project :: String
 project = "liquidhaskell"
+-- project = "liquidhaskell --fast --test-arguments=\"-p Peano\""
 
 branch :: String
 branch = "develop"
 
 tmpFile :: FilePath
-tmpFile = "/tmp/commits.txt"
-
-logDir :: FilePath 
-logDir = "/tmp/summary-"
+tmpFile = "/tmp/commits"
 
 --------------------------------------------------------------------------------
 main :: IO ()
@@ -57,6 +55,7 @@ testCommits f = do
   mapM_ (putStrLn . ("  " ++)) is
   runCmd setupCmd
   mapM_ runCommit is
+  runCmd setupCmd
 
 strParam :: String -> Param
 strParam s
@@ -108,5 +107,5 @@ commitCmd i =
   [ printf "git checkout %s"       i
   ,        "git submodule update"
   , printf "stack test %s"         project
-  , printf "cp tests/logs/cur/summary.csv %s-%s.csv" logDir i
+  , printf "cp tests/logs/cur/summary.csv ~/tmp/summary-%s.csv" i
   ]

--- a/tests/todo/Incr.hs
+++ b/tests/todo/Incr.hs
@@ -1,0 +1,6 @@
+module Incr (incr) where 
+
+
+{-@ axiomatize incr @-}
+incr :: Int -> Int
+incr x = x + 1

--- a/tests/todo/Refl.hs
+++ b/tests/todo/Refl.hs
@@ -1,0 +1,19 @@
+{-@ LIQUID "--higherorder"     @-}
+{-@ LIQUID "--totality"        @-}
+{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--higherorderqs"   @-}
+
+module Peano where
+
+import ProofCombinators
+
+{-@ axiomatize incr @-}
+incr :: Int -> Int
+incr x = x + 1
+
+{-@ pf :: () -> { incr 2 == 3 }  @-}
+pf () = incr 2 *** QED
+
+
+
+pf :: () -> Proof

--- a/tests/todo/ReflImp.hs
+++ b/tests/todo/ReflImp.hs
@@ -1,0 +1,18 @@
+{-@ LIQUID "--higherorder"     @-}
+{-@ LIQUID "--totality"        @-}
+{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--higherorderqs"   @-}
+
+module Peano where
+
+import ProofCombinators
+
+import Incr (incr)
+
+{-@ pf :: () -> { incr 2 == 3 }  @-}
+pf () = incr 2 *** QED
+
+
+
+
+pf :: () -> Proof


### PR DESCRIPTION
Some tidying up, towards making the code slightly less impenetrable.

* Rename fields of `GhcSpec` so they are prefixed by `gs` -- to facilitate easy search of where they get values,

* Move some stuff out of the gigantic `Constraint.Generate` into `Constraint.Fresh` and a new `Constraint.Init`.

**Please update ASAP if you are working on develop**