### PR TITLE
Wide Help 

### DIFF
--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -174,7 +174,7 @@ pprintMany :: (PPrint a) => [a] -> Doc
 pprintMany xs = vcat [ F.pprint x $+$ text " " | x <- xs ]
 
 instance Show Cinfo where
-  show = show . F.toFix 
+  show = show . F.toFix
 
 solveCs :: Config -> FilePath -> CGInfo -> GhcInfo -> Maybe [String] -> IO (Output Doc)
 solveCs cfg tgt cgi info names = do

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -47,7 +47,7 @@ import System.Console.CmdArgs.Explicit
 import System.Console.CmdArgs.Implicit     hiding (Loud)
 import System.Console.CmdArgs.Text
 
-import Data.List                           (nub)
+import Data.List                           (nub, isInfixOf)
 
 
 import System.FilePath                     (isAbsolute, takeDirectory, (</>))
@@ -383,7 +383,9 @@ cmdArgsRun' md as
       Right a -> cmdArgsApply a
     where
       helpMsg e = showText defaultWrap $ helpText [e] HelpFormatDefault md
-      parseResult = process md as -- <$> getArgs
+      parseResult = process md (wideHelp as)
+      wideHelp = map (\a -> if "-help" `isInfixOf` a then "--help=120" else a)
+
 
 --------------------------------------------------------------------------------
 withSmtSolver :: Config -> IO Config

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -47,7 +47,7 @@ import System.Console.CmdArgs.Explicit
 import System.Console.CmdArgs.Implicit     hiding (Loud)
 import System.Console.CmdArgs.Text
 
-import Data.List                           (nub, isInfixOf)
+import Data.List                           (nub)
 
 
 import System.FilePath                     (isAbsolute, takeDirectory, (</>))
@@ -384,7 +384,7 @@ cmdArgsRun' md as
     where
       helpMsg e = showText defaultWrap $ helpText [e] HelpFormatDefault md
       parseResult = process md (wideHelp as)
-      wideHelp = map (\a -> if "-help" `isInfixOf` a then "--help=120" else a)
+      wideHelp = map (\a -> if a == "--help" || a == "-help" then "--help=120" else a)
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
So that the descriptions don't get wrapped into teeny narrow columns.

PS: sorry for the this being so hacky, the `CmdArgs` library doesn't allow tweaking the format of its generated help menu...

Before:
<img width="1440" alt="screen shot 2017-10-02 at 6 34 54 pm" src="https://user-images.githubusercontent.com/586708/31106423-6f22d634-a7a0-11e7-937c-a652fc3b2872.png">

After:
<img width="1440" alt="screen shot 2017-10-02 at 6 34 46 pm" src="https://user-images.githubusercontent.com/586708/31106424-6f276d70-a7a0-11e7-897c-4b74bb82416e.png">