### PR TITLE
Tweaking circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,8 +3,9 @@ machine:
     version: 7.10.2
   pre:
     - sudo add-apt-repository -y ppa:hvr/z3
+    - sudo add-apt-repository -y ppa:hvr/ghc
     - sudo apt-get -y update
-    - sudo apt-get -y install z3
+    - sudo apt-get -y install z3 ghc-7.10.3
 
 checkout:
   post:
@@ -17,10 +18,10 @@ dependencies:
     - cabal sandbox init
     - cabal sandbox add-source ./liquid-fixpoint
     - cabal sandbox add-source ./liquiddesugar
-    - cabal install --upgrade-dependencies --reorder-goals --constraint="template-haskell installed" --dependencies-only --enable-tests
+    - cabal install --upgrade-dependencies --reorder-goals --constraint="template-haskell installed" --dependencies-only --enable-tests --with-compiler=/opt/ghc/7.10.3/bin/ghc
     # - cabal install hpc-coveralls
     # - cabal configure --enable-tests --enable-library-coverage -finclude -fdevel
-    - cabal configure --enable-tests -finclude -fdevel
+    - cabal configure --enable-tests -finclude -fdevel --with-compiler=/opt/ghc/7.10.3/bin/ghc
 
 test:
   pre:
@@ -28,6 +29,9 @@ test:
   override:
     - cabal build
     - cabal copy && cabal register
+    - mkdir -p $CIRCLE_TEST_REPORTS/tasty/
+    # We get a "test: ./tasty/junit.xml: canonicalizePath: does not exist (No such file or directory)" fail if it does not exist
+    - touch $CIRCLE_TEST_REPORTS/tasty/junit.xml
     - cabal exec -- sh -c "./dist/build/test/test -j2 --xml=$CIRCLE_TEST_REPORTS/tasty/junit.xml --liquid-opts='--cores 1'":
         timeout: 1800
   post:


### PR DESCRIPTION
1. GHC 7.10.3

If a fresh circleci build is started (no cache) the available ghc is
8.0.1, and the machine config does not seem to do anything.

Explicitly install ghc-7.10.3, and configure the build to use it.

2. tasty junit output

For some reason, the --xml file to capture the junit.xml output has to
exist before the tests run, otherwise it crashes with an error related
to canonicalizePath. Create this file before running the tests.