### PR TITLE
Add CHANGES.md and README.md to extra-source-files

### DIFF
--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -38,7 +38,9 @@ data-files: include/*.hquals
           , include/710/Data/*.spec
           , syntax/liquid.css
 
-extra-source-files: tests/pos/*.hs
+extra-source-files: CHANGES.md
+                  , README.md
+                  , tests/pos/*.hs
                   , tests/neg/*.hs
                   , tests/import/lib/*.hs
                   , tests/import/client/*.hs


### PR DESCRIPTION
Doing so makes Hackage link directly to the changelog, and renders the README in the Hackage description of the library.