### PR TITLE
triggering interface

### DIFF
--- a/benchmarks/pldi17/pos/MapFusion.hs
+++ b/benchmarks/pldi17/pos/MapFusion.hs
@@ -14,7 +14,7 @@ import Prelude hiding (map)
 
 import Proves
 
-{-@ reflect compose @-}
+{-@ axiomatize compose @-}
 compose :: (b -> c) -> (a -> b) -> a -> c
 compose f g x = f (g x)
 

--- a/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
+++ b/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
@@ -47,4 +47,4 @@ targetFInfo info cgi = F.fi cs ws bs ls consts ks qs bi aHO aHOqs es
     bi               = (`Ci` Nothing) <$> bindSpans cgi
     aHO              = allowHO cgi
     aHOqs            = higherOrderFlag info
-    es               = gsAxioms (spec info)
+    es               = F.defaultTrigger <$> gsAxioms (spec info)

--- a/src/Test/Target/Serialize.hs
+++ b/src/Test/Target/Serialize.hs
@@ -114,6 +114,7 @@ instance SMTLIB2 Command where
   smt2 (Define t)          = build "(declare-sort {})"            (Only $ smt2 t)
   smt2 (Assert Nothing p)  = build "(assert {})"                  (Only $ smt2 p)
   smt2 (Assert (Just i) p) = build "(assert (! {} :named p-{}))"  (smt2 p, i)
+  smt2 (AssertAxiom t)     = build "(assert {})"                  (Only $ smt2 t)
   smt2 (Distinct az)       = build "(assert (distinct {}))"       (Only $ smt2s az)
   smt2 (Push)              = "(push 1)"
   smt2 (Pop)               = "(pop 1)"
@@ -122,6 +123,8 @@ instance SMTLIB2 Command where
                            $ ["(get-value ("] ++ fmap smt2 xs ++ ["))"]
   smt2 (CMany cmds)        = smt2many (smt2 <$> cmds)
 
+instance SMTLIB2 (Triggered Expr) where
+  smt2 (TR _ e) = smt2 e  
 
 smt2s    :: SMTLIB2 a => [a] -> Builder
 smt2s as = smt2many (smt2 <$> as)


### PR DESCRIPTION
Adding a trigger to only instantiate axioms when the left hand side of the axioms equality is ground.

This trigger does not diverge when the compose axiom exists, which made most of our pldi example diverge!

Currently all axiomatized functions use the default (LeftHandSide) trigger https://github.com/ucsd-progsys/liquidhaskell/blob/10178fd99f89fce9e8822ae666a19bbe307d1a1f/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs#L50.

Since all axiomatized functions terminate this trigger should not diverge, but who knows...