### PR TITLE
Add a single column to error location

### DIFF
--- a/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -38,7 +38,7 @@ import           ErrUtils
 import           CoreLint
 import           CoreMonad
 
-import           Text.Parsec.Pos                            (sourceName, sourceLine, sourceColumn, newPos)
+import           Text.Parsec.Pos                            (incSourceColumn, sourceName, sourceLine, sourceColumn, newPos)
 
 import           Name
 import           Module                                     (moduleNameFS)
@@ -262,7 +262,8 @@ sourcePos2SrcSpan p p' = RealSrcSpan $ realSrcSpan f l c l' c'
     (_, l', c')        = F.sourcePosElts p'
 
 sourcePosSrcSpan   :: SourcePos -> SrcSpan
-sourcePosSrcSpan = srcLocSpan . sourcePosSrcLoc
+-- sourcePosSrcSpan = srcLocSpan . sourcePosSrcLoc
+sourcePosSrcSpan p = sourcePos2SrcSpan p (incSourceColumn p 1)
 
 sourcePosSrcLoc    :: SourcePos -> SrcLoc
 sourcePosSrcLoc p = mkSrcLoc (fsLit file) line col


### PR DESCRIPTION
Now that we have super parse errors (thanks again @alanz!), am tweaking the error location reporting to play better with editor modes.