### PR TITLE
Smt axiomatization

### DIFF
--- a/benchmarks/pldi17/neg/Ackermann.hs
+++ b/benchmarks/pldi17/neg/Ackermann.hs
@@ -13,7 +13,7 @@ import Helper
 
 -- | First ackermann definition
 
-{-@ axiomatize ack @-}
+{-@ reflect ack @-}
 {-@ ack :: n:Nat -> x:Nat -> Nat / [n, x] @-}
 ack :: Int -> Int -> Int
 ack n x
@@ -26,7 +26,7 @@ ack n x
 
 -- | Second ackermann definition
 
-{-@ axiomatize iack @-}
+{-@ reflect iack @-}
 {-@ iack :: Nat -> Nat -> Nat -> Nat @-}
 
 iack :: Int -> Int -> Int -> Int
@@ -290,7 +290,7 @@ lemma10_helper n x l
 
 
 -- | Lader as helper definition and properties
-{-@ axiomatize ladder @-}
+{-@ reflect ladder @-}
 {-@ ladder :: Nat -> {n:Int | 0 < n } -> Nat -> Nat @-}
 ladder :: Int -> Int -> Int -> Int
 ladder l n b

--- a/benchmarks/pldi17/neg/ApplicativeList.hs
+++ b/benchmarks/pldi17/neg/ApplicativeList.hs
@@ -46,7 +46,7 @@ fmap f xs
 id :: a -> a
 id x = x
 
-{-@ axiomatize idollar @-}
+{-@ reflect idollar @-}
 idollar :: a -> (a -> b) -> b
 idollar x f = f x
 

--- a/benchmarks/pldi17/neg/ApplicativeList.hs
+++ b/benchmarks/pldi17/neg/ApplicativeList.hs
@@ -50,7 +50,7 @@ id x = x
 idollar :: a -> (a -> b) -> b
 idollar x f = f x
 
-{-@ axiomatize compose @-}
+{-@ reflect compose @-}
 compose :: (b -> c) -> (a -> b) -> a -> c
 compose f g x = f (g x)
 

--- a/benchmarks/pldi17/neg/ApplicativeMaybe.hs
+++ b/benchmarks/pldi17/neg/ApplicativeMaybe.hs
@@ -18,32 +18,32 @@ import Helper
 -- | interchange   u <*> pure y = pure ($ y) <*> u
 
 
-{-@ axiomatize pure @-}
+{-@ reflect pure @-}
 pure :: a -> Maybe a
 pure x = Just x
 
-{-@ axiomatize seq @-}
+{-@ reflect seq @-}
 seq :: Maybe (a -> b) -> Maybe a -> Maybe b
 seq f x
   | is_Just f, is_Just x = Just (from_Just f (from_Just x))
   | otherwise            = Nothing
 
 
-{-@ axiomatize fmap @-}
+{-@ reflect fmap @-}
 fmap :: (a -> b) -> Maybe a -> Maybe b
 fmap f x
   | is_Just x  = Just (f (from_Just x))
   | otherwise = Nothing
 
-{-@ axiomatize id @-}
+{-@ reflect id @-}
 id :: a -> a
 id x = x
 
-{-@ axiomatize idollar @-}
+{-@ reflect idollar @-}
 idollar :: a -> (a -> b) -> b
 idollar x f = f x
 
-{-@ axiomatize compose @-}
+{-@ reflect compose @-}
 compose :: (b -> c) -> (a -> b) -> a -> c
 compose f g x = f (g x)
 

--- a/benchmarks/pldi17/neg/FunctorList.hs
+++ b/benchmarks/pldi17/neg/FunctorList.hs
@@ -29,7 +29,7 @@ fmap f xs
 id :: a -> a
 id x = x
 
-{-@ axiomatize compose @-}
+{-@ reflect compose @-}
 compose :: (b -> c) -> (a -> b) -> a -> c
 compose f g x = f (g x)
 

--- a/benchmarks/pldi17/neg/FunctorMaybe.hs
+++ b/benchmarks/pldi17/neg/FunctorMaybe.hs
@@ -27,7 +27,7 @@ fmap f x
 id :: a -> a
 id x = x
 
-{-@ axiomatize compose @-}
+{-@ reflect compose @-}
 compose :: (b -> c) -> (a -> b) -> a -> c
 compose f g x = f (g x)
 

--- a/benchmarks/pldi17/neg/MapFusion.hs
+++ b/benchmarks/pldi17/neg/MapFusion.hs
@@ -12,7 +12,7 @@ import Prelude hiding (map)
 
 import Proves
 
-{-@ axiomatize compose @-}
+{-@ reflect compose @-}
 compose :: (b -> c) -> (a -> b) -> a -> c
 compose f g x = f (g x)
 

--- a/benchmarks/pldi17/neg/MonadReader.hs
+++ b/benchmarks/pldi17/neg/MonadReader.hs
@@ -21,11 +21,11 @@ import Proves
 {-@ data Reader r a = Reader { runIdentity :: r -> a } @-}
 data Reader r a     = Reader { runIdentity :: r -> a }
 
-{-@ axiomatize return @-}
+{-@ reflect return @-}
 return :: a -> Reader r a
 return x = Reader (\r -> x)
 
-{-@ axiomatize bind @-}
+{-@ reflect bind @-}
 bind :: Reader r a -> (a -> Reader r b) -> Reader r b
 bind (Reader x) f = Reader (\r -> fromReader (f (x r)) r)
 

--- a/benchmarks/pldi17/pos/Ackermann.hs
+++ b/benchmarks/pldi17/pos/Ackermann.hs
@@ -14,7 +14,7 @@ import Helper
 
 -- | First ackermann definition
 
-{-@ axiomatize ack @-}
+{-@ reflect ack @-}
 {-@ ack :: n:Nat -> x:Nat -> Nat / [n, x] @-}
 ack :: Int -> Int -> Int
 ack n x
@@ -27,7 +27,7 @@ ack n x
 
 -- | Second ackermann definition
 
-{-@ axiomatize iack @-}
+{-@ reflect iack @-}
 {-@ iack :: Nat -> Nat -> Nat -> Nat @-}
 
 iack :: Int -> Int -> Int -> Int
@@ -290,7 +290,7 @@ lemma10_helper n x l
 
 
 -- | Lader as helper definition and properties
-{-@ axiomatize ladder @-}
+{-@ reflect ladder @-}
 {-@ ladder :: Nat -> {n:Int | 0 < n } -> Nat -> Nat @-}
 ladder :: Int -> Int -> Int -> Int
 ladder l n b

--- a/benchmarks/pldi17/pos/ApplicativeId.hs
+++ b/benchmarks/pldi17/pos/ApplicativeId.hs
@@ -21,23 +21,23 @@ import Helper
 -- | interchange   u <*> pure y = pure ($ y) <*> u
 
 
-{-@ axiomatize pure @-}
+{-@ reflect pure @-}
 pure :: a -> Identity a
 pure x = Identity x
 
-{-@ axiomatize seq @-}
+{-@ reflect seq @-}
 seq :: Identity (a -> b) -> Identity a -> Identity b
 seq (Identity f) (Identity x) = Identity (f x)
 
-{-@ axiomatize id @-}
+{-@ reflect id @-}
 id :: a -> a
 id x = x
 
-{-@ axiomatize idollar @-}
+{-@ reflect idollar @-}
 idollar :: a -> (a -> b) -> b
 idollar x f = f x
 
-{-@ axiomatize compose @-}
+{-@ reflect compose @-}
 compose :: (b -> c) -> (a -> b) -> a -> c
 compose f g x = f (g x)
 

--- a/benchmarks/pldi17/pos/ApplicativeMaybe.hs
+++ b/benchmarks/pldi17/pos/ApplicativeMaybe.hs
@@ -20,29 +20,29 @@ import Helper
 -- | interchange   u <*> pure y = pure ($ y) <*> u
 
 
-{-@ axiomatize pure @-}
+{-@ reflect pure @-}
 pure :: a -> Maybe a
 pure x = Just x
 
-{-@ axiomatize seq @-}
+{-@ reflect seq @-}
 seq :: Maybe (a -> b) -> Maybe a -> Maybe b
 seq (Just f) (Just x) = Just (f x)
 seq _         _       = Nothing
 
-{-@ axiomatize fmap @-}
+{-@ reflect fmap @-}
 fmap :: (a -> b) -> Maybe a -> Maybe b
 fmap f (Just x) = Just (f x)
 fmap f Nothing  = Nothing
 
-{-@ axiomatize id @-}
+{-@ reflect id @-}
 id :: a -> a
 id x = x
 
-{-@ axiomatize idollar @-}
+{-@ reflect idollar @-}
 idollar :: a -> (a -> b) -> b
 idollar x f = f x
 
-{-@ axiomatize compose @-}
+{-@ reflect compose @-}
 compose :: (b -> c) -> (a -> b) -> a -> c
 compose f g x = f (g x)
 

--- a/benchmarks/pldi17/pos/FoldrUniversal.hs
+++ b/benchmarks/pldi17/pos/FoldrUniversal.hs
@@ -12,7 +12,7 @@ import Proves
 import Prelude hiding (foldr)
 
 -- | foldrUniversal
-{-@ axiomatize foldr @-}
+{-@ reflect foldr @-}
 foldr :: (a -> b -> b) -> b -> L a -> b
 foldr f b xs
   | llen xs > 0
@@ -102,7 +102,7 @@ fuse_base h f e
   ==. h e
   *** QED
 
-{-@ axiomatize compose @-}
+{-@ reflect compose @-}
 compose :: (b -> c) -> (a -> b) ->  a -> c
 compose f g x = f (g x)
 

--- a/benchmarks/pldi17/pos/FunctorId.hs
+++ b/benchmarks/pldi17/pos/FunctorId.hs
@@ -22,15 +22,15 @@ import Helper
 data Identity a = Identity a
 
 
-{-@ axiomatize fmap @-}
+{-@ reflect fmap @-}
 fmap :: (a -> b) -> Identity a -> Identity b
 fmap f (Identity x) = Identity (f x)
 
-{-@ axiomatize id @-}
+{-@ reflect id @-}
 id :: a -> a
 id x = x
 
-{-@ axiomatize compose @-}
+{-@ reflect compose @-}
 compose :: (b -> c) -> (a -> b) -> a -> c
 compose f g x = f (g x)
 

--- a/benchmarks/pldi17/pos/FunctorList.hs
+++ b/benchmarks/pldi17/pos/FunctorList.hs
@@ -20,17 +20,17 @@ import Helper
 
 
 
-{-@ axiomatize fmap @-}
+{-@ reflect fmap @-}
 fmap :: (a -> b) -> L a -> L b
 fmap f xs
   | llen xs == 0 = N
   | otherwise    = C (f (hd xs)) (fmap f (tl xs))
 
-{-@ axiomatize id @-}
+{-@ reflect id @-}
 id :: a -> a
 id x = x
 
-{-@ axiomatize compose @-}
+{-@ reflect compose @-}
 compose :: (b -> c) -> (a -> b) -> a -> c
 compose f g x = f (g x)
 

--- a/benchmarks/pldi17/pos/FunctorMaybe.hs
+++ b/benchmarks/pldi17/pos/FunctorMaybe.hs
@@ -20,16 +20,16 @@ import Helper
 
 
 
-{-@ axiomatize fmap @-}
+{-@ reflect fmap @-}
 fmap :: (a -> b) -> Maybe a -> Maybe b
 fmap f Nothing  = Nothing
 fmap f (Just x) = Just (f x)
 
-{-@ axiomatize id @-}
+{-@ reflect id @-}
 id :: a -> a
 id x = x
 
-{-@ axiomatize compose @-}
+{-@ reflect compose @-}
 compose :: (b -> c) -> (a -> b) -> a -> c
 compose f g x = f (g x)
 

--- a/benchmarks/pldi17/pos/FunctorReader.NoExtensionality.hs
+++ b/benchmarks/pldi17/pos/FunctorReader.NoExtensionality.hs
@@ -20,15 +20,15 @@ import Proves
 {-@ data Reader r a = Reader { runIdentity :: r -> a } @-}
 data Reader r a     = Reader { runIdentity :: r -> a }
 
-{-@ axiomatize fmap @-}
+{-@ reflect fmap @-}
 fmap :: (a -> b) -> Reader r a -> Reader r b
 fmap f (Reader rd) = Reader (\r -> f (rd r))
 
-{-@ axiomatize id @-}
+{-@ reflect id @-}
 id :: a -> a
 id x = x
 
-{-@ axiomatize compose @-}
+{-@ reflect compose @-}
 compose :: (b -> c) -> (a -> b) -> a -> c
 compose f g x = f (g x)
 

--- a/benchmarks/pldi17/pos/FunctorReader.hs
+++ b/benchmarks/pldi17/pos/FunctorReader.hs
@@ -20,15 +20,15 @@ import Helper
 {-@ data Reader r a = Reader { runIdentity :: r -> a } @-}
 data Reader r a     = Reader { runIdentity :: r -> a }
 
-{-@ axiomatize fmap @-}
+{-@ reflect fmap @-}
 fmap :: (a -> b) -> Reader r a -> Reader r b
 fmap f (Reader rd) = Reader (\r -> f (rd r))
 
-{-@ axiomatize id @-}
+{-@ reflect id @-}
 id :: a -> a
 id x = x
 
-{-@ axiomatize compose @-}
+{-@ reflect compose @-}
 compose :: (b -> c) -> (a -> b) -> a -> c
 compose f g x = f (g x)
 

--- a/benchmarks/pldi17/pos/MapFusion.hs
+++ b/benchmarks/pldi17/pos/MapFusion.hs
@@ -14,11 +14,11 @@ import Prelude hiding (map)
 
 import Proves
 
-{-@ axiomatize compose @-}
+{-@ reflect compose @-}
 compose :: (b -> c) -> (a -> b) -> a -> c
 compose f g x = f (g x)
 
-{-@ axiomatize map @-}
+{-@ reflect map @-}
 map :: (a -> b) -> L a -> L b
 map f xs
   | llen xs == 0 = N

--- a/benchmarks/pldi17/pos/MapFusion.hs
+++ b/benchmarks/pldi17/pos/MapFusion.hs
@@ -14,7 +14,7 @@ import Prelude hiding (map)
 
 import Proves
 
-{-@ reflect compose @-}
+{-@ axiomatize compose @-}
 compose :: (b -> c) -> (a -> b) -> a -> c
 compose f g x = f (g x)
 

--- a/benchmarks/pldi17/pos/MapFusion.hs
+++ b/benchmarks/pldi17/pos/MapFusion.hs
@@ -14,7 +14,7 @@ import Prelude hiding (map)
 
 import Proves
 
-{-@ axiomatize compose @-}
+{-@ reflect compose @-}
 compose :: (b -> c) -> (a -> b) -> a -> c
 compose f g x = f (g x)
 

--- a/docs/blog/2017-01-06-reductions.lhs
+++ b/docs/blog/2017-01-06-reductions.lhs
@@ -1,0 +1,261 @@
+---
+layout: post
+title: "Proof Reductions on Homomorphisms"
+date: 2017-01-02
+comments: true
+external-url:
+author: Niki Vazou and Vikraman Choudhury
+published: true
+categories: reflection proof-reductions homomorphism abstract-refinements
+demo: Reductions.hs
+---
+
+[Previously][refinement-reflection] we saw how Refinement Reflection
+can be used to write and prove **in Haskell** theorems **about Haskell**
+functions on data types and have such proofs machine checked by Liquid Haskell.
+
+Today we will see how proof generation can be simplified by proof reduction on homomorphic data types. 
+
+As an example, we define a user-defined `Peano` data type
+and prove that it enjoys various 
+arithmetic properties (like totality of comparison)
+by 
+1. creating a proof that an arithmetic property holds on Natural numbers, and then 
+2. reduce the proof from Natural numbers to Peano numbers. 
+This proof reduction is possible since Peano numbers are homomorphic to Natural numbers. 
+
+<!-- more -->
+
+<br>
+<br>
+<br>
+
+<div class="row-fluid">
+  <div class="span12 pagination-centered">
+  <img src="http://4.bp.blogspot.com/-oltF9WI2KhY/VBMwdj15IvI/AAAAAAAAAtg/V3-k6IylIZM/s1600/picasso_bull.jpg"
+       alt="Picasso bull" width="400">
+       <br>
+       <br>
+       <br>
+  </div>
+</div>
+
+
+<div class="hidden">
+\begin{code}
+{-@ LIQUID "--higherorder"    @-}
+{-@ LIQUID "--totalhaskell"   @-}
+{-@ LIQUID "--exactdc"        @-}
+{-@ LIQUID "--diffcheck"      @-}
+{-@ LIQUID "--pruneunsorted"  @-}
+{-@ LIQUID "--eliminate=some" @-}
+
+module Reductions where
+
+import Language.Haskell.Liquid.ProofCombinators
+
+geqZero  :: Peano -> Proof 
+leqTotal :: Peano -> Peano -> Proof
+toNat    :: Peano -> Int
+
+geqZeroNat          :: Nat -> Proof 
+geqZeroByReduction  :: Peano -> Proof 
+leqTotalByReduction :: Peano -> Peano -> Proof 
+leqTotalNat         :: Nat -> Nat -> Proof
+
+\end{code}
+
+</div>
+
+Properties of Peano Numbers
+----------------------------
+
+First, we define `Peano` numbers as a data type 
+and the function `leqPeano` that compares two Peano numbers.
+
+
+\begin{code}
+{-@ data Peano [toNat] = Z | S {prev :: Peano } @-}
+data Peano = Z | S { prev :: Peano } deriving (Eq)
+
+{-@ reflect leqPeano @-}
+leqPeano :: Peano -> Peano -> Bool
+leqPeano Z _         = True
+leqPeano _ Z         = False
+leqPeano (S n) (S m) = leqPeano n m
+\end{code}
+
+We can use Refinement Reflection to provide an 
+**explicit proof** that no Peano number is greater than zero (`Z`).
+
+\begin{code}
+{-@ geqZero :: n:Peano -> {leqPeano Z n} @-}
+geqZero n = leqPeano Z n *** QED 
+\end{code}
+
+The proof proceeds simply by invocation of the 
+first case of the `leqPeano` definition. 
+
+As another Peano property, we can use Refinement Reflection to 
+show that comparison on Peano numbers is *total*, 
+that is, for every two numbers `n` and `m` 
+either `leqPeano n m` or `leqPeano m n` always holds. 
+
+\begin{code}
+{-@ leqTotal :: n:Peano -> m:Peano 
+             -> {(leqPeano n m) || (leqPeano m n)} 
+             /  [toNat n + toNat m] @-}
+leqTotal Z m = leqPeano Z m *** QED
+leqTotal n Z = leqPeano Z n *** QED
+leqTotal (S n) (S m)
+  =   (leqPeano (S n) (S m) || leqPeano (S m) (S n))
+  ==. (leqPeano n m || leqPeano (S m) (S n)) 
+      ? (leqTotal n m)
+  ==. (leqPeano n m || leqPeano m n) 
+      ? (leqTotal m n)
+  *** QED
+\end{code}
+
+The proof proceeds by induction on the sum of `n` and `m`. 
+Liquid Haskell captures this generalized induction by 
+ensuring that the value `toNat n + toNat m` is decreasing
+where `toNat` maps Peano to Natural numbers. 
+
+\begin{code}
+{-@ measure toNat @-}
+{-@ toNat :: Peano -> Nat @-}
+toNat Z     = 0
+toNat (S n) = 1 + toNat n
+\end{code}
+
+Note, that the type `Nat` is just a refinement on the Haskell's integers
+\begin{code}
+{-@ type Nat = { n:Int | 0 <= n } @-}
+type Nat     = Int
+\end{code}
+
+Following the totality proof, 
+one can prove further properties of Peano comparisons, 
+like reflexivity and transitivity.
+
+The above totality proof is verbose! 
+Moreover, it is very similar 
+to the classic totality on Natural numbers. 
+Since the SMT knowns that comparison of Nat is total, we can just reduce 
+Peano to Natural number totality!
+
+
+Reduction of Operators 
+-----------------------
+
+Since `toNat` is a homomorphism (i.e., a transformation) from `Peano` to `Nat`
+one can compare two Peano numbers via comparison of Natural numbers. 
+
+\begin{code}
+{-@ reflect leqPeanoNat @-}
+leqPeanoNat :: Peano -> Peano -> Bool 
+leqPeanoNat n m = toNat n `leqInt` toNat m  
+\end{code}
+
+where `leqInt` the Haskell comparison operator restricted to `Ints`.
+
+\begin{code}
+{-@ reflect leqInt @-}
+leqInt :: Int -> Int -> Bool 
+leqInt x y = x <= y
+\end{code}
+
+Note that `leqPeanoNat` is exactly equivalent to `leqPeano`. 
+For this blog post, we leave the equivalence proof as an exercise for the reader.
+
+
+Proof Reductions
+-----------------
+
+After reducing the Peano comparison operator to
+comparison on Natural numbers, we can reduce 
+proofs on Peano numbers to proofs on Natural numbers.
+The great benefit of this reduction is that proofs on Natural number
+are automated by the underlying SMT solver!
+
+For example, we prove that no Natural number is less than `0`
+by unfolding `leqInt` on `0` 
+and then let linear arithmetic decision procedure of the SMT complete the proof. 
+\begin{code}
+{-@ geqZeroNat :: n:Nat -> {leqInt 0 n} @-}
+geqZeroNat n = leqInt 0 n *** QED 
+\end{code}
+
+
+We then reduce the above property to the respective property on Peano numbers.
+\begin{code}
+{-@ geqZeroByReduction :: n:Peano -> {leqPeanoNat Z n} @-}
+geqZeroByReduction n 
+  = leqPeanoNat Z n ==. True 
+  ? reduction toNat geqZeroNat n 
+  *** QED 
+\end{code}
+
+The reduction occurs via the function `reduction`.
+The function `reduction f thm n`, for each homomorphism `f :: a -> b`, 
+reduces a theorem `thm x` on `a`s to the respective theorems on `b` via 
+[Abstract Refinements][abstract-refinements].
+\begin{code}
+{-@ reduction :: forall<p :: a -> Proof -> Bool>. 
+                 f:(b -> a) 
+              -> (x:a -> Proof<p x>) 
+              -> (y:b -> Proof<p (f y)>) @-}
+reduction :: (b -> a) -> (a -> Proof) -> (b -> Proof)
+reduction f thm y = thm (f y)              
+\end{code}
+
+Users with model theoretic background may observe that `reduction` 
+is actually encoding [Łoś–Tarski preservation theorem][preservation-theorem]!
+
+Similarly, `reduction2` reduces theorems with two `a` arguments
+to theorems with two `b` arguments via a homomorphism. 
+
+\begin{code}
+{-@ reduction2 :: forall<p :: a -> a -> Proof -> Bool >. 
+                  f:(b -> a) 
+               -> (x1:a -> x2:a -> Proof<p x1 x2>) 
+               -> (y1:b -> y2:b-> Proof<p (f y1) (f y2)>) @-}
+reduction2 :: (b -> a) -> (a -> a -> Proof) -> (b -> b -> Proof)
+reduction2 f thm y1 y2  = thm (f y1) (f y2)
+\end{code}
+
+For example, the SMT-automated proof of totality on Natural numbers 
+\begin{code}
+{-@ leqTotalNat :: n:Nat -> m:Nat -> { leqInt n m || leqInt m n } @-}
+leqTotalNat n m = (leqInt n m || leqInt m n) *** QED 
+\end{code}
+
+can be easily reduced to totality on Peano numbers
+
+\begin{code}
+{-@ leqTotalByReduction :: n:Peano -> m:Peano
+   -> { leqPeanoNat n m || leqPeanoNat m n } @-}
+leqTotalByReduction n m 
+  = (leqPeanoNat n m || leqPeanoNat m n) ==. True 
+  ? reduction2 toNat leqTotalNat n m  
+  *** QED 
+\end{code}
+
+
+Conclusion
+-----------
+
+We presented an example of how the SMT-automated proofs on 
+Natural numbers can be reduced to the respective proofs on the 
+Peano numbers, because Peano are homomorphic to Natural numbers. 
+
+Proof reduction greatly simplifies proof composition
+as it allows for shorter and more elegant proofs 
+that take advantage of SMT-automated or other existing
+proofs on homomorphic data structures. 
+
+
+[refinement-reflection]: http://goto.ucsd.edu/~rjhala/liquid/haskell/blog/blog/2016/09/18/refinement-reflection.lhs/
+[reduction-lib]: https://github.com/ucsd-progsys/liquidhaskell/tree/develop/include/Language/Haskell/Liquid/Reduction.hs
+[abstract-refinements]: http://goto.ucsd.edu/~rjhala/liquid/haskell/blog/blog/2013/06/03/abstracting-over-refinements.lhs/
+[preservation-theorem]: https://en.wikipedia.org/wiki/%C5%81o%C5%9B%E2%80%93Tarski_preservation_theorem

--- a/docs/blog/todo/Iso.lhs
+++ b/docs/blog/todo/Iso.lhs
@@ -1,0 +1,281 @@
+---
+layout: post
+title: "Isomorphisms"
+date: 2016-24-12 
+author: Vikraman Choudhury 
+published: false
+comments: true
+external-url:
+categories: basic
+demo: Iso.hs
+---
+
+\begin{comment}
+\begin{code}
+{-@ LIQUID "--higherorder" @-}
+{-@ LIQUID "--totalhaskell" @-}
+{-@ LIQUID "--exactdc" @-}
+{-@ LIQUID "--diffcheck" @-}
+
+module Iso where
+
+import Language.Haskell.Liquid.ProofCombinators
+\end{code}
+\end{comment}
+
+In this blog post, we show how to use Liquid Haskell to build "verified" typeclasses. A verified typeclass allows one to
+express typeclass laws directly as Haskell code. We also show a technique to build verified instances and scale them up
+to compound datatypes using isomorphisms.
+
+First, we'll express verified typeclasses using Haskell records, but with LiquidHaskell refinements to express laws. As
+an example, let's define `VerifiedOrd`, which is the same as the `Ord` typeclass, but with total order laws added.
+
+\begin{code}
+{-@ data VerifiedOrd a = VerifiedOrd {
+      leq     :: a -> a -> Bool
+    , refl    :: x:a -> { Prop (leq x x) }
+    , antisym :: x:a -> y:a -> { Prop (leq x y) && Prop (leq y x) ==> x == y }
+    , trans   :: x:a -> y:a -> z:a -> { Prop (leq x y) && Prop (leq y z) ==> Prop (leq x z) }
+    , total   :: x:a -> y:a -> { Prop (leq x y) || Prop (leq y x) }
+    }
+@-}
+data VerifiedOrd a = VerifiedOrd {
+    leq     :: a -> a -> Bool
+  , refl    :: a -> Proof
+  , antisym :: a -> a -> Proof
+  , trans   :: a -> a -> a -> Proof
+  , total   :: a -> a -> Proof
+}
+\end{code}
+
+The `leq` function represents the `<=` operator in `Ord`, and `refl`, `antisym`, `trans`, `total`, express the
+reflexivity, antisymmetry, transitivity and totality properties respectively, that a total order requires. Notice how
+the refinements express the laws, and the actual code is simply a function that returns `Proof` or `()`.
+
+Now, let's see how to define some simple verified instances. We need to instantiate `leq` for our type, "reflect" it
+into the logic, and prove all the required properties. For primitive types like `Int` or `Double`, it's "trivial"
+because we trust the SMT solver which already knows about integers.
+
+\begin{code}
+{-@ axiomatize leqInt @-}
+leqInt :: Int -> Int -> Bool
+leqInt x y = x <= y
+
+{-@ leqIntRefl :: x:Int -> { leqInt x x } @-}
+leqIntRefl :: Int -> Proof
+leqIntRefl x = leqInt x x ==. x <= x *** QED
+
+{-@ leqIntAntisym :: x:Int -> y:Int -> { leqInt x y && leqInt y x ==> x == y } @-}
+leqIntAntisym :: Int -> Int -> Proof
+leqIntAntisym x y = (leqInt x y && leqInt y x) ==. (x <= y && y <= x) ==. x == y *** QED
+
+{-@ leqIntTrans :: x:Int -> y:Int -> z:Int -> { leqInt x y && leqInt y z ==> leqInt x z } @-}
+leqIntTrans :: Int -> Int -> Int -> Proof
+leqIntTrans x y z = (leqInt x y && leqInt y z) ==. (x <= y && y <= z) ==. x <= z ==. leqInt x z *** QED
+
+{-@ leqIntTotal :: x:Int -> y:Int -> { leqInt x y || leqInt y x } @-}
+leqIntTotal :: Int -> Int -> Proof
+leqIntTotal x y = (leqInt x y || leqInt y x) ==. (x <= y || y <= x) *** QED
+
+vordInt :: VerifiedOrd Int
+vordInt = VerifiedOrd leqInt leqIntRefl leqIntAntisym leqIntTrans leqIntTotal
+\end{code}
+
+How about a complex datatype? Let's consider an inductive datatype, the peano natural numbers. Not surprisingly, the
+proofs follow by induction. For conciseness, we only show totality and elide the rest.
+
+\begin{code}
+{-@ data Peano [toNat] = Z | S Peano @-}
+data Peano = Z | S Peano deriving (Eq)
+
+{-@ measure toNat @-}
+{-@ toNat :: Peano -> { n:Int | 0 <= n } @-}
+toNat :: Peano -> Int
+toNat Z = 0
+toNat (S n) = 1 + toNat n
+
+{-@ axiomatize leqPeano @-}
+leqPeano :: Peano -> Peano -> Bool
+leqPeano Z _ = True
+leqPeano _ Z = False
+leqPeano (S n) (S m) = leqPeano n m
+
+{-@ leqNTotal :: n:Peano -> m:Peano -> {(leqPeano n m) || (leqPeano m n)} / [toNat n + toNat m] @-}
+leqNTotal :: Peano -> Peano -> Proof
+leqNTotal Z m = leqPeano Z m *** QED
+leqNTotal n Z = leqPeano Z n *** QED
+leqNTotal (S n) (S m)
+  =   (leqPeano (S n) (S m) || leqPeano (S m) (S n))
+  ==. (leqPeano n m || leqPeano (S m) (S n)) ? (leqNTotal n m )
+  ==. (leqPeano n m || leqPeano m n) ? (leqNTotal m n)
+  *** QED
+\end{code}
+
+Writing down proofs for more complex datatypes is tedious, it requires case analysis for each constructor and using the
+induction hypothesis. However, we can decompose Haskell datatypes into sums and products, and we can build up compound
+proofs using isomorphisms! To that end, we design some machinery to express isomorphisms, and prove that laws are
+preserved under isomorphic images.
+
+\begin{code}
+{-@ data Iso a b = Iso {
+      to   :: a -> b
+    , from :: b -> a
+    , tof  :: y:b -> { to (from y) == y }
+    , fot  :: x:a -> { from (to x) == x }
+    }
+@-}
+data Iso a b = Iso {
+    to   :: a -> b
+  , from :: b -> a
+  , tof  :: b -> Proof
+  , fot  :: a -> Proof
+}
+\end{code}
+
+An isomorphism between types `a` and `b` is a pair of functions `to :: a -> b` and `from :: b -> a` that are mutually
+inverse to each other. We now claim that total order laws are preserved under `Iso`; this amounts to building up a
+`VerifiedOrd b`, given a `VerifiedOrd a` and an `Iso a b`.
+
+\begin{code}
+{-@ axiomatize leqFrom @-}
+leqFrom :: (a -> a -> Bool)
+        -> (b -> a)
+        -> (b -> b -> Bool)
+leqFrom leqa from x y = leqa (from x) (from y)
+
+{-@ leqFromRefl :: leqa:(a -> a -> Bool) -> leqaRefl:(x:a -> { Prop (leqa x x) })
+                -> from:(b -> a)
+                -> x:b -> { leqFrom leqa from x x }
+@-}
+leqFromRefl :: (a -> a -> Bool) -> (a -> Proof)
+            -> (b -> a)
+            -> b -> Proof
+leqFromRefl leqa leqaRefl from x =
+      leqFrom leqa from x x
+  ==. leqa (from x) (from x)
+  ==. True ? leqaRefl (from x)
+  *** QED
+
+{-@ leqFromAntisym :: leqa:(a -> a -> Bool)
+                   -> leqaAntisym:(x:a -> y:a -> { Prop (leqa x y) && Prop (leqa y x) ==> x == y })
+                   -> to:(a -> b) -> from:(b -> a) -> tof:(y:b -> { to (from y) == y })
+                   -> x:b -> y:b -> { leqFrom leqa from x y && leqFrom leqa from y x ==> x == y }
+@-}
+leqFromAntisym :: (Eq a, Eq b)
+               => (a -> a -> Bool) -> (a -> a -> Proof)
+               -> (a -> b) -> (b -> a) -> (b -> Proof)
+               -> b -> b -> Proof
+leqFromAntisym leqa leqaAntisym to from tof x y
+  =   (leqFrom leqa from x y && leqFrom leqa from y x)
+  ==. (leqa (from x) (from y) && leqa (from y) (from x))
+  ==. from x == from y ? leqaAntisym (from x) (from y)
+  ==. to (from x) == to (from y)
+  ==. x == to (from y) ? tof x
+  ==. x == y           ? tof y
+  *** QED
+
+{-@ leqFromTrans :: leqa:(a -> a -> Bool)
+                 -> leqaTrans:(x:a -> y:a -> z:a -> { Prop (leqa x y) && Prop (leqa y z) ==> Prop (leqa x z) })
+                 -> from:(b -> a)
+                 -> x:b -> y:b -> z:b
+                 -> { leqFrom leqa from x y && leqFrom leqa from y z ==> leqFrom leqa from x z }
+@-}
+leqFromTrans :: (a -> a -> Bool) -> (a -> a -> a -> Proof)
+             -> (b -> a)
+             -> b -> b -> b -> Proof
+leqFromTrans leqa leqaTrans from x y z =
+      (leqFrom leqa from x y && leqFrom leqa from y z)
+  ==. (leqa (from x) (from y) && leqa (from y) (from z))
+  ==. leqa (from x) (from z) ? leqaTrans (from x) (from y) (from z)
+  ==. leqFrom leqa from x z
+  *** QED
+
+{-@ leqFromTotal :: leqa:(a -> a -> Bool) -> leqaTotal:(x:a -> y:a -> { Prop (leqa x y) || Prop (leqa y x) })
+                 -> from:(b -> a) -> x:b -> y:b -> { leqFrom leqa from x y || leqFrom leqa from y x }
+@-}
+leqFromTotal :: (a -> a -> Bool) -> (a -> a -> Proof)
+             -> (b -> a) -> b -> b -> Proof
+leqFromTotal leqa leqaTotal from x y =
+      (leqFrom leqa from x y || leqFrom leqa from y x)
+  ==. (leqa (from x) (from y) || leqa (from y) (from x))
+  ==. True ? leqaTotal (from x) (from y)
+  ==. leqFrom leqa from y x
+  *** QED
+
+vordIso :: (Eq a, Eq b) => Iso a b -> VerifiedOrd a -> VerifiedOrd b
+vordIso (Iso to from tof fot) (VerifiedOrd leqa leqaRefl leqaAntisym leqaTrans leqaTotal) =
+  VerifiedOrd
+    (leqFrom leqa from)
+    (leqFromRefl leqa leqaRefl from)
+    (leqFromAntisym leqa leqaAntisym to from tof)
+    (leqFromTrans leqa leqaTrans from)
+    (leqFromTotal leqa leqaTotal from)
+\end{code}
+
+We can now write a `VerifiedOrd` for `Peano` by mapping it onto `type Nat = { n:Int | 0 <= n }`, which is easier to
+prove properties about because it's just an integer!
+
+\begin{code}
+{-@ type Nat = { n:Int | 0 <= n } @-}
+type Nat = Int
+
+{-@ axiomatize fromNat @-}
+{-@ fromNat :: Nat -> Peano @-}
+fromNat :: Nat -> Peano
+fromNat n
+  | n == 0 = Z
+  | otherwise = S (fromNat (n - 1))
+
+{-@ toFrom :: x:Nat -> { toNat (fromNat x) == x } @-}
+toFrom :: Nat -> Proof
+toFrom n
+  | n == 0 = toNat (fromNat 0) ==. toNat Z ==. 0 *** QED
+  | n > 0 = toNat (fromNat n)
+        ==. toNat (S (fromNat (n - 1)))
+        ==. 1 + toNat (fromNat (n - 1))
+        ==. 1 + (n - 1) ? toFrom (n - 1)
+        ==. n
+        *** QED
+
+{-@ fromTo :: x:Peano -> { fromNat (toNat x) == x } @-}
+fromTo :: Peano -> Proof
+fromTo Z = fromNat (toNat Z) ==. fromNat 0 ==. Z *** QED
+fromTo (S n) = fromNat (toNat (S n))
+           ==. fromNat (1 + toNat n)
+           ==. S (fromNat ((1 + toNat n) - 1))
+           ==. S (fromNat (toNat n))
+           ==. S n ? fromTo n
+           *** QED
+
+{-@ isoNatPeano :: Iso Nat Peano @-}
+isoNatPeano :: Iso Nat Peano
+isoNatPeano = Iso fromNat toNat fromTo toFrom
+
+vordNat :: VerifiedOrd Nat
+vordNat = VerifiedOrd leqInt leqIntRefl leqIntAntisym leqIntTrans leqIntTotal
+
+vordPeano :: VerifiedOrd Peano
+vordPeano = vordIso isoNatPeano vordNat
+\end{code}
+
+Similarly, we can break down compound datatypes into sums and products, just like what happens in `GHC.Generics`, and
+use the isomorphism to write down `VerifiedOrd` instances. We do however need to provide instances of `VerifiedOrd` for
+sums and products.
+
+\begin{code}
+vordProd :: VerifiedOrd a -> VerifiedOrd b -> VerifiedOrd (a, b)
+vordSum :: VerifiedOrd a -> VerifiedOrd b -> VerifiedOrd (Either a b)
+\end{code}
+
+\begin{comment}
+\begin{code}
+vordSum = undefined
+vordProd = undefined
+\end{code}
+\end{comment}
+
+Our [library](https://github.com/iu-parfunc/verified-instances) explores this idea to build some verified typeclasses,
+such as `VerifiedOrd` and `VerifiedMonoid`. We also provide combinators to build verified instances by using
+isomorphisms. Also, using a [reflection hack](https://www.schoolofhaskell.com/user/thoughtpolice/using-reflection), we
+can reify these "verified" terms to typeclass dictionaries at runtime, to call legacy functions which require `Ord`
+constraints and so on.

--- a/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -128,7 +128,9 @@ makeAssumeType tce lmap x v xts ams def = assumedtype
     grapBody (Tick _ e) = grapBody e
     grapBody e          = ([], e)
 
-    xss = [(F.symbol x, rTypeSort tce t) | (x, t) <- zip xs (ty_args (toRTypeRep at)), not (isClassType t)]
+    xss = [(mkSymbol x t, rTypeSort tce t) | (x, t) <- zip xs (ty_args (toRTypeRep at)), not (isClassType t)]
+
+    mkSymbol x t = if isFunTy t then simplesymbol x else F.symbol x 
 
 
     ty_non_dict_binds trep = [x | (x, t) <- zip (ty_binds trep) (ty_args trep), not (isClassType t)]

--- a/src/Language/Haskell/Liquid/Constraint/Axioms.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Axioms.hs
@@ -556,7 +556,7 @@ initAEEnv info sigs
          lts   <- cgLits      <$> get
          i     <- freshIndex  <$> get
          modify $ \s -> s{freshIndex = i + 1}
-         return $ AE { ae_axioms  = gsAxioms spc
+         return $ AE { ae_axioms  = gsReflects spc
                      , ae_binds   = []
                      , ae_lmap    = gsLogicMap spc
                      , ae_consts  = L.nub vs

--- a/src/Language/Haskell/Liquid/Constraint/Qualifier.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Qualifier.hs
@@ -132,7 +132,7 @@ specBinders info = mconcat
     sp  = spec info 
 
 specAxiomVars :: GhcInfo -> [Var]
-specAxiomVars =  map (fst . aname) . gsAxioms . spec
+specAxiomVars =  map (fst . aname) . gsReflects . spec
 
 -- GRAVEYARD: scraping quals from imports kills the system with too much crap
 -- specificationQualifiers info = {- filter okQual -} qs

--- a/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
+++ b/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
@@ -35,7 +35,7 @@ ignoreQualifiers info fi
   -- NOPROP where noQuals = (FC.All == ) . eliminate . getConfig . spec $ info
 
 targetFInfo :: GhcInfo -> CGInfo -> F.FInfo Cinfo
-targetFInfo info cgi = F.fi cs ws bs ls consts ks qs bi aHO aHOqs
+targetFInfo info cgi = F.fi cs ws bs ls consts ks qs bi aHO aHOqs es 
   where
     cs               = fixCs    cgi
     ws               = fixWfs   cgi
@@ -47,3 +47,4 @@ targetFInfo info cgi = F.fi cs ws bs ls consts ks qs bi aHO aHOqs
     bi               = (`Ci` Nothing) <$> bindSpans cgi
     aHO              = allowHO cgi
     aHOqs            = higherOrderFlag info
+    es               = gsAxioms (spec info)

--- a/src/Language/Haskell/Liquid/Measure.hs
+++ b/src/Language/Haskell/Liquid/Measure.hs
@@ -64,7 +64,8 @@ data Spec ty bndr  = Spec
   , decr       :: ![(LocSymbol, [Int])]          -- ^ Information on decreasing arguments
   , lvars      :: ![LocSymbol]                   -- ^ Variables that should be checked in the environment they are used
   , lazy       :: !(S.HashSet LocSymbol)         -- ^ Ignore Termination Check in these Functions
-  , axioms     :: !(S.HashSet LocSymbol)         -- ^ Binders to turn into axiomatized functions
+  , axioms     :: !(S.HashSet LocSymbol)         -- ^ Binders to turn into SMT axioms 
+  , reflects   :: !(S.HashSet LocSymbol)         -- ^ Binders to turn into axiomatized functions
   , hmeas      :: !(S.HashSet LocSymbol)         -- ^ Binders to turn into measures using haskell definitions
   , hbounds    :: !(S.HashSet LocSymbol)         -- ^ Binders to turn into bounds using haskell definitions
   , inlines    :: !(S.HashSet LocSymbol)         -- ^ Binders to turn into logic inline using haskell definitions
@@ -148,6 +149,7 @@ instance Monoid (Spec ty bndr) where
            , lvars      =           lvars s1      ++ lvars s2
            , lazy       = S.union   (lazy s1)        (lazy s2)
            , axioms     = S.union   (axioms s1)      (axioms s2)
+           , reflects   = S.union   (reflects s1)    (reflects s2)
            , hmeas      = S.union   (hmeas s1)       (hmeas s2)
            , hbounds    = S.union   (hbounds s1)     (hbounds s2)
            , inlines    = S.union   (inlines s1)     (inlines s2)
@@ -183,6 +185,7 @@ instance Monoid (Spec ty bndr) where
            , lazy       = S.empty
            , hmeas      = S.empty
            , axioms     = S.empty
+           , reflects   = S.empty
            , hbounds    = S.empty
            , inlines    = S.empty
            , autosize   = S.empty

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -688,6 +688,7 @@ data Pspec ty ctor
   | Lazy    LocSymbol
   | HMeas   LocSymbol
   | Axiom   LocSymbol
+  | Reflect LocSymbol
   | Inline  LocSymbol
   | ASize   LocSymbol
   | HBound  LocSymbol
@@ -723,6 +724,7 @@ instance Show (Pspec a b) where
   show (LVars  _) = "LVars"
   show (Lazy   _) = "Lazy"
   show (Axiom  _) = "Axiom"
+  show (Reflect _) = "Reflect"
   show (HMeas  _) = "HMeas"
   show (HBound _) = "HBound"
   show (Inline _) = "Inline"
@@ -758,6 +760,7 @@ mkSpec name xs         = (name,) $ Measure.qualifySpec (symbol name) Measure.Spe
   , Measure.lvars      = [d | LVars d  <- xs]
   , Measure.lazy       = S.fromList [s | Lazy   s <- xs]
   , Measure.axioms     = S.fromList [s | Axiom  s <- xs]
+  , Measure.reflects   = S.fromList [s | Reflect s <- xs]
   , Measure.hmeas      = S.fromList [s | HMeas  s <- xs]
   , Measure.inlines    = S.fromList [s | Inline s <- xs]
   , Measure.autosize   = S.fromList [s | ASize  s <- xs]
@@ -780,7 +783,7 @@ specP
     <|> (reservedToken "autosize"     >> liftM ASize  asizeP    )
     <|> (reservedToken "Local"        >> liftM LAsrt  tyBindP   )
     <|> (reservedToken "axiomatize"   >> liftM Axiom  axiomP    )
-    <|> (reservedToken "reflect"      >> liftM Axiom  axiomP    )
+    <|> (reservedToken "reflect"      >> liftM Reflect  axiomP    )
     <|> try (reservedToken "measure"  >> liftM Meas   measureP  )
     <|> (reservedToken "define"   >> liftM Define defineP   )
     <|> try (reservedToken "infixl"   >> liftM BFix   infixlP   )

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -199,7 +199,7 @@ module Language.Haskell.Liquid.Types (
   -- * String Literals
   , liquidBegin, liquidEnd
 
-  , Axiom(..), HAxiom, LAxiom
+  , Axiom(..), HAxiom, LAxiom, SMTAxiom
 
   , rtyVarUniqueSymbol, tyVarUniqueSymbol, rtyVarType
   )
@@ -350,7 +350,8 @@ data GhcSpec = SP {
   , gsMeasures  :: [Measure SpecType DataCon]
   , gsTyconEnv  :: M.HashMap TyCon RTyCon
   , gsDicts     :: DEnv Var SpecType              -- ^ Dictionary Environment
-  , gsAxioms    :: [HAxiom]                       -- ^ Axioms from axiomatized functions
+  , gsAxioms    :: [SMTAxiom]                     -- ^ Axioms from axiomatized functions
+  , gsReflects  :: [HAxiom]                       -- ^ Axioms from reflected functions 
   , gsLogicMap  :: LogicMap
   , gsProofType :: Maybe Type
   , gsRTAliases :: !RTEnv                         -- ^ Refinement type aliases
@@ -1001,6 +1002,7 @@ data Axiom b s e = Axiom { aname  :: (Var, Maybe DataCon)
 type HAxiom = Axiom Var Type CoreExpr
 type LAxiom = Axiom Symbol Sort Expr
 
+type SMTAxiom = Expr 
 
 instance Show (Axiom Var Type CoreExpr) where
   show (Axiom (n, c) v bs _ts lhs rhs) = "Axiom : " ++

--- a/tests/neg/Automate.hs
+++ b/tests/neg/Automate.hs
@@ -1,0 +1,35 @@
+module Automate where
+
+import Language.Haskell.Liquid.ProofCombinators 
+
+
+fibA :: Int -> Int 
+{-@ axiomatize fibA @-}
+{-@ fibA :: Nat -> Nat @-}
+fibA i | i <= 1 = i
+      | otherwise = fibA (i-1) + fibA (i-2)
+
+
+fibR :: Int -> Int 
+{-@ reflect fibR @-}
+{-@ fibR :: Nat -> Nat @-}
+fibR i | i <= 1 = i
+      | otherwise = fibR (i-1) + fibR (i-2)
+
+
+{-@ prop :: () -> {fibA 30 == 832040 } @-}
+prop :: () -> Proof 
+prop _ = trivial  
+
+-- This is unsafe because it is actually false 
+
+{-@ propUNSAFE :: () -> {fibA 30 == 832042 } @-}
+propUNSAFE :: () -> Proof 
+propUNSAFE _ = trivial  
+
+
+-- This is unsafe because the reflected fibR (vs. axiomatized fibA)
+-- does not create an SMT axiom
+{-@ propR :: () -> {fibR 30 == 832040 } @-}
+propR :: () -> Proof 
+propR _ = trivial  

--- a/tests/pos/Automate.hs
+++ b/tests/pos/Automate.hs
@@ -9,6 +9,11 @@ fibA :: Int -> Int
 fibA i | i <= 1 = i
       | otherwise = fibA (i-1) + fibA (i-2)
 
+fibUp :: Int -> Proof 
+{-@ fibUp :: i:Nat -> {fibA i <= fibA (i+1)} @-}
+fibUp i 
+ | i <= 2    = trivial
+ | otherwise = fibUp (i-1) &&& fibUp (i-2) *** QED 
 
 {-@ prop :: () -> {fibA 30 == 832040 } @-}
 prop :: () -> Proof 

--- a/tests/pos/Automate.hs
+++ b/tests/pos/Automate.hs
@@ -1,0 +1,15 @@
+module Automate where
+
+import Language.Haskell.Liquid.ProofCombinators 
+
+
+fibA :: Int -> Int 
+{-@ axiomatize fibA @-}
+{-@ fibA :: Nat -> Nat @-}
+fibA i | i <= 1 = i
+      | otherwise = fibA (i-1) + fibA (i-2)
+
+
+{-@ prop :: () -> {fibA 30 == 832040 } @-}
+prop :: () -> Proof 
+prop _ = trivial  


### PR DESCRIPTION
See tests/pos|neg/Automate.hs for axiomatization of the fib function. 

Surprisingly, SMT proving `fibA 30 == 832040` is faster than running `fibA 30` in Haskell! 

I suggest 
  - rename all current axiomatize to reflect 
  - use the current reflect to build further fuel strategies etc?