### PR TITLE
Ensure installation via cabal

### DIFF
--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -263,8 +263,7 @@ test-suite test
                ,     filepath >= 1.3
                ,     mtl >= 2.1
                ,     process >= 1.2
-               ,     optparse-applicative >= 0.13
-               ,     semigroups >= 0.18
+               ,     optparse-applicative >= 0.11 && < 0.13
                ,     stm >= 2.4
                ,     tagged >= 0.7.3
                ,     tasty >= 0.10

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -58,7 +58,7 @@ Flag include
 
 Executable liquid
   default-language: Haskell98
-  Build-Depends: base >= 4 && < 5
+  Build-Depends: base == 4.8.*
                , ghc
                , cmdargs
                , deepseq
@@ -77,7 +77,7 @@ Executable liquid
 
 Executable lhi
   default-language: Haskell98
-  Build-Depends: base >= 4 && < 5
+  Build-Depends: base == 4.8.*
                , ghc
                , cmdargs
                , deepseq
@@ -103,7 +103,7 @@ Executable lhi
 
 Library
    Default-Language: Haskell98
-   Build-Depends: base >= 4 && < 5
+   Build-Depends: base == 4.8.*
                 , ghc >= 7.10.2 && < 7.11
                 , template-haskell >= 2.9
                 , time >= 1.4
@@ -131,7 +131,7 @@ Library
                 , liquid-fixpoint >= 0.5 && < 0.6
                 , located-base
                 -- , prover
-                , aeson >= 0.10
+                , aeson >= 0.10 && < 1.0
                 , bytestring >= 0.10
                 , fingertree >= 0.1
                 , Cabal >= 1.18
@@ -257,13 +257,14 @@ test-suite test
   if flag(devel)
     ghc-options: -Werror
   main-is:           test.hs
-  build-depends:     base  >= 4 && < 5
+  build-depends:     base  == 4.8.*
                ,     containers >= 0.5
                ,     directory >= 1.2
                ,     filepath >= 1.3
                ,     mtl >= 2.1
                ,     process >= 1.2
-               ,     optparse-applicative >= 0.11
+               ,     optparse-applicative >= 0.13
+               ,     semigroups >= 0.18
                ,     stm >= 2.4
                ,     tagged >= 0.7.3
                ,     tasty >= 0.10

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -15,6 +15,7 @@ import qualified Data.IntMap as IntMap
 import Data.Maybe (fromMaybe)
 import Data.Monoid (Sum(..))
 import Data.Proxy
+import Data.Semigroup ((<>))
 import Data.Tagged
 import Data.Typeable
 import Options.Applicative

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -15,7 +15,6 @@ import qualified Data.IntMap as IntMap
 import Data.Maybe (fromMaybe)
 import Data.Monoid (Sum(..))
 import Data.Proxy
-import Data.Semigroup ((<>))
 import Data.Tagged
 import Data.Typeable
 import Options.Applicative


### PR DESCRIPTION
1. Limit the compiler to GHC 7.10.*
2. Add missing bounds on aeson
3. Use optparse-applicative-0.13 in the tests.

The 3rd can be done alternately by adding an upper bound of
optparse-applicative < 0.13, in which case the new semigroups dependancy and
change to test.hs are not needed.