### PR TITLE
imported reflected HO functions

### DIFF
--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -1289,8 +1289,25 @@ makeSingleton γ e t
   = t
 
 funExpr :: CGEnv -> CoreExpr -> Maybe F.Expr
+
+{- OLD: only sinlgetons for 
+-- reflected functions as appear in aenv
+-- this breaks now as imported relfected functions
+-- do no live in aenv
+-- NV to RJ: to restore this code add imported reflected
+-- functions to aenv 
 funExpr γ (Var v) | M.member v $ aenv γ
   = F.EVar <$> (M.lookup v $ aenv γ)
+-- local function arguments
+funExpr γ (Var v) | S.member v (fargs γ)
+  = Just $ F.EVar (F.symbol v)
+-}
+
+{- NEW: singletons for everything! -}
+
+funExpr _ (Var v)
+  = Just $ F.EVar (F.symbol v)
+
 funExpr γ (App e1 e2)
   = case (funExpr γ e1, argExpr γ e2) of
       (Just e1', Just e2') | not (isClassPred $ exprType e2)
@@ -1298,8 +1315,6 @@ funExpr γ (App e1 e2)
       (Just e1', Just _)
                            -> Just e1'
       _                    -> Nothing
-funExpr γ (Var v) | S.member v (fargs γ)
-  = Just $ F.EVar (F.symbol v)
 funExpr _ _
   = Nothing
 

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -1290,22 +1290,12 @@ makeSingleton γ e t
 
 funExpr :: CGEnv -> CoreExpr -> Maybe F.Expr
 
-{- OLD: only sinlgetons for 
--- reflected functions as appear in aenv
--- this breaks now as imported relfected functions
--- do no live in aenv
--- NV to RJ: to restore this code add imported reflected
--- functions to aenv 
+-- reflectefd functions 
 funExpr γ (Var v) | M.member v $ aenv γ
   = F.EVar <$> (M.lookup v $ aenv γ)
+
 -- local function arguments
 funExpr γ (Var v) | S.member v (fargs γ)
-  = Just $ F.EVar (F.symbol v)
--}
-
-{- NEW: singletons for everything! -}
-
-funExpr _ (Var v)
   = Just $ F.EVar (F.symbol v)
 
 funExpr γ (App e1 e2)
@@ -1315,6 +1305,7 @@ funExpr γ (App e1 e2)
       (Just e1', Just _)
                            -> Just e1'
       _                    -> Nothing
+
 funExpr _ _
   = Nothing
 

--- a/src/Language/Haskell/Liquid/Constraint/Init.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Init.hs
@@ -211,7 +211,8 @@ measEnv sp xts cbs _tcb lt1s lt2s asms itys hs info = CGE
       filterHO xs = if higherOrderFlag sp then xs else filter (F.isFirstOrder . snd) xs
       lts         = lt1s ++ lt2s
       tcb'        = []
-      axEnv       = M.mapWithKey (fromMaybe . F.symbol). lmVarSyms . gsLogicMap
+      axEnv sp    = M.union (M.mapWithKey (fromMaybe . F.symbol) $ lmVarSyms $ gsLogicMap sp)
+                            (M.fromList [(v, F.symbol v) | v <- gsReflects sp])
 
 
 assm :: GhcInfo -> [(Var, SpecType)]

--- a/tests/theorem_proving/T1106.hs
+++ b/tests/theorem_proving/T1106.hs
@@ -1,0 +1,48 @@
+{-@ LIQUID "--exactdc"     @-}
+{-@ LIQUID "--higherorder" @-}
+
+module T1106 where
+
+import T1106Defs 
+
+import Language.Haskell.Liquid.ProofCombinators
+
+data Foo a = Foo a 
+  deriving Eq
+
+{-@ reflect mapFoo @-}
+mapFoo :: (b1 -> b2) -> Foo b1 -> Foo b2
+mapFoo f (Foo b) = Foo (f b)
+
+thmRef :: (Eq b) => b -> c -> (c -> b -> b) -> ()
+{-@ 
+thmRef :: b:b -> c:c 
+    -> f:(c -> b -> b) 
+    -> {mapFoo (bar c) (Foo b) = Foo (bar c b)}
+  @-}
+thmRef b c f
+  = mapFoo (bar c) (Foo b) == Foo (bar c b) *** QED 
+
+thmVar :: (Eq b) => b -> c -> (c -> b -> b) -> ()
+{-@ 
+thmVar :: b:b -> c:c 
+    -> f:(c -> b -> b) 
+    -> {mapFoo (f c) (Foo b) = Foo (f c b)}
+  @-}
+thmVar b c f
+  = mapFoo (f c) (Foo b) == Foo (f c b) *** QED 
+
+thmImp :: (Eq b) => b -> c -> (c -> b -> b) -> ()
+{-@ 
+thmImp :: b:b -> c:c 
+    -> f:(c -> b -> b) 
+    -> {mapFoo (foo c) (Foo b) = Foo (foo c b)}
+  @-}
+thmImp b c f
+  = mapFoo (foo c) (Foo b) == Foo (foo c b) *** QED 
+
+
+
+
+{-@reflect bar @-}
+bar c t = t  

--- a/tests/theorem_proving/T1106Defs.hs
+++ b/tests/theorem_proving/T1106Defs.hs
@@ -1,0 +1,7 @@
+{-@ LIQUID "--higherorder" @-}
+
+module T1106Defs where
+
+
+{-@reflect foo @-}
+foo c t = t


### PR DESCRIPTION
Before this edit we could not prove the below theorem (see [here](https://github.com/ucsd-progsys/liquidhaskell/blob/42fa24a8a2ace7b6464007b8b13da5f77769a046/tests/theorem_proving/T1106.hs)) when `foo` is imported. 

```
mapFoo (foo c) (Foo b) = Foo (foo c b)
```

The reason? The type of `foo c` is true while it should be `{v: a -> b | v == foo c}`


When higher-order flag is on two kinds of functions were given singleton/functional types (like `v == foo c`)

  - local fuctional variable (as stored in `fargs γ`)
  - reflected functions (as stored in `aenv γ`)

The problem: imported reflected functions are not added in `aenv`

This branch solves this problem by giving singleton functional types to all function applications, when the HO flag is on. 
But, travis rejects this solution since it can give internal unsorted refinements. 

Another solution would be to add imported reflected functions to `aenv` . 
@ranjitjhala where can I find the names for all the imported reflected functions??? 

@jprider63 this PR will solve your problem once merged. 

