### PR TITLE
Tidy reflection error messages

### DIFF
--- a/src/Language/Haskell/Liquid/Bare/Misc.hs
+++ b/src/Language/Haskell/Liquid/Bare/Misc.hs
@@ -78,7 +78,7 @@ makeDataConSelector' d i
   | consDataCon == d, i == 2
   = F.symbol "tail"
   | otherwise
-  = symbolMeasure "select" (dcSymbol d) (Just i)
+  = symbolMeasure "$select" (dcSymbol d) (Just i)
 
 dcSymbol :: DataCon -> F.Symbol
 dcSymbol = simpleSymbolVar . dataConWorkId

--- a/src/Language/Haskell/Liquid/UX/Errors.hs
+++ b/src/Language/Haskell/Liquid/UX/Errors.hs
@@ -68,7 +68,7 @@ tidyCtx       :: [Symbol] -> Ctx -> (Subst, Ctx)
 --------------------------------------------------------------------------------
 tidyCtx xs m  = (θ, M.fromList yts)
   where
-    yts       = [tBind x t | (x, t) <- xts]
+    yts       = [tBind x $ tidySpecType Full t | (x, t) <- xts]
     (θ, xts)  = tidyTemps $ second stripReft <$> tidyREnv xs m
     tBind x t = (x', shiftVV t x') where x' = tidySymbol x
 


### PR DESCRIPTION
Simplify errors like 
```
53 |   ==!  C x (N ++ N)
             ^^^^^^^^^^^^

   Inferred type
     VV : {v : (L a) | ListExample.size v == 1 + ListExample.size ?g
                       && (is$ListExample.N v <=> false)
                       && lqdc##select v == ?g
                       && lqdc##select v == x
                       && lqdc##select v == ?g
                       && lqdc##select v == x
                       && (is$ListExample.C v <=> true)
                       && v == ListExample.C x ?g
                       && v == ListExample.C x ?g
                       && ListExample.size v >= 0
                       && v == ?f
                       && ListExample.size v >= 0}

   not a subtype of Required type
     VV : {VV : (L a) | VV == ?c}

   In Context
     ?g : {?g : (L a) | ?g == ListExample.++ ?a ?e
                        && ?g == (if is$ListExample.C ?a then ListExample.C (lqdc##select ?a) (ListExample.++ (lqdc##select ?a) ?e) else ?e)
                        && ?g == ListExample.++ ?a ?e
                        && ListExample.size ?g >= 0}

     xs : {v : (L a) | ListExample.size v >= 0}

     ?f : {?f : (L a) | ListExample.size ?f == 1 + ListExample.size ?g
                        && (is$ListExample.N ?f <=> false)
                        && lqdc##select ?f == ?g
                        && lqdc##select ?f == x
                        && lqdc##select ?f == ?g
                        && lqdc##select ?f == x
                        && (is$ListExample.C ?f <=> true)
                        && ?f == ListExample.C x ?g
                        && ?f == ListExample.C x ?g
                        && ListExample.size ?f >= 0}

     ?c : {?c : (L a) | ?c == ListExample.++ ?d ?b
                        && ?c == (if is$ListExample.C ?d then ListExample.C (lqdc##select ?d) (ListExample.++ (lqdc##select ?d) ?b) else ?b)
                        && ?c == ListExample.++ ?d ?b
                        && ListExample.size ?c >= 0}

     ?e : {?e : (L a) | ListExample.size ?e == 0
                        && (is$ListExample.N ?e <=> true)
                        && (is$ListExample.C ?e <=> false)
                        && ?e == ListExample.N
                        && ?e == ListExample.N
                        && ?e == ListExample.N
                        && ?e == ListExample.N
                        && ListExample.size ?e >= 0}

     ?b : {?b : (L a) | ListExample.size ?b == 0
                        && (is$ListExample.N ?b <=> true)
                        && (is$ListExample.C ?b <=> false)
                        && ?b == ListExample.N
                        && ?b == ListExample.N
                        && ?b == ListExample.N
                        && ?b == ListExample.N
                        && ListExample.size ?b >= 0}

     x : a

     ?d : {?d : (L a) | ListExample.size ?d == 1 + ListExample.size xs
                        && (is$ListExample.N ?d <=> false)
                        && lqdc##select ?d == xs
                        && lqdc##select ?d == x
                        && lqdc##select ?d == xs
                        && lqdc##select ?d == x
                        && (is$ListExample.C ?d <=> true)
                        && ?d == ListExample.C x xs
                        && ?d == ListExample.C x xs
                        && ListExample.size ?d >= 0}

     ?a : {?a : (L a) | ListExample.size ?a == 0
                        && (is$ListExample.N ?a <=> true)
                        && (is$ListExample.C ?a <=> false)
                        && ?a == ListExample.N
                        && ?a == ListExample.N
                        && ?a == ListExample.N
                        && ?a == ListExample.N
                        && ListExample.size ?a >= 0}
```
To the following
```
/Users/niki/llio/lmonad-meta/src/src/ListExamples.hs:53:8-19: Error: Liquid Type Mismatch

 53 |   ==!  C x (N ++ N)
             ^^^^^^^^^^^^

   Inferred type
     VV : {v : (L a) | ListExample.size v == 1 + ListExample.size ?g
                       && lqdc##$select v == ?g
                       && lqdc##$select v == x
                       && v == ListExample.C x ?g
                       && ListExample.size v >= 0
                       && v == ?f}

   not a subtype of Required type
     VV : {VV : (L a) | VV == ?c}

   In Context
     ?g : {?g : (L a) | ?g == ListExample.++ ?a ?e
                        && ListExample.size ?g >= 0}

     xs : {v : (L a) | ListExample.size v >= 0}

     ?f : {?f : (L a) | ListExample.size ?f == 1 + ListExample.size ?g
                        && ?f == ListExample.C x ?g
                        && ListExample.size ?f >= 0}

     ?c : {?c : (L a) | ?c == ListExample.++ ?d ?b
                        && ListExample.size ?c >= 0}

     ?e : {?e : (L a) | ListExample.size ?e == 0
                        && ?e == ListExample.N
                        && ListExample.size ?e >= 0}

     ?b : {?b : (L a) | ListExample.size ?b == 0
                        && ?b == ListExample.N
                        && ListExample.size ?b >= 0}

     x : a

     ?d : {?d : (L a) | ListExample.size ?d == 1 + ListExample.size xs
                        && ?d == ListExample.C x xs
                        && ListExample.size ?d >= 0}

     ?a : {?a : (L a) | ListExample.size ?a == 0
                        && ?a == ListExample.N
                        && ListExample.size ?a >= 0}
```