### PR TITLE
Infix Operators in the logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,6 +800,17 @@ see [tests/pos/Map.hs](tests/pos/Map.hs)
 2. Value parameters are specified in **upper**case: `X`, `Y`, `Z` etc.
 
 
+Infix Logic Operators
+---------------------
+
+You can define infix operators in logic, following Haskell's infix notation. 
+For example, if (+++) is defined as a measure or reflected function, you can use it infix by declaring
+
+   {-@ infixl 9 +++ @-}
+
+
+Note: infix operators cannot contain the dot character `.`.
+
 Specifying Measures
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -803,13 +803,14 @@ see [tests/pos/Map.hs](tests/pos/Map.hs)
 Infix Logic Operators
 ---------------------
 
-You can define infix operators in logic, following Haskell's infix notation. 
+You can define infix operators in logic, following [Haskell's infix notation](Build in Haskell ops https://www.haskell.org/onlinereport/decls.html#fixity). 
 For example, if (+++) is defined as a measure or reflected function, you can use it infix by declaring
 
    {-@ infixl 9 +++ @-}
 
 
 Note: infix operators cannot contain the dot character `.`.
+
 
 Specifying Measures
 -------------------

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -62,7 +62,7 @@ hsSpecificationP :: ModuleName
                  -> Either [Error] (ModName, Measure.BareSpec)
 -------------------------------------------------------------------------------
 hsSpecificationP modName specComments specQuotes =
-  case go ([], []) initPState $ specComments of
+  case go ([], []) initPState $ reverse specComments of
     ([], specs) ->
       Right $ mkSpec (ModName SrcImport modName) (specs ++ specQuotes)
     (errs, _) ->

--- a/tests/pos/T819.hs
+++ b/tests/pos/T819.hs
@@ -1,0 +1,35 @@
+{-@ LIQUID "--totality"        @-}
+{-@ LIQUID "--higherorder"        @-}
+{-@ LIQUID "--exactdc" @-}
+module Data.Foo where
+
+
+import Language.Haskell.Liquid.ProofCombinators
+
+
+data L a = N 
+{-@ infixl 9 <> @-}
+
+
+{-@ foo :: xs:L a -> {xs <> N == N } @-}
+foo :: L a -> Proof
+foo N = N <> N ==. N *** QED 
+
+
+{-@ reflect <> @-}
+(<>) :: L a -> L a -> L a 
+N <> N = N 
+
+
+{-@ infixl 9 +++ @-}
+{-@ data N = Zero | Succ {next :: N} @-}
+data N = Zero | Succ N 
+
+{-@ reflect +++ @-}
+(+++) :: N -> N -> N
+n +++ m = n
+
+{-@ lemma :: { v:() | Zero +++ Zero == Zero } @-}
+lemma :: ()
+lemma = Zero +++ Zero ==. Zero *** QED
+


### PR DESCRIPTION
Infix operators can be defined in the logic using a Haskell like notation

     {-@ infixl 9 <> @-}

Addresses issue #819