### PR TITLE
add local defines

### DIFF
--- a/src/Language/Haskell/Liquid/Bare/Env.hs
+++ b/src/Language/Haskell/Liquid/Bare/Env.hs
@@ -20,6 +20,7 @@ module Language.Haskell.Liquid.Bare.Env (
 
   , insertLogicEnv
   , insertAxiom
+  , addDefs
   ) where
 
 import           HscTypes
@@ -34,6 +35,7 @@ import           Control.Monad.Writer
 
 import qualified Control.Exception                    as Ex
 import qualified Data.HashMap.Strict                  as M
+import qualified Data.HashSet                         as S
 
 
 import           Language.Fixpoint.Types              (Expr(..), Symbol, symbol, TCEmb)
@@ -76,6 +78,10 @@ data BareEnv = BE { modName  :: !ModName
 
 setEmbeds :: MonadState BareEnv m => TCEmb TyCon -> m () 
 setEmbeds emb = modify $ \be -> be {embeds = emb}
+
+addDefs :: MonadState BareEnv m => S.HashSet (Var, Symbol) -> m ()
+addDefs ds 
+  = modify $ \be -> be {logicEnv = (logicEnv be) {axiom_map =  M.union (axiom_map $ logicEnv be) (M.fromList $ S.toList ds)}}
 
 insertLogicEnv
   :: MonadState BareEnv m => Symbol -> [Symbol] -> Expr -> m ()

--- a/src/Language/Haskell/Liquid/Bare/GhcSpec.hs
+++ b/src/Language/Haskell/Liquid/Bare/GhcSpec.hs
@@ -325,6 +325,8 @@ makeGhcSpec4 quals defVars specs name su sp
        texprs' <- mconcat <$> mapM (makeTExpr defVars . snd) specs
        lazies  <- mkThing makeLazy
        lvars'  <- mkThing makeLVar
+       defs'   <- mkThing makeDefs 
+       addDefs defs' 
        asize'  <- S.fromList <$> makeASize
        hmeas   <- mkThing makeHMeas
        hinls   <- mkThing makeHInlines

--- a/src/Language/Haskell/Liquid/Bare/Spec.hs
+++ b/src/Language/Haskell/Liquid/Bare/Spec.hs
@@ -9,6 +9,7 @@ module Language.Haskell.Liquid.Bare.Spec (
   , makeHints
   , makeLVar
   , makeLazy
+  , makeDefs
   , makeHMeas, makeHInlines
   , makeTExpr
   , makeTargetVars
@@ -109,6 +110,9 @@ makeLazy :: [Var]
          -> Ms.Spec ty bndr
          -> BareM [Var]
 makeLazy    vs spec = fmap fst <$> varSymbols id vs [(v, ()) | v <- S.toList $ Ms.lazy spec]
+
+makeDefs :: [Var] -> Ms.Spec ty bndr -> BareM [(Var, F.Symbol)]
+makeDefs vs spec = varSymbols id vs (M.toList $ Ms.defs spec)
 
 makeHBounds :: [Var] -> Ms.Spec ty bndr -> BareM [(Var, LocSymbol)]
 makeHBounds vs spec = varSymbols id vs [(v, v ) | v <- S.toList $ Ms.hbounds spec]

--- a/src/Language/Haskell/Liquid/Measure.hs
+++ b/src/Language/Haskell/Liquid/Measure.hs
@@ -77,6 +77,7 @@ data Spec ty bndr  = Spec
   , rinstance  :: ![RInstance ty]
   , dvariance  :: ![(LocSymbol, [Variance])]
   , bounds     :: !(RRBEnv ty)
+  , defs       :: !(M.HashMap LocSymbol Symbol)
   }
 
 
@@ -159,6 +160,7 @@ instance Monoid (Spec ty bndr) where
            , rinstance  =           rinstance s1  ++ rinstance s2
            , dvariance  =           dvariance s1  ++ dvariance s2
            , bounds     = M.union   (bounds s1)      (bounds s2)
+           , defs       = M.union   (defs s1)        (defs s2)
            }
 
   mempty
@@ -192,6 +194,7 @@ instance Monoid (Spec ty bndr) where
            , rinstance  = []
            , dvariance  = []
            , bounds     = M.empty
+           , defs       = M.empty
            }
 
 dataConTypes :: MSpec (RRType Reft) DataCon -> ([(Var, RRType Reft)], [(LocSymbol, RRType Reft)])

--- a/tests/pos/NatClass.hs
+++ b/tests/pos/NatClass.hs
@@ -1,0 +1,50 @@
+{-@ LIQUID "--higherorder"     @-}
+{-@ LIQUID "--totality"        @-}
+{-@ LIQUID "--exact-data-cons" @-}
+
+module Nat where
+
+import Language.Haskell.Liquid.ProofCombinators
+
+{-@ data N [toInt] = Zero | Suc N @-}
+data N = Zero | Suc N
+
+{-@ measure toInt @-}
+{-@ toInt :: N -> Nat @-}
+toInt :: N -> Int
+toInt Zero = 0
+toInt (Suc n) = 1 + toInt n
+
+
+{-@ class (Eq a) => VerifiedEq a where
+      eq :: a -> a -> Bool
+      refl :: x:a -> { v:() | Prop (eq x x) }
+@-}
+class (Eq a) => VerifiedEq a where
+  eq :: a -> a -> Bool
+  refl :: a -> Proof
+
+
+{-@ axiomatize eqN @-}
+eqN :: N -> N -> Bool
+eqN Zero Zero = True
+eqN (Suc m) (Suc n) = eqN m n
+eqN _ _ = False
+
+{-@ eqNRefl :: x:N -> { eqN x x } @-}
+eqNRefl :: N -> Proof
+eqNRefl Zero =   eqN Zero Zero
+             ==. True
+             *** QED
+eqNRefl (Suc n) =   eqN (Suc n) (Suc n)
+                ==. eqN n n
+                ==. True ? eqNRefl n
+                *** QED
+
+instance Eq N where
+  (==) = eqN
+
+instance VerifiedEq N where
+  {-@ define $ceq = eqN @-}
+  eq x y   = eqN x y 
+  refl  = eqNRefl


### PR DESCRIPTION
With define we can replace Haskell variables with symbols during constrain. generation 

eg, in the following example

https://github.com/ucsd-progsys/liquidhaskell/pull/867/commits/0123b4081cad10df96ee23f6cc621766b32c8cdc#diff-6e20e8531df8072c56366fdfad9b6c4fR48

```
{-@ define $ceq = eqN @-}
```

replaces the internal class method `$ceq` with `eqN`. 


I am not supplying documentation yet, as this is a temporal solution.