### PR TITLE
Add cabal install instruction to check GHC version

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,6 +23,13 @@ Simply do:
 
 We are working to put `liquid` on `stackage`.
 
+Note: Currently, LiquidHaskell on hackage does not compile against GHC 8.
+Please make sure you are installing with GHC version less than 8. You can
+designate a specific version of LiquidHaskell to ensure that the correct
+GHC version is in the environment. As an example,
+
+    cabal install liquidhaskell-0.6.0.0
+
 ## Step 2: Install `liquid` from Source
 
 If you want the most recent version, you can build from source as follows,


### PR DESCRIPTION
This pull request updates installation guide when using `cabal` to ensure that the correct GHC version is in the environment. Without this, `cabal install liquidhaskell` with GHC 8 will try to install liquidhaskell-0.4.x.x which does not has an upper bound on GHC's version (and will fail to compile).
The user might not realize that `cabal install` is trying an old version due to dependency problem.

```
$ ghc -V
The Glorious Glasgow Haskell Compilation System, version 8.0.1
$ cabal install liquidhaskell --dry-run
Resolving dependencies...
In order, the following would be installed (use -v for more details):
... [skipped] ...
liquid-fixpoint-0.3.0.1 (latest: 0.5.0.1)
liquidhaskell-0.4.1.1 (latest: 0.6.0.0)
```
