### PR TITLE
Safer liquid haskell

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,10 +298,7 @@ To use unqualified names, much easier to read, use:
 Totality Check
 --------------
 
-LiquidHaskell can prove the absence of pattern match failures.
-Use the `totality` flag to prove that all defined functions are total.
-
-    liquid --totality test.hs
+LiquidHaskell proves the absence of pattern match failures.
 
 For example, the definition
 
@@ -314,6 +311,10 @@ If we exclude `Nothing` from its domain, for example using the following specifi
     {-@ fromJust :: {v:Maybe a | (isJust v)} -> a @-}
 
 `fromJust` will be safe.
+
+Use the `no-totality` flag to disable totality checking.
+
+    liquid --no-totality test.hs
 
 Termination Check
 -----------------

--- a/benchmarks/bytestring-0.9.2.1/Data/ByteString.T.hs
+++ b/benchmarks/bytestring-0.9.2.1/Data/ByteString.T.hs
@@ -206,6 +206,7 @@ module Data.ByteString (
 
   ) where
 
+import Language.Haskell.Liquid.Prelude
 import qualified Prelude as P
 import Prelude hiding           (reverse,head,tail,last,init,null
                                 ,length,map,lines,foldl,foldr,unlines
@@ -288,7 +289,7 @@ import GHC.Handle
 #define assert  assertS "__FILE__ : __LINE__"
 assertS :: String -> Bool -> a -> a
 assertS _ True  = id
-assertS s False = error ("assertion failed at "++s)
+assertS s False = unsafeError ("assertion failed at "++s)
 #endif
 
 -- LIQUID

--- a/benchmarks/bytestring-0.9.2.1/Data/ByteString.T.hs
+++ b/benchmarks/bytestring-0.9.2.1/Data/ByteString.T.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_GHC -cpp -fglasgow-exts -fno-warn-orphans #-}
 {-@ LIQUID "--pruneunsorted" @-}
+{-@ LIQUID "--no-totality" @-}
 
 -- #prune
 

--- a/benchmarks/bytestring-0.9.2.1/Data/ByteString.T.hs
+++ b/benchmarks/bytestring-0.9.2.1/Data/ByteString.T.hs
@@ -206,7 +206,7 @@ module Data.ByteString (
 
   ) where
 
-import Language.Haskell.Liquid.Prelude
+import Language.Haskell.Liquid.Prelude (unsafeError)
 import qualified Prelude as P
 import Prelude hiding           (reverse,head,tail,last,init,null
                                 ,length,map,lines,foldl,foldr,unlines
@@ -305,13 +305,13 @@ import Language.Haskell.Liquid.Foreign
                      -> {v:CSize | (OkPLen v p)} -> IO (Ptr ())
   @-}
 memcpy_ptr_baoff :: Ptr a -> RawBuffer b -> Int -> CSize -> IO (Ptr ())
-memcpy_ptr_baoff = error "LIQUIDCOMPAT"
+memcpy_ptr_baoff = unsafeError "LIQUIDCOMPAT"
 
 readCharFromBuffer :: RawBuffer b -> Int -> IO (Char, Int)
-readCharFromBuffer x y = error "LIQUIDCOMPAT"
+readCharFromBuffer x y = unsafeError "LIQUIDCOMPAT"
 
 wantReadableHandleLIQUID :: String -> Handle -> (Handle__ -> IO a) -> IO a
-wantReadableHandleLIQUID x y f = error $ show $ liquidCanaryFusion 12 -- "LIQUIDCOMPAT"
+wantReadableHandleLIQUID x y f = unsafeError $ show $ liquidCanaryFusion 12 -- "LIQUIDCOMPAT"
 
 {- IN INCLUDE FILE qualif Gimme(v:a, n:b, acc:a): (len v) = (n + 1 + (len acc)) @-}
 {- qualif Zog(v:a, p:a)         : (plen p) <= (plen v)          @-}

--- a/benchmarks/bytestring-0.9.2.1/Data/ByteString.hs
+++ b/benchmarks/bytestring-0.9.2.1/Data/ByteString.hs
@@ -208,7 +208,7 @@ module Data.ByteString (
 
   ) where
 
-import Language.Haskell.Liquid.Prelude
+import Language.Haskell.Liquid.Prelude (unsafeError)
 import qualified Prelude as P
 import Prelude hiding           (reverse,head,tail,last,init,null
                                 ,length,map,lines,foldl,foldr,unlines
@@ -311,13 +311,13 @@ import Language.Haskell.Liquid.Foreign
                      -> {v:CSize | (OkPLen v p)} -> IO (Ptr ())
   @-}
 memcpy_ptr_baoff :: Ptr a -> RawBuffer b -> Int -> CSize -> IO (Ptr ())
-memcpy_ptr_baoff = error "LIQUIDCOMPAT"
+memcpy_ptr_baoff = unsafeError "LIQUIDCOMPAT"
 
 readCharFromBuffer :: RawBuffer b -> Int -> IO (Char, Int)
-readCharFromBuffer x y = error "LIQUIDCOMPAT"
+readCharFromBuffer x y = unsafeError "LIQUIDCOMPAT"
 
 wantReadableHandleLIQUID :: String -> Handle -> (Handle__ -> IO a) -> IO a
-wantReadableHandleLIQUID x y f = error $ show $ liquidCanaryFusion 12 -- "LIQUIDCOMPAT"
+wantReadableHandleLIQUID x y f = unsafeError $ show $ liquidCanaryFusion 12 -- "LIQUIDCOMPAT"
 
 -- for unfoldrN 
 

--- a/benchmarks/bytestring-0.9.2.1/Data/ByteString.hs
+++ b/benchmarks/bytestring-0.9.2.1/Data/ByteString.hs
@@ -208,6 +208,7 @@ module Data.ByteString (
 
   ) where
 
+import Language.Haskell.Liquid.Prelude
 import qualified Prelude as P
 import Prelude hiding           (reverse,head,tail,last,init,null
                                 ,length,map,lines,foldl,foldr,unlines
@@ -294,7 +295,7 @@ import GHC.Handle
 #define assert  assertS "__FILE__ : __LINE__"
 assertS :: String -> Bool -> a -> a
 assertS _ True  = id
-assertS s False = error ("assertion failed at "++s)
+assertS s False = unsafeError ("assertion failed at "++s)
 #endif
 
 -- LIQUID

--- a/benchmarks/bytestring-0.9.2.1/Data/ByteString.hs
+++ b/benchmarks/bytestring-0.9.2.1/Data/ByteString.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-totality" @-}
 {-@ LIQUID "--notermination" @-}
 {-@ LIQUID "--pruneunsorted" @-}
 

--- a/benchmarks/bytestring-0.9.2.1/Data/ByteString/Char8.hs
+++ b/benchmarks/bytestring-0.9.2.1/Data/ByteString/Char8.hs
@@ -1060,7 +1060,7 @@ readInteger as
   @-}
 {-@ decrease combine1 2 @-}
 combine1 :: Integer -> [Integer] -> Integer
-combine1 _ []  = error "impossible"
+combine1 _ []  = unsafeError "impossible"
 combine1 _ [n] = n
 combine1 b ns  = combine1 (b*b) $ combine2 b ns
 

--- a/benchmarks/bytestring-0.9.2.1/Data/ByteString/Char8.hs
+++ b/benchmarks/bytestring-0.9.2.1/Data/ByteString/Char8.hs
@@ -1,4 +1,5 @@
 {-@ LIQUID "--notermination" @-}
+{-@ LIQUID "--no-totality"   @-}
 {-@ LIQUID "--pruneunsorted" @-}
 
 

--- a/benchmarks/bytestring-0.9.2.1/Data/ByteString/Lazy.hs
+++ b/benchmarks/bytestring-0.9.2.1/Data/ByteString/Lazy.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-totality"   @-}
 {-@ LIQUID "--pruneunsorted" @-}
 
 {-# OPTIONS_GHC -cpp -fglasgow-exts -fno-warn-orphans -fno-warn-incomplete-patterns #-}

--- a/benchmarks/bytestring-0.9.2.1/Data/ByteString/Lazy.hs
+++ b/benchmarks/bytestring-0.9.2.1/Data/ByteString/Lazy.hs
@@ -205,7 +205,7 @@ module Data.ByteString.Lazy (
 
   ) where
 
-import Language.Haskell.Liquid.Prelude
+import Language.Haskell.Liquid.Prelude (unsafeError)
 import qualified Prelude
 import Prelude hiding
     (reverse,head,tail,last,init,null,length,map,lines,foldl,foldr,unlines

--- a/benchmarks/bytestring-0.9.2.1/Data/ByteString/Lazy.hs
+++ b/benchmarks/bytestring-0.9.2.1/Data/ByteString/Lazy.hs
@@ -205,6 +205,7 @@ module Data.ByteString.Lazy (
 
   ) where
 
+import Language.Haskell.Liquid.Prelude
 import qualified Prelude
 import Prelude hiding
     (reverse,head,tail,last,init,null,length,map,lines,foldl,foldr,unlines
@@ -1649,7 +1650,7 @@ errorEmptyList fun = moduleError fun "empty ByteString"
 
 {-@ moduleError :: String -> String -> a @-}
 moduleError :: String -> String -> a
-moduleError fun msg = error ("Data.ByteString.Lazy." ++ fun ++ ':':' ':msg)
+moduleError fun msg = unsafeError ("Data.ByteString.Lazy." ++ fun ++ ':':' ':msg)
 
 
 -- reverse a list of non-empty chunks into a lazy ByteString

--- a/benchmarks/bytestring-0.9.2.1/Data/ByteString/Lazy/Char8.hs
+++ b/benchmarks/bytestring-0.9.2.1/Data/ByteString/Lazy/Char8.hs
@@ -188,6 +188,8 @@ module Data.ByteString.Lazy.Char8 (
 
   ) where
 
+import Language.Haskell.Liquid.Prelude (unsafeError)
+
 -- Functions transparently exported
 import Data.ByteString.Lazy 
         (ByteString, fromChunks, toChunks

--- a/benchmarks/bytestring-0.9.2.1/Data/ByteString/Lazy/Char8.hs
+++ b/benchmarks/bytestring-0.9.2.1/Data/ByteString/Lazy/Char8.hs
@@ -1,4 +1,5 @@
 {-@ LIQUID "--notermination" @-}
+{-@ LIQUID "--no-totality"   @-}
 {-@ LIQUID "--pruneunsorted" @-}
 
 

--- a/benchmarks/esop2013-submission/Base.hs
+++ b/benchmarks/esop2013-submission/Base.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--totality" @-}
 {-@ LIQUID "--prune-unsorted" @-}
 {-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__

--- a/benchmarks/esop2013-submission/Splay.hs
+++ b/benchmarks/esop2013-submission/Splay.hs
@@ -226,7 +226,7 @@ member x t = case split x t of
 
 {-@ minimum :: OSplay a -> MinEqSPair a @-}
 minimum :: Splay a -> (a, Splay a)
-minimum Leaf = error "minimum"
+minimum Leaf = unsafeError "minimum"
 minimum t = let (x,mt) = deleteMin t in (x, Node x Leaf mt)
 
 {-| Finding the maximum element.
@@ -239,7 +239,7 @@ minimum t = let (x,mt) = deleteMin t in (x, Node x Leaf mt)
 
 {-@ maximum :: OSplay a -> MaxEqSPair a @-}
 maximum :: Splay a -> (a, Splay a)
-maximum Leaf = error "maximum"
+maximum Leaf = unsafeError "maximum"
 maximum t = let (x,mt) = deleteMax t in (x, Node x mt Leaf)
 
 ----------------------------------------------------------------
@@ -254,7 +254,7 @@ True
 
 {-@ deleteMin :: OSplay a -> MinSPair a @-}
 deleteMin :: Splay a -> (a, Splay a)
-deleteMin Leaf                          = error "deleteMin"
+deleteMin Leaf                          = unsafeError "deleteMin"
 deleteMin (Node x Leaf r)               = (x,r)
 deleteMin (Node x (Node lx Leaf lr) r)  = (lx, Node x lr r)
 deleteMin (Node x (Node lx ll lr) r)    = let (k,mt) = deleteMin ll
@@ -271,7 +271,7 @@ True
 
 {-@ deleteMax :: OSplay a -> MaxSPair a @-}
 deleteMax :: Splay a -> (,) a (Splay a)
-deleteMax Leaf                          = error "deleteMax"
+deleteMax Leaf                          = unsafeError "deleteMax"
 deleteMax (Node x l Leaf)               = (x,l)
 deleteMax (Node x l (Node rx rl Leaf))  = (rx, Node x l rl)
 deleteMax (Node x l (Node rx rl rr))    = let (k,mt) = deleteMax rr

--- a/benchmarks/esop2013-submission/Splay.hs
+++ b/benchmarks/esop2013-submission/Splay.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-totality" @-}
 {-|
   Purely functional top-down splay sets.
 

--- a/benchmarks/icfp15/pos/CompareConstraints.hs
+++ b/benchmarks/icfp15/pos/CompareConstraints.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-totality" @-}
 module Foo where
 
 import Language.Haskell.Liquid.Prelude

--- a/benchmarks/icfp15/pos/ICFP15.lhs
+++ b/benchmarks/icfp15/pos/ICFP15.lhs
@@ -3,6 +3,8 @@ module ICFP15 where
 
 import Prelude hiding ((.), (++),  filter)
 
+import Language.Haskell.Liquid.Prelude (unsafeError)
+
 {-@ LIQUID "--no-termination" @-}
 {-@ LIQUID "--no-totality" @-}
 {-@ LIQUID "--short-names" @-}
@@ -74,7 +76,7 @@ main i = app (check i) i
 {-@ check :: x:Int -> {y:Int | x <= y} -> () @-}
 check :: Int -> Int -> ()
 check x y | x < y     = ()
-          | otherwise = error "oups!"
+          | otherwise = unsafeError "oups!"
 \end{code}
 
 

--- a/benchmarks/icfp15/pos/ICFP15.lhs
+++ b/benchmarks/icfp15/pos/ICFP15.lhs
@@ -4,6 +4,7 @@ module ICFP15 where
 import Prelude hiding ((.), (++),  filter)
 
 {-@ LIQUID "--no-termination" @-}
+{-@ LIQUID "--no-totality" @-}
 {-@ LIQUID "--short-names" @-}
 
 \end{code}

--- a/benchmarks/pldi17/neg/Ackermann.hs
+++ b/benchmarks/pldi17/neg/Ackermann.hs
@@ -4,7 +4,6 @@
 
 {-@ LIQUID "--higherorder"     @-}
 {-@ LIQUID "--autoproofs"      @-}
-{-@ LIQUID "--totality"        @-}
 
 module Ackermann where
 

--- a/benchmarks/pldi17/neg/Append.hs
+++ b/benchmarks/pldi17/neg/Append.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 
 

--- a/benchmarks/pldi17/neg/ApplicativeList.hs
+++ b/benchmarks/pldi17/neg/ApplicativeList.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 
 

--- a/benchmarks/pldi17/neg/ApplicativeMaybe.hs
+++ b/benchmarks/pldi17/neg/ApplicativeMaybe.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 
 {-# LANGUAGE IncoherentInstances   #-}

--- a/benchmarks/pldi17/neg/BasicLambdas.hs
+++ b/benchmarks/pldi17/neg/BasicLambdas.hs
@@ -1,7 +1,6 @@
 
 {-@ LIQUID "--higherorder"      @-}
 {-@ LIQUID "--autoproofs"      @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 module Append where
 

--- a/benchmarks/pldi17/neg/Fibonacci.hs
+++ b/benchmarks/pldi17/neg/Fibonacci.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 
 module FunctionAbstraction where
 import Proves 

--- a/benchmarks/pldi17/neg/FunctorList.hs
+++ b/benchmarks/pldi17/neg/FunctorList.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 
 

--- a/benchmarks/pldi17/neg/FunctorMaybe.hs
+++ b/benchmarks/pldi17/neg/FunctorMaybe.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 
 {-# LANGUAGE IncoherentInstances   #-}

--- a/benchmarks/pldi17/neg/Helper.hs
+++ b/benchmarks/pldi17/neg/Helper.hs
@@ -4,7 +4,6 @@
 
 {-@ LIQUID "--higherorder"   @-}
 {-@ LIQUID "--autoproofs"    @-}
-{-@ LIQUID "--totality"      @-}
 
 module Helper (
 

--- a/benchmarks/pldi17/neg/MapFusion.hs
+++ b/benchmarks/pldi17/neg/MapFusion.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 
 {-# LANGUAGE IncoherentInstances #-}

--- a/benchmarks/pldi17/neg/MonadList.hs
+++ b/benchmarks/pldi17/neg/MonadList.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 
 

--- a/benchmarks/pldi17/neg/MonadMaybe.hs
+++ b/benchmarks/pldi17/neg/MonadMaybe.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 
 

--- a/benchmarks/pldi17/neg/MonadReader.hs
+++ b/benchmarks/pldi17/neg/MonadReader.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--extensionality"  @-}
 

--- a/benchmarks/pldi17/pos/Ackermann.hs
+++ b/benchmarks/pldi17/pos/Ackermann.hs
@@ -4,7 +4,6 @@
 
 {-@ LIQUID "--higherorder"     @-}
 {-@ LIQUID "--autoproofs"      @-}
-{-@ LIQUID "--totality"        @-}
 
 
 module Ackermann where

--- a/benchmarks/pldi17/pos/AlphaEquivalence.hs
+++ b/benchmarks/pldi17/pos/AlphaEquivalence.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--alphaequivalence"  @-}
 {-@ LIQUID "--betaequivalence"  @-}

--- a/benchmarks/pldi17/pos/Append.hs
+++ b/benchmarks/pldi17/pos/Append.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--higherorderqs" @-}
 

--- a/benchmarks/pldi17/pos/ApplicativeId.hs
+++ b/benchmarks/pldi17/pos/ApplicativeId.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--higherorderqs" @-}
 

--- a/benchmarks/pldi17/pos/ApplicativeList.hs
+++ b/benchmarks/pldi17/pos/ApplicativeList.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {- LIQUID "--higherorderqs" -} -- this seems to kill it?
 

--- a/benchmarks/pldi17/pos/ApplicativeMaybe.hs
+++ b/benchmarks/pldi17/pos/ApplicativeMaybe.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 
 

--- a/benchmarks/pldi17/pos/ApplicativeReader.hs
+++ b/benchmarks/pldi17/pos/ApplicativeReader.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--alphaequivalence" @-}
 {-@ LIQUID "--betaequivalence" @-}

--- a/benchmarks/pldi17/pos/BasicLambdas.hs
+++ b/benchmarks/pldi17/pos/BasicLambdas.hs
@@ -1,6 +1,5 @@
 
 {-@ LIQUID "--higherorder"      @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 
 module Append where

--- a/benchmarks/pldi17/pos/BasicLambdas0.hs
+++ b/benchmarks/pldi17/pos/BasicLambdas0.hs
@@ -1,7 +1,6 @@
 
 {-@ LIQUID "--higherorder"      @-}
 {-@ LIQUID "--autoproofs"      @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {- LIQUID "--extensionality"  @-}
 module Append where

--- a/benchmarks/pldi17/pos/Compose.hs
+++ b/benchmarks/pldi17/pos/Compose.hs
@@ -1,7 +1,6 @@
 {-@ LIQUID "--higherorder"     @-}
 
 {-@ LIQUID "--autoproofs"      @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 
 {-# LANGUAGE IncoherentInstances   #-}

--- a/benchmarks/pldi17/pos/Euclide.hs
+++ b/benchmarks/pldi17/pos/Euclide.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"      @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 
 module Euclide where

--- a/benchmarks/pldi17/pos/Fibonacci.hs
+++ b/benchmarks/pldi17/pos/Fibonacci.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 
 module Fibonacci where
 import Proves

--- a/benchmarks/pldi17/pos/FoldrUniversal.hs
+++ b/benchmarks/pldi17/pos/FoldrUniversal.hs
@@ -2,7 +2,6 @@
 -- | cite : http://www.seas.upenn.edu/~sweirich/papers/congruence-extended.pdf
 
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--eliminate=all"   @-}
 

--- a/benchmarks/pldi17/pos/FunctionEquality101.hs
+++ b/benchmarks/pldi17/pos/FunctionEquality101.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--betaequivalence"  @-}
 

--- a/benchmarks/pldi17/pos/FunctorId.hs
+++ b/benchmarks/pldi17/pos/FunctorId.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 
 {-# LANGUAGE IncoherentInstances   #-}

--- a/benchmarks/pldi17/pos/FunctorList.hs
+++ b/benchmarks/pldi17/pos/FunctorList.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--higherorderqs" @-}
 

--- a/benchmarks/pldi17/pos/FunctorMaybe.hs
+++ b/benchmarks/pldi17/pos/FunctorMaybe.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--higherorderqs" @-}
 

--- a/benchmarks/pldi17/pos/FunctorReader.NoExtensionality.hs
+++ b/benchmarks/pldi17/pos/FunctorReader.NoExtensionality.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--betaequivalence"  @-}
 

--- a/benchmarks/pldi17/pos/FunctorReader.hs
+++ b/benchmarks/pldi17/pos/FunctorReader.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--alphaequivalence" @-}
 {-@ LIQUID "--betaequivalence"  @-}

--- a/benchmarks/pldi17/pos/Helper.hs
+++ b/benchmarks/pldi17/pos/Helper.hs
@@ -4,7 +4,6 @@
 
 {-@ LIQUID "--higherorder"     @-}
 {-@ LIQUID "--autoproofs"      @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--betaequivalence" @-}
 
 

--- a/benchmarks/pldi17/pos/MapFusion.hs
+++ b/benchmarks/pldi17/pos/MapFusion.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--higherorderqs" @-}
 

--- a/benchmarks/pldi17/pos/MonadId.hs
+++ b/benchmarks/pldi17/pos/MonadId.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--betaequivalence" @-}
 

--- a/benchmarks/pldi17/pos/MonadList.hs
+++ b/benchmarks/pldi17/pos/MonadList.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--betaequivalence"  @-}
 

--- a/benchmarks/pldi17/pos/MonadMaybe.hs
+++ b/benchmarks/pldi17/pos/MonadMaybe.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"      @-}
-{-@ LIQUID "--totality"         @-}
 {-@ LIQUID "--exact-data-cons"  @-}
 
 {-@ LIQUID "--alphaequivalence" @-}

--- a/benchmarks/pldi17/pos/MonadReader.hs
+++ b/benchmarks/pldi17/pos/MonadReader.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"       @-}
-{-@ LIQUID "--totality"          @-}
 {-@ LIQUID "--exact-data-cons"   @-}
 
 -- NOPROP probably breaks some fixpoint flag 

--- a/benchmarks/pldi17/pos/MonoidList.hs
+++ b/benchmarks/pldi17/pos/MonoidList.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--higherorderqs" @-}
 

--- a/benchmarks/pldi17/pos/MonoidMaybe.hs
+++ b/benchmarks/pldi17/pos/MonoidMaybe.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 
 module MonoidMaybe where

--- a/benchmarks/pldi17/pos/NormalForm.hs
+++ b/benchmarks/pldi17/pos/NormalForm.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"      @-}
-{-@ LIQUID "--totality"         @-}
 {-@ LIQUID "--exact-data-cons"  @-}
 {-@ LIQUID "--alphaequivalence" @-}
 {-@ LIQUID "--betaequivalence"  @-}

--- a/benchmarks/pldi17/pos/Overview.hs
+++ b/benchmarks/pldi17/pos/Overview.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 
 module FunctionAbstraction where
 import Proves

--- a/benchmarks/pldi17/pos/OverviewListInfix.hs
+++ b/benchmarks/pldi17/pos/OverviewListInfix.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--eliminate" @-}
 {-@ LIQUID "--maxparams=10"  @-}

--- a/benchmarks/pldi17/pos/Peano.hs
+++ b/benchmarks/pldi17/pos/Peano.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--higherorderqs" @-}
 

--- a/benchmarks/pldi17/pos/Solver.hs
+++ b/benchmarks/pldi17/pos/Solver.hs
@@ -6,7 +6,6 @@
 -- | Also, &&, not and rest logical operators are not in scope in the axioms
 
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--pruneunsorted"   @-}
 

--- a/benchmarks/pldi17/pos/Unification.hs
+++ b/benchmarks/pldi17/pos/Unification.hs
@@ -6,7 +6,6 @@
 -- where? switch off non-lin-cuts in higher-order mode?
 
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--eliminate=all"   @-}
 

--- a/benchmarks/proofautomation/pos/Ackermann.hs
+++ b/benchmarks/proofautomation/pos/Ackermann.hs
@@ -3,7 +3,6 @@
 -- | http://www.cs.yorku.ca/~gt/papers/Ackermann-function.pdf
 
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 {-@ LIQUID "--proof-method=arithmetic" @-}
 

--- a/benchmarks/proofautomation/pos/AlphaEquivalence.hs
+++ b/benchmarks/proofautomation/pos/AlphaEquivalence.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--alphaequivalence"  @-}
 {-@ LIQUID "--betaequivalence"  @-}

--- a/benchmarks/proofautomation/pos/Append.hs
+++ b/benchmarks/proofautomation/pos/Append.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--higherorderqs" @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}

--- a/benchmarks/proofautomation/pos/ApplicativeId.hs
+++ b/benchmarks/proofautomation/pos/ApplicativeId.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--higherorderqs" @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}

--- a/benchmarks/proofautomation/pos/ApplicativeList.hs
+++ b/benchmarks/proofautomation/pos/ApplicativeList.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 

--- a/benchmarks/proofautomation/pos/ApplicativeMaybe.hs
+++ b/benchmarks/proofautomation/pos/ApplicativeMaybe.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{- LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 

--- a/benchmarks/proofautomation/pos/BasicLambdas.hs
+++ b/benchmarks/proofautomation/pos/BasicLambdas.hs
@@ -1,6 +1,5 @@
 
 {-@ LIQUID "--higherorder"      @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 
 {- LIQUID "--automatic-instances=liquidinstances" @-}

--- a/benchmarks/proofautomation/pos/Compose.hs
+++ b/benchmarks/proofautomation/pos/Compose.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--higherorder"     @-}
 
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 

--- a/benchmarks/proofautomation/pos/Euclide.hs
+++ b/benchmarks/proofautomation/pos/Euclide.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"      @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 

--- a/benchmarks/proofautomation/pos/Fibonacci.hs
+++ b/benchmarks/proofautomation/pos/Fibonacci.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 {-@ LIQUID "--proof-method=arithmetic" @-}
 

--- a/benchmarks/proofautomation/pos/FoldrUniversal.hs
+++ b/benchmarks/proofautomation/pos/FoldrUniversal.hs
@@ -2,7 +2,6 @@
 -- | cite : http://www.seas.upenn.edu/~sweirich/papers/congruence-extended.pdf
 
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 

--- a/benchmarks/proofautomation/pos/FunctionEquality101.hs
+++ b/benchmarks/proofautomation/pos/FunctionEquality101.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--betaequivalence"  @-}
 

--- a/benchmarks/proofautomation/pos/FunctorId.hs
+++ b/benchmarks/proofautomation/pos/FunctorId.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--higherorderqs" @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}

--- a/benchmarks/proofautomation/pos/FunctorList.hs
+++ b/benchmarks/proofautomation/pos/FunctorList.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--higherorderqs" @-}
 

--- a/benchmarks/proofautomation/pos/FunctorMaybe.hs
+++ b/benchmarks/proofautomation/pos/FunctorMaybe.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--higherorderqs" @-}
 

--- a/benchmarks/proofautomation/pos/Helper.hs
+++ b/benchmarks/proofautomation/pos/Helper.hs
@@ -3,7 +3,6 @@
 -- | http://www.cs.yorku.ca/~gt/papers/Ackermann-function.pdf
 
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--betaequivalence" @-}
 
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}

--- a/benchmarks/proofautomation/pos/Lists.hs
+++ b/benchmarks/proofautomation/pos/Lists.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 
 

--- a/benchmarks/proofautomation/pos/MapFusion.hs
+++ b/benchmarks/proofautomation/pos/MapFusion.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--higherorderqs" @-}
 

--- a/benchmarks/proofautomation/pos/Maybe.hs
+++ b/benchmarks/proofautomation/pos/Maybe.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 
 

--- a/benchmarks/proofautomation/pos/MonadId.hs
+++ b/benchmarks/proofautomation/pos/MonadId.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--betaequivalence" @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}

--- a/benchmarks/proofautomation/pos/MonadList.hs
+++ b/benchmarks/proofautomation/pos/MonadList.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--betaequivalence"  @-}
 

--- a/benchmarks/proofautomation/pos/MonadMaybe.hs
+++ b/benchmarks/proofautomation/pos/MonadMaybe.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"      @-}
-{-@ LIQUID "--totality"         @-}
 {-@ LIQUID "--exact-data-cons"  @-}
 
 {-@ LIQUID "--alphaequivalence" @-}

--- a/benchmarks/proofautomation/pos/MonoidList.hs
+++ b/benchmarks/proofautomation/pos/MonoidList.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--higherorderqs" @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}

--- a/benchmarks/proofautomation/pos/MonoidMaybe.hs
+++ b/benchmarks/proofautomation/pos/MonoidMaybe.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 

--- a/benchmarks/proofautomation/pos/NaturalDeduction.hs
+++ b/benchmarks/proofautomation/pos/NaturalDeduction.hs
@@ -6,7 +6,6 @@
 module Examples where
 
 {-@ LIQUID "--higherorder" @-}
-{-@ LIQUID "--totality" @-}
 
 import Language.Haskell.Liquid.ProofCombinators
 

--- a/benchmarks/proofautomation/pos/NormalForm.hs
+++ b/benchmarks/proofautomation/pos/NormalForm.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"      @-}
-{-@ LIQUID "--totality"         @-}
 {-@ LIQUID "--exact-data-cons"  @-}
 {-@ LIQUID "--alphaequivalence" @-}
 {-@ LIQUID "--betaequivalence"  @-}

--- a/benchmarks/proofautomation/pos/Overview.hs
+++ b/benchmarks/proofautomation/pos/Overview.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 
 module FunctionAbstraction where
 import Language.Haskell.Liquid.ProofCombinators

--- a/benchmarks/proofautomation/pos/OverviewListInfix.hs
+++ b/benchmarks/proofautomation/pos/OverviewListInfix.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--maxparams=10"  @-}
 {-@ LIQUID "--higherorderqs" @-}

--- a/benchmarks/proofautomation/pos/Peano.hs
+++ b/benchmarks/proofautomation/pos/Peano.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--higherorderqs" @-}
 

--- a/benchmarks/proofautomation/pos/Solver.hs
+++ b/benchmarks/proofautomation/pos/Solver.hs
@@ -6,7 +6,6 @@
 -- | Also, &&, not and rest logical operators are not in scope in the axioms
 
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--pruneunsorted"   @-}
 

--- a/benchmarks/proofautomation/pos/Unification.hs
+++ b/benchmarks/proofautomation/pos/Unification.hs
@@ -6,7 +6,6 @@
 -- where? switch off non-lin-cuts in higher-order mode?
 
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--eliminate=all"   @-}
 

--- a/benchmarks/sf/Basics.hs
+++ b/benchmarks/sf/Basics.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
-{-@ LIQUID "--totality"                            @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 
 {- NOTE:

--- a/benchmarks/sf/Induction.hs
+++ b/benchmarks/sf/Induction.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
-{-@ LIQUID "--totality"                            @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 
 module Induction where

--- a/benchmarks/sf/InductionRJ.hs
+++ b/benchmarks/sf/InductionRJ.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
-{-@ LIQUID "--totality"                            @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 
 module Induction where

--- a/benchmarks/sf/Lists.hs
+++ b/benchmarks/sf/Lists.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
-{-@ LIQUID "--totality"                            @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 
 module Lists where

--- a/benchmarks/text-0.11.2.3/Data/Text/Fusion/Size.hs
+++ b/benchmarks/text-0.11.2.3/Data/Text/Fusion/Size.hs
@@ -198,4 +198,4 @@ isEmpty _         = False
 
 {-@ overflowError :: Nat @-}
 overflowError :: Int
-overflowError = error "Data.Text.Fusion.Size: size overflow"
+overflowError = unsafeError "Data.Text.Fusion.Size: size overflow"

--- a/benchmarks/text-0.11.2.3/Data/Text/Fusion/Size.hs
+++ b/benchmarks/text-0.11.2.3/Data/Text/Fusion/Size.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-totality" @-}
 {-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-missing-methods #-}
 -- |

--- a/benchmarks/text-0.11.2.3/Data/Text/Lazy.hs
+++ b/benchmarks/text-0.11.2.3/Data/Text/Lazy.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-totality" @-}
 {-@ LIQUID "--pruneunsorted" @-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}

--- a/benchmarks/text-0.11.2.3/Data/Text/Lazy/Encoding.hs
+++ b/benchmarks/text-0.11.2.3/Data/Text/Lazy/Encoding.hs
@@ -1,5 +1,6 @@
 {-@ LIQUID "--pruneunsorted" @-}
 {-@ LIQUID "--notermination" @-}
+{-@ LIQUID "--no-totality" @-}
 
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE Rank2Types #-}

--- a/benchmarks/vector-algorithms-0.5.4.2/Data/Vector/Algorithms/Radix.hs
+++ b/benchmarks/vector-algorithms-0.5.4.2/Data/Vector/Algorithms/Radix.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-totality" @-}
 {-# LANGUAGE ScopedTypeVariables, BangPatterns, TypeOperators #-}
 
 -- ---------------------------------------------------------------------------

--- a/include/GHC/List.spec
+++ b/include/GHC/List.spec
@@ -1,6 +1,6 @@
 module spec GHC.List where 
 
-// head         :: xs:{v: [a] | len(v) > 0} -> {v:a | v = head xs}
+head         :: xs:{v: [a] | len(v) > 0} -> {v:a | v = head xs}
 
 tail         :: xs:{v: [a] | len(v) > 0} -> {v: [a] | len(v) = (len(xs) - 1) && v = tail xs}
 last         :: xs:{v: [a] | len(v) > 0} -> a

--- a/include/Language/Haskell/Liquid/Prelude.hs
+++ b/include/Language/Haskell/Liquid/Prelude.hs
@@ -82,6 +82,10 @@ liquidAssumeB p x | p x = x
                   | otherwise = error "liquidAssumeB fails"
 
 
+{-# NOINLINE unsafeError #-}
+unsafeError :: String -> a
+unsafeError = error
+
 
 {-@ assume liquidError :: {v:String | 0 = 1} -> a  @-}
 {-# NOINLINE liquidError #-}

--- a/include/Prelude.spec
+++ b/include/Prelude.spec
@@ -11,8 +11,12 @@ import Data.Foldable
 import Data.Maybe
 import GHC.Exts
 
+import GHC.Err 
+
 
 GHC.Types.D# :: x:_ -> {v:_ | v = x}
+
+assume error :: {v:_ | false} -> a 
 
 assume GHC.Base.. :: forall <p :: b -> c -> Bool, q :: a -> b -> Bool, r :: a -> c -> Bool>. 
                      {xcmp::a, wcmp::b<q xcmp> |- c<p wcmp> <: c<r xcmp>}

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -193,8 +193,9 @@ config = cmdArgsMode $ Config {
     = def &= help "Disable Trueing Top Level Types"
           &= name "no-true-types"
 
- , totality
-    = def &= help "Check totality"
+ , nototality
+    = def &= help "Disable totality check"
+          &= name "no-totality"
 
  , cores
     = def &= help "Use m cores to solve logical constraints"
@@ -508,7 +509,7 @@ defConfig = Config { files             = def
                    , nocaseexpand      = def
                    , strata            = def
                    , notruetypes       = def
-                   , totality          = def
+                   , nototality        = False
                    , pruneUnsorted     = def
                    , exactDC           = def
                    , noMeasureFields   = def

--- a/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/src/Language/Haskell/Liquid/UX/Config.hs
@@ -61,7 +61,7 @@ data Config = Config {
   , nocaseexpand   :: Bool       -- ^ disable case expand
   , strata         :: Bool       -- ^ enable strata analysis
   , notruetypes    :: Bool       -- ^ disable truing top level types
-  , totality       :: Bool       -- ^ check totality in definitions
+  , nototality     :: Bool       -- ^ disable totality check in definitions
   , pruneUnsorted  :: Bool       -- ^ enable prunning unsorted Refinements
   , cores          :: Maybe Int  -- ^ number of cores used to solve constraints
   , minPartSize    :: Int        -- ^ Minimum size of a partition
@@ -168,7 +168,7 @@ terminationCheck :: (HasConfig t) => t -> Bool
 terminationCheck = terminationCheck' . getConfig
 
 totalityCheck' :: Config -> Bool
-totalityCheck' cfg = totality cfg || totalHaskell cfg
+totalityCheck' cfg = (not (nototality cfg)) || totalHaskell cfg
 
 terminationCheck' :: Config -> Bool
 terminationCheck' cfg = totalHaskell cfg || not (notermination cfg)

--- a/tests/errors/AmbiguousReflect.hs
+++ b/tests/errors/AmbiguousReflect.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--totality"          @-}
 {-@ LIQUID "--exact-data-cons"     @-}
 {-@ LIQUID "--higherorder"        @-}
 

--- a/tests/errors/ExportReflect0.hs
+++ b/tests/errors/ExportReflect0.hs
@@ -2,7 +2,6 @@
 
 {-@ LIQUID "--exactdc"     @-}
 {-@ LIQUID "--higherorder" @-}
-{-@ LIQUID "--totality"    @-}
 
 module Bug (foo, zogbert) where
 

--- a/tests/import/client/ReflectClient1.hs
+++ b/tests/import/client/ReflectClient1.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--totality" @-}
-
 module ReflectClient0 where
 
 import ReflectLib1

--- a/tests/import/client/ReflectClient3.hs
+++ b/tests/import/client/ReflectClient3.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--totality"                            @-}
 {-@ LIQUID "--exact-data-con"                      @-}
 {- LIQUID "--automatic-instances=liquidinstances" @-}
 

--- a/tests/import/client/ReflectClient4.hs
+++ b/tests/import/client/ReflectClient4.hs
@@ -1,5 +1,3 @@
-
-{-@ LIQUID "--totality"                            @-}
 {-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 

--- a/tests/import/client/ReflectClient4a.hs
+++ b/tests/import/client/ReflectClient4a.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--totality"                            @-}
 {-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 

--- a/tests/import/client/ReflectClient5.hs
+++ b/tests/import/client/ReflectClient5.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--totality"                            @-}
 {-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 

--- a/tests/import/client/ReflectClient6.hs
+++ b/tests/import/client/ReflectClient6.hs
@@ -1,5 +1,3 @@
-
-{-@ LIQUID "--totality"                            @-}
 {-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 

--- a/tests/import/client/ReflectClient7.hs
+++ b/tests/import/client/ReflectClient7.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"    @-}
-{-@ LIQUID "--totality"       @-}
 {-@ LIQUID "--exactdc"        @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 

--- a/tests/import/lib/ReflectLib3.hs
+++ b/tests/import/lib/ReflectLib3.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--totality"                            @-}
 {-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 

--- a/tests/import/lib/ReflectLib4.hs
+++ b/tests/import/lib/ReflectLib4.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--totality"                            @-}
 {-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 

--- a/tests/import/lib/ReflectLib5.hs
+++ b/tests/import/lib/ReflectLib5.hs
@@ -1,5 +1,3 @@
-
-{-@ LIQUID "--totality"                            @-}
 {-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 

--- a/tests/import/lib/ReflectLib6.hs
+++ b/tests/import/lib/ReflectLib6.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--totality"                            @-}
 {-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 

--- a/tests/import/lib/ReflectLib7.hs
+++ b/tests/import/lib/ReflectLib7.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"    @-}
-{-@ LIQUID "--totality"       @-}
 {-@ LIQUID "--exactdc"        @-}
 
 module ReflectLib7 where

--- a/tests/neg/CompareConstraints.hs
+++ b/tests/neg/CompareConstraints.hs
@@ -1,3 +1,5 @@
+{-@ LIQUID "--no-totality" @-}
+
 module Foo where
 
 import Language.Haskell.Liquid.Prelude

--- a/tests/neg/GeneralizedTermination.hs
+++ b/tests/neg/GeneralizedTermination.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-totality" @-}
 module GenTerm () where
 
 foo :: Int -> Int -> Int

--- a/tests/neg/NoExhaustiveGuardsError.hs
+++ b/tests/neg/NoExhaustiveGuardsError.hs
@@ -1,5 +1,7 @@
 module Foo where
 
+{-@ LIQUID "--no-totality"      @-}
+
 bar :: Int -> Int -> Int
 bar x y | x >  y = 1
         | x == y = 0

--- a/tests/neg/NoExhaustiveGuardsError.hs
+++ b/tests/neg/NoExhaustiveGuardsError.hs
@@ -1,7 +1,5 @@
 module Foo where
 
-{-@ LIQUID "--no-totality"      @-}
-
 bar :: Int -> Int -> Int
 bar x y | x >  y = 1
         | x == y = 0

--- a/tests/neg/NoExhaustiveGuardsError.hs
+++ b/tests/neg/NoExhaustiveGuardsError.hs
@@ -1,6 +1,5 @@
 module Foo where
 
-{-@ LIQUID "--totality" @-}
 bar :: Int -> Int -> Int
 bar x y | x >  y = 1
         | x == y = 0

--- a/tests/neg/SafePartialFunctions.hs
+++ b/tests/neg/SafePartialFunctions.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--totality" @-}
 module SafePartialFunctions (gotail, gohead) where
 
 import Prelude hiding (fromJust, tail, head)

--- a/tests/neg/grty1.hs
+++ b/tests/neg/grty1.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-totality" @-}
 module Foo () where
 
 moo = insert 4 [1, 2, 0]

--- a/tests/neg/record0.hs
+++ b/tests/neg/record0.hs
@@ -14,4 +14,4 @@ mk x n = BXYZ n (clone x 0)
 
 {-@ clone :: x:a -> n:Int -> {v:[a]| (len v) = n} @-}
 clone :: a -> Int -> [a]
-clone = error "FOO"
+clone = undefined 

--- a/tests/neg/risers.hs
+++ b/tests/neg/risers.hs
@@ -1,7 +1,5 @@
 module Risers  where
 
-{-@ LIQUID "--totality" @-}
-
 {-@ predicate NonNull X = ((len X) > 0) @-}
 
 {- risers :: (Ord a) => zs:[a] -> {v: [[a]] | ((NonNull zs) => (NonNull v)) } @-} 

--- a/tests/pos/ANF.hs
+++ b/tests/pos/ANF.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--no-termination"    @-}
-{-@ LIQUID "--totality"          @-}
 {-@ LIQUID "--no-pattern-inline" @-}
 
 module ANF (Op (..), Expr (..), isImm, isAnf, anf) where

--- a/tests/pos/AVL.hs
+++ b/tests/pos/AVL.hs
@@ -1,6 +1,5 @@
 {- Example of AVL trees by michaelbeaumont -}
 
-{-@ LIQUID "--totality" @-}
 module AVL (Tree, singleton, insert, ht, bFac) where
 
 -- Basic functions

--- a/tests/pos/AVLRJ.hs
+++ b/tests/pos/AVLRJ.hs
@@ -1,7 +1,6 @@
 {- Example of AVL trees by michaelbeaumont -}
 
 {-@ LIQUID "--no-termination" @-}
-{-@ LIQUID "--totality" @-}
 
 module AVL (Tree, empty, singleton, insert, ht, bFac, balanced) where
 

--- a/tests/pos/BST.hs
+++ b/tests/pos/BST.hs
@@ -1,3 +1,5 @@
+{-@ LIQUID "--no-totality" @-}
+
 module BST () where
 
 import Language.Haskell.Liquid.Prelude

--- a/tests/pos/BST.hs
+++ b/tests/pos/BST.hs
@@ -51,7 +51,7 @@ delete k' (Bind k v l r)
 getMin (Bind k v Empty rt) = P k v rt
 getMin (Bind k v lt rt)    = P k0min v0min (Bind k v l' rt)
    where P k0min v0min l' = getMin lt
-getMin _                   = error "getMin"
+getMin _                   = unsafeError "getMin"
 
 chkMin x Empty            = liquidAssertB True
 chkMin x (Bind k v lt rt) = liquidAssertB (x<k) && chkMin x lt && chkMin x rt

--- a/tests/pos/BST000.hs
+++ b/tests/pos/BST000.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-totality" @-}
 module BST where
 
 import Language.Haskell.Liquid.Prelude

--- a/tests/pos/CasesToLogic.hs
+++ b/tests/pos/CasesToLogic.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--totality"          @-}
 {-@ LIQUID "--exact-data-cons"     @-}
 {-@ LIQUID "--higherorder"        @-}
 

--- a/tests/pos/Cat.hs
+++ b/tests/pos/Cat.hs
@@ -1,3 +1,5 @@
+{-@ LIQUID "--no-totality" @-}
+
 {-# LANGUAGE GADTs #-}
 import Control.Category
 import Prelude hiding ((.), id)

--- a/tests/pos/ClassReg.hs
+++ b/tests/pos/ClassReg.hs
@@ -1,3 +1,5 @@
+{-@ LIQUID "--no-totality" @-}
+
 module Compose where
 
 

--- a/tests/pos/CompareConstraints.hs
+++ b/tests/pos/CompareConstraints.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-totality" @-}
 module Foo where
 
 import Language.Haskell.Liquid.Prelude

--- a/tests/pos/ExactFunApp.hs
+++ b/tests/pos/ExactFunApp.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-totality" @-}
 {-@ LIQUID "--higherorder"     @-}
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--higherorderqs" @-}

--- a/tests/pos/FractionalInstance.hs
+++ b/tests/pos/FractionalInstance.hs
@@ -1,3 +1,5 @@
+{-@ LIQUID "--no-totality" @-}
+
 module Fractional where
 
 data Frac a

--- a/tests/pos/GeneralizedTermination.hs
+++ b/tests/pos/GeneralizedTermination.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-totality" @-}
 module GenTerm () where
 
 import Prelude hiding (reverse)

--- a/tests/pos/IcfpDemo.hs
+++ b/tests/pos/IcfpDemo.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-totality" @-}
 module IcfpDemo where
 
 import Prelude hiding (gcd, map, repeat, take)

--- a/tests/pos/Infinity.hs
+++ b/tests/pos/Infinity.hs
@@ -1,7 +1,6 @@
 module Infinity () where
 
 import Language.Haskell.Liquid.Prelude
-{-@ LIQUID "--totality" @-}
 {-@ lazy inf @-}
 
 {-@ inf :: {v:[Int] | (((len v) > oo) && ((len v) > 2))} @-}

--- a/tests/pos/LambdaDeBruijn.hs
+++ b/tests/pos/LambdaDeBruijn.hs
@@ -6,8 +6,6 @@ module LambdaDeBruijn where
 
 import Language.Haskell.Liquid.Prelude
 
-{-@ LIQUID "--totality" @-}
-
 type Var = Int
 {-@ type EVar = {v:Expr| isEVar v} @-}
 

--- a/tests/pos/LambdaEvalMini.hs
+++ b/tests/pos/LambdaEvalMini.hs
@@ -52,7 +52,7 @@ evalVar x ((y, v):sto)
   = evalVar x sto
 
 evalVar x []
-  = error "unbound variable"
+  = unsafeError "unbound variable"
 
 -- A "value" is simply: {v: Expr | isValue v } *)
 
@@ -67,7 +67,7 @@ eval sto (App e1 e2)
         (sto1XXX, e1') = eval sto e1
     in case e1' of
          (Lam x e) -> eval ((x, v2): sto1XXX) e
-         _         -> error "non-function application"
+         _         -> unsafeError "non-function application"
 
 eval sto (Lam x e)
   = (sto, Lam x e)

--- a/tests/pos/LambdaEvalMini.hs
+++ b/tests/pos/LambdaEvalMini.hs
@@ -1,4 +1,5 @@
 {-@ LIQUID "--no-termination" @-}
+{-@ LIQUID "--no-totality" @-}
 
 module LambdaEvalMini () where
 

--- a/tests/pos/LambdaEvalSuperTiny.hs
+++ b/tests/pos/LambdaEvalSuperTiny.hs
@@ -2,6 +2,7 @@
 {-@ LIQUID "--no-totality" @-}
 
 module LambdaEvalMini () where
+import Language.Haskell.Liquid.Prelude 
 
 ---------------------------------------------------------------------
 ----------------------- Datatype Definition -------------------------
@@ -47,7 +48,7 @@ data Expr [elen]
 
 {-@ evalVar :: Bndr -> Store -> Value @-}
 evalVar :: Bndr -> LL (Pair Bndr Expr) -> Expr
-evalVar = error "HIDEME"
+evalVar = unsafeError "HIDEME"
 
 {-@ eval :: Store -> e:Expr -> (Pair Store Value) @-}
 {-@ decrease eval 2 @-}
@@ -59,7 +60,7 @@ eval sto (App e1 e2)
         (P sto1 e1') = eval sto e1
     in case e1' of
          (Lam x e) -> eval (Cons (P x v2) sto1) e
-         _         -> error "non-function application"
+         _         -> unsafeError "non-function application"
 
 eval sto (Lam x e)
   = P sto (Lam x e)

--- a/tests/pos/LambdaEvalSuperTiny.hs
+++ b/tests/pos/LambdaEvalSuperTiny.hs
@@ -1,4 +1,5 @@
 {-@ LIQUID "--no-termination" @-}
+{-@ LIQUID "--no-totality" @-}
 
 module LambdaEvalMini () where
 

--- a/tests/pos/LambdaEvalTiny.hs
+++ b/tests/pos/LambdaEvalTiny.hs
@@ -2,6 +2,7 @@
 {-@ LIQUID "--no-totality" @-}
 
 module LambdaEvalMini () where
+import Language.Haskell.Liquid.Prelude 
 
 ---------------------------------------------------------------------
 ----------------------- Datatype Definition -------------------------
@@ -44,7 +45,7 @@ data Expr [elen]
 
 {-@ evalVar :: Bndr -> Store -> Value @-}
 evalVar :: Bndr -> [(Bndr, Expr)] -> Expr
-evalVar = error "HIDEME"
+evalVar = unsafeError "HIDEME"
 
 {-@ decrease eval 2 @-}
 
@@ -58,7 +59,7 @@ eval sto (App e1 e2)
         (sto1, e1') = eval sto e1
     in case e1' of
          (Lam x e) -> eval ((x, v2) : sto1) e
-         _         -> error "non-function application"
+         _         -> unsafeError "non-function application"
 
 eval sto (Lam x e)
   = (sto, Lam x e)

--- a/tests/pos/LambdaEvalTiny.hs
+++ b/tests/pos/LambdaEvalTiny.hs
@@ -1,4 +1,5 @@
 {-@ LIQUID "--no-termination" @-}
+{-@ LIQUID "--no-totality" @-}
 
 module LambdaEvalMini () where
 

--- a/tests/pos/LiquidArray.hs
+++ b/tests/pos/LiquidArray.hs
@@ -17,4 +17,4 @@ get i a = a i
 
 {-@ empty :: i: {v: Int | 0 = 1} -> a @-}
 empty :: Int -> a
-empty = const (error "Empty array!")
+empty = const undefined 

--- a/tests/pos/LogicCurry1.hs
+++ b/tests/pos/LogicCurry1.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--maxparams=5"     @-}
 
 

--- a/tests/pos/MapFusion.hs
+++ b/tests/pos/MapFusion.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}

--- a/tests/pos/MapReduceVerified.hs
+++ b/tests/pos/MapReduceVerified.hs
@@ -4,7 +4,6 @@
 -- | Niki Vazou Sep 2016 
 
 {-@ LIQUID "--higherorder"   @-}
-{-@ LIQUID "--totality"      @-}
 {-@ LIQUID "--exactdc"       @-}
 
 

--- a/tests/pos/MutualRec.hs
+++ b/tests/pos/MutualRec.hs
@@ -21,18 +21,18 @@ fromDistinctAscList xs
 -- LIQUID for n = 1 n `div` 2 = 0 and the assume does not hold
     create c 1 xs' = case xs' of
                        (k1,x1):xx -> c (singleton k1 x1) xx
-                       _ -> error "fromDistinctAscList create"
+                       _ -> unsafeError "fromDistinctAscList create"
     create c 5 xs' = case xs' of
                        ((k1,x1):(k2,x2):(k3,x3):(k4,x4):(k5,x5):xx)
                             -> c (bin k4 x4 (bin k2 x2 (singleton k1 x1) (singleton k3 x3)) (singleton k5 x5)) xx
-                       _ -> error "fromDistinctAscList create"
+                       _ -> unsafeError "fromDistinctAscList create"
     create c n xs' = seq nr $ create (createR nr c) nl xs'
       where nl = liquidAssume (m < n && m >= 0) m
             m  = n `div` 2
             nr = n - nl - 1
 
     createR (n::Int) c l ((k,x):ys) = create (createB l k x c) n ys
-    createR _ _ _ []         = error "fromDistinctAscList createR []"
+    createR _ _ _ []         = unsafeError "fromDistinctAscList createR []"
     createB l k x c r zs     = c (bin k x l r) zs
 
 

--- a/tests/pos/NatClass.hs
+++ b/tests/pos/NatClass.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 {-@ LIQUID "--exact-data-cons" @-}
 
 module Nat where

--- a/tests/pos/NoExhaustiveGuardsError.hs
+++ b/tests/pos/NoExhaustiveGuardsError.hs
@@ -1,6 +1,6 @@
 module Foo where
 
-{-@ LIQUID "--totality" @-}
+{-@ LIQUID "--no-totality" @-}
 bar :: Int -> Int -> Int
 bar x y | x >  y = 1
         | x <= y = 0

--- a/tests/pos/ORM.hs
+++ b/tests/pos/ORM.hs
@@ -1,7 +1,6 @@
 module ORM where 
 
 {-@ LIQUID "--exactdc"  @-}
-{-@ LIQUID "--totality" @-}
 {-@ LIQUID "--higherorder" @-}
 
 

--- a/tests/pos/PointDist.hs
+++ b/tests/pos/PointDist.hs
@@ -50,6 +50,6 @@ root x  = assume (rx > 0) rx
 
 {-@ assume     :: b:_ -> a -> {v:a | b} @-}
 assume True  x = x
-assume False _ = error "Failed Dynamic Check!"
+assume False _ = undefined -- error "Failed Dynamic Check!"
 
 

--- a/tests/pos/Product.hs
+++ b/tests/pos/Product.hs
@@ -1,6 +1,3 @@
-{-@ LIQUID "--totality" @-}
-
-
 module Vectors where
 
 import Prelude hiding (sum, product, zipWith)

--- a/tests/pos/RBTree-color.hs
+++ b/tests/pos/RBTree-color.hs
@@ -100,13 +100,13 @@ deleteMin' x (Node B lx ll lr) r = (k, lbalS x l' r )   where (k, l') = deleteMi
 lbalS k (Node R x a b) r              = Node R k (Node B x a b) r
 lbalS k l (Node B y a b)              = let t = rbal k l (Node R y a b) in t 
 lbalS k l (Node R z (Node B y a b) c) = Node R y (Node B k l a) (rbal z b (makeRed c))
-lbalS k l r                           = error "nein"
+lbalS k l r                           = unsafeError "nein"
 
 {-@ rbalS                             :: k:a -> l:RBT a -> r:ARBT a -> {v: ARBT a | ((IsB l) => (isRB v))} @-}
 rbalS k l (Node R y b c)              = Node R k l (Node B y b c)
 rbalS k (Node B x a b) r              = let t = lbal k (Node R x a b) r in t 
 rbalS k (Node R x a (Node B y b c)) r = Node R y (lbal x (makeRed a) b) (Node B k c r)
-rbalS k l r                           = error "nein" 
+rbalS k l r                           = unsafeError "nein" 
 
 {-@ lbal                              :: k:a -> l:ARBT a -> RBT a -> RBT a @-}
 lbal k (Node R y (Node R x a b) c) r  = Node R y (Node B x a b) (Node B k c r)
@@ -126,7 +126,7 @@ rbal x l r                            = Node B x l r
 
 {-@ makeRed :: l:BlackRBT a -> ARBT a @-}
 makeRed (Node B x l r) = Node R x l r
-makeRed _              = error "nein" 
+makeRed _              = unsafeError "nein" 
 
 {-@ makeBlack :: ARBT a -> RBT a @-}
 makeBlack Leaf           = Leaf

--- a/tests/pos/RBTree-height.hs
+++ b/tests/pos/RBTree-height.hs
@@ -1,5 +1,6 @@
 
 {-@ LIQUID "--no-termination"   @-}
+{-@ LIQUID "--no-totality"      @-}
 
 module RedBlackTree where
 

--- a/tests/pos/RBTree-height.hs
+++ b/tests/pos/RBTree-height.hs
@@ -102,13 +102,13 @@ deleteMin' x (Node B lx ll lr) r = (k, lbalS x l' r )   where (k, l') = deleteMi
 lbalS k (Node R x a b) r              = Node R k (Node B x a b) r
 lbalS k l (Node B y a b)              = let t = rbal k l (Node R y a b) in t 
 lbalS k l (Node R z (Node B y a b) c) = Node R y (Node B k l a) (rbal z b (makeRed c))
-lbalS k l r                           = error "nein"
+lbalS k l r                           = unsafeError "nein"
 
 {-@ rbalS  :: k:a -> l:RBT a -> r:RBTN a {(bh l) - 1} -> RBTN a {(bh l)}    @-}
 rbalS k l (Node R y b c)              = Node R k l (Node B y b c)
 rbalS k (Node B x a b) r              = let t = lbal k (Node R x a b) r in t 
 rbalS k (Node R x a (Node B y b c)) r = Node R y (lbal x (makeRed a) b) (Node B k c r)
-rbalS k l r                           = error "nein"
+rbalS k l r                           = unsafeError "nein"
 
 {-@ lbal  :: k:a -> l:RBT a -> RBTN a {(bh l)} -> RBTN a {1 + (bh l)} @-}
 lbal k (Node R y (Node R x a b) c) r  = Node R y (Node B x a b) (Node B k c r)
@@ -126,7 +126,7 @@ rbal x l r                            = Node B x l r
 
 {-@ makeRed :: l:RBT a -> RBTN a {(bh l) - 1} @-}
 makeRed (Node B x l r) = Node R x l r
-makeRed _              = error "nein"
+makeRed _              = unsafeError "nein"
 
 {-@ makeBlack :: RBT a -> RBT a @-}
 makeBlack Leaf           = Leaf

--- a/tests/pos/RBTree-ord.hs
+++ b/tests/pos/RBTree-ord.hs
@@ -99,12 +99,12 @@ deleteMin' x (Node B lx ll lr) r = (k, lbalS x l' r )   where (k, l') = deleteMi
 lbalS k (Node R x a b) r              = Node R k (Node B x a b) r
 lbalS k l (Node B y a b)              = let t = rbal k l (Node R y a b) in t
 lbalS k l (Node R z (Node B y a b) c) = Node R y (Node B k l a) (rbal z b (makeRed c))
-lbalS k l r                           = error "nein"
+lbalS k l r                           = unsafeError "nein"
 
 rbalS k l (Node R y b c)              = Node R k l (Node B y b c)
 rbalS k (Node B x a b) r              = let t = lbal k (Node R x a b) r in t
 rbalS k (Node R x a (Node B y b c)) r = Node R y (lbal x (makeRed a) b) (Node B k c r)
-rbalS k l r                           = error "nein"
+rbalS k l r                           = unsafeError "nein"
 
 lbal k (Node R y (Node R x a b) c) r  = Node R y (Node B x a b) (Node B k c r)
 lbal k (Node R x a (Node R y b c)) r  = Node R y (Node B x a b) (Node B k c r)
@@ -119,7 +119,7 @@ rbal x l r                            = Node B x l r
 ---------------------------------------------------------------------------
 
 makeRed (Node _ x l r) = Node R x l r
-makeRed Leaf           = error "nein"
+makeRed Leaf           = unsafeError "nein"
 
 makeBlack Leaf           = Leaf
 makeBlack (Node _ x l r) = Node B x l r

--- a/tests/pos/RBTree-ord.hs
+++ b/tests/pos/RBTree-ord.hs
@@ -1,5 +1,6 @@
 
 {-@ LIQUID "--no-termination"   @-}
+{-@ LIQUID "--no-totality"      @-}
 
 module Foo (add, remove, deleteMin, deleteMin') where
 

--- a/tests/pos/RecordSelectorError.hs
+++ b/tests/pos/RecordSelectorError.hs
@@ -1,8 +1,5 @@
 module Foo where
 
-{-@ LIQUID "--totality" @-}
-
-
 data F a b = F {fx :: a, fy :: b} | G {fx :: a}
 {-@ data F a b = F {fx :: a, fy :: b} | G {fx :: a} @-}
 

--- a/tests/pos/ReflectBooleanFunctions.hs
+++ b/tests/pos/ReflectBooleanFunctions.hs
@@ -1,6 +1,5 @@
-{-@ LIQUID "--totality"        @-}
-{-@ LIQUID "--exactdc" @-}
-{-@ LIQUID "--higherorder"        @-}
+{-@ LIQUID "--exactdc"      @-}
+{-@ LIQUID "--higherorder"  @-}
 module Data.Foo where
 
 

--- a/tests/pos/SafePartialFunctions.hs
+++ b/tests/pos/SafePartialFunctions.hs
@@ -1,6 +1,3 @@
-
-{-@ LIQUID "--totality" @-}
-
 module SafePartialFunctions (gotail, gohead) where
 
 import Prelude hiding (fromJust, tail, head)

--- a/tests/pos/StackMachine.hs
+++ b/tests/pos/StackMachine.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--totality"       @-}
 {-@ LIQUID "--no-termination" @-}
 {-@ LIQUID "--prune-unsorted" @-}
 

--- a/tests/pos/T1013.hs
+++ b/tests/pos/T1013.hs
@@ -1,6 +1,6 @@
 {-@ LIQUID "--higherorder"    @-}
-{-@ LIQUID "--totality"       @-}
 {-@ LIQUID "--exactdc"        @-}
+
 {-# LANGUAGE RankNTypes #-}
 module Generics2 where
 

--- a/tests/pos/T1024.hs
+++ b/tests/pos/T1024.hs
@@ -1,7 +1,5 @@
 {-@ LIQUID "--exactdc"     @-}
 {-@ LIQUID "--higherorder" @-}
-{-@ LIQUID "--totality"    @-}
-
 
 module Bug where
 

--- a/tests/pos/T1025.hs
+++ b/tests/pos/T1025.hs
@@ -1,6 +1,6 @@
 {-@ LIQUID "--exactdc"     @-}                                                            
 {-@ LIQUID "--higherorder" @-}                                                            
-{-@ LIQUID "--totality"    @-}                                                            
+
 module Bug where                                                                          
                                                                                           
 import Language.Haskell.Liquid.ProofCombinators                                           

--- a/tests/pos/T1025a.hs
+++ b/tests/pos/T1025a.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--exactdc"     @-}                                                            
 {-@ LIQUID "--higherorder" @-}                                                            
-{-@ LIQUID "--totality"    @-}                                                            
 
 module Bug where                                                                          
                                                                                           

--- a/tests/pos/T595a.hs
+++ b/tests/pos/T595a.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--totality" @-}
-
 module T595a where
 
 data Tree a = Nil | Tree { key :: a, l::Tree a, r :: Tree a}

--- a/tests/pos/T819.hs
+++ b/tests/pos/T819.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--totality"    @-}
 {-@ LIQUID "--higherorder" @-}
 {-@ LIQUID "--exactdc"     @-}
 module Data.Foo where

--- a/tests/pos/T820.hs
+++ b/tests/pos/T820.hs
@@ -1,6 +1,5 @@
-{-@ LIQUID "--totality"        @-}
-{-@ LIQUID "--exactdc" @-}
-{-@ LIQUID "--higherorder"        @-}
+{-@ LIQUID "--exactdc"     @-}
+{-@ LIQUID "--higherorder" @-}
 module Data.Foo where
 
 import Language.Haskell.Liquid.ProofCombinators 

--- a/tests/pos/T866.hs
+++ b/tests/pos/T866.hs
@@ -1,3 +1,5 @@
+{-@ LIQUID "--no-totality"    @-}
+
 -- see https://github.com/ucsd-progsys/liquidhaskell/issues/866
 
 module T866 where 

--- a/tests/pos/Term.hs
+++ b/tests/pos/Term.hs
@@ -1,3 +1,5 @@
+{-@ LIQUID "--no-totality"    @-}
+
 module Term where
 
 

--- a/tests/pos/Term.hs
+++ b/tests/pos/Term.hs
@@ -2,16 +2,17 @@
 
 module Term where
 
+import Language.Haskell.Liquid.Prelude (unsafeError)
 
 -- TODO: If we remove the type signature LH crashes
 f :: (Num a) => String -> [a] -> [a]
 {-@ f :: _ -> xs : [a] -> [a] / [len xs] @-}
-f er [] = error er
+f er [] = unsafeError er
 f er (x:xs) = (x+1) : f er xs
 
 f' :: String -> [a] -> [a]
 {-@ f' :: _ -> xs : [a] -> [a] / [len xs] @-}
-f' er [] = error er
+f' er [] = unsafeError er
 f' er (x:xs) = x : f' er xs
 
 {-@ type ListN a N = {v:[a] | len v = N} @-}
@@ -21,4 +22,4 @@ safeZipWithError :: String -> [a] -> [b] -> [(a, b)]
 {-@ safeZipWithError :: _ -> xs:[a] -> ListL b xs -> ListL (a,b) xs / [len xs] @-}
 safeZipWithError msg (x:xs) (y:ys) = (x,y) : safeZipWithError msg xs ys
 safeZipWithError _   []     []     = []
-safeZipWithError msg _      _      = error msg
+safeZipWithError msg _      _      = unsafeError msg

--- a/tests/pos/ToyMVar.hs
+++ b/tests/pos/ToyMVar.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE MagicHash     #-}
 {-# LANGUAGE UnboxedTuples #-}
 
+{-@ LIQUID "--no-totality"       @-}
 {-@ LIQUID "--no-termination"    @-}
 {-@ LIQUID "--no-pattern-inline" @-}
 

--- a/tests/pos/VerifiedMonoid.hs
+++ b/tests/pos/VerifiedMonoid.hs
@@ -2,7 +2,6 @@ module Data.Monoid where
 
 {-@ LIQUID "--higherorder" @-}
 {-@ LIQUID "--exactdc" @-}
-{-@ LIQUID "--totality" @-}
 
 import Prelude hiding (Monoid (..))
 

--- a/tests/pos/WrapUnWrap.hs
+++ b/tests/pos/WrapUnWrap.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--totality"     @-}
 {-@ LIQUID "--higherorder"  @-}
 {-@ LIQUID "--exactdc"      @-}
 module Data.Foo where

--- a/tests/pos/case-lambda-join.hs
+++ b/tests/pos/case-lambda-join.hs
@@ -11,7 +11,7 @@ data Color    = B | R deriving (Eq)
 
 {-@ rbalBAD, rbalOK :: k:_ -> l:_ -> r:_ -> {v:_ | Join v k l r} @-}
 rbalBAD x l r = case r of
-  Node R y b (Node R z c d) -> error "ASD" -- Node R y (Node B x l b) (Node B z c d)
+  Node R y b (Node R z c d) -> unsafeError "ASD" -- Node R y (Node B x l b) (Node B z c d)
   Node R z (Node R y b c) d -> Node R y (Node B x l b) (Node B z c d)
 
 rbalOK x l r = case r of

--- a/tests/pos/case-lambda-join.hs
+++ b/tests/pos/case-lambda-join.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-totality" @-}
 {-@ LIQUID "--no-termination"   @-}
 
 module Foo where

--- a/tests/pos/dropwhile.hs
+++ b/tests/pos/dropwhile.hs
@@ -1,5 +1,6 @@
 {-@ LIQUID "--no-termination" @-}
 {-@ LIQUID "--no-pattern-inline" @-}
+{-@ LIQUID "--no-totality" @-}
 
 module DropWhile where
 

--- a/tests/pos/duplicate-bind.hs
+++ b/tests/pos/duplicate-bind.hs
@@ -3,4 +3,4 @@ module Meas where
 import Language.Haskell.Liquid.Prelude
 
 insert key value [] = [(key, value)]
-insert _ _ _        = error ""
+insert _ _ _        = unsafeError ""

--- a/tests/pos/elim-ex-list.hs
+++ b/tests/pos/elim-ex-list.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-totality" @-}
 
 {-# LANGUAGE QuasiQuotes #-}
 

--- a/tests/pos/elim00.hs
+++ b/tests/pos/elim00.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-totality" @-}
 {-@ LIQUID "--short-names"  @-}
 
 module Elim where

--- a/tests/pos/foldr.hs
+++ b/tests/pos/foldr.hs
@@ -4,7 +4,7 @@ import Language.Haskell.Liquid.Prelude
 import Data.List (foldl')
 
 foo ::  a -> b -> c -> d
-foo = \_ _ _ -> error "False" 
+foo = \_ _ _ -> unsafeError "False" 
 
 bar ::  p -> [(q, r)] -> p
 bar = foldr (\(k, v) -> foo k v)

--- a/tests/pos/gimme.hs
+++ b/tests/pos/gimme.hs
@@ -1,12 +1,14 @@
 module Blank () where
 
+import Language.Haskell.Liquid.Prelude
+
 {- qualif Gimme(v:[a], n:int, acc:[a]): (len v == n + 1 + len acc) -}
 
 {-@ gimme :: xs:[a] -> n:Int -> acc:[a] -> {v:[a] | len v = n + 1 + len acc} @-}
 gimme :: [a] -> Int -> [a] -> [a]
 gimme xs (-1) acc  = acc
 gimme (x:xs) n acc = gimme xs (n-1) (x : acc)
-gimme _ _ _        = error "gimme"
+gimme _ _ _        = unsafeError "gimme"
 
 {-@ boober :: n:Int -> Int -> {v:[Int] | (len v) = n} @-}
 boober :: Int -> Int -> [Int]

--- a/tests/pos/grty1.hs
+++ b/tests/pos/grty1.hs
@@ -1,4 +1,5 @@
 module Test () where
+import Language.Haskell.Liquid.Prelude 
 
 {-@ sz :: {v:[a]|((len v) = 1)} -> a @-}
 -- sz (x:xs) = sz xs
@@ -7,4 +8,4 @@ sz [x]    = x
 {-@ poo :: [a] -> a @-}
 poo (x:xs) = poo xs
 poo [x]    = x
-poo _      = error "poo"
+poo _      = unsafeError "poo"

--- a/tests/pos/inline.hs
+++ b/tests/pos/inline.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-totality" @-}
 module Fixme where
 
 {-@ inline eqq @-}

--- a/tests/pos/maybe0.hs
+++ b/tests/pos/maybe0.hs
@@ -5,7 +5,7 @@ import Language.Haskell.Liquid.Prelude
 {-@ foo :: x:Maybe a -> {v:a | ((isJust(x)) => (fromJust(x) = v)) } @-}
 foo :: Maybe a -> a 
 foo (Just x)  = x 
-foo (Nothing) = error "foo"
+foo (Nothing) = unsafeError "foo"
 
 {-@ bar :: x:Maybe a -> {v:Bool | v <=> isJust x } @-}
 bar (Just x)  = True 

--- a/tests/pos/maybe1.hs
+++ b/tests/pos/maybe1.hs
@@ -1,3 +1,5 @@
+{-@ LIQUID "--no-totality" @-}
+
 module Test (isJustS, fromJustS) where
 
 data MaybeS a = NothingS | JustS !a

--- a/tests/pos/meas00.hs
+++ b/tests/pos/meas00.hs
@@ -1,3 +1,5 @@
+{-@ LIQUID "--no-totality" @-}
+
 module Zog () where
 
 import Language.Haskell.Liquid.Prelude

--- a/tests/pos/meas10.hs
+++ b/tests/pos/meas10.hs
@@ -2,6 +2,9 @@ module Meas where
 
 import Data.Set (Set(..))
 
+import Language.Haskell.Liquid.Prelude
+
+
 {-@ include <listSet.hquals> @-}
 
 {-@ myrev :: xs:[a] -> {v:[a]| listElts(v) = listElts(xs)} @-}
@@ -15,7 +18,7 @@ myrev xs = go [] xs
 {- goo :: xs:[a] -> ys:[a] -> {v:[a] | listElts(v) = Set_cup(listElts(xs), listElts(ys))} @-}
 goo :: [a] -> [a] -> [a]
 goo acc []     = acc
-goo acc (y:ys) = error "foo" -- goRev (y:acc) ys
+goo acc (y:ys) = unsafeError "foo" -- goRev (y:acc) ys
 
 {-@ emptySet :: a -> {v:[b] | Set_emp(listElts(v))} @-}
 emptySet :: a -> [b]

--- a/tests/pos/partialmeasure.hs
+++ b/tests/pos/partialmeasure.hs
@@ -1,3 +1,5 @@
+{-@ LIQUID "--no-totality" @-}
+
 module Head where
 
 -- Note: `partialmeasureOld.hs` works fine 

--- a/tests/pos/propmeasure.hs
+++ b/tests/pos/propmeasure.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--totality" @-}
 {-# LANGUAGE EmptyDataDecls #-}
 
 module BoolMeasure where

--- a/tests/pos/record0.hs
+++ b/tests/pos/record0.hs
@@ -20,4 +20,4 @@ bk (BXYZ n xs) = liquidAssert (length xs == n) n
 
 {-@ clone :: x:a -> n:Int -> {v:[a]| (len v) = n} @-}
 clone :: a -> Int -> [a]
-clone = error "FOO"
+clone = unsafeError "FOO"

--- a/tests/pos/record1.hs
+++ b/tests/pos/record1.hs
@@ -11,5 +11,5 @@ data Map k a  = Tip
   @-}
 
 trim :: Map k a
-trim = error "TODO"
+trim = undefined 
 

--- a/tests/pos/reflect0.hs
+++ b/tests/pos/reflect0.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--totality"        @-}
 
 module FunctionAbstraction where
 

--- a/tests/pos/risers.hs
+++ b/tests/pos/risers.hs
@@ -1,7 +1,5 @@
 module Risers () where
 
-{-@ LIQUID "--totality" @-}
-
 {-@ predicate NonNull X = ((len X) > 0) @-}
 
 {-@ risers :: (Ord a) => zs:[a] -> {v: [[a]] | ((NonNull zs) => (NonNull v)) } @-} 

--- a/tests/pos/take.hs
+++ b/tests/pos/take.hs
@@ -1,3 +1,5 @@
+{-@ LIQUID "--no-totality"    @-}
+
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE CPP,  NoImplicitPrelude, MagicHash #-}
 {-# OPTIONS_HADDOCK hide #-}
@@ -9,7 +11,7 @@ module Take (
 
 import Data.Maybe
 import GHC.Base 
-import Language.Haskell.Liquid.Prelude (liquidAssert, liquidError) 
+import Language.Haskell.Liquid.Prelude (liquidAssert, liquidError, unsafeError) 
 
 
 
@@ -20,7 +22,7 @@ take0 (I# n#) xs = take_unsafe_UInt0 n# xs
 take_unsafe_UInt0 :: Int# -> [a] -> [a]
 take_unsafe_UInt0 0#  _     = []
 take_unsafe_UInt0 n  (x:xs) = x : take_unsafe_UInt0 (n -# 1#) xs
-take_unsafe_UInt0 _   _     = error "unsafe take"
+take_unsafe_UInt0 _   _     = unsafeError "unsafe take"
 
 {-@ assert take  :: n: {v: Int | v >= 0 } -> xs:[a] -> {v:[a] | len v = if len xs < n then (len xs) else n } @-}
 take (I# n#) xs = takeUInt n# xs

--- a/tests/pos/zipper0.hs
+++ b/tests/pos/zipper0.hs
@@ -1,3 +1,5 @@
+{-@ LIQUID "--no-totality" @-}
+
 module Zipper (getUp, getDown, getFocus) where
 
 import Prelude hiding (reverse)

--- a/tests/pos/zipper000.hs
+++ b/tests/pos/zipper000.hs
@@ -1,3 +1,5 @@
+{-@ LIQUID "--no-totality" @-}
+
 module Zipper (getUp, getDown) where
 
 import Data.Set


### PR DESCRIPTION
Turn on the totality check by default. 

Give false precondition to Haskell's `error` function. 