### PR TITLE
Make cabal new-build possible with liquidhaskell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,11 @@ _build
 *~
 *.swp
 *.swo
+dist-newstyle
+.cabal-sandbox/
+cabal.sandbox.config
+.ghc.environment.*
+cabal.project.local
 
 /.stack-work/
 /.vagrant/

--- a/cabal.project
+++ b/cabal.project
@@ -3,7 +3,6 @@
 
 packages: .
           ./liquid-fixpoint
-          ./liquiddesugar
 
 package liquid-fixpoint
   flags: devel


### PR DESCRIPTION
`liquiddesugar` is no longer a submodule, yet it was still listed in `cabal.project`, which confuses `cabal new-build`.

While I was in town, I added some build artifacts produced by `cabal new-build`.