### PR TITLE
[WIP don't merge] Improve error messages

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,6 +32,7 @@ compile:
   override:
     # - stack build liquidhaskell --fast --pedantic --flag liquidhaskell:include --flag liquidhaskell:devel
     - stack build liquidhaskell --fast --flag liquidhaskell:include --flag liquidhaskell:devel
+    - stack build liquidhaskell --fast --flag liquidhaskell:include --flag liquidhaskell:devel --test --no-run-tests
 
 test:
   override:

--- a/src/Language/Haskell/Liquid/Bare/OfType.hs
+++ b/src/Language/Haskell/Liquid/Bare/OfType.hs
@@ -59,7 +59,7 @@ import Language.Haskell.Liquid.Bare.Lookup
 import Language.Haskell.Liquid.Bare.Resolve
 -- import Language.Haskell.Liquid.Bare.RefToLogic
 
-import Data.Data (toConstr)
+-- import Data.Data (toConstr)
 
 --------------------------------------------------------------------------------
 ofBareType :: SourcePos -> BareType -> BareM SpecType

--- a/src/Language/Haskell/Liquid/Bare/OfType.hs
+++ b/src/Language/Haskell/Liquid/Bare/OfType.hs
@@ -59,6 +59,8 @@ import Language.Haskell.Liquid.Bare.Lookup
 import Language.Haskell.Liquid.Bare.Resolve
 -- import Language.Haskell.Liquid.Bare.RefToLogic
 
+import Data.Data (toConstr)
+
 --------------------------------------------------------------------------------
 ofBareType :: SourcePos -> BareType -> BareM SpecType
 ofBareType l
@@ -263,6 +265,7 @@ exprArg msg (RAppTy (RVar f _) t _)
   = mkEApp (dummyLoc $ symbol f) [exprArg msg t]
 exprArg msg z
   = panic Nothing $ printf "Unexpected expression parameter: %s in %s" (show z) msg
+  -- = panic Nothing $ printf "Unexpected expression parameter: %s in %s" (show z ++ "[" ++ show (toConstr z) ++ "]") msg
     -- FIXME: Handle this error much better!
 
 --------------------------------------------------------------------------------

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -235,10 +235,12 @@ refBindP bp rp kindP'
               reservedOp "|"
               ra <- rp <* spaces
               let xi = intSymbol x i
+              -- xi is a unique var based on the name in x.
+              -- su replaces any use of x in the balance of the expression with the unique val
               let su v = if v == x then xi else v
-              -- TODO:AZ I think the 'substa' call below together with the try might be what breaks the @crhisdone parse test
               return $ substa su $ t (Reft (x, ra)) ))
      <|> ((RHole . uTop . Reft . ("VV",)) <$> (rp <* spaces))
+     <?> "refBindP"
    )
 
 refP :: Parser (Reft -> BareType) -> Parser BareType
@@ -247,6 +249,8 @@ refP = refBindP bindP refaP
 refDefP :: Symbol -> Parser Expr -> Parser (Reft -> BareType) -> Parser BareType
 refDefP x  = refBindP (optBindP x)
 
+
+-- "sym :" or return the devault sym
 optBindP :: Symbol
          -> Parser Symbol
 optBindP x = try bindP <|> return x
@@ -557,9 +561,9 @@ monoPredicateP
 
 monoPredicate1P :: Parser Predicate
 monoPredicate1P
-   =  try (reserved "True" >> return mempty)
-  <|> try (pdVar <$> parens predVarUseP)
-  <|> (    pdVar <$>        predVarUseP)
+   =  (reserved "True" >> return mempty)
+  <|> (pdVar <$> parens predVarUseP)
+  <|> (pdVar <$>        predVarUseP)
   <?> "monoPredicate1P"
 
 predVarUseP :: IsString t

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -230,8 +230,9 @@ bareTypeP
 bareTypeBracesP :: Parser BareType
 bareTypeBracesP = do
   t <-  (try (
-          do ct <- braces constraintP
-             return $ Right ct ))
+          braces $ do
+               ct <- constraintP
+               return $ Right ct ))
        <|> (braces (
             (try(do x  <- symbolP
                     _ <- colon
@@ -254,11 +255,11 @@ bareTypeBracesP = do
       return $ rrTy ct tt
 
 
-bareConstraintP :: Parser BareType
-bareConstraintP
-  = do ct   <- braces constraintP
-       t    <- bareTypeP
-       return $ rrTy ct t
+-- bareConstraintP :: Parser BareType
+-- bareConstraintP
+--   = do ct   <- braces constraintP
+--        t    <- bareTypeP
+--        return $ rrTy ct t
 
 bareArgP :: Symbol -> Parser BareType
 bareArgP vv

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -110,7 +110,7 @@ parseWithError pstate parser p s =
     (Right (_, rem, _), _) -> Left  $ parseErrorError $ remParseError p s rem
   where
     -- See http://stackoverflow.com/questions/16209278/parsec-consume-all-input
-    doParse = setPosition p >> remainderP (whiteSpace *> parser <* eof)
+    doParse = setPosition p >> remainderP (whiteSpace *> parser <* (whiteSpace >> eof))
 
 
 ---------------------------------------------------------------------------

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -244,6 +244,7 @@ compP = circleP <* whiteSpace <|> parens btP <?> "compP"
 circleP :: Parser ParamComp
 circleP
   =  nullPC <$> (reserved "forall" >> (bareAllP <|> bareAllS))
+ <|> nullPC <$> holeP -- starts with '_'
  <|> namedCircleP -- starts with lower
  <|> nullPC <$> bareTypeBracesP -- starts with '{'
  <|> unnamedCircleP
@@ -415,10 +416,9 @@ optBindP :: Symbol
          -> Parser Symbol
 optBindP x = try bindP <|> return x
 
-holeP :: Parser (RType c tv (UReft Reft))
-holeP       = reserved "_" >> spaces >> return (RHole $ uTop $ Reft ("VV", hole))
+holeP :: Parser BareType
+holeP    = reserved "_" >> spaces >> return (RHole $ uTop $ Reft ("VV", hole))
 
--- holeRefP :: Parser (r -> RType c tv (UReft r))
 holeRefP :: Parser (Reft -> BareType)
 holeRefP = reserved "_" >> spaces >> return (RHole . uTop)
 

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -227,7 +227,7 @@ btP :: Parser ParamComp
 btP = do
   c@(PC sb _) <- compP
   case sb of
-    PcNoSymbol -> return c
+    PcNoSymbol   -> return c
     PcImplicit b -> parseFun c b
     PcExplicit b -> parseFun c b
   <?> "btP"
@@ -251,7 +251,7 @@ compP = circleP <* whiteSpace <|> parens btP <?> "compP"
 circleP :: Parser ParamComp
 circleP
   =  nullPC <$> (reserved "forall" >> (bareAllP <|> bareAllS))
- <|> nullPC <$> holeP -- starts with '_'
+ <|> holePC -- starts with '_'
  <|> namedCircleP -- starts with lower
  <|> bareTypeBracesP -- starts with '{'
  <|> unnamedCircleP
@@ -261,6 +261,12 @@ circleP
              -- starts with '<'
  <|> nullPC <$> (dummyP (bbaseP <* spaces)) -- starts with '_' or '[' or '(' or lower or "'" or upper
  <?> "circeP"
+
+holePC :: Parser ParamComp
+holePC = do
+  h <- holeP
+  b <- dummyBindP
+  return (PC (PcImplicit b) h)
 
 namedCircleP :: Parser ParamComp
 namedCircleP = do

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -276,7 +276,9 @@ namedCircleP = do
       let b = val lb
       t1 <- bareArgP b
       return $ PC (PcExplicit b) t1
-    <|> PC (PcExplicit (val lb)) <$> dummyP (lowerIdTail (val lb))
+    <|> do
+      b <- dummyBindP
+      PC (PcImplicit b) <$> dummyP (lowerIdTail (val lb))
     )
 
 unnamedCircleP :: Parser ParamComp

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -388,6 +388,10 @@ testSucceeds =
     , testCase "type spec 17" $
        parseSingleSpec " ==. :: x:a -> y:{a| x == y} -> {v:b | v ~~ x && v ~~ y } " @?=
            "Asrts ([\"==.\" (dummyLoc)],(x:a -> y:{y##0 : a | x == y##0} -> {v##1 : b | v##1 ~~ x\n                                               && v##1 ~~ y} (dummyLoc),Nothing))"
+
+    , testCase "type spec 18" $
+       parseSingleSpec "measure snd :: (a,b) -> b" @?=
+           "Meas snd :: lq_tmp$db##0:(a, b) -> b"
     ]
 
 -- ---------------------------------------------------------------------

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -415,6 +415,13 @@ testSucceeds =
        parseSingleSpec "makeq :: l:_ -> r:{ _ | size r <= size l + 1} -> _ " @?=
            "Asrts ([\"makeq\" (dummyLoc)],(l:{VV : _ | $HOLE} -> r:{r##0 : _ | size r##0 <= size l + 1} -> {VV : _ | $HOLE} (dummyLoc),Nothing))"
 
+    , testCase "type spec 21" $
+       parseSingleSpec "newRGRef :: forall <p :: a -> Bool, r :: a -> a -> Bool >.\n   e:a<p> ->\n  e2:a<r e> ->\n  f:(x:a<p> -> y:a<r x> -> {v:a<p> | (v = y)}) ->\n IO (RGRef <p, r> a)" @?=
+         "Asrts ([\"newRGRef\" (dummyLoc)],(e:{VV : a | true} -> e2:{VV : a | true} -> f:(x:{VV : a | true} -> y:{VV : a | true} -> {v##3 : a | v##3 == y}) -> (IO (RGRef a)) (dummyLoc),Nothing))"
+
+    , testCase "type spec 22" $
+       parseSingleSpec "cycle        :: {v: [a] | len(v) > 0 } -> [a]" @?=
+         "Asrts ([\"cycle\" (dummyLoc)],(lq_tmp$db##0:{v##1 : [a] | len v##1 > 0} -> [a] (dummyLoc),Nothing))"
     ]
 
 -- ---------------------------------------------------------------------

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -422,6 +422,10 @@ testSucceeds =
     , testCase "type spec 22" $
        parseSingleSpec "cycle        :: {v: [a] | len(v) > 0 } -> [a]" @?=
          "Asrts ([\"cycle\" (dummyLoc)],(lq_tmp$db##0:{v##1 : [a] | len v##1 > 0} -> [a] (dummyLoc),Nothing))"
+
+    , testCase "type spec 23" $
+       parseSingleSpec "cons :: x:a -> _ -> {v:[a] | hd v = x} " @?=
+         "Asrts ([\"cons\" (dummyLoc)],(x:a -> lq_tmp$db##0:{VV : _ | $HOLE} -> {v##1 : [a] | hd v##1 == x} (dummyLoc),Nothing))"
     ]
 
 -- ---------------------------------------------------------------------

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -282,6 +282,14 @@ testSucceeds =
        (parseSingleSpec "x :: Int") @?=
           "Asrts ([\"x\" (dummyLoc)],(Int (dummyLoc),Nothing))"
 
+    , testCase "x :: a" $
+       (parseSingleSpec "x :: a") @?=
+          "Asrts ([\"x\" (dummyLoc)],(a (dummyLoc),Nothing))"
+
+    , testCase "x :: a -> a" $
+       (parseSingleSpec "x :: a -> a") @?=
+          "Asrts ([\"x\" (dummyLoc)],(a -> a (dummyLoc),Nothing))"
+
     , testCase "x :: Int -> Int" $
        (parseSingleSpec "x :: Int -> Int") @?=
           "Asrts ([\"x\" (dummyLoc)],(Int -> Int (dummyLoc),Nothing))"
@@ -290,11 +298,11 @@ testSucceeds =
        (parseSingleSpec "x :: k:Int -> Int") @?=
           "Asrts ([\"x\" (dummyLoc)],(k:Int -> Int (dummyLoc),Nothing))"
 
-    , testCase "type spec 1" $
+    , testCase "type spec 1 " $
        parseSingleSpec "type IncrListD a D = [a]<{\\x y -> (x+D) <= y}>" @?=
           "Alias type IncrListD \"a\" \"D\" = [a] -- defined at \"Fixpoint.Types.dummyLoc\" (line 0, column 0)"
 
-    , testCase "type spec 2" $
+    , testCase "type spec 2 " $
        parseSingleSpec "takeL :: Ord a => x:a -> [a] -> [{v:a|v<=x}]" @?=
           "Asrts ([\"takeL\" (dummyLoc)],((Ord a) -> x:a -> lq_tmp$db##1:[a] -> [{v##2 : a | v##2 <= x}] (dummyLoc),Nothing))"
 
@@ -310,7 +318,7 @@ testSucceeds =
        parseSingleSpec "mapKeysWith :: (Ord k2) => (a -> a -> a) -> (k1->k2) -> OMap k1 a -> OMap k2 a" @?=
           "Asrts ([\"mapKeysWith\" (dummyLoc)],((Ord k2) -> lq_tmp$db##1:(lq_tmp$db##2:a -> lq_tmp$db##3:a -> a) -> lq_tmp$db##4:(lq_tmp$db##5:k1 -> k2) -> lq_tmp$db##6:(OMap k1 a) -> (OMap k2 a) (dummyLoc),Nothing))"
 
-    , testCase "type spec 6" $
+    , testCase "type spec 6 " $
        parseSingleSpec (unlines $
          [ "data Tree [ht] a = Nil"
          , "            | Tree { key :: a"

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -278,9 +278,13 @@ testReservedAliases =
 testSucceeds :: TestTree
 testSucceeds =
   testGroup "Should succeed"
-    [ testCase "Int" $
+    [ testCase "x :: Int" $
        (parseSingleSpec "x :: Int") @?=
           "Asrts ([\"x\" (dummyLoc)],(Int (dummyLoc),Nothing))"
+
+    , testCase "x :: Int -> Int" $
+       (parseSingleSpec "x :: Int -> Int") @?=
+          "Asrts ([\"x\" (dummyLoc)],(Int -> Int (dummyLoc),Nothing))"
 
     , testCase "k:Int -> Int" $
        (parseSingleSpec "x :: k:Int -> Int") @?=

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -426,6 +426,10 @@ testSucceeds =
     , testCase "type spec 23" $
        parseSingleSpec "cons :: x:a -> _ -> {v:[a] | hd v = x} " @?=
          "Asrts ([\"cons\" (dummyLoc)],(x:a -> lq_tmp$db##0:{VV : _ | $HOLE} -> {v##1 : [a] | hd v##1 == x} (dummyLoc),Nothing))"
+
+    , testCase "type spec 24" $
+       parseSingleSpec "set :: a:Vector a -> i:Idx a -> a -> {v:Vector a | vlen v = vlen a}" @?=
+         "Asrts ([\"set\" (dummyLoc)],(a:(Vector a) -> i:(Idx a) -> lq_tmp$db##0:a -> {v##1 : (Vector a) | vlen v##1 == vlen a} (dummyLoc),Nothing))"
     ]
 
 -- ---------------------------------------------------------------------

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -385,7 +385,7 @@ testFails =
   testGroup "Does fail"
     [ testCase "Maybe k:Int -> Int" $
           parseSingleSpec "x :: Maybe k:Int -> Int" @?=
-            "<test>:1:13: Error: Cannot parse specification:\n    Leftover while parsing"
+            "<test>:1:13: Error: Cannot parse specification:\n    unexpected ':'\n    expecting stratumP, monoPredicateP, white space, bareTyArgP, mmonoPredicateP or end of input"
     ]
 
 
@@ -396,7 +396,7 @@ testErrorReporting =
   testGroup "Error reprting"
     [ testCase "assume mallocForeignPtrBytes :: n:Nat -> IO (ForeignPtrN a n " $
           parseSingleSpec "assume mallocForeignPtrBytes :: n:Nat -> IO (ForeignPtrN a n " @?=
-            "<test>:1:45: Error: Cannot parse specification:\n    Leftover while parsing"
+            "<test>:1:62: Error: Cannot parse specification:\n    unexpected end of input\n    expecting bareTyArgP"
     ]
 
 -- ---------------------------------------------------------------------

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -37,9 +37,9 @@ tests =
   testGroup "Tests"
     [
       testSucceeds
-    , testFails
     , testSpecP
     , testReservedAliases
+    , testFails
     , testErrorReporting
     ]
 
@@ -384,6 +384,10 @@ testSucceeds =
     , testCase "type spec 16" $
        parseSingleSpec "sort :: (Ord a) => xs:[a] -> OListN a {len xs}" @?=
            "Asrts ([\"sort\" (dummyLoc)],((Ord a) -> xs:[a] -> (OListN a {len xs}) (dummyLoc),Nothing))"
+
+    , testCase "type spec 17" $
+       parseSingleSpec " ==. :: x:a -> y:{a| x == y} -> {v:b | v ~~ x && v ~~ y } " @?=
+           "Asrts ([\"==.\" (dummyLoc)],(x:a -> y:{y##0 : a | x == y##0} -> {v##1 : b | v##1 ~~ x\n                                               && v##1 ~~ y} (dummyLoc),Nothing))"
     ]
 
 -- ---------------------------------------------------------------------

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -155,7 +155,8 @@ testSpecP =
 
     , testCase "using" $
        parseSingleSpec "using (Tree a) as  {v:Tree a   | 0 <= height v}" @?=
-          "IAlias ((Tree a) (dummyLoc),{v##0 : (Tree a) | 0 <= height v##0} (dummyLoc))"
+          -- "IAlias ((Tree a) (dummyLoc),{v##0 : (Tree a) | 0 <= height v##0} (dummyLoc))"
+             "IAlias ((Tree a) (dummyLoc),{v##2 : (Tree a) | 0 <= height v##2} (dummyLoc))"
 
     , testCase "type" $
        parseSingleSpec "type PosInt = {v: Int | v >= 0}" @?=
@@ -288,11 +289,13 @@ testSucceeds =
 
     , testCase "x :: a -> a" $
        (parseSingleSpec "x :: a -> a") @?=
-          "Asrts ([\"x\" (dummyLoc)],(a -> a (dummyLoc),Nothing))"
+          -- "Asrts ([\"x\" (dummyLoc)],(a -> a (dummyLoc),Nothing))"
+             "Asrts ([\"x\" (dummyLoc)],(lq_tmp$db##0:a -> a (dummyLoc),Nothing))"
 
     , testCase "x :: Int -> Int" $
        (parseSingleSpec "x :: Int -> Int") @?=
-          "Asrts ([\"x\" (dummyLoc)],(Int -> Int (dummyLoc),Nothing))"
+          -- "Asrts ([\"x\" (dummyLoc)],(Int -> Int (dummyLoc),Nothing))"
+             "Asrts ([\"x\" (dummyLoc)],(lq_tmp$db##0:Int -> Int (dummyLoc),Nothing))"
 
     , testCase "k:Int -> Int" $
        (parseSingleSpec "x :: k:Int -> Int") @?=
@@ -304,7 +307,8 @@ testSucceeds =
 
     , testCase "type spec 2 " $
        parseSingleSpec "takeL :: Ord a => x:a -> [a] -> [{v:a|v<=x}]" @?=
-          "Asrts ([\"takeL\" (dummyLoc)],((Ord a) -> x:a -> lq_tmp$db##1:[a] -> [{v##2 : a | v##2 <= x}] (dummyLoc),Nothing))"
+          -- "Asrts ([\"takeL\" (dummyLoc)],((Ord a) -> x:a -> lq_tmp$db##1:[a] -> [{v##2 : a | v##2 <= x}] (dummyLoc),Nothing))"
+             "Asrts ([\"takeL\" (dummyLoc)],((Ord a) -> x:a -> lq_tmp$db##1:[a] -> [{v##4 : a | v##4 <= x}] (dummyLoc),Nothing))"
 
     , testCase "type spec 3" $
        parseSingleSpec "bar :: t 'Nothing" @?=
@@ -316,7 +320,8 @@ testSucceeds =
 
     , testCase "type spec 5" $
        parseSingleSpec "mapKeysWith :: (Ord k2) => (a -> a -> a) -> (k1->k2) -> OMap k1 a -> OMap k2 a" @?=
-          "Asrts ([\"mapKeysWith\" (dummyLoc)],((Ord k2) -> lq_tmp$db##1:(lq_tmp$db##2:a -> lq_tmp$db##3:a -> a) -> lq_tmp$db##4:(lq_tmp$db##5:k1 -> k2) -> lq_tmp$db##6:(OMap k1 a) -> (OMap k2 a) (dummyLoc),Nothing))"
+          -- "Asrts ([\"mapKeysWith\" (dummyLoc)],((Ord k2) -> lq_tmp$db##1:(lq_tmp$db##2:a -> lq_tmp$db##3:a -> a) -> lq_tmp$db##4:(lq_tmp$db##5:k1 -> k2) -> lq_tmp$db##6:(OMap k1 a) -> (OMap k2 a) (dummyLoc),Nothing))"
+             "Asrts ([\"mapKeysWith\" (dummyLoc)],((Ord k2) -> lq_tmp$db##2:(lq_tmp$db##3:a -> lq_tmp$db##4:a -> a) -> lq_tmp$db##6:(lq_tmp$db##7:k1 -> k2) -> lq_tmp$db##9:(OMap k1 a) -> (OMap k2 a) (dummyLoc),Nothing))"
 
     , testCase "type spec 6 " $
        parseSingleSpec (unlines $
@@ -329,13 +334,14 @@ testSucceeds =
           "DDecl DataDecl: data = \"Tree\" (dummyLoc), tyvars = [\"a\"]"
 
     , testCase "type spec 7" $
-       -- parseSingleSpec "type AVLL a X    = AVLTree {v:a | v < X}" @?=
        parseSingleSpec "type AVLL a X    = AVLTree {v:a | v < X}" @?=
-          "Alias type AVLL \"a\" \"X\" = (AVLTree {v##0 : a | v##0 < X}) -- defined at \"Fixpoint.Types.dummyLoc\" (line 0, column 0)"
+          -- "Alias type AVLL \"a\" \"X\" = (AVLTree {v##0 : a | v##0 < X}) -- defined at \"Fixpoint.Types.dummyLoc\" (line 0, column 0)"
+              "Alias type AVLL \"a\" \"X\" = (AVLTree {v##1 : a | v##1 < X}) -- defined at \"Fixpoint.Types.dummyLoc\" (line 0, column 0)"
 
     , testCase "type spec 8" $
        parseSingleSpec "type AVLR a X    = AVLTree {v:a |X< v} " @?=
-          "Alias type AVLR \"a\" \"X\" = (AVLTree {v##0 : a | X < v##0}) -- defined at \"Fixpoint.Types.dummyLoc\" (line 0, column 0)"
+          -- "Alias type AVLR \"a\" \"X\" = (AVLTree {v##0 : a | X < v##0}) -- defined at \"Fixpoint.Types.dummyLoc\" (line 0, column 0)"
+             "Alias type AVLR \"a\" \"X\" = (AVLTree {v##1 : a | X < v##1}) -- defined at \"Fixpoint.Types.dummyLoc\" (line 0, column 0)"
 
     , testCase "type spec 9 " $
        parseSingleSpec (unlines $
@@ -345,7 +351,8 @@ testSucceeds =
       , "  {a<q> <: a<r>} "
       , "  Ord a => OList (a<p>) -> OList (a<q>) -> OList a<r> "])
         @?=
-          "Assm (\"(++)\" (dummyLoc),(Ord a) =>\n{x :: {VV : a | true} |- {VV : a | true} <: {v##3 : a | x <= v##3}} =>\n{|- {VV : a | true} <: {VV : a | true}} =>\n{|- {VV : a | true} <: {VV : a | true}} =>\nlq_tmp$db##5:(OList {VV : a | true}) -> lq_tmp$db##6:(OList {VV : a | true}) -> (OList {VV : a | true}) (dummyLoc))"
+          -- "Assm (\"(++)\" (dummyLoc),(Ord a) =>\n{x :: {VV : a | true} |- {VV : a | true} <: {v##3 : a | x <= v##3}} =>\n{|- {VV : a | true} <: {VV : a | true}} =>\n{|- {VV : a | true} <: {VV : a | true}} =>\nlq_tmp$db##5:(OList {VV : a | true}) -> lq_tmp$db##6:(OList {VV : a | true}) -> (OList {VV : a | true}) (dummyLoc))"
+             "Assm (\"(++)\" (dummyLoc),(Ord a) =>\n{x :: {VV : a | true} |- {VV : a | true} <: {v##8 : a | x <= v##8}} =>\n{|- {VV : a | true} <: {VV : a | true}} =>\n{|- {VV : a | true} <: {VV : a | true}} =>\nlq_tmp$db##14:(OList {VV : a | true}) -> lq_tmp$db##16:(OList {VV : a | true}) -> (OList {VV : a | true}) (dummyLoc))"
 
     , testCase "type spec 10" $
        parseSingleSpec (unlines $
@@ -368,7 +375,8 @@ testSucceeds =
           , "       {x::Int<q> |- {v:Int| v = x + 1} <: Int<q>}"
           , "       (Int<p> -> ()) -> x:Int<q> -> ()" ])
           @?=
-          "Asrts ([\"app\" (dummyLoc)],({|- Int <: Int} =>\n{x :: Int |- {v##2 : Int | v##2 == x + 1} <: Int} =>\nlq_tmp$db##3:(lq_tmp$db##4:Int -> ()) -> x:Int -> () (dummyLoc),Nothing))"
+          -- "Asrts ([\"app\" (dummyLoc)],({|- Int <: Int} =>\n{x :: Int |- {v##2 : Int | v##2 == x + 1} <: Int} =>\nlq_tmp$db##3:(lq_tmp$db##4:Int -> ()) -> x:Int -> () (dummyLoc),Nothing))"
+             "Asrts ([\"app\" (dummyLoc)],({|- Int <: Int} =>\n{x :: Int |- {v##7 : Int | v##7 == x + 1} <: Int} =>\nlq_tmp$db##9:(lq_tmp$db##10:Int -> ()) -> x:Int -> () (dummyLoc),Nothing))"
 
     , testCase "type spec 13" $
        parseSingleSpec (unlines $
@@ -377,7 +385,8 @@ testSucceeds =
           , "         {x::a<p> |- {v:a | x <= v} <: a<q>}"
           , "         xs:[{v:a<p> | 0 <= v}] -> {v:a<q> | len xs >= 0 && 0 <= v } "])
           @?=
-          "Asrts ([\"ssum\" (dummyLoc)],({|- {v##2 : a | v##2 == 0} <: {VV : a | true}} =>\n{x :: {VV : a | true} |- {v##3 : a | x <= v##3} <: {VV : a | true}} =>\nxs:[{v##4 : a | 0 <= v##4}] -> {v##5 : a | len xs >= 0\n                                           && 0 <= v##5} (dummyLoc),Nothing))"
+          -- "Asrts ([\"ssum\" (dummyLoc)],({|- {v##2 : a | v##2 == 0} <: {VV : a | true}} =>\n{x :: {VV : a | true} |- {v##3 : a | x <= v##3} <: {VV : a | true}} =>\nxs:[{v##4 : a | 0 <= v##4}] -> {v##5 : a | len xs >= 0\n                                           && 0 <= v##5} (dummyLoc),Nothing))"
+             "Asrts ([\"ssum\" (dummyLoc)],({|- {v##4 : a | v##4 == 0} <: {VV : a | true}} =>\n{x :: {VV : a | true} |- {v##7 : a | x <= v##7} <: {VV : a | true}} =>\nxs:[{v##9 : a | 0 <= v##9}] -> {v##10 : a | len xs >= 0\n                                            && 0 <= v##10} (dummyLoc),Nothing))"
 
     , testCase "type spec 14" $
        parseSingleSpec (unlines $
@@ -391,7 +400,8 @@ testSucceeds =
 
     , testCase "type spec 15" $
        parseSingleSpec "assume (=*=.) :: Arg a => f:(a -> b) -> g:(a -> b) -> (r:a -> {f r == g r}) -> {v:(a -> b) | f == g}" @?=
-          "Assm (\"(=*=.)\" (dummyLoc),(Arg a) -> f:(lq_tmp$db##1:a -> b) -> g:(lq_tmp$db##2:a -> b) -> lq_tmp$db##3:(r:a -> {VV : _ | f r == g r}) -> {VV : lq_tmp$db##5:a -> b | f == g} (dummyLoc))"
+          -- "Assm (\"(=*=.)\" (dummyLoc),(Arg a) -> f:(lq_tmp$db##1:a -> b) -> g:(lq_tmp$db##2:a -> b) -> lq_tmp$db##3:(r:a -> {VV : _ | f r == g r}) -> {VV : lq_tmp$db##5:a -> b | f == g} (dummyLoc))"
+             "Assm (\"(=*=.)\" (dummyLoc),(Arg a) -> f:(lq_tmp$db##1:a -> b) -> g:(lq_tmp$db##3:a -> b) -> lq_tmp$db##5:(r:a -> {VV : _ | f r == g r}) -> {VV : lq_tmp$db##7:a -> b | f == g} (dummyLoc))"
 
     , testCase "type spec 16" $
        parseSingleSpec "sort :: (Ord a) => xs:[a] -> OListN a {len xs}" @?=
@@ -417,11 +427,13 @@ testSucceeds =
 
     , testCase "type spec 21" $
        parseSingleSpec "newRGRef :: forall <p :: a -> Bool, r :: a -> a -> Bool >.\n   e:a<p> ->\n  e2:a<r e> ->\n  f:(x:a<p> -> y:a<r x> -> {v:a<p> | (v = y)}) ->\n IO (RGRef <p, r> a)" @?=
-         "Asrts ([\"newRGRef\" (dummyLoc)],(e:{VV : a | true} -> e2:{VV : a | true} -> f:(x:{VV : a | true} -> y:{VV : a | true} -> {v##3 : a | v##3 == y}) -> (IO (RGRef a)) (dummyLoc),Nothing))"
+         -- "Asrts ([\"newRGRef\" (dummyLoc)],(e:{VV : a | true} -> e2:{VV : a | true} -> f:(x:{VV : a | true} -> y:{VV : a | true} -> {v##3 : a | v##3 == y}) -> (IO (RGRef a)) (dummyLoc),Nothing))"
+            "Asrts ([\"newRGRef\" (dummyLoc)],(e:{VV : a | true} -> e2:{VV : a | true} -> f:(x:{VV : a | true} -> y:{VV : a | true} -> {v##5 : a | v##5 == y}) -> (IO (RGRef a)) (dummyLoc),Nothing))"
 
     , testCase "type spec 22" $
        parseSingleSpec "cycle        :: {v: [a] | len(v) > 0 } -> [a]" @?=
-         "Asrts ([\"cycle\" (dummyLoc)],(lq_tmp$db##0:{v##1 : [a] | len v##1 > 0} -> [a] (dummyLoc),Nothing))"
+         -- "Asrts ([\"cycle\" (dummyLoc)],(lq_tmp$db##0:{v##1 : [a] | len v##1 > 0} -> [a] (dummyLoc),Nothing))"
+            "Asrts ([\"cycle\" (dummyLoc)],(v:{v##0 : [a] | len v##0 > 0} -> [a] (dummyLoc),Nothing))"
 
     , testCase "type spec 23" $
        parseSingleSpec "cons :: x:a -> _ -> {v:[a] | hd v = x} " @?=
@@ -439,7 +451,7 @@ testFails =
   testGroup "Does fail"
     [ testCase "Maybe k:Int -> Int" $
           parseSingleSpec "x :: Maybe k:Int -> Int" @?=
-            "<test>:1:13: Error: Cannot parse specification:\n    unexpected ':'\n    expecting stratumP, monoPredicateP, white space, bareTyArgP, mmonoPredicateP, \"/\" or end of input"
+            "<test>:1:13: Error: Cannot parse specification:\n    unexpected ':'\n    expecting stratumP, monoPredicateP, white space, bareTyArgP, mmonoPredicateP, \"->\", \"=>\", \"/\" or end of input"
     ]
 
 

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -40,6 +40,7 @@ tests =
     , testFails
     , testSpecP
     , testReservedAliases
+    , testErrorReporting
     ]
 
 -- ---------------------------------------------------------------------
@@ -387,6 +388,17 @@ testFails =
             "<test>:1:13: Error: Cannot parse specification:\n    Leftover while parsing"
     ]
 
+
+-- ---------------------------------------------------------------------
+
+testErrorReporting :: TestTree
+testErrorReporting =
+  testGroup "Error reprting"
+    [ testCase "assume mallocForeignPtrBytes :: n:Nat -> IO (ForeignPtrN a n " $
+          parseSingleSpec "assume mallocForeignPtrBytes :: n:Nat -> IO (ForeignPtrN a n " @?=
+            "<test>:1:45: Error: Cannot parse specification:\n    Leftover while parsing"
+    ]
+
 -- ---------------------------------------------------------------------
 
 -- | Parse a single type signature containing LH refinements. To be
@@ -404,3 +416,5 @@ dummyLocs = everywhere (mkT posToDummy)
   where
     posToDummy :: SourcePos -> SourcePos
     posToDummy _ = dummyPos "Fixpoint.Types.dummyLoc"
+
+-- ---------------------------------------------------------------------

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -385,7 +385,7 @@ testFails =
   testGroup "Does fail"
     [ testCase "Maybe k:Int -> Int" $
           parseSingleSpec "x :: Maybe k:Int -> Int" @?=
-            "<test>:1:13: Error: Cannot parse specification:\n    unexpected ':'\n    expecting stratumP, monoPredicateP, white space, bareTyArgP, mmonoPredicateP or end of input"
+            "<test>:1:13: Error: Cannot parse specification:\n    unexpected ':'\n    expecting stratumP, monoPredicateP, white space, bareTyArgP, mmonoPredicateP, \"/\" or end of input"
     ]
 
 
@@ -397,6 +397,11 @@ testErrorReporting =
     [ testCase "assume mallocForeignPtrBytes :: n:Nat -> IO (ForeignPtrN a n " $
           parseSingleSpec "assume mallocForeignPtrBytes :: n:Nat -> IO (ForeignPtrN a n " @?=
             "<test>:1:62: Error: Cannot parse specification:\n    unexpected end of input\n    expecting bareTyArgP"
+
+    , testCase "Missing |" $
+          parseSingleSpec "ff :: {v:Nat  v >= 0 }" @?=
+          -- parseSingleSpec "ff :: {v :  }" @?=
+            "<test>:1:17: Error: Cannot parse specification:\n    unexpected \">\"\n    expecting stratumP, monoPredicateP, white space, bareTyArgP, mmonoPredicateP or |"
     ]
 
 -- ---------------------------------------------------------------------

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -404,6 +404,17 @@ testSucceeds =
     , testCase "type spec 18" $
        parseSingleSpec "measure snd :: (a,b) -> b" @?=
            "Meas snd :: lq_tmp$db##0:(a, b) -> b"
+
+    , testCase "type spec 19" $
+       parseSingleSpec "returnST :: xState:a \n             -> ST <{\\xs xa v -> (xa = xState)}> a s " @?=
+                     -- returnST :: a -> ST a s
+                     -- returnST x = S $ \s -> (x, s)
+           "Asrts ([\"returnST\" (dummyLoc)],(xState:a -> (ST a s) (dummyLoc),Nothing))"
+
+    , testCase "type spec 20" $
+       parseSingleSpec "makeq :: l:_ -> r:{ _ | size r <= size l + 1} -> _ " @?=
+           "Asrts ([\"makeq\" (dummyLoc)],(l:{VV : _ | $HOLE} -> r:{r##0 : _ | size r##0 <= size l + 1} -> {VV : _ | $HOLE} (dummyLoc),Nothing))"
+
     ]
 
 -- ---------------------------------------------------------------------

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -376,6 +376,10 @@ testSucceeds =
           , "       && ((len XS <= N ) => len V == 1)) "])
           @?=
           "EAlias type ValidChunk  \"V\" \"XS\" \"N\" = PAnd [PImp (PAtom Eq (EApp (EVar \"len\") (EVar \"XS\")) (ECon (I 0))) (PAtom Eq (EApp (EVar \"len\") (EVar \"V\")) (ECon (I 0))),PImp (PNot (PAtom Eq (EApp (EVar \"len\") (EVar \"XS\")) (ECon (I 0)))) (PAnd [PImp (PAnd [PAtom Lt (ECon (I 1)) (EApp (EVar \"len\") (EVar \"XS\")),PAtom Lt (ECon (I 1)) (EVar \"N\")]) (PAtom Lt (EApp (EVar \"len\") (EVar \"V\")) (EApp (EVar \"len\") (EVar \"XS\"))),PImp (PAtom Le (EApp (EVar \"len\") (EVar \"XS\")) (EVar \"N\")) (PAtom Eq (EApp (EVar \"len\") (EVar \"V\")) (ECon (I 1)))])] -- defined at \"Fixpoint.Types.dummyLoc\" (line 0, column 0)"
+
+    , testCase "type spec 15" $
+       parseSingleSpec "assume (=*=.) :: Arg a => f:(a -> b) -> g:(a -> b) -> (r:a -> {f r == g r}) -> {v:(a -> b) | f == g}" @?=
+          "Assm (\"(=*=.)\" (dummyLoc),(Arg a) -> f:(lq_tmp$db##1:a -> b) -> g:(lq_tmp$db##2:a -> b) -> lq_tmp$db##3:(r:a -> {VV : _ | f r == g r}) -> {VV : lq_tmp$db##5:a -> b | f == g} (dummyLoc))"
     ]
 
 -- ---------------------------------------------------------------------
@@ -401,7 +405,7 @@ testErrorReporting =
     , testCase "Missing |" $
           parseSingleSpec "ff :: {v:Nat  v >= 0 }" @?=
           -- parseSingleSpec "ff :: {v :  }" @?=
-            "<test>:1:17: Error: Cannot parse specification:\n    unexpected \">\"\n    expecting stratumP, monoPredicateP, white space, bareTyArgP, mmonoPredicateP or |"
+            "<test>:1:17: Error: Cannot parse specification:\n    unexpected \">\"\n    expecting  |"
     ]
 
 -- ---------------------------------------------------------------------

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -337,7 +337,7 @@ testSucceeds =
        parseSingleSpec "type AVLR a X    = AVLTree {v:a |X< v} " @?=
           "Alias type AVLR \"a\" \"X\" = (AVLTree {v##0 : a | X < v##0}) -- defined at \"Fixpoint.Types.dummyLoc\" (line 0, column 0)"
 
-    , testCase "type spec 9" $
+    , testCase "type spec 9 " $
        parseSingleSpec (unlines $
       [ "assume (++) :: forall <p :: a -> Bool, q :: a -> Bool, r :: a -> Bool>."
       , "  {x::a<p> |- a<q> <: {v:a| x <= v}} "

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -380,6 +380,10 @@ testSucceeds =
     , testCase "type spec 15" $
        parseSingleSpec "assume (=*=.) :: Arg a => f:(a -> b) -> g:(a -> b) -> (r:a -> {f r == g r}) -> {v:(a -> b) | f == g}" @?=
           "Assm (\"(=*=.)\" (dummyLoc),(Arg a) -> f:(lq_tmp$db##1:a -> b) -> g:(lq_tmp$db##2:a -> b) -> lq_tmp$db##3:(r:a -> {VV : _ | f r == g r}) -> {VV : lq_tmp$db##5:a -> b | f == g} (dummyLoc))"
+
+    , testCase "type spec 16" $
+       parseSingleSpec "sort :: (Ord a) => xs:[a] -> OListN a {len xs}" @?=
+           "Asrts ([\"sort\" (dummyLoc)],((Ord a) -> xs:[a] -> (OListN a {len xs}) (dummyLoc),Nothing))"
     ]
 
 -- ---------------------------------------------------------------------
@@ -405,7 +409,7 @@ testErrorReporting =
     , testCase "Missing |" $
           parseSingleSpec "ff :: {v:Nat  v >= 0 }" @?=
           -- parseSingleSpec "ff :: {v :  }" @?=
-            "<test>:1:17: Error: Cannot parse specification:\n    unexpected \">\"\n    expecting  |"
+            "<test>:1:9: Error: Cannot parse specification:\n    unexpected \":\"\n    expecting operator, white space or \"}\""
     ]
 
 -- ---------------------------------------------------------------------

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -150,8 +150,10 @@ mkTest code dir file
       else do
         createDirectoryIfMissing True $ takeDirectory log
         bin <- binPath "liquid"
+        hSetBuffering stdout LineBuffering -- or even NoBuffering
         withFile log WriteMode $ \h -> do
-          let cmd     = testCmd bin dir file smt $ mappend (extraOptions dir test) opts
+          -- let cmd     = testCmd bin dir file smt $ mappend (extraOptions dir test) opts
+          let cmd     = testCmd bin dir file smt $ mappend (extraOptions dir test) $ mappend "-v" opts
           (_,_,_,ph) <- createProcess $ (shell cmd) {std_out = UseHandle h, std_err = UseHandle h}
           c          <- waitForProcess ph
           renameFile log $ log <.> (if code == c then "pass" else "fail")

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -152,8 +152,8 @@ mkTest code dir file
         bin <- binPath "liquid"
         hSetBuffering stdout LineBuffering -- or even NoBuffering
         withFile log WriteMode $ \h -> do
-          -- let cmd     = testCmd bin dir file smt $ mappend (extraOptions dir test) opts
-          let cmd     = testCmd bin dir file smt $ mappend (extraOptions dir test) $ mappend "-v" opts
+          let cmd     = testCmd bin dir file smt $ mappend (extraOptions dir test) opts
+          -- let cmd     = testCmd bin dir file smt $ mappend (extraOptions dir test) $ mappend "-v" opts
           (_,_,_,ph) <- createProcess $ (shell cmd) {std_out = UseHandle h, std_err = UseHandle h}
           c          <- waitForProcess ph
           renameFile log $ log <.> (if code == c then "pass" else "fail")


### PR DESCRIPTION
Finally, use the parsec ability to generate reaonable error messages.

To start with I just put the name of the production in the `<?>` tags, these can be changed to something more useful over time.

Also, we now get the actual error message, rather than just a location and "leftover when parsing".