### PR TITLE
Make "--eliminate=all" explicit (not default)

### DIFF
--- a/benchmarks/pldi17/pos/FoldrUniversal.hs
+++ b/benchmarks/pldi17/pos/FoldrUniversal.hs
@@ -4,6 +4,7 @@
 {-@ LIQUID "--higherorder"     @-}
 {-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--eliminate=all"   @-}
 
 module FoldrUniversal where
 

--- a/benchmarks/pldi17/pos/Solver.hs
+++ b/benchmarks/pldi17/pos/Solver.hs
@@ -6,10 +6,13 @@
 -- | Should use cases and auto translate like in the paper's theory
 -- | Also, &&, not and rest logical operators are not in scope in the axioms
 module Solver where
+
 {-@ LIQUID "--higherorder"     @-}
 {-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--pruneunsorted"   @-}
+{-@ LIQUID "--eliminate=all"   @-}
+
 import Data.Tuple
 import Data.List (nub)
 import Language.Haskell.Liquid.Prelude ((==>))

--- a/benchmarks/pldi17/pos/Unification.hs
+++ b/benchmarks/pldi17/pos/Unification.hs
@@ -8,6 +8,7 @@
 {-@ LIQUID "--higherorder"     @-}
 {-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--eliminate=all"   @-}
 
 module Unify where
 

--- a/src/Language/Haskell/Liquid/Constraint/Qualifier.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Qualifier.hs
@@ -25,27 +25,37 @@ import Data.Maybe               (catMaybes, fromMaybe, isNothing)
 import qualified Data.HashSet as S
 -- import Data.Bifunctor           (second)
 import Debug.Trace (trace)
+-- import Language.Fixpoint.Misc (traceShow)
 
 -----------------------------------------------------------------------------------
 specificationQualifiers :: Int -> GhcInfo -> SEnv Sort -> [Qualifier]
 -----------------------------------------------------------------------------------
 specificationQualifiers k info lEnv
-  =[ q | (x, t) <- specBinders info
-        , x `S.member` (S.fromList $ defVars info ++
-                                     -- NOTE: this mines extra, useful qualifiers but causes
-                                     -- a significant increase in running time, so we hide it
-                                     -- behind `--scrape-imports` and `--scrape-used-imports`
-                                     if info `hasOpt` scrapeUsedImports
-                                     then useVars info
-                                     else if info `hasOpt` scrapeImports
-                                     then impVars info
-                                     else [])
+  = [ q | (x, t) <- specBinders info
+        , x `S.member` qbs
         , q <- refTypeQuals lEnv (getSourcePos x) (gsTcEmbeds $ spec info) (val t)
         -- NOTE: large qualifiers are VERY expensive, so we only mine
         -- qualifiers up to a given size, controlled with --max-params
         , length (qParams q) <= k + 1
     ]
+  where qbs = qualifyingBinders info
     -- where lEnv = trace ("Literals: " ++ show lEnv') lEnv'
+
+qualifyingBinders :: GhcInfo -> S.HashSet Var
+qualifyingBinders info = {- traceShow "qualifyingBinders" $ -} S.difference sTake sDrop
+  where
+    sTake              = S.fromList $ defVars       info ++ scrapeVars info
+    sDrop              = S.fromList $ specAxiomVars info
+
+
+-- NOTE: this mines extra, useful qualifiers but causes
+-- a significant increase in running time, so we hide it
+-- behind `--scrape-imports` and `--scrape-used-imports`
+scrapeVars :: GhcInfo -> [Var]
+scrapeVars info
+  | info `hasOpt` scrapeUsedImports = useVars info
+  | info `hasOpt` scrapeImports     = impVars info
+  | otherwise                       = []
 
 specBinders :: GhcInfo -> [(Var, LocSpecType)]
 specBinders info = mconcat
@@ -55,6 +65,9 @@ specBinders info = mconcat
   , if (info `hasOpt` scrapeInternals) then (gsInSigs sp) else []
   ]
   where sp = spec info
+
+specAxiomVars :: GhcInfo -> [Var]
+specAxiomVars =  map (fst . aname) . gsAxioms . spec
 
 -- GRAVEYARD: scraping quals from imports kills the system with too much crap
 -- specificationQualifiers info = {- filter okQual -} qs

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -192,7 +192,7 @@ fixConfig tgt cfg = def
   { FC.solver           = fromJust (smtsolver cfg)
   , FC.linear           = linear            cfg
   , FC.eliminate        = eliminate         cfg
-  , FC.nonLinCuts       = not (eliminate cfg == FC.All) 
+  , FC.nonLinCuts       = not (higherOrderFlag cfg) -- eliminate cfg /= FC.All
   , FC.save             = saveQuery         cfg
   , FC.srcFile          = tgt
   , FC.cores            = cores             cfg
@@ -208,7 +208,7 @@ fixConfig tgt cfg = def
   , FC.normalForm       = normalForm       cfg
   , FC.stringTheory     = stringTheory     cfg
   }
- 
+
 e2u :: F.FixSolution -> Error -> UserError
 e2u s = fmap F.pprint . tidyError s
 

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -416,7 +416,7 @@ mkOpts cfg = do
 canonConfig :: Config -> Config
 canonConfig cfg = cfg
   { diffcheck   = diffcheck cfg && not (fullcheck cfg)
-  , eliminate   = if higherOrderFlag cfg then FC.All else eliminate cfg
+  -- , eliminate   = if higherOrderFlag cfg then FC.All else eliminate cfg
   }
 
 --------------------------------------------------------------------------------

--- a/tests/pos/mapreduce.hs
+++ b/tests/pos/mapreduce.hs
@@ -1,45 +1,46 @@
-{-@ LIQUID "--higherorder"         @-}
-{-@ LIQUID "--totality"            @-}
-{-@ LIQUID "--exactdc"             @-}
-{-@ LIQUID "--no-measure-fields"   @-}
+{-@ LIQUID "--higherorder"       @-}
+{-@ LIQUID "--totality"          @-}
+{-@ LIQUID "--exactdc"           @-}
+{-@ LIQUID "--no-measure-fields" @-}
+{-@ LIQUID "--eliminate=all"     @-}
 
 
-module DivideAndQunquer where 
+module DivideAndQunquer where
 
 import Prelude hiding (error, map, take, drop)
-import Language.Haskell.Liquid.ProofCombinators 
+import Language.Haskell.Liquid.ProofCombinators
 
 {-@ reflect mapReduce @-}
-mapReduce :: Int -> (List a -> b) -> (b -> b -> b) -> List a -> b 
-mapReduce n f op N  = f N  
-mapReduce n f op is = reduce op (map f (chunk n is)) 
+mapReduce :: Int -> (List a -> b) -> (b -> b -> b) -> List a -> b
+mapReduce n f op N  = f N
+mapReduce n f op is = reduce op (map f (chunk n is))
 
 chunk  :: Int -> List a -> List (List a)
 map    :: (a -> b) -> List a -> List b
-reduce :: (b -> b -> b) -> List b -> b  
+reduce :: (b -> b -> b) -> List b -> b
 
 {-@ mapReduceTheorem :: n:Int -> f:(List a -> b) -> op:(b -> b -> b) -> is:List a
-      -> distributionThm:(is1:List a -> is2:List a -> {op (f is1) (f is2) == f (append is1 is2)} ) -> 
+      -> distributionThm:(is1:List a -> is2:List a -> {op (f is1) (f is2) == f (append is1 is2)} ) ->
       { f is == mapReduce n f op is } / [llen is] @-}
-mapReduceTheorem :: Int -> (List a -> b) -> (b -> b -> b) -> List a -> (List a -> List a -> Proof)  -> Proof 
+mapReduceTheorem :: Int -> (List a -> b) -> (b -> b -> b) -> List a -> (List a -> List a -> Proof)  -> Proof
 mapReduceTheorem n f op N _
-  =   mapReduce n f op N 
-  ==. f N 
-  *** QED 
+  =   mapReduce n f op N
+  ==. f N
+  *** QED
 
-mapReduceTheorem n f op is _ 
-  | llen is <= n || n <= 1 
-  =   mapReduce n f op is 
+mapReduceTheorem n f op is _
+  | llen is <= n || n <= 1
+  =   mapReduce n f op is
   ==. reduce op (map f (chunk n is))
   ==. reduce op (map f (C is N))
   ==. reduce op (f is `C` map f N)
   ==. reduce op (f is `C` N)
   ==. f is
-  *** QED 
+  *** QED
 
-mapReduceTheorem n f op is distributionThm 
-  = undefined   
-{-  =   mapReduce n f op is 
+mapReduceTheorem n f op is distributionThm
+  = undefined
+{-  =   mapReduce n f op is
   ==. reduce op (map f (chunk n is))
   ==. reduce op (map f (C (take n is) (chunk n (drop n is))))
   ==. reduce op (f (take n is) `C` map f (chunk n (drop n is)))
@@ -49,9 +50,9 @@ mapReduceTheorem n f op is distributionThm
         ? mapReduceTheorem n f op (drop n is) distributionThm
   ==. f (append (take n is) (drop n is))
         ? distributionThm (take n is) (drop n is)
-  ==. f is 
+  ==. f is
         ? appendTakeDrop n is
-  *** QED  
+  *** QED
  -}
 -------------------------------------------------------------------------------
 -----------  List Definition --------------------------------------------------
@@ -61,10 +62,10 @@ mapReduceTheorem n f op is distributionThm
 {-@ data List [llen] a = N | C {lhead :: a, ltail :: List a} @-}
 data List a = N | C a (List a)
 
-llen :: List a -> Int 
+llen :: List a -> Int
 {-@ measure llen @-}
 {-@ llen :: List a -> Nat @-}
-llen N        = 0 
+llen N        = 0
 llen (C _ xs) = 1 + llen xs
 
 -------------------------------------------------------------------------------
@@ -73,68 +74,67 @@ llen (C _ xs) = 1 + llen xs
 {-@ reflect map @-}
 {-@ map :: (a -> b) -> xs:List a -> {v:List b | llen v == llen xs } @-}
 map _  N       = N
-map f (C x xs) = f x `C` map f xs 
+map f (C x xs) = f x `C` map f xs
 
 {-@ reflect append @-}
-append :: List a -> List a -> List a 
-append N        ys = ys  
+append :: List a -> List a -> List a
+append N        ys = ys
 append (C x xs) ys = x `C` (append xs ys)
 
 {-@ reflect reduce @-}
-{-@ reduce :: (b -> b -> b) -> is:{List b | 1 <= llen is } -> b @-}  
-reduce _  (C x N)  = x 
+{-@ reduce :: (b -> b -> b) -> is:{List b | 1 <= llen is } -> b @-}
+reduce _  (C x N)  = x
 reduce op (C x xs) = op x (reduce op xs)
 
 {-@ reflect chunk @-}
 {-@ chunk :: i:Int -> xs:List a -> {v:List (List a) | (1 <= llen v) &&  (if (i <= 1 || llen xs <= i) then (llen v == 1) else (llen v < llen xs)) } / [llen xs] @-}
-chunk i xs 
-  | i <= 1 
-  = C xs N 
-  | llen xs <= i 
-  = C xs N 
+chunk i xs
+  | i <= 1
+  = C xs N
+  | llen xs <= i
+  = C xs N
   | otherwise
   = C (take i xs) (chunk i (drop i xs))
 
 {-@ reflect drop @-}
-{-@ drop :: i:Nat -> xs:{List a | i <= llen xs } -> {v:List a | llen v == llen xs - i } @-} 
-drop :: Int -> List a -> List a 
-drop i N = N 
+{-@ drop :: i:Nat -> xs:{List a | i <= llen xs } -> {v:List a | llen v == llen xs - i } @-}
+drop :: Int -> List a -> List a
+drop i N = N
 drop i (C x xs)
-  | i == 0 
-  = C x xs  
-  | otherwise 
-  = drop (i-1) xs 
+  | i == 0
+  = C x xs
+  | otherwise
+  = drop (i-1) xs
 
 {-@ reflect take @-}
-{-@ take :: i:Nat -> xs:{List a | i <= llen xs } -> {v:List a | llen v == i} @-} 
-take :: Int -> List a -> List a 
-take i N = N 
+{-@ take :: i:Nat -> xs:{List a | i <= llen xs } -> {v:List a | llen v == i} @-}
+take :: Int -> List a -> List a
+take i N = N
 take i (C x xs)
-  | i == 0 
-  = N  
-  | otherwise 
+  | i == 0
+  = N
+  | otherwise
   = C x (take (i-1) xs)
 
--- | Helper Theorem 
-{-@ appendTakeDrop :: i:Nat -> xs:{List a | i <= llen xs} 
+-- | Helper Theorem
+{-@ appendTakeDrop :: i:Nat -> xs:{List a | i <= llen xs}
   -> {xs == append (take i xs) (drop i xs) }  @-}
 
-appendTakeDrop :: Int -> List a -> Proof 
-appendTakeDrop i N 
+appendTakeDrop :: Int -> List a -> Proof
+appendTakeDrop i N
   =   append (take i N) (drop i N)
-  ==. append N N 
-  ==. N 
-  *** QED 
+  ==. append N N
+  ==. N
+  *** QED
 appendTakeDrop i (C x xs)
-  | i == 0 
+  | i == 0
   =   append (take 0 (C x xs)) (drop 0 (C x xs))
   ==. append N (C x xs)
-  ==. C x xs 
-  *** QED 
+  ==. C x xs
+  *** QED
   | otherwise
   =   append (take i (C x xs)) (drop i (C x xs))
   ==. append (C x (take (i-1) xs)) (drop (i-1) xs)
   ==. C x (append (take (i-1) xs) (drop (i-1) xs))
-  ==. C x xs ? appendTakeDrop (i-1) xs 
-  *** QED 
-
+  ==. C x xs ? appendTakeDrop (i-1) xs
+  *** QED


### PR DESCRIPTION
Because you can get cyclic dependencies due to polymorphic instantiation, see:

https://github.com/iu-parfunc/verified-instances/blob/master/examples/Peano.hs

where the last trivial proof "instantiating" the Iso is killed if we "--eliminate=all" due to the cycle
induced by

```
data Iso a b = Iso { to   :: a -> b, from :: b -> a ... }
```

Not clear what the best solution here is; really need the qualifiers to solve the above out to `Nat`. 

Hence, am reverting to making `--eliminate=all` be *explicit* (not implied by `--higherorder`).
