### PR TITLE
Rename ANF Suffix

### DIFF
--- a/src/Language/Haskell/Liquid/Transforms/ANF.hs
+++ b/src/Language/Haskell/Liquid/Transforms/ANF.hs
@@ -19,8 +19,8 @@ import qualified DsMonad
 import           DsMonad                          (initDs)
 import           GHC                              hiding (exprType)
 import           HscTypes
-import           OccName                          (mkVarOccFS)
-import           Id                               (mkUserLocalM)
+import           OccName                          (OccName, mkVarOccFS)
+import           Id                               (mkUserLocal)
 import           Literal
 import           MkCore                           (mkCoreLets)
 import           Outputable                       (trace)
@@ -31,12 +31,12 @@ import           TyCon                            (tyConDataCons_maybe)
 import           DataCon                          (dataConInstArgTys)
 import           FamInstEnv                       (emptyFamInstEnv)
 import           VarEnv                           (VarEnv, emptyVarEnv, extendVarEnv, lookupWithDefaultVarEnv)
-import           UniqSupply                       (MonadUnique)
-
+import           UniqSupply                       (MonadUnique, getUniqueM)
+import           Unique                           (getKey)
 import           Control.Monad.State.Lazy
 import           System.Console.CmdArgs.Verbosity (whenLoud)
 import           Language.Fixpoint.Misc             (fst3)
-import           Language.Fixpoint.Types            (anfPrefix)
+import           Language.Fixpoint.Types            (intSymbol, anfPrefix)
 
 import           Language.Haskell.Liquid.UX.Config  (Config, untidyCore, nocaseexpand, noPatternInline)
 import           Language.Haskell.Liquid.Misc       (concatMapM)
@@ -44,6 +44,7 @@ import           Language.Haskell.Liquid.GHC.Misc   (MGIModGuts(..), showCBs, sh
 import           Language.Haskell.Liquid.Transforms.Rec
 import           Language.Haskell.Liquid.Transforms.Rewrite
 import           Language.Haskell.Liquid.Types.Errors
+
 import qualified Language.Haskell.Liquid.GHC.SpanStack as Sp
 import qualified Language.Haskell.Liquid.GHC.Resugar   as Rs
 import           Data.Maybe                       (fromMaybe)
@@ -327,10 +328,14 @@ sortCases = sortBy (\x y -> cmpAltCon (fst3 x) (fst3 y))
 -- freshNormalVar = mkSysLocalM (symbolFastString anfPrefix)
 
 freshNormalVar :: AnfEnv -> Type -> DsM Id
-freshNormalVar γ t = mkUserLocalM anfOcc t sp
-  where
-    anfOcc         = mkVarOccFS $ symbolFastString anfPrefix
-    sp             = Sp.srcSpan (aeSrcSpan γ)
+freshNormalVar γ t = do
+  u     <- getUniqueM
+  let i  = getKey u
+  let sp = Sp.srcSpan (aeSrcSpan γ)
+  return (mkUserLocal (anfOcc i) u t sp)
+
+anfOcc :: Int -> OccName
+anfOcc = mkVarOccFS . symbolFastString . intSymbol anfPrefix
 
 data AnfEnv = AnfEnv
   { aeVarEnv  :: VarEnv Id

--- a/tests/tmp/Class2.hs
+++ b/tests/tmp/Class2.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-@ LIQUID "--no-termination" @-}
+module Class () where
+
+import Language.Haskell.Liquid.Prelude
+import Prelude hiding (sum, length, (!!), Functor(..))
+
+{- qualif Size(v:Int, xs:a): v = size xs @-}
+{- qualif Size(v:Int, xs:MList a): v = size xs @-}
+
+data MList a = Nil | Cons a (MList a)
+
+{-@ (!!) :: xs:MList a -> {v:Nat | v < sz xs} -> a @-}
+(!!) :: MList a -> Int -> a
+(Cons x _)  !! 0 = x
+(Cons _ xs) !! i = xs !! (i - 1)
+
+{-@ class measure sz :: forall a. a -> Int  @-}
+
+{-@ class Sized s where
+      size :: forall a. x:s a -> {v:Nat | v = sz x}
+  @-}
+class Sized s where
+  size :: s a -> Int
+
+instance Sized MList where
+  {-@ instance measure sz :: MList a -> Int
+      sz (Nil)       = 0
+      sz (Cons x xs) = 1 + sz xs
+    @-}
+  size = length
+
+{-@ length :: xs:MList a -> {v:Nat | v = sz xs} @-}
+length :: MList a -> Int
+length Nil         = 0
+length (Cons _ xs) = 1 + length xs
+
+{-@ bob :: xs:MList a -> {v:Nat | v = sz xs} @-}
+bob :: MList a -> Int
+bob = length
+
+
+instance Sized [] where
+  {-@ instance measure sz :: [a] -> Int
+      sz ([])   = 0
+      sz (x:xs) = 1 + (sz xs)
+    @-}
+  size [] = 0
+  size (_:xs) = 1 + size xs
+
+{-@ class (Sized s) => Indexable s where
+      index :: forall a. x:s a -> {v:Nat | v < sz x} -> a
+  @-}
+class (Sized s) => Indexable s where
+  index :: s a -> Int -> a
+
+
+
+instance Indexable MList where
+  index = (!!)
+
+{-@ sum :: Indexable s => s Int -> Int @-}
+sum :: Indexable s => s Int -> Int
+sum xs = go n 0
+  where
+    n = size xs
+    go (d::Int) i
+      | i < n     = index xs i + go (d-1) (i+1)
+      | otherwise = 0
+
+
+{-@ sumMList :: MList Int -> Int @-}
+sumMList :: MList Int -> Int
+sumMList xs = go max 0
+  where
+    max = size xs
+    go (d::Int) i
+      | i < max   = index xs i + go (d-1) (i+1)
+      | otherwise = 0
+
+
+{-@ mlist3 :: {v:MList Int | sz v = 3}  @-}
+mlist3 :: MList Int
+mlist3 = 1 `Cons` (2 `Cons` (3 `Cons` Nil))
+
+foo = liquidAssert $ size (Cons 1 Nil) == size [1]

--- a/tests/tmp/Class3.hs
+++ b/tests/tmp/Class3.hs
@@ -1,0 +1,16 @@
+-- | LH refuses to parse the `allPos` measure
+
+module Class3 where
+
+{-@ class Pos s where
+      allPos :: x:s Int -> {v:Bool | Prop v <=> allPos x}
+  @-}
+class Pos s where
+  allPos :: s Int -> Bool
+
+instance Pos [] where
+  {-@ instance measure allPos :: [Int] -> Bool
+      allPos ([])   = true
+      allPos (x:xs) = ((x > 0) && (allPos xs))          @-}
+  allPos []     = True
+  allPos (x:xs) = (x > 0) && (allPos xs)

--- a/tests/tmp/LiquidR.hs
+++ b/tests/tmp/LiquidR.hs
@@ -1,0 +1,328 @@
+-- The following file includes several refinements that have been
+-- commented out, marked with 'UNCOMMENT'. As-is, running LiquidHaskell
+-- on this file produces the message:
+--    liquid: Prelude.head: empty list
+-- The refinemnts marked with UNCOMMENT can be uncommented one-by-one,
+-- each producing a different error.
+
+{-# LANGUAGE
+      Rank2Types,
+      TypeFamilies,
+      ExplicitForAll,
+      FlexibleInstances,
+      MultiParamTypeClasses,
+      ConstraintKinds,
+      FunctionalDependencies
+ #-}
+
+module LiquidR
+  (array,
+   combine,
+   and,
+   add,
+   indexNullary,
+   indexUnary,
+   indexNAry) where
+
+import Prelude ()
+-- UNCOMMENT this to avoid 'Not in scope' error
+-- Note that `Char` isn't used anywhere in this file.
+import Data.Char
+import Data.Int
+import Data.Bool
+import Data.Ord
+import Data.Maybe
+
+import qualified Mode
+
+unimplemented :: a
+unimplemented = unimplemented
+
+------------------------------------------------------------------------
+-- Container Types -----------------------------------------------------
+------------------------------------------------------------------------
+
+type Vector a = [a]
+
+data Array a = Array{
+    shape :: [Mode.Numeric],
+    elems :: [a]
+  }
+
+{-@ type ListN a N =
+      {v:[a] | (size v) = N}
+@-}
+
+{-@ measure product :: [Mode.Numeric] -> real
+      product([]) = 1
+      product(x:xs) = (fromJust x) * (product xs)
+@-}
+
+{-@ data Array a = Array{
+      shape :: (NonEmptyList PositiveNumeric),
+      elems :: (ListN a (product shape))
+    }
+@-}
+
+{-@ type NonEmptyList a =
+      {v:[a] | (size v) > 0}
+@-}
+
+{-@ type NonNegativeNumeric =
+      {v:Mode.Numeric |
+        (isJust v) =>
+          (fromJust v) >= 0 }
+@-}
+
+{-@ type PositiveNumeric =
+      {v:Mode.Numeric |
+        (isJust v) =>
+          (fromJust v) > 0 }
+@-}
+
+{-@ measure nonNegativeNumeric :: (Mode.Numeric) -> Bool @-}
+nonNegativeNumeric (Just a)  = a >= 0
+nonNegativeNumeric (Nothing) = True
+
+{-@ measure nonPositiveNumeric :: (Mode.Numeric) -> Bool @-}
+nonPositiveNumeric (Just a)  = a <= 0
+nonPositiveNumeric (Nothing) = True
+
+{-@ type NonPositiveNumeric =
+      {v:Mode.Numeric |
+        (isJust v) =>
+          (fromJust v) >= 0 }
+@-}
+
+{-@ class measure allNonNegative :: (R a) -> Bool @-}
+{-@ instance measure allNonNegative :: (Array a) -> Bool
+  allNonNegative (Array shape elems) = allNonNegative elems
+@-}
+
+{-@ instance measure allNonNegative :: [(Mode.Numeric)] -> Bool @-}
+allNonNegative ([])   = True
+allNonNegative (y:ys) = (nonNegativeNumeric y) && (allNonNegative ys)
+
+{-@ class measure allNonPositive :: (R a) -> Bool @-}
+{-@ instance measure allNonPositive :: (Array a) -> Bool
+  allNonPositive (Array shape elems) = allNonPositive elems
+@-}
+{-@ instance measure allNonPositive :: [(Mode.Numeric)] -> Bool @-}
+allNonPositive ([])   = True
+allNonPositive (y:ys) = (nonPositiveNumeric y) && (allNonPositive ys)
+
+{-@ instance measure size :: [a] -> Int
+    size ([])   = 0
+    size (x:xs) = 1 + (size xs)
+@-}
+
+{-@ instance measure size :: (Array a) -> Int
+  size (Array shape elems)   = len elems
+@-}
+
+class R m where
+  type Elem m
+  length :: m -> Int
+  length = unimplemented
+
+instance R (Vector a) where
+  type Elem (Vector a) = a
+
+instance R (Array a) where
+  type Elem (Array a) = a
+
+type ROf c m = (R c, Elem c ~ m)
+
+{-@ type RNonEmpty t m =
+      {v:(R t m) | (size v) > 0}
+  @-}
+
+{-@ type RNonEmptyOf t m =
+      {v:(ROf t m) | (size v) > 0}
+@-}
+
+
+------------------------------------------------------------------------
+-- Container Constructors ----------------------------------------------
+------------------------------------------------------------------------
+
+-- Constructor for vectors
+{-@ measure lsize :: [[a]] -> Int
+    lsize ([])   = 0
+    lsize (x:xs) = (size x) + (lsize xs)
+@-}
+
+{-@ combine ::
+     ys:([[_]]) ->
+     {v:([_]) | (size v) = (lsize ys)}
+@-}
+combine :: [[a]] ->  [a]
+combine = unimplemented
+
+-- Constructor for arrays
+{- array :: forall t u m.(R t, R u, Mode.Mode m) =>
+    a:(RNonEmptyOf t NonNegativeNumeric) => t ->
+    b:(RNonEmptyOf u m)                  => u ->
+      (Array m)
+@-}
+array :: forall a b m.(R a, R b, Mode.Mode m) =>
+            (ROf b Mode.Numeric) => b
+         -> (ROf a m) => a
+         -> (Array m)
+array shape elems = unimplemented
+
+
+-- x = array [Just 2.0 :: Mode.Numeric] [Just 2.0 :: Mode.Numeric]
+
+------------------------------------------------------------------------
+-- Subscript -----------------------------------------------------------
+------------------------------------------------------------------------
+-- UNCOMMENT; Produces error:
+-- > Error: Bad Type Specification
+-- > LiquidR.indexNullary :: (R a, Mode b) =>
+-- >                         ((R a), (~ (Elem a) b)) -> a -> {VV : [b] | size a == size VV}
+-- >     Sort Error in Refinement: {VV : [m_a17t] | size a == size VV}
+-- >     Unbound Symbol a
+-- > Perhaps you meant: VV
+
+{- indexNullary :: forall t m.(R t, Mode.Mode m) =>
+      a:(ROf t m) => t ->
+     {b:(Vector m) | (size a) = (size b) }
+@-}
+indexNullary :: forall t m.(R t, Mode.Mode m) =>
+  (ROf t m) => t -> (Vector m)
+indexNullary _ = unimplemented
+
+
+class (R a, R b, Mode.Mode c, (Elem b) ~ c)
+    => UnarySubscript a b c where
+  indexUnary :: a -> b -> (Vector (Elem a))
+  indexUnary = unimplemented
+
+-- UNCOMMENT; produces error:
+-- > liquid: <no location info>: Error: Uh oh.
+-- >     This should never happen! If you are seeing this message,
+-- > please submit a bug report at
+-- > https://github.com/ucsd-progsys/liquidhaskell/issues
+-- > with this message and the source file that caused this error.
+-- >
+-- > RefType.toType cannot handle: {v##0 : _ | allNonNegative a
+-- >             || allNonPositive v##0}
+{- instance (R t, R u, _)
+      => UnarySubscript t u (Mode.Numeric) where
+  indexUnary ::
+    a:t ->
+    b:{v:_ |
+          (allNonNegative a)
+       || (allNonPositive v)} ->
+   {c:t | if (allNonNegative b)
+          then (size c) == (size b)
+          else if (allNonPositive b)
+          then (size c) <= (size b)
+          else false}
+@-}
+instance (R a, R b, (Elem b) ~ Mode.Numeric)
+    => UnarySubscript a b Mode.Numeric
+
+{- don't know how to say anything meaningful here yet -}
+instance (R a, R b, (Elem b) ~ Mode.Logical)
+    => UnarySubscript a b Mode.Logical
+
+
+class (R a, R b) => NarySubscript a b where
+  indexNAry :: (R c, Elem a ~ Elem c) => a -> [b] -> c
+  indexNAry = unimplemented
+
+instance (Mode.Mode a, R b) => NarySubscript (Array a) b
+
+
+
+------------------------------------------------------------------------
+--Binary Operations ----------------------------------------------------
+------------------------------------------------------------------------
+
+-- The length of the result of any numeric or logical binary operation
+-- should be the length of the longest operand. The length of the
+-- longest operand must be a multiple of the length of the shortest
+-- operand. If either operand has length 0, the length of the result
+-- is 0.
+{-@ predicate ArithmeticResult A B C =
+      if (size A) = 0 || (size B) = 0
+      then (size C) = 0
+      else if (size A) >= (size B)
+           && (size A) mod (size B) = 0
+        then (size C) = (size A)
+      else if (size A) < (size B)
+           && (size B) mod (size A) = 0
+        then (size C) = (size B)
+      else false
+@-}
+
+-- UNCOMMENT; (error omitted for brevity)
+{- class (R t, R u, R v) => Addition t u v where
+    add :: a:t ->
+           b:u ->
+          {c:v | ArithmeticResult a b c }
+@-}
+class (R a, R b, R c) => Addition a b c | a b -> c  where
+  add  :: a -> b -> c
+  add  = unimplemented
+
+-- Container type of binop result depends on
+-- container type of arguments:
+--    Vector `op` Vector = Array
+--    Vector `op` Array  = Array
+--    Array  `op` Vector = Array
+--    Array  `op` Array  = Array
+
+instance (Mode.IntoNumeric a, Mode.IntoNumeric b)
+    => Addition (Vector a) (Vector b) (Vector Mode.Numeric)
+
+instance (Mode.IntoNumeric a, Mode.IntoNumeric b)
+    => Addition (Array a) (Vector b) (Array Mode.Numeric)
+
+instance (Mode.IntoNumeric a, Mode.IntoNumeric b)
+    => Addition (Vector a) (Array b) (Array Mode.Numeric)
+
+instance (Mode.IntoNumeric a, Mode.IntoNumeric b)
+    => Addition (Array a) (Array b) (Array Mode.Numeric)
+
+-- UNCOMMENT; produces same error as previous class annotation
+{- class (R t, R u, R v) => Conjunction t u v where
+    and :: a:t ->
+           b:u ->
+          {c:v | ArithmeticResult a b c }
+@-}
+class (R a, R b, R c) => Conjunction a b c | a b -> c  where
+  and :: a -> b -> c
+  and = unimplemented
+
+-- Alternatively, we can use instance refinements. These produce errors
+-- as well, but note that the error changes between one being
+-- uncommented vs. multiple being uncommented.
+-- UNCOMMENT;
+{-@ instance (Mode.IntoLogical t, Mode.IntoLogical u)
+    => Conjunction (Vector t) (Vector u) (Vector Mode.Logical) where
+    and :: a:(Vector t) ->
+           b:(Vector u) ->
+          {c:(Vector Mode.Logical) | ArithmeticResult a b c }
+@-}
+instance (Mode.IntoLogical a, Mode.IntoLogical b)
+    => Conjunction (Vector a) (Vector b) (Vector Mode.Logical)
+-- UNCOMMENT;
+{- instance (Mode.IntoLogical t, Mode.IntoLogical u)
+    => Conjunction (Array t) (Vector u) (Array Mode.Logical) where
+    and :: a:(Array t) ->
+           b:(Vector u) ->
+          {c:(Array Mode.Logical) | ArithmeticResult a b c }
+@-}
+instance (Mode.IntoLogical a, Mode.IntoLogical b)
+    => Conjunction (Array a) (Vector b) (Array Mode.Logical)
+
+instance (Mode.IntoLogical a, Mode.IntoLogical b)
+    => Conjunction (Vector a) (Array b) (Array Mode.Logical)
+
+instance (Mode.IntoLogical a, Mode.IntoLogical b)
+    => Conjunction (Array a) (Array b) (Array Mode.Logical)
+
+-- and so on...

--- a/tests/tmp/Mode.hs
+++ b/tests/tmp/Mode.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE FlexibleInstances #-}
+
+module Mode where
+
+type Logical = Maybe Bool
+type Numeric = Maybe Double
+
+class Mode a
+instance Mode Logical
+instance Mode Numeric
+
+
+class (Mode a) => IntoNumeric a where
+  intoNumeric :: a -> Numeric
+
+instance IntoNumeric Numeric where
+  intoNumeric = id
+
+instance IntoNumeric Logical where
+  intoNumeric Nothing = Nothing
+  intoNumeric (Just True)  = Just (1.0 :: Double)
+  intoNumeric (Just False) = Just (0.0 :: Double)
+
+
+class (Mode a) => IntoLogical a where
+  intoLogical :: a -> Logical
+
+instance IntoLogical Logical where
+  intoLogical = id
+
+instance IntoLogical Numeric where
+  intoLogical Nothing    = Nothing
+  intoLogical (Just 0.0) = Just False
+  intoLogical (Just   _) = Just True
+
+
+add :: (IntoNumeric a, IntoNumeric b) => a -> b -> Numeric
+add l r = case (intoNumeric l, intoNumeric r) of
+  ((Just l),(Just r)) -> Just (l + r)
+  (       _,       _) -> Nothing
+
+and :: (IntoLogical a, IntoLogical b) => a -> b -> Logical
+and l r = case (intoLogical l, intoLogical r) of
+  ((Just l),(Just r)) -> Just (l && r)
+  (       _,       _) -> Nothing

--- a/tests/tmp/T776.hs
+++ b/tests/tmp/T776.hs
@@ -1,0 +1,28 @@
+{- | There are 2 bugs here, that have to do with `--prune-unsorted`.
+
+     1. Why is the `prod` measure being used in the generic `size`
+        function where it doesn't fit?
+
+     2. Why are we getting such a meaningless error message?!
+
+        At the very least some mention of try `prune-unsorted` ?
+
+        Can we not put in a simple check in Bare for now:
+
+        The measure `prod` is not-polymorphic, please run with --prune-unsorted.
+        
+ -}
+
+{-@ LIQUID "--prune-unsorted" @-}
+
+module LiquidR where
+
+{-@ measure size @-}
+size        :: [a] -> Int
+size []     = 0
+size (_:xs) = 1 + size xs
+
+{-@ measure prod @-}
+prod :: [Int] -> Int
+prod []     = 1
+prod (x:xs) = x + prod xs

--- a/tests/tmp/T777.hs
+++ b/tests/tmp/T777.hs
@@ -1,0 +1,6 @@
+module Goo where 
+
+{-@ instance measure glub @-}
+glub :: [Int] -> Bool
+glub []     = True
+glub (x:xs) = ((x > 0) && (glub xs))

--- a/tests/todo/T791.hs
+++ b/tests/todo/T791.hs
@@ -2,9 +2,8 @@ import Prelude hiding (null, head, tail, notElem, empty)
 
 import Data.Vector hiding (singleton, empty)
 import qualified Data.Vector.Mutable as M
-import Control.Monad.Primitive
 import qualified Data.Vector as V
-
+import Control.Monad.Primitive
 
 {-@ measure mvlen :: forall a. (MVector s a) -> Int @-}
 {-@ invariant {mv:MVector s a | 0 <= mvlen mv } @-}


### PR DESCRIPTION
Minor change that ensures that ANF variables have distinct ids, 
to make understanding the `Core` easier. 

[LOG](https://github.com/ucsd-progsys/liquid-logger/blob/master/logs/logs-rename-prefix/out/out.csv)