### PR TITLE
Fix a broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1114,7 +1114,7 @@ verification attempts.
   your system. If not, `hscolour` is used to render the HTML.
 
   It is also possible to generate *slide shows* from the above.
-  See the [tutorial directory](docs/tutorial) for an example.
+  See the [slides directory](docs/slides) for an example.
 
 Editor Integration
 ==================


### PR DESCRIPTION
I'm afraid that the original target `docs/tutorial` no longer exists.