### PR TITLE
Simplify PLE (Instantiate) with ADTs

### DIFF
--- a/benchmarks/proofautomation/pos/ApplicativeId.hs
+++ b/benchmarks/proofautomation/pos/ApplicativeId.hs
@@ -1,13 +1,12 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
-{-@ LIQUID "--higherorderqs" @-}
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
+{-@ LIQUID "--higherorder"                          @-}
+{-@ LIQUID "--exact-data-cons"                      @-}
+{-@ LIQUID "--higherorderqs"                        @-}
+{-@ LIQUID "--automatic-instances=liquidinstances"  @-}
 
+{-# LANGUAGE IncoherentInstances  #-}
+{-# LANGUAGE FlexibleContexts     #-}
 
-
-{-# LANGUAGE IncoherentInstances   #-}
-{-# LANGUAGE FlexibleContexts #-}
-module FunctorList where
+module ApplicativeId where
 
 import Prelude hiding (fmap, id, pure, seq)
 
@@ -47,8 +46,7 @@ data Identity a = Identity a
 -- | Identity
 {-@ identity :: x:Identity a -> { seq (pure id) x == x } @-}
 identity :: Identity a -> Proof
-identity (Identity x)
-  =   trivial 
+identity (Identity x) = trivial
 
 -- | Composition
 
@@ -58,7 +56,7 @@ identity (Identity x)
                 -> { (seq (seq (seq (pure compose) x) y) z) == seq x (seq y z) } @-}
 composition :: Identity (a -> a) -> Identity (a -> a) -> Identity a -> Proof
 composition (Identity x) (Identity y) (Identity z)
-  =   trivial 
+  =   trivial
 
 -- | homomorphism  pure f <*> pure x = pure (f x)
 
@@ -66,11 +64,11 @@ composition (Identity x) (Identity y) (Identity z)
                  -> { seq (pure f) (pure x) == pure (f x) } @-}
 homomorphism :: (a -> a) -> a -> Proof
 homomorphism f x
-  =   trivial 
+  =   trivial
 
 interchange :: Identity (a -> a) -> a -> Proof
 {-@ interchange :: u:(Identity (a -> a)) -> y:a
      -> { seq u (pure y) == seq (pure (idollar y)) u }
   @-}
 interchange (Identity f) x
-  =   trivial 
+  =   trivial

--- a/benchmarks/sf/Induction.hs
+++ b/benchmarks/sf/Induction.hs
@@ -9,7 +9,7 @@ import qualified Prelude
 
 import Language.Haskell.Liquid.ProofCombinators
 
-{-@ data Peano [toNat] = O | S Peano @-}
+{-@ data Peano [toNat] @-} 
 data Peano = O | S Peano
 
 {-@ measure toNat @-}

--- a/benchmarks/sf/Lists.hs
+++ b/benchmarks/sf/Lists.hs
@@ -149,7 +149,7 @@ app (Cons h t) l2 = Cons h (app t l2)
 {-@ reflect hd @-}
 hd :: Peano -> NatList -> Peano
 hd def Nil        = def
-hd _   (Cons h t) = h 
+hd _   (Cons h t) = h
 
 {-@ reflect tl @-}
 tl :: NatList -> NatList
@@ -176,7 +176,7 @@ nonzeros' l = filter (\x -> negb (beq x O)) l
 
 -- TODO: Stuck. See: https://github.com/ucsd-progsys/liquidhaskell/issues/1035
 
--- {-@ testNonzeros' :: { 
+-- {-@ testNonzeros' :: {
 --   nonzeros' (Cons p0 (Cons p1 (Cons p0 (Cons p2 (Cons p3 (Cons p0 (Cons p0 Nil))))))) =
 --   (Cons p1 (Cons p2 (Cons p3 Nil))) } @-}
 
@@ -427,7 +427,7 @@ subset (Cons h t) s2 = case member h s2 of
 -- | Reasoning About Lists -----------------------------------------------------
 --------------------------------------------------------------------------------
 
-{-@ thmNilApp :: { lhs : NatList | lhs = Nil } 
+{-@ thmNilApp :: { lhs : NatList | lhs = Nil }
               -> rhs : NatList
               -> { app lhs rhs = rhs }
 @-}

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -337,7 +337,6 @@ makeGhcSpec' cfg file cbs tcs instenv vars defVars exports specs0 = do
   syms0 <- liftedVarMap (varInModule name) expSyms
   syms1 <- symbolVarMap (varInModule name) vars (S.toList $ importedSymbols name   specs)
   (tycons, datacons, dcSs, recSs, tyi, adts) <- makeGhcSpecCHOP1 cfg specs embs (syms0 ++ syms1)
-  -- setDataDecls (F.tracepp "DATADECLS" adts)
   checkShadowedSpecs dcSs (Ms.measures mySpec) expSyms defVars
   makeBounds embs name defVars cbs specs
   modify                                   $ \be -> be { tcEnv = tyi }
@@ -666,7 +665,7 @@ makeGhcSpecCHOP1 cfg specs embs syms = do
   let tds          = [(name, tc, dd) | (name, tc, _, Just dd) <- tcDds]
   let adts         = makeDataDecls cfg embs tds datacons
   dm              <- gets dcEnv
-  setDataDecls (F.tracepp "DATADECLS" adts)
+  _               <- setDataDecls adts
   let dcSelectors  = concatMap (makeMeasureSelectors cfg dm) datacons
   recSels         <- makeRecordSelectorSigs datacons
   return             (tycons, second val <$> datacons, dcSelectors, recSels, tyi, adts)
@@ -837,7 +836,7 @@ replaceLocalBindsOne allowHO v
                              env' (zip ty_binds ty_args)
            let res  = substa (f env) ty_res
            let t'   = fromRTypeRep $ t { ty_args = args, ty_res = res }
-           let msg  = ErrTySpec (GM.sourcePosSrcSpan l) (text "replaceLocalBindsOne" <+> pprint v) t'
+           let msg  = ErrTySpec (GM.sourcePosSrcSpan l) ({- text "replaceLocalBindsOne" <+> -} pprint v) t'
            case checkTy allowHO msg emb tyi fenv (Loc l l' t') of
              Just err -> Ex.throw err
              Nothing  -> modify (first $ M.insert v (Loc l l' t'))

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -337,7 +337,7 @@ makeGhcSpec' cfg file cbs tcs instenv vars defVars exports specs0 = do
   syms0 <- liftedVarMap (varInModule name) expSyms
   syms1 <- symbolVarMap (varInModule name) vars (S.toList $ importedSymbols name   specs)
   (tycons, datacons, dcSs, recSs, tyi, adts) <- makeGhcSpecCHOP1 cfg specs embs (syms0 ++ syms1)
-  setDataDecls (F.tracepp "DATADECLS" adts)
+  -- setDataDecls (F.tracepp "DATADECLS" adts)
   checkShadowedSpecs dcSs (Ms.measures mySpec) expSyms defVars
   makeBounds embs name defVars cbs specs
   modify                                   $ \be -> be { tcEnv = tyi }
@@ -665,7 +665,9 @@ makeGhcSpecCHOP1 cfg specs embs syms = do
   datacons        <- makePluggedDataCons embs tyi (concat dcs ++ wiredDataCons)
   let tds          = [(name, tc, dd) | (name, tc, _, Just dd) <- tcDds]
   let adts         = makeDataDecls cfg embs tds datacons
-  let dcSelectors  = concatMap (makeMeasureSelectors cfg) datacons
+  dm              <- gets dcEnv
+  setDataDecls (F.tracepp "DATADECLS" adts)
+  let dcSelectors  = concatMap (makeMeasureSelectors cfg dm) datacons
   recSels         <- makeRecordSelectorSigs datacons
   return             (tycons, second val <$> datacons, dcSelectors, recSels, tyi, adts)
 

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -214,7 +214,7 @@ makeLiftedSpec0 cfg embs cbs tcs mySpec = do
   return  $ mempty { Ms.ealiases  = lmapEAlias . snd <$> xils
                    , Ms.measures  = ms
                    , Ms.reflects  = Ms.reflects mySpec
-                   , Ms.dataDecls = makeHaskellDataDecls cfg mySpec tcs
+                   , Ms.dataDecls = F.tracepp "DATADECLS" $ makeHaskellDataDecls cfg mySpec tcs
                    }
 
 makeLiftedSpec1
@@ -337,7 +337,7 @@ makeGhcSpec' cfg file cbs tcs instenv vars defVars exports specs0 = do
   syms0 <- liftedVarMap (varInModule name) expSyms
   syms1 <- symbolVarMap (varInModule name) vars (S.toList $ importedSymbols name   specs)
   (tycons, datacons, dcSs, recSs, tyi, adts) <- makeGhcSpecCHOP1 cfg specs embs (syms0 ++ syms1)
-  setDataDecls adts
+  setDataDecls (F.tracepp "DATADECLS" adts)
   checkShadowedSpecs dcSs (Ms.measures mySpec) expSyms defVars
   makeBounds embs name defVars cbs specs
   modify                                   $ \be -> be { tcEnv = tyi }
@@ -835,7 +835,7 @@ replaceLocalBindsOne allowHO v
                              env' (zip ty_binds ty_args)
            let res  = substa (f env) ty_res
            let t'   = fromRTypeRep $ t { ty_args = args, ty_res = res }
-           let msg  = ErrTySpec (GM.sourcePosSrcSpan l) ({- text "replaceLocalBindsOne" <+> -} pprint v) t'
+           let msg  = ErrTySpec (GM.sourcePosSrcSpan l) (text "replaceLocalBindsOne" <+> pprint v) t'
            case checkTy allowHO msg emb tyi fenv (Loc l l' t') of
              Just err -> Ex.throw err
              Nothing  -> modify (first $ M.insert v (Loc l l' t'))

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -214,7 +214,7 @@ makeLiftedSpec0 cfg embs cbs tcs mySpec = do
   return  $ mempty { Ms.ealiases  = lmapEAlias . snd <$> xils
                    , Ms.measures  = ms
                    , Ms.reflects  = Ms.reflects mySpec
-                   , Ms.dataDecls = F.tracepp "DATADECLS" $ makeHaskellDataDecls cfg mySpec tcs
+                   , Ms.dataDecls = makeHaskellDataDecls cfg mySpec tcs
                    }
 
 makeLiftedSpec1

--- a/src/Language/Haskell/Liquid/Bare/DataType.hs
+++ b/src/Language/Haskell/Liquid/Bare/DataType.hs
@@ -11,6 +11,9 @@ module Language.Haskell.Liquid.Bare.DataType
   , meetDataConSpec
   , makeNumericInfo
 
+  , DataConMap
+  , dataConMap
+
     -- * Tests
   -- , isPropDecl
   -- , qualifyDataDecl

--- a/src/Language/Haskell/Liquid/Bare/DataType.hs
+++ b/src/Language/Haskell/Liquid/Bare/DataType.hs
@@ -89,11 +89,9 @@ type DataPropDecl = (DataDecl, Maybe SpecType)
 makeDataDecls :: Config -> F.TCEmb TyCon -> [(ModName, TyCon, DataPropDecl)]
               -> [(DataCon, Located DataConP)]
               -> [F.DataDecl]
-
 makeDataDecls cfg tce tds ds
-  | makeDecls = -- F.tracepp "makeDataDecls" $
-                concat [ makeFDataDecls tce tc dd ctors
-                       | (tc, (dd, ctors)) <- groupDataCons tds' ds ]
+  | makeDecls = [ makeFDataDecls tce tc dd ctors
+                | (tc, (dd, ctors)) <- groupDataCons tds' ds ]
   | otherwise = []
   where
     makeDecls = exactDC cfg && not (noADT cfg)
@@ -108,8 +106,8 @@ groupDataCons tds ds = M.toList $ M.intersectionWith (,) declM ctorM
 
 
 makeFDataDecls :: F.TCEmb TyCon -> TyCon -> DataPropDecl -> [(DataCon, DataConP)]
-               -> [F.DataDecl]
-makeFDataDecls tce tc dd ctors = [makeDataDecl tce tc (fst dd) ctors]
+               -> F.DataDecl
+makeFDataDecls tce tc dd ctors = makeDataDecl tce tc (fst dd) ctors
                                -- ++ maybeToList (makePropDecl tce tc dd) -- TODO: AUTO-INDPRED
 
 makeDataDecl :: F.TCEmb TyCon -> TyCon -> DataDecl -> [(DataCon, DataConP)]

--- a/src/Language/Haskell/Liquid/Bare/Env.hs
+++ b/src/Language/Haskell/Liquid/Bare/Env.hs
@@ -1,15 +1,11 @@
-{-# LANGUAGE FlexibleContexts         #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TupleSections    #-}
 
 module Language.Haskell.Liquid.Bare.Env (
     BareM
   , Warn
   , TCEnv
   , BareEnv(..)
-
-  -- * mapping fields to ADTs
-  , DataConMap
-  , dataConMap
-
   , InlnEnv
 
   , inModule
@@ -25,6 +21,11 @@ module Language.Haskell.Liquid.Bare.Env (
   , insertLogicEnv
   , insertAxiom
   , addDefs
+
+
+  -- * Exact DataConstructor Functions
+  , DataConMap
+  , dataConMap
   ) where
 
 import           HscTypes
@@ -49,6 +50,18 @@ import           Language.Haskell.Liquid.UX.Errors    ()
 import           Language.Haskell.Liquid.Types
 import           Language.Haskell.Liquid.Types.Bounds
 
+--------------------------------------------------------------------------------
+-- | 'DataConMap' stores the names of those ctor-fields that have been declared
+--   as SMT ADTs so we don't make up new names for them.
+--------------------------------------------------------------------------------
+type DataConMap = M.HashMap (F.Symbol, Int) F.Symbol
+
+dataConMap :: [F.DataDecl] -> DataConMap
+dataConMap ds = M.fromList $ do
+  d     <- ds
+  c     <- F.ddCtors d
+  let fs = F.symbol <$> F.dcFields c
+  zip ((F.symbol c,) <$> [1..]) fs
 
 --------------------------------------------------------------------------------
 -- | Error-Reader-IO For Bare Transformation -----------------------------------

--- a/src/Language/Haskell/Liquid/Bare/Env.hs
+++ b/src/Language/Haskell/Liquid/Bare/Env.hs
@@ -4,10 +4,12 @@ module Language.Haskell.Liquid.Bare.Env (
     BareM
   , Warn
   , TCEnv
-
   , BareEnv(..)
 
-  -- , TInline(..)
+  -- * mapping fields to ADTs
+  , DataConMap
+  , dataConMap
+
   , InlnEnv
 
   , inModule
@@ -15,7 +17,8 @@ module Language.Haskell.Liquid.Bare.Env (
 
   , setRTAlias
   , setREAlias
-  , setEmbeds
+  -- , setEmbeds
+  , setDataDecls
 
   , execBare
 
@@ -39,7 +42,8 @@ import qualified Data.HashMap.Strict                  as M
 import qualified Data.HashSet                         as S
 
 
-import           Language.Fixpoint.Types              (Expr(..), Symbol, symbol, TCEmb)
+import           Language.Fixpoint.Types              (Expr(..), TCEmb)
+import qualified Language.Fixpoint.Types as F
 
 import           Language.Haskell.Liquid.UX.Errors    ()
 import           Language.Haskell.Liquid.Types
@@ -51,41 +55,41 @@ import           Language.Haskell.Liquid.Types.Bounds
 --------------------------------------------------------------------------------
 
 -- FIXME: don't use WriterT [], very slow
-type BareM = WriterT [Warn] (ExceptT Error (StateT BareEnv IO))
-
-type Warn  = String
-
-type TCEnv = M.HashMap TyCon RTyCon
-
-type InlnEnv = M.HashMap Symbol LMap
+type BareM   = WriterT [Warn] (ExceptT Error (StateT BareEnv IO))
+type Warn    = String
+type TCEnv   = M.HashMap TyCon RTyCon
+type InlnEnv = M.HashMap F.Symbol LMap
 
 data BareEnv = BE
   { modName  :: !ModName
   , tcEnv    :: !TCEnv
   , rtEnv    :: !RTEnv
-  , varEnv   :: !(M.HashMap Symbol Var)
+  , varEnv   :: !(M.HashMap F.Symbol Var)
   , hscEnv   :: !(HscEnv)
   , logicEnv :: !LogicMap
+  , dcEnv    :: !DataConMap
   , bounds   :: !(RBEnv)
   , embeds   :: !(TCEmb TyCon)
-  , axSyms   :: !(M.HashMap Symbol LocSymbol)
-  , propSyms :: !(M.HashMap Symbol LocSymbol)
+  , axSyms   :: !(M.HashMap F.Symbol LocSymbol)
+  , propSyms :: !(M.HashMap F.Symbol LocSymbol)
   }
 
-setEmbeds :: TCEmb TyCon -> BareM ()
-setEmbeds emb = modify $ \be -> be {embeds = emb}
 
+setDataDecls :: [F.DataDecl] -> BareM ()
+setDataDecls adts = modify $ \be -> be { dcEnv = dataConMap adts }
 
-insertLogicEnv :: String -> LocSymbol -> [Symbol] -> Expr -> BareM ()
+_setEmbeds :: TCEmb TyCon -> BareM ()
+_setEmbeds emb = modify $ \be -> be {embeds = emb}
+
+insertLogicEnv :: String -> LocSymbol -> [F.Symbol] -> Expr -> BareM ()
 insertLogicEnv _msg x ys e = modify $ \be -> be {logicEnv = (logicEnv be) {lmSymDefs = M.insert (val x) (LMap x ys e) $ lmSymDefs $ logicEnv be}}
 
-insertAxiom :: Var -> Maybe Symbol -> BareM ()
+insertAxiom :: Var -> Maybe F.Symbol -> BareM ()
 insertAxiom x s
   = modify $ \be -> be {logicEnv = (logicEnv be) {lmVarSyms = M.insert x s $ lmVarSyms $ logicEnv be}}
 
-addDefs :: S.HashSet (Var, Symbol) -> BareM ()
-addDefs ds
-  = forM_ (S.toList ds) $ \(v, x) -> insertAxiom v (Just x)
+addDefs :: S.HashSet (Var, F.Symbol) -> BareM ()
+addDefs ds = forM_ (S.toList ds) $ \(v, x) -> insertAxiom v (Just x)
 
 setModule :: ModName -> BareEnv -> BareEnv
 setModule m b = b { modName = m }
@@ -106,18 +110,18 @@ withVArgs :: (Foldable t, PPrint a)
           -> BareM b
 withVArgs l l' vs act = do
   old <- gets rtEnv
-  mapM_ (mkExprAlias l l' . symbol . showpp) vs
+  mapM_ (mkExprAlias l l' . F.symbol . showpp) vs
   res <- act
   modify $ \be -> be { rtEnv = old }
   return res
 
-mkExprAlias :: SourcePos -> SourcePos -> Symbol -> BareM ()
-mkExprAlias l l' v = setRTAlias v (RTA v [] [] (RExprArg (Loc l l' $ EVar $ symbol v)) l l')
+mkExprAlias :: SourcePos -> SourcePos -> F.Symbol -> BareM ()
+mkExprAlias l l' v = setRTAlias v (RTA v [] [] (RExprArg (Loc l l' $ EVar $ F.symbol v)) l l')
 
-setRTAlias :: Symbol -> RTAlias RTyVar SpecType -> BareM ()
+setRTAlias :: F.Symbol -> RTAlias RTyVar SpecType -> BareM ()
 setRTAlias s a = modify $ \b -> b { rtEnv = mapRT (M.insert s a) $ rtEnv b }
 
-setREAlias :: Symbol -> RTAlias Symbol Expr -> BareM ()
+setREAlias :: F.Symbol -> RTAlias F.Symbol Expr -> BareM ()
 setREAlias s a = modify $ \b -> b { rtEnv = mapRE (M.insert s a) $ rtEnv b }
 
 ------------------------------------------------------------------

--- a/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -77,6 +77,7 @@ makeHaskellDataDecls :: Config -> Ms.BareSpec -> [TyCon] -> [DataDecl]
 makeHaskellDataDecls cfg spec
   | exactDC cfg = mapMaybe tyConDataDecl
                 . zipMap   (hasDataDecl spec)
+                . F.tracepp "VANILLATC"
                 . filter    isVanillaAlgTyCon
   | otherwise   = const []
 

--- a/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -77,7 +77,6 @@ makeHaskellDataDecls :: Config -> Ms.BareSpec -> [TyCon] -> [DataDecl]
 makeHaskellDataDecls cfg spec
   | exactDC cfg = mapMaybe tyConDataDecl
                 . zipMap   (hasDataDecl spec)
-                . F.tracepp "VANILLATC"
                 . filter    isVanillaAlgTyCon
   | otherwise   = const []
 

--- a/src/Language/Haskell/Liquid/Bare/Misc.hs
+++ b/src/Language/Haskell/Liquid/Bare/Misc.hs
@@ -15,11 +15,8 @@ module Language.Haskell.Liquid.Bare.Misc (
   , hasBoolResult
   , symbolMeasure
   , isKind
-
-  -- * Exact DataConstructor Functions
   , makeDataConChecker
   , makeDataConSelector
-
   ) where
 
 import           Name
@@ -67,9 +64,15 @@ makeDataConChecker d
 --   e.g. `select$Cons$1` and `select$Cons$2` are respectively
 --   equivalent to `head` and `tail`.
 --------------------------------------------------------------------------------
-makeDataConSelector :: DataCon -> Int -> F.Symbol
---------------------------------------------------------------------------------
-makeDataConSelector d i
+makeDataConSelector :: Maybe DataConMap -> DataCon -> Int -> F.Symbol
+makeDataConSelector mbDm d i = case mbDm of
+  Nothing -> def
+  Just dm -> M.lookupDefault def (F.symbol d, i) dm
+  where
+    def   =  makeDataConSelector' d i
+
+makeDataConSelector' :: DataCon -> Int -> F.Symbol
+makeDataConSelector' d i
   | consDataCon == d, i == 1
   = F.symbol "head"
   | consDataCon == d, i == 2

--- a/src/Language/Haskell/Liquid/Bare/Misc.hs
+++ b/src/Language/Haskell/Liquid/Bare/Misc.hs
@@ -14,10 +14,12 @@ module Language.Haskell.Liquid.Bare.Misc (
   , simpleSymbolVar
   , hasBoolResult
   , symbolMeasure
+  , isKind
+
   -- * Exact DataConstructor Functions
   , makeDataConChecker
   , makeDataConSelector
-  , isKind
+
   ) where
 
 import           Name

--- a/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -125,36 +125,37 @@ strengthenResult' v
 type LogicM = ExceptT Error (StateT LState Identity)
 
 data LState = LState
-  { symbolMap :: LogicMap
-  , mkError   :: String -> Error
-  , ltce      :: TCEmb TyCon
-  , boolbinds :: [Var]
+  { lsSymMap  :: LogicMap
+  , lsError   :: String -> Error
+  , lsEmb     :: TCEmb TyCon
+  , lsBools   :: [Var]
+  , lsDCMap   :: DataConMap
   }
 
 throw :: String -> LogicM a
 throw str = do
-  fmkError  <- mkError <$> get
+  fmkError  <- lsError <$> get
   throwError $ fmkError str
 
 getState :: LogicM LState
 getState = get
 
 runToLogic
-  :: TCEmb TyCon -> LogicMap -> (String -> Error) -> LogicM t
-  -> Either Error t
+  :: TCEmb TyCon -> LogicMap -> DataConMap -> (String -> Error)
+  -> LogicM t -> Either Error t
 runToLogic = runToLogicWithBoolBinds []
 
 runToLogicWithBoolBinds
-  :: [Var] -> TCEmb TyCon -> LogicMap -> (String -> Error) -> LogicM t
-  -> Either Error t
-runToLogicWithBoolBinds xs tce lmap ferror m
-       = evalState (runExceptT m) s0
-  where
-    s0 = LState { symbolMap = lmap
-                , mkError   = ferror
-                , ltce      = tce
-                , boolbinds = xs
-                }
+  :: [Var] -> TCEmb TyCon -> LogicMap -> DataConMap -> (String -> Error)
+  -> LogicM t -> Either Error t
+runToLogicWithBoolBinds xs tce lmap dm ferror m
+  = evalState (runExceptT m) $ LState
+      { lsSymMap = lmap
+      , lsError  = ferror
+      , lsEmb    = tce
+      , lsBools  = xs
+      , lsDCMap  = dm
+      }
 
 coreToDef :: Reftable r => LocSymbol -> Var -> C.CoreExpr
           -> LogicM [Def (Located (RRType r)) DataCon]
@@ -216,14 +217,14 @@ coreToLg (C.Var x)
   | x == trueDataConId
   = return PTrue
   | otherwise
-  = (symbolMap <$> getState) >>= eVarWithMap x
+  = (lsSymMap <$> getState) >>= eVarWithMap x
 coreToLg e@(C.App _ _)
   = toPredApp e
 coreToLg (C.Case e b _ alts) | eqType (varType b) boolTy
   = checkBoolAlts alts >>= coreToIte e
 coreToLg (C.Lam x e)
   = do p   <- coreToLg e
-       tce <- ltce <$> getState
+       tce <- lsEmb <$> getState
        return $ ELam (symbol x, typeSort tce $ varType x) p
 coreToLg (C.Case e b _ alts)
   = do p <- coreToLg e
@@ -264,14 +265,21 @@ checkDataCon :: DataCon -> Expr -> LogicM Expr
 checkDataCon d e
   = return $ EApp (EVar $ makeDataConChecker d) e
 
+dataConSelector :: DataConMap -> DataCon -> Int -> Symbol
+dataConSelector dm d i = {- F.tracepp msg $ -} M.lookupDefault def (symbol d, i) dm
+  where
+    def                = makeDataConSelector d i
+    -- msg                = "DataConSelector: d = " ++ F.showpp d ++ " i = " ++ show i
+
 altToLg :: Expr -> C.CoreAlt -> LogicM (DataCon, Expr)
 altToLg de (C.DataAlt d, xs, e)
-  = do p <- coreToLg e
-       let su = mkSubst $ concat [ f x i | (x, i) <- zip xs [1..]]
+  = do p  <- coreToLg e
+       dm <- gets lsDCMap
+       let su = mkSubst $ concat [ f dm x i | (x, i) <- zip xs [1..]]
        return (d, subst su p)
   where
-    f x i = let t = EApp (EVar $ makeDataConSelector d i) de
-            in [(symbol x, t), (simplesymbol x, t)]
+    f dm x i = let t = EApp (EVar $ dataConSelector dm d i) de
+               in [(symbol x, t), (simplesymbol x, t)]
 altToLg _ (C.LitAlt _, _, _)
   = throw "altToLg on Lit"
 altToLg _ (C.DEFAULT, _, _)
@@ -314,8 +322,8 @@ toLogicApp e = do
   let (f, es) = splitArgs e
   case f of
     C.Var _ -> do args <- mapM coreToLg es
-                  lmap       <- symbolMap <$> getState
-                  def        <- (`mkEApp` args) <$> tosymbol f
+                  lmap <- lsSymMap <$> getState
+                  def  <- (`mkEApp` args) <$> tosymbol f
                   ((\x -> makeApp def lmap x args) <$> (tosymbol' f))
     _       -> do (fe : args) <- mapM coreToLg (f:es)
                   return $ foldl EApp fe args

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -89,9 +89,6 @@ module Language.Haskell.Liquid.Types (
   , DataConP (..)
   , TyConP   (..)
 
-  , DataConMap
-  , dataConMap
-
   -- * Pre-instantiated RType
   , RRType, RRProp
   , BRType, BRProp
@@ -1156,18 +1153,7 @@ instance F.PPrint DataDecl where
 -- | Name of the data-type
 instance F.Symbolic DataDecl where
   symbol =  F.symbol . tycName
-
--- | 'DataConMap' stores the names of those ctor-fields that have been declared
---   as SMT ADTs so we don't make up new names for them.
-type DataConMap = M.HashMap (Symbol, Int) Symbol
-
-dataConMap :: [F.DataDecl] -> DataConMap
-dataConMap ds = M.fromList $ do
-  d     <- ds
-  c     <- F.ddCtors d
-  let fs = F.symbol <$> F.dcFields c
-  zip ((F.symbol c,) <$> [1..]) fs
-
+  
 --------------------------------------------------------------------------------
 -- | Refinement Type Aliases
 --------------------------------------------------------------------------------

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ConstraintKinds            #-}
 {-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE TupleSections              #-}
 
 -- | This module should contain all the global type definitions and basic instances.
 
@@ -87,6 +88,9 @@ module Language.Haskell.Liquid.Types (
   , DataCtor (..)
   , DataConP (..)
   , TyConP   (..)
+
+  , DataConMap
+  , dataConMap
 
   -- * Pre-instantiated RType
   , RRType, RRProp
@@ -1152,6 +1156,17 @@ instance F.PPrint DataDecl where
 -- | Name of the data-type
 instance F.Symbolic DataDecl where
   symbol =  F.symbol . tycName
+
+-- | 'DataConMap' stores the names of those ctor-fields that have been declared
+--   as SMT ADTs so we don't make up new names for them.
+type DataConMap = M.HashMap (Symbol, Int) Symbol
+
+dataConMap :: [F.DataDecl] -> DataConMap
+dataConMap ds = M.fromList $ do
+  d     <- ds
+  c     <- F.ddCtors d
+  let fs = F.symbol <$> F.dcFields c
+  zip ((F.symbol c,) <$> [1..]) fs
 
 --------------------------------------------------------------------------------
 -- | Refinement Type Aliases

--- a/tests/neg/EvalQuery.hs
+++ b/tests/neg/EvalQuery.hs
@@ -1,0 +1,48 @@
+
+{-@ LIQUID "--exact-data-con"                      @-}
+{-@ LIQUID "--higherorder"                         @-}
+{-@ LIQUID "--no-termination"                      @-}
+{-@ LIQUID "--automatic-instances=liquidinstances" @-}
+
+module Query where
+
+data Atom  = VarX
+           | VarY
+           | Const Int
+
+data Query = Le  Atom  Atom
+           | And Query Query
+           | Or  Query Query
+
+{-@ data Blob  = B { xVal :: Int, yVal :: Int } @-}
+data Blob  = B { xVal :: Int, yVal :: Int }
+
+
+{-@ reflect evalA @-}
+evalA :: Blob -> Atom -> Int
+evalA b VarX      = xVal b
+evalA b VarY      = yVal b
+evalA _ (Const n) = n
+
+{-@ reflect evalQ @-}
+evalQ :: Blob -> Query -> Bool
+evalQ b (Le  a1 a2) = (evalA b a1) <= (evalA b a2)
+evalQ b (And q1 q2) = (evalQ b q1) && (evalQ b q2)
+evalQ b (Or  q1 q2) = (evalQ b q1) || (evalQ b q2)
+
+{-@ filterQ :: q:Query -> [Blob] -> [{b:Blob | evalQ b q}] @-}
+filterQ :: Query -> [Blob] -> [Blob]
+filterQ q []     = []
+filterQ q (b:bs)
+  | evalQ b q    = b : filterQ q bs
+  | otherwise    =     filterQ q bs
+
+{-@ test1 :: [Blob] -> [{v: Blob | xVal v <= 5}] @-}
+test1   = filterQ q1
+  where
+  q1    = (VarX `Le` (Const 10))
+
+{-@ test2 :: [Blob] -> [{v: Blob | xVal v <= 10 && yVal v <= 20}] @-}
+test2  = filterQ q2
+  where
+  q2   = (VarX `Le` (Const 10)) `And` (VarY `Le` (Const 20))

--- a/tests/pos/EvalQuery.hs
+++ b/tests/pos/EvalQuery.hs
@@ -1,0 +1,48 @@
+
+{-@ LIQUID "--exact-data-con"                      @-}
+{-@ LIQUID "--higherorder"                         @-}
+{-@ LIQUID "--no-termination"                      @-}
+{-@ LIQUID "--automatic-instances=liquidinstances" @-}
+
+module Query where
+
+data Atom  = VarX
+           | VarY
+           | Const Int
+
+data Query = Le  Atom  Atom
+           | And Query Query
+           | Or  Query Query
+
+{-@ data Blob  = B { xVal :: Int, yVal :: Int } @-}
+data Blob  = B { xVal :: Int, yVal :: Int }
+
+
+{-@ reflect evalA @-}
+evalA :: Blob -> Atom -> Int
+evalA b VarX      = xVal b
+evalA b VarY      = yVal b
+evalA _ (Const n) = n
+
+{-@ reflect evalQ @-}
+evalQ :: Blob -> Query -> Bool
+evalQ b (Le  a1 a2) = (evalA b a1) <= (evalA b a2)
+evalQ b (And q1 q2) = (evalQ b q1) && (evalQ b q2)
+evalQ b (Or  q1 q2) = (evalQ b q1) || (evalQ b q2)
+
+{-@ filterQ :: q:Query -> [Blob] -> [{b:Blob | evalQ b q}] @-}
+filterQ :: Query -> [Blob] -> [Blob]
+filterQ q []     = []
+filterQ q (b:bs)
+  | evalQ b q    = b : filterQ q bs
+  | otherwise    =     filterQ q bs
+
+{-@ test1 :: [Blob] -> [{v: Blob | xVal v <= 10}] @-}
+test1   = filterQ q1
+  where
+  q1    = (VarX `Le` (Const 10))
+
+{-@ test2 :: [Blob] -> [{v: Blob | xVal v <= 10 && yVal v <= 20}] @-}
+test2  = filterQ q2
+  where
+  q2   = (VarX `Le` (Const 10)) `And` (VarY `Le` (Const 20))

--- a/tests/pos/T1074.hs
+++ b/tests/pos/T1074.hs
@@ -32,32 +32,3 @@ the2 = undefined
 
 {-@ measure headP :: a -> b @-}
 
-Hi everyone,
-
-Its 2017 and it feels odd to send emails cc-ed to 30 people.
-Plus, its tedious to copy-paste the 30 addresses.
-
-I made a mailing list so we can just write to a single address.
-
-(I hope everyone gets this ... hmm I guess the only way to
-find out is to copy-paste again... curses... foiled again!)
-
-- Ranjit.
-
-Frances Ajo <frances.ajo@gmail.com>,
-Heather Oberly <hroberly@gmail.com>,
-Ian Silverman <Islander403@hotmail.com>,
-Julie Stope <juliej22779@yahoo.com>,
-Kamalika Chaudhuri <kamalika@cs.ucsd.edu>,
-Kayleigh Gebreselassie <kvondoll@gmail.com>,
-Kelly Carll <jones.kellyr@gmail.com>,
-Kim Sparrow <kim.sparrow@gmail.com>,
-Lauren Zamler <lzamler@gmail.com>,
-Lisa Starace <lisa.a.starace@gmail.com>,
-Mike DeEmedio <deemedio32@yahoo.com>,
-Morgan Craft <craft.morganc@gmail.com>,
-Rachel Jensen <racheljensen@hotmail.com>,
-Ranjit Jhala <jhala@cs.ucsd.edu>,
-Sarah Thomas <sapsel@gmail.com>,
-Scott Armstrong <sjordan72@gmail.com>,
-Tony Winney <twinney@gmail.com>

--- a/tests/pos/VerifiedMonoid.hs
+++ b/tests/pos/VerifiedMonoid.hs
@@ -82,7 +82,7 @@ instance VerifiedMonoid (List a) where
 {-@ instance VerifiedMonoid (List a) where
   assume mempty  :: {v:List a | (v = N) && (v = memptyList) };
   assume mappend :: {v:(x:List a -> y:List a
-                 -> {v:List a | (v = mappendList x y) && (if (is$Data.Monoid.N x) then (v == y) else (v == C (lqdc##select##C##1 x) (mappendList (lqdc##select##C##2 x) y) )) })  | v == mappendList};
+                 -> {v:List a | (v = mappendList x y) && (if (is$Data.Monoid.N x) then (v == y) else (v == C (hd x) (mappendList (tl x) y) )) })  | v == mappendList};
   leftId  :: x:List a -> {v:Proof | mappendList memptyList x = x } ;
   rightId :: x:List a -> {v:Proof | mappendList x memptyList = x } ;
   assoc   :: x:List a -> y:List a -> z:List a -> {v:Proof | mappendList x (mappendList y z) = mappendList (mappendList x y) z}


### PR DESCRIPTION
A lot of the measure instantiation stuff is not needed when using ADTs.

This PR ensures selectors and tests are the same as those used for ADT fields, 

and then eliminates a bunch of the code corresponding to the selectors and test measures.

Matching PR for https://github.com/ucsd-progsys/liquid-fixpoint/pull/325