### PR TITLE
Add trivial parser test suite

### DIFF
--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -281,3 +281,19 @@ test-suite test
                ,     tasty-hunit >= 0.9
                ,     tasty-rerun >= 1.1
                ,     transformers >= 0.3
+
+test-suite liquidhaskell-parser
+  default-language: Haskell2010
+  type: exitcode-stdio-1.0
+  hs-source-dirs: tests
+  ghc-options: -W
+  main-is: Parser.hs
+  build-depends:
+    base  >= 4 && < 5,
+    liquidhaskell,
+    HUnit,
+    hspec,
+    parsec,
+    bifunctors,
+    text,
+    mtl

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -701,10 +701,10 @@ data Pspec ty ctor
   | Varia   (LocSymbol, [Variance])
   | BFix    ()
   | Define  (LocSymbol, Symbol)
-  deriving (Data, Typeable)
+  deriving (Data, Typeable, Show)
 
 -- | For debugging
-instance Show (Pspec a b) where
+{-instance Show (Pspec a b) where
   show (Meas   _) = "Meas"
   show (Assm   _) = "Assm"
   show (Asrt   _) = "Asrt"
@@ -738,7 +738,7 @@ instance Show (Pspec a b) where
   show (RInst  _) = "RInst"
   show (ASize  _) = "ASize"
   show (BFix   _) = "BFix"
-  show (Define _) = "Define"
+  show (Define _) = "Define"-}
 
 mkSpec :: ModName -> [BPspec] -> (ModName, Measure.Spec (Located BareType) LocSymbol)
 mkSpec name xs         = (name,) $ Measure.qualifySpec (symbol name) Measure.Spec

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -995,7 +995,7 @@ data RInstance t = RI
   { riclass :: BTyCon
   , ritype  :: [t]
   , risigs  :: [(LocSymbol, RISig t)]
-  } deriving (Generic, Functor, Data, Typeable)
+  } deriving (Generic, Functor, Data, Typeable, Show)
 
 data RISig t = RIAssumed t | RISig t
   deriving (Generic, Functor, Data, Typeable, Show)

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -1,0 +1,58 @@
+-- | Simple test suite to test the parser.
+--
+-- Run as:
+--
+-- $ stack test :liquidhaskell-parser
+
+module Main where
+
+import           Data.Bifunctor
+import qualified Language.Haskell.Liquid.Parse as LH
+import qualified Language.Haskell.Liquid.Types as LH
+import           Test.Hspec
+import           Text.Parsec.Pos
+
+-- | Test suite entry point, returns exit failure if any test fails.
+main :: IO ()
+main = hspec spec
+
+-- | Test suite.
+spec :: Spec
+spec = do
+  describe "Should succeed" succeeds
+  describe "Should fail" fails
+
+-- | Tests for the parser.
+succeeds :: Spec
+succeeds = do
+  it
+    "Int"
+    (shouldBe
+       (parseSingleSpec "x :: Int")
+       (Right
+          "Asrts ([\"x\" defined from: \"<test input>\" (line 1, column 1) to: \"<test input>\" (line 1, column 2)],(Int defined from: \"<test input>\" (line 1, column 6) to: \"<test input>\" (line 1, column 9),Nothing))"))
+  it
+    "k:Int -> Int"
+    (shouldBe
+       (parseSingleSpec "x :: k:Int -> Int")
+       (Right
+          "Asrts ([\"x\" defined from: \"<test input>\" (line 1, column 1) to: \"<test input>\" (line 1, column 2)],(k:Int -> Int defined from: \"<test input>\" (line 1, column 6) to: \"<test input>\" (line 1, column 18),Nothing))"))
+
+fails :: Spec
+fails = do
+  it
+    "Maybe k:Int -> Int"
+    (shouldBe
+       (bimap
+          (unwords . words . show)
+          show
+          (parseSingleSpec "x :: Maybe k:Int -> Int"))
+       (Left
+          "<test input>:1:13: Error: Cannot parse specification: Leftover while parsing"))
+
+-- | Parse a single type signature containing LH refinements. To be
+-- used in the REPL.
+parseSingleSpec
+  :: String
+  -> Either LH.Error String
+parseSingleSpec = fmap show . (LH.singleSpecP (initialPos "<test input>"))


### PR DESCRIPTION
I anticipate this is an easy to merge PR. This adds a simple test suite that you can run like this:

```
bash-3.2$ stack test :liquidhaskell-parser
liquidhaskell-0.7.0.0: test (suite: liquidhaskell-parser)


Should succeed
  Int
  k:Int -> Int
Should fail
  Maybe k:Int -> Int

Finished in 0.0048 seconds
3 examples, 0 failures
```

I spent most of my energy on trying to get Eq or Show instances for the `Pspec` and related types, but gave up. So I just put in three cases. The Show instance for Psec is now derived. If you want the debugging one, it's still there commented out. 

When you discover a new case (that should or shouldn't work), you just run this in the REPL

```haskell
> parseSingleSpec "a :: {x:Int|x>0} -> ()"
Right "Asrts ([\"a\" defined from: \"<test input>\" (line 1, column 1) to: \"<test input>\" (line 1, column 2)],(lq_tmp$db##0:{x##1 : Int | x##1 > 0} -> () defined from: \"<test input>\" (line 1, column 6) to: \"<test input>\" (line 1, column 23),Nothing))"
```

and then you can just copy/paste that into the test suite as a fail/succeed case. 

As I discover odd parse errors or messages that could be improved, I can add them here.