### PR TITLE
Enable Hackage-friendly stack.yaml setting

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -17,3 +17,4 @@ extra-deps:
 - located-base-0.1.1.0
 compiler-check: newer-minor
 resolver: nightly-2016-05-21
+pvp-bounds: both


### PR DESCRIPTION
This will transparently add upper and lower bounds to all package dependencies not currently having them, based on the snapshot in use, when the package is uploaded via either stack upload or stack sdist.