### PR TITLE
Lift Imported TyCons

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,18 @@
+{-@ reflect baz @-}
+bar :: Int -> Int
+bar n = n
 
+{-@ reflect baz @-}
+baz :: Int -> Int
+baz n = n
+
+{-@ reflect foo @-}
+foo 0 = bar 0  
+foo 1 = baz 1
+foo n = baz 1
+
+prop :: n:Int -> { foo n == 0 || foo n == 1 }
+prop n = ()
 
 
 

--- a/benchmarks/popl18/ple/pos/Fibonacci.hs
+++ b/benchmarks/popl18/ple/pos/Fibonacci.hs
@@ -18,27 +18,27 @@ import Language.Haskell.Liquid.ProofCombinators
 
 {-@ reflect fib @-}
 
-fib :: Int -> Int 
+fib :: Int -> Int
 {-@ fib :: i:Nat -> Nat @-}
-fib i | i == 0    = 0 
-      | i == 1    = 1 
+fib i | i == 0    = 0
+      | i == 1    = 1
       | otherwise = fib (i-1) + fib (i-2)
 
 {-@ fib1 :: () -> {fib 16 == 987 } @-}
-fib1 :: () -> Proof 
-fib1 _ = trivial 
+fib1 :: () -> Proof
+fib1 _ = trivial
 
 
-fibUp :: Int -> Proof 
+fibUp :: Int -> Proof
 {-@ fibUp :: i:Nat -> {fib i <= fib (i+1)} @-}
 fibUp i
   | i == 0
-  =   [fib 0, fib 1] *** QED  
+  =   [fib 0, fib 1] *** QED
   | i == 1
-  =  [fib 1, fib 0, fib 2] *** QED  
+  =  [fib 1, fib 0, fib 2] *** QED
   | otherwise
-  = [[fib (i+1), fib i] *** QED , fibUp (i-1), fibUp (i-2)] *** QED 
-{- 
+  = [[fib (i+1), fib i] *** QED , fibUp (i-1), fibUp (i-2)] *** QED
+{-
   | otherwise
   =   fibUp (i-1)
   &&& fibUp (i-2)
@@ -49,14 +49,14 @@ fibUp i
 
 
 {-
-FStar failing 
+FStar failing
 
 val fib: x:int{x>=0} -> Tot int
-let rec fib n = 
-  if n = 0 then 0 
+let rec fib n =
+  if n = 0 then 0
   else if n = 1 then 1 else fib (n-1) + fib (n-2)
-  
-  
+
+
 val prop: x:int -> Tot (v:int {fib 15 = 610})
 let prop x =  0
 
@@ -69,61 +69,61 @@ let prop x =  0
 -- | Note, no inference occurs: logic only reasons about
 -- | linear arithmetic and equalities
 
-{- 
-fibUp :: Int -> Proof 
+{-
+fibUp :: Int -> Proof
 {-@ fibUp :: i:Nat -> {fib i <= fib (i+1)} @-}
 fibUp i
   | i == 0
-  =   trivial 
+  =   trivial
   | i == 1
-  =  trivial --  fib 2 *** QED 
+  =  trivial --  fib 2 *** QED
   | otherwise
   =   fibUp (i-1)
   &&& fibUp (i-2)
 -}
 {-
-Explicit Proof 
-fibMonotonic x y 
-  | y == x + 1 
-  =   fib x 
-  <=. fib (x+1) ? fibUp x 
-  <=. fib y 
-  *** QED  
-  | x < y - 1 
-  =   fib x 
+Explicit Proof
+fibMonotonic x y
+  | y == x + 1
+  =   fib x
+  <=. fib (x+1) ? fibUp x
+  <=. fib y
+  *** QED
+  | x < y - 1
+  =   fib x
   <=. fib (y-1) ? fibMonotonic x (y-1)
-  <=. fib y     ? fibUp (y-1) 
-  *** QED   
+  <=. fib y     ? fibUp (y-1)
+  *** QED
 
-FStar Proof 
+FStar Proof
 
 val fibUp :i:int{0 <= i} -> Tot (v:int {fib i <= fib (i+1)})
-let rec fibUp i = 
-    if i=0 then 0 else 
+let rec fibUp i =
+    if i=0 then 0 else
     if i=1 then 1 else (fibUp (i-1) + fibUp (i-2))
 -}
 
 
-fibMonotonic :: Int -> Int -> Proof 
-{-@ fibMonotonic :: x:Nat -> y:{Nat | x < y }  
+fibMonotonic :: Int -> Int -> Proof
+{-@ fibMonotonic :: x:Nat -> y:{Nat | x < y }
      -> {fib x <= fib y}  / [y] @-}
-fibMonotonic x y 
-  | y == x + 1 
-  =   fibUp x 
-  | x < y - 1 
+fibMonotonic x y
+  | y == x + 1
+  =   fibUp x
+  | x < y - 1
   =   fibMonotonic x (y-1)
-  &&& fibUp (y-1) 
+  &&& fibUp (y-1)
 
 
 fMono :: (Int -> Int)
       -> (Int -> Proof)
-      -> Int -> Int -> Proof 
+      -> Int -> Int -> Proof
 {-@ fMono :: f:(Nat -> Int)
           -> fUp:(z:Nat -> {f z <= f (z+1)})
           -> x:Nat
           -> y:{Nat|x < y}
           -> {f x <= f y} / [y] @-}
-fMono f fUp x y  
+fMono f fUp x y
   | x + 1 == y
   = fUp x
   | x + 1 < y
@@ -131,12 +131,12 @@ fMono f fUp x y
   &&& fUp (y-1)
 
 
-fibMonoHO :: Int -> Int -> Proof 
+fibMonoHO :: Int -> Int -> Proof
 {-@ fibMonoHO :: n:Nat -> m:{Nat | n < m }  -> {fib n <= fib m} @-}
 fibMonoHO     = fMono fib fibUp
 
--- forall n:Nat. exists m: (n<m => exists m'. fib n <== m') 
+-- forall n:Nat. exists m: (n<m => exists m'. fib n <== m')
 fibEx :: Int -> (Int, Proof) -> (Int, Proof)
-{-@ fibEx :: n:Nat -> (m::Int, {v:Proof | n < m}) 
+{-@ fibEx :: n:Nat -> (m::Int, {v:Proof | n < m})
          -> (m'::Int, {v:Proof | fib n <= m' }) @-}
 fibEx n (m, pf) = (fib m, fibMonoHO n m)

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -97,7 +97,6 @@ makeGhcSpec :: Config
             -> IO GhcSpec
 --------------------------------------------------------------------------------
 makeGhcSpec cfg file name cbs tcs instenv vars defVars exports env lmap specs = do
-  putStrLn $ "hsc_type_env_var = " ++ show (isJust (hsc_type_env_var env))
   sp         <- throwLeft =<< execBare act initEnv
   let renv    = L.foldl' (\e (x, s) -> insertSEnv x (RR s mempty) e) (ghcSpecEnv sp) wiredSortedSyms
   throwLeft . checkGhcSpec specs renv $ postProcess cbs renv sp
@@ -215,7 +214,6 @@ makeLiftedSpec0 cfg embs cbs defTcs mySpec = do
   ms        <- makeHaskellMeasures embs cbs mySpec
   let refTcs = reflectedTyCons cfg embs cbs mySpec
   let tcs    = defTcs ++ refTcs
-  liftIO     $ putStrLn $ "REFLECTED-TYCONS" ++ show tcs
   return     $ mempty
                 { Ms.ealiases  = lmapEAlias . snd <$> xils
                 , Ms.measures  = F.notracepp "MS-MEAS" $ ms
@@ -372,7 +370,7 @@ makeGhcSpec' cfg file cbs tcs instenv vars defVars exports specs0 = do
   name           <- modName <$> get
   let mySpec      = fromMaybe mempty (lookup name specs0)
   embs           <- makeNumericInfo instenv <$> (mconcat <$> mapM makeTyConEmbeds specs0)
-  lSpec0         <- makeLiftedSpec0 cfg embs cbs (GM.tracePpr "TCS" tcs) mySpec
+  lSpec0         <- makeLiftedSpec0 cfg embs cbs tcs mySpec
   let fullSpec    = mySpec `mappend` lSpec0
   lmap           <- lmSymDefs . logicEnv    <$> get
   let specs       = insert name fullSpec specs0

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -49,13 +49,13 @@ import qualified Data.HashSet                               as S
 import           System.Directory                           (doesFileExist)
 
 import           Language.Fixpoint.Utils.Files              -- (extFileName)
-import           Language.Fixpoint.Misc                     (sortNub, applyNonNull, ensurePath, thd3, mapFst, mapSnd)
+import           Language.Fixpoint.Misc                     (applyNonNull, ensurePath, thd3, mapFst, mapSnd)
 import           Language.Fixpoint.Types                    hiding (DataDecl, Error, panic)
 import qualified Language.Fixpoint.Types                    as F
 import qualified Language.Fixpoint.Smt.Theories             as Thy
 
 import           Language.Haskell.Liquid.Types.Dictionaries
-import           Language.Haskell.Liquid.Misc               (sortDiff, nubHashOn)
+import           Language.Haskell.Liquid.Misc               (nubHashOn)
 import qualified Language.Haskell.Liquid.GHC.Misc  as GM
 import           Language.Haskell.Liquid.Types.PredType     (makeTyConInfo)
 import           Language.Haskell.Liquid.Types.RefType
@@ -214,7 +214,8 @@ makeLiftedSpec0 cfg embs cbs defTcs mySpec = do
   xils      <- makeHaskellInlines  embs cbs mySpec
   ms        <- makeHaskellMeasures embs cbs mySpec
   let refTcs = reflectedTyCons cfg embs cbs mySpec
-  let tcs    = if True then refTcs else F.notracepp "REFLECTED-TYCONS" $ sortNub (defTcs ++ refTcs) `sortDiff` wiredInTyCons
+  let tcs    = defTcs ++ refTcs
+  liftIO     $ putStrLn $ "REFLECTED-TYCONS" ++ show tcs
   return     $ mempty
                 { Ms.ealiases  = lmapEAlias . snd <$> xils
                 , Ms.measures  = F.notracepp "MS-MEAS" $ ms

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -55,7 +55,7 @@ import qualified Language.Fixpoint.Types                    as F
 import qualified Language.Fixpoint.Smt.Theories             as Thy
 
 import           Language.Haskell.Liquid.Types.Dictionaries
-import           Language.Haskell.Liquid.Misc               (nubHashOn)
+import           Language.Haskell.Liquid.Misc               (sortDiff, nubHashOn)
 import qualified Language.Haskell.Liquid.GHC.Misc  as GM
 import           Language.Haskell.Liquid.Types.PredType     (makeTyConInfo)
 import           Language.Haskell.Liquid.Types.RefType
@@ -214,7 +214,7 @@ makeLiftedSpec0 cfg embs cbs defTcs mySpec = do
   xils      <- makeHaskellInlines  embs cbs mySpec
   ms        <- makeHaskellMeasures embs cbs mySpec
   let refTcs = reflectedTyCons cfg embs cbs mySpec
-  let tcs    = F.notracepp "REFLECTED-TYCONS" $ sortNub (defTcs ++ refTcs)
+  let tcs    = if True then refTcs else F.notracepp "REFLECTED-TYCONS" $ sortNub (defTcs ++ refTcs) `sortDiff` wiredInTyCons
   return     $ mempty
                 { Ms.ealiases  = lmapEAlias . snd <$> xils
                 , Ms.measures  = F.notracepp "MS-MEAS" $ ms
@@ -882,7 +882,7 @@ replaceLocalBindsOne allowHO v
                              env' (zip ty_binds ty_args)
            let res  = substa (f env) ty_res
            let t'   = fromRTypeRep $ t { ty_args = args, ty_res = res }
-           let msg  = ErrTySpec (GM.sourcePosSrcSpan l) (  text "replaceLocalBindsOne" <+>  pprint v) t'
+           let msg  = ErrTySpec (GM.sourcePosSrcSpan l) ( {- text "replaceLocalBindsOne" <+> -} pprint v) t'
            case checkTy allowHO msg emb tyi fenv (Loc l l' t') of
              Just err -> Ex.throw err
              Nothing  -> modify (first $ M.insert v (Loc l l' t'))

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -166,11 +166,11 @@ ghcSpecEnv sp        = res
   where
     res              = fromListSEnv binds
     emb              = gsTcEmbeds sp
-    binds            =  [(x,        rSort t) | (x, Loc _ _ t) <- gsMeas sp]
+    binds            =  (F.notracepp "ghcSpecEnv1" $ [(x,        rSort t) | (x, Loc _ _ t) <- gsMeas sp])
                      ++ [(symbol v, rSort t) | (v, Loc _ _ t) <- gsCtors sp]
                      ++ [(x,        vSort v) | (x, v)         <- gsFreeSyms sp,
                                                                  isConLikeId v ]
-                     ++ concatMap adtEnv (gsADTs sp)
+                     -- ++ (F.tracepp "ghcSpecEnv2" $ concatMap adtEnv (gsADTs sp))
     rSort            = rTypeSortedReft emb
     vSort            = rSort . varRSort
     varRSort         :: Var -> RSort
@@ -181,8 +181,8 @@ ghcSpecEnv sp        = res
     -- env1             = fromListSEnv (tracepp "PROPBINDS" propBinds)
     -- propBinds        = [ propCtor d          | d <- gsADTs sp, isPropDecl d  ]
 
-adtEnv      :: F.DataDecl -> [(F.Symbol, F.SortedReft)]
-adtEnv      = map (mapSnd thySort) . Thy.dataDeclSymbols
+_adtEnv     :: F.DataDecl -> [(F.Symbol, F.SortedReft)]
+_adtEnv     = map (mapSnd thySort) . Thy.dataDeclSymbols
   where
     thySort = F.trueSortedReft . F.tsSort
 
@@ -211,26 +211,50 @@ _propCtor (F.DDecl c _ _)            = panic (Just (GM.fSrcSpan c)) msg
 makeLiftedSpec0 :: Config -> TCEmb TyCon -> [CoreBind] -> [TyCon] -> Ms.BareSpec
                 -> BareM Ms.BareSpec
 makeLiftedSpec0 cfg embs cbs defTcs mySpec = do
-  xils    <- makeHaskellInlines  embs cbs mySpec
-  ms      <- makeHaskellMeasures embs cbs mySpec
-  reflTcs <- reflectedTyCons          cfg mySpec
-  let tcs  = F.tracepp "REFLECTED-TYCONS" $ sortNub (defTcs ++ reflTcs)
-  return   $ mempty { Ms.ealiases  = lmapEAlias . snd <$> xils
-                    , Ms.measures  = F.tracepp "MS-MEAS" $ ms
-                    , Ms.reflects  = F.tracepp "MS-REFLS" $ Ms.reflects mySpec
-                    , Ms.dataDecls = F.tracepp "MS-DATADECL" $ makeHaskellDataDecls cfg mySpec tcs
-                    }
+  xils      <- makeHaskellInlines  embs cbs mySpec
+  ms        <- makeHaskellMeasures embs cbs mySpec
+  let refTcs = reflectedTyCons cfg embs cbs mySpec
+  let tcs    = F.notracepp "REFLECTED-TYCONS" $ sortNub (defTcs ++ refTcs)
+  return     $ mempty
+                { Ms.ealiases  = lmapEAlias . snd <$> xils
+                , Ms.measures  = F.notracepp "MS-MEAS" $ ms
+                , Ms.reflects  = F.notracepp "MS-REFLS" $ Ms.reflects mySpec
+                , Ms.dataDecls = F.notracepp "MS-DATADECL" $ makeHaskellDataDecls cfg mySpec tcs
+                }
 
--- | 'externalTyCons' returns the list of `[TyCon]` that must be reflected but
+-- | '_reflectedTyCons' returns the list of `[TyCon]` that must be reflected but
 --   which are defined *outside* the current module e.g. in Base or somewhere
 --   that we don't have access to the code.
-reflectedTyCons :: Config -> Ms.BareSpec -> BareM [TyCon]
-reflectedTyCons cfg spec
+_reflectedTyCons :: Config -> Ms.BareSpec -> BareM [TyCon]
+_reflectedTyCons cfg spec
   | exactDC cfg = mapM (lookupGhcTyCon "reflectedTyCons") $ tycName <$> Ms.dataDecls spec
   | otherwise   = return []
 
+reflectedTyCons :: Config -> TCEmb TyCon -> [CoreBind] -> Ms.BareSpec -> [TyCon]
+reflectedTyCons cfg embs cbs spec
+  | exactDC cfg = filter (not . isEmbedded embs)
+                $ concatMap varTyCons
+                $ reflectedVars spec cbs
+
+  | otherwise   = []
+
+-- | We cannot reflect embedded tycons (e.g. Bool) as that gives you a sort
+--   conflict: e.g. what is the type of is-True? does it take a GHC.Types.Bool
+--   or its embedding, a bool?
+isEmbedded :: TCEmb TyCon -> TyCon -> Bool
+isEmbedded embs c = M.member c embs
+
+varTyCons :: Var -> [TyCon]
+varTyCons = specTypeCons . ofType . varType
+
+specTypeCons           :: SpecType -> [TyCon]
+specTypeCons           = foldRType tc []
+  where
+    tc acc t@(RApp {}) = (rtc_tc $ rt_tycon t) : acc
+    tc acc _           = acc
+
 reflectedVars :: Ms.BareSpec -> [CoreBind] -> [Var]
-reflectedVars spec cbs = fst <$> xDefs 
+reflectedVars spec cbs = fst <$> xDefs
   where
     xDefs              = mapMaybe (`GM.findVarDef` cbs) reflSyms
     reflSyms           = fmap val . S.toList . Ms.reflects $ spec
@@ -238,8 +262,6 @@ reflectedVars spec cbs = fst <$> xDefs
 -- findVarDef :: Symbol -> [CoreBind] -> Maybe (Var, CoreExpr)
 
 -- makeASize       = mapM (lookupGhcTyCon "makeASize") [v | (m, s) <- specs, m == name, v <- S.toList (Ms.autosize s)]
--- specTypeCons :: SpecType -> [TyCon]
--- specTypeCons = _fixme
 
 makeLiftedSpec1
   :: FilePath -> ModName -> Ms.BareSpec -> [(Var, LocSpecType)] -> [AxiomEq]
@@ -248,8 +270,8 @@ makeLiftedSpec1 file name lSpec0 xts axs
   = liftIO $ saveLiftedSpec file name lSpec1
   where
     xbs    = [ (varLocSym x, specToBare <$> t) | (x, t) <- xts ]
-    lSpec1 = lSpec0 { Ms.asmSigs  = F.tracepp "ASM-SIGS"  xbs
-                    , Ms.reflSigs = F.tracepp "REFL-SIGS" xbs
+    lSpec1 = lSpec0 { Ms.asmSigs  = F.notracepp "ASM-SIGS"  xbs
+                    , Ms.reflSigs = F.notracepp "REFL-SIGS" xbs
                     , Ms.axeqs    = axs }
 
 varLocSym :: Var -> LocSymbol
@@ -447,7 +469,7 @@ makeGhcAxioms file name embs cbs su specs lSpec0 adts sp = do
   _       <- makeLiftedSpec1 file name lSpec0 xts mAxs
   let xts' = xts ++ gsAsmSigs sp
   let vts  = [ (v, t)        | (v, t) <- xts', let vx = GM.dropModuleNames $ symbol v, S.member vx rfls ]
-  let msR  = tracepp "makeGhcAxioms:msR" [ (symbol v, t) | (v, t) <- vts ]
+  let msR  = [ (symbol v, t) | (v, t) <- vts ]
   let vs   = [ v             | (v, _) <- vts ]
   return   $ sp { gsAsmSigs  = xts'                   -- the IMPORTED refl-sigs are in gsAsmSigs sp
                 , gsMeas     = msR ++ gsMeas     sp   -- we must add them to gsMeas to allow the names in specifications
@@ -690,7 +712,7 @@ makeGhcSpecCHOP1 cfg specs embs syms = do
   let adts         = makeDataDecls cfg embs tds datacons
   dm              <- gets dcEnv
   _               <- setDataDecls adts
-  let dcSelectors  = concatMap (makeMeasureSelectors cfg dm) $ F.tracepp "CHOP1-datacons" datacons
+  let dcSelectors  = concatMap (makeMeasureSelectors cfg dm) $ F.notracepp "CHOP1-datacons" datacons
   recSels         <- makeRecordSelectorSigs datacons
   return             (tycons, second val <$> datacons, dcSelectors, recSels, tyi, adts)
 
@@ -769,8 +791,7 @@ makeGhcSpecCHOP2 :: [(ModName, Ms.BareSpec)]
 makeGhcSpecCHOP2 specs dcSelectors datacons cls embs = do
   measures'   <- mconcat <$> mapM makeMeasureSpec specs
   tyi         <- gets tcEnv
-  let measures = mconcat [ measures'
-                         , Ms.mkMSpec' dcSelectors]
+  let measures = mconcat [ measures' , Ms.mkMSpec' dcSelectors]
   let (cs, ms) = makeMeasureSpec' measures
   let cms      = makeClassMeasureSpec measures
   let cms'     = [ (x, Loc l l' $ cSort t) | (Loc l l' x, t) <- cms ]
@@ -861,7 +882,7 @@ replaceLocalBindsOne allowHO v
                              env' (zip ty_binds ty_args)
            let res  = substa (f env) ty_res
            let t'   = fromRTypeRep $ t { ty_args = args, ty_res = res }
-           let msg  = ErrTySpec (GM.sourcePosSrcSpan l) (  {- text "replaceLocalBindsOne" <+> -} pprint v) t'
+           let msg  = ErrTySpec (GM.sourcePosSrcSpan l) (  text "replaceLocalBindsOne" <+>  pprint v) t'
            case checkTy allowHO msg emb tyi fenv (Loc l l' t') of
              Just err -> Ex.throw err
              Nothing  -> modify (first $ M.insert v (Loc l l' t'))

--- a/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -60,7 +60,7 @@ checkGhcSpec :: [(ModName, Ms.BareSpec)]
              -> GhcSpec
              -> Either [Error] GhcSpec
 
-checkGhcSpec specs env sp =  applyNonNull (Right sp) Left errors
+checkGhcSpec specs env0 sp =  applyNonNull (Right sp) Left errors
   where
     errors           =  -- mapMaybe (checkBind allowHO "constructor"  emb tcEnv env) (dcons      sp) ++
                         mapMaybe (checkBind allowHO "measure"      emb tcEnv env) (gsMeas       sp)
@@ -84,11 +84,12 @@ checkGhcSpec specs env sp =  applyNonNull (Right sp) Left errors
                      -- but make sure that all the specs are checked.
                      -- ++ checkRefinedClasses                        rClasses rInsts
                      ++ checkSizeFun emb env                        (gsTconsP sp)
+    env               = tracepp "checkGhcSpec ENV = " env0
     _rClasses         = concatMap (Ms.classes   . snd) specs
     _rInsts           = concatMap (Ms.rinstance . snd) specs
     tAliases          = concat [Ms.aliases sp  | (_, sp) <- specs]
     eAliases          = concat [Ms.ealiases sp | (_, sp) <- specs]
-    emb              = gsTcEmbeds sp
+    emb              = tracepp "checkGhcSpec TCEMB" $ gsTcEmbeds sp
     tcEnv            = gsTyconEnv sp
     ms               = gsMeasures sp
     clsSigs sp       = [ (v, t) | (v, t) <- gsTySigs sp, isJust (isClassOpId_maybe v) ]
@@ -272,11 +273,12 @@ checkRType :: (PPrint r, Reftable r, SubsTy RTyVar (RType RTyCon RTyVar ()) r, R
            => Bool -> TCEmb TyCon -> SEnv SortedReft -> RRType (UReft r) -> Maybe Doc
 ------------------------------------------------------------------------------------------------
 
-checkRType allowHO emb env t
+checkRType allowHO emb env t0
   =   checkAppTys t
   <|> checkAbstractRefs t
   <|> efoldReft farg cb (tyToBind emb) (rTypeSortedReft emb) f insertPEnv env Nothing t
   where
+    t                  = tracepp "checkRType: " t0
     cb c ts            = classBinds (rRCls c ts)
     farg _ t           = allowHO || isBase t  -- NOTE: this check should be the same as the one in addCGEnv
     f env me r err     = err <|> checkReft env emb me r

--- a/src/Language/Haskell/Liquid/Bare/DataType.hs
+++ b/src/Language/Haskell/Liquid/Bare/DataType.hs
@@ -389,7 +389,7 @@ ofBDataCtor name l l' tc αs ps ls πs (DataCtor c xts res) = do
   let cs        = RT.ofType <$> dataConStupidTheta c'
   let t0'       = fromMaybe t0 res'
   cfg          <- gets beConfig
-  let (yts, ot) = qualifyDataCtor (exactDC cfg && not isGadt) name dLoc (zip xs ts', t0')
+  let (yts, ot) = F.tracepp "OFBDataCTOR" $ qualifyDataCtor (exactDC cfg && not isGadt) name dLoc (zip xs ts', t0')
   let zts       = zipWith (normalizeField c') [1..] (reverse yts)
   return          (c', DataConP l αs πs ls cs zts ot isGadt l')
   where

--- a/src/Language/Haskell/Liquid/Bare/DataType.hs
+++ b/src/Language/Haskell/Liquid/Bare/DataType.hs
@@ -389,7 +389,7 @@ ofBDataCtor name l l' tc αs ps ls πs (DataCtor c xts res) = do
   let cs        = RT.ofType <$> dataConStupidTheta c'
   let t0'       = fromMaybe t0 res'
   cfg          <- gets beConfig
-  let (yts, ot) = F.tracepp "OFBDataCTOR" $ qualifyDataCtor (exactDC cfg && not isGadt) name dLoc (zip xs ts', t0')
+  let (yts, ot) = F.notracepp "OFBDataCTOR" $ qualifyDataCtor (exactDC cfg && not isGadt) name dLoc (zip xs ts', t0')
   let zts       = zipWith (normalizeField c') [1..] (reverse yts)
   return          (c', DataConP l αs πs ls cs zts ot isGadt l')
   where

--- a/src/Language/Haskell/Liquid/Bare/Lookup.hs
+++ b/src/Language/Haskell/Liquid/Bare/Lookup.hs
@@ -204,7 +204,6 @@ lookupGhcVar x = do
     fv (AConLike (RealDataCon x)) = Just $ dataConWorkId x
     fv _                          = Nothing
 
-
 lookupGhcTyCon   ::  GhcLookup a => String -> a -> BareM TyCon
 lookupGhcTyCon src s = do
   lookupGhcThing err ftc (Just tcName) s  `catchError` \_ ->

--- a/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -37,7 +37,7 @@ import Data.Bifunctor
 import Data.Maybe
 import Data.Char (toUpper)
 
-import TysWiredIn (boolTyCon)
+import TysWiredIn (boolTyCon, wiredInTyCons)
 
 import Data.Traversable (forM, mapM)
 import Text.PrettyPrint.HughesPJ (text)
@@ -80,8 +80,17 @@ makeHaskellDataDecls cfg spec
                 . traceShow "VanillaTCs 2 "
                 . zipMap   (hasDataDecl spec)
                 . F.tracepp "VanillaTCs 1 "
-                . filter    isVanillaAlgTyCon
+                . liftableTyCons
+
   | otherwise   = const []
+
+liftableTyCons :: [TyCon] -> [TyCon]
+liftableTyCons = filter   (not . isBoxedTupleTyCon)
+               . filter   isVanillaAlgTyCon
+               . (`sortDiff` wiredInTyCons)
+
+  -- F.notracepp "REFLECTED-TYCONS" $ (sortNub (defTcs ++ refTcs))
+
 
 zipMap :: (a -> b) -> [a] -> [(a, b)]
 zipMap f xs = zip xs (map f xs)

--- a/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -48,7 +48,7 @@ import qualified Data.List as L
 import qualified Data.HashMap.Strict as M
 import qualified Data.HashSet        as S
 
-import Language.Fixpoint.Misc (traceShow, mlookup, sortNub, groupList, mapSnd, mapFst)
+import Language.Fixpoint.Misc (mlookup, sortNub, groupList, mapSnd, mapFst)
 import Language.Fixpoint.Types (Symbol, dummySymbol, symbolString, symbol, Expr(..), meet)
 import Language.Fixpoint.SortCheck (isFirstOrder)
 
@@ -77,9 +77,9 @@ makeHaskellDataDecls :: Config -> Ms.BareSpec -> [TyCon] -> [DataDecl]
 --------------------------------------------------------------------------------
 makeHaskellDataDecls cfg spec
   | exactDC cfg = mapMaybe tyConDataDecl
-                . traceShow "VanillaTCs 2 "
+                -- . traceShow "VanillaTCs 2 "
                 . zipMap   (hasDataDecl spec)
-                . F.tracepp "VanillaTCs 1 "
+                . F.notracepp "VanillaTCs 1 "
                 . liftableTyCons
 
   | otherwise   = const []
@@ -88,9 +88,6 @@ liftableTyCons :: [TyCon] -> [TyCon]
 liftableTyCons = filter   (not . isBoxedTupleTyCon)
                . filter   isVanillaAlgTyCon
                . (`sortDiff` wiredInTyCons)
-
-  -- F.notracepp "REFLECTED-TYCONS" $ (sortNub (defTcs ++ refTcs))
-
 
 zipMap :: (a -> b) -> [a] -> [(a, b)]
 zipMap f xs = zip xs (map f xs)

--- a/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -48,7 +48,7 @@ import qualified Data.List as L
 import qualified Data.HashMap.Strict as M
 import qualified Data.HashSet        as S
 
-import Language.Fixpoint.Misc (mlookup, sortNub, groupList, mapSnd, mapFst)
+import Language.Fixpoint.Misc (traceShow, mlookup, sortNub, groupList, mapSnd, mapFst)
 import Language.Fixpoint.Types (Symbol, dummySymbol, symbolString, symbol, Expr(..), meet)
 import Language.Fixpoint.SortCheck (isFirstOrder)
 
@@ -77,7 +77,9 @@ makeHaskellDataDecls :: Config -> Ms.BareSpec -> [TyCon] -> [DataDecl]
 --------------------------------------------------------------------------------
 makeHaskellDataDecls cfg spec
   | exactDC cfg = mapMaybe tyConDataDecl
+                . traceShow "VanillaTCs 2 "
                 . zipMap   (hasDataDecl spec)
+                . F.tracepp "VanillaTCs 1 "
                 . filter    isVanillaAlgTyCon
   | otherwise   = const []
 
@@ -87,6 +89,7 @@ zipMap f xs = zip xs (map f xs)
 data HasDataDecl
   = NoDecl  (Maybe SizeFun)
   | HasDecl
+  deriving (Show)
 
 hasDataDecl :: Ms.BareSpec -> TyCon -> HasDataDecl
 hasDataDecl spec = \tc -> M.lookupDefault def (tcSym tc) decls
@@ -97,8 +100,10 @@ hasDataDecl spec = \tc -> M.lookupDefault def (tcSym tc) decls
 
 hasDecl :: DataDecl -> HasDataDecl
 hasDecl d
-  | Just s <- tycSFun d, null (tycDCons d)
-  = NoDecl (Just s)
+  | null (tycDCons d)
+  = NoDecl (tycSFun d)
+  -- // | Just s <- tycSFun d, null (tycDCons d)
+  -- // = NoDecl (Just s)
   | otherwise
   = HasDecl
 

--- a/src/Language/Haskell/Liquid/Measure.hs
+++ b/src/Language/Haskell/Liquid/Measure.hs
@@ -72,7 +72,6 @@ data Spec ty bndr  = Spec
   , decr       :: ![(LocSymbol, [Int])]          -- ^ Information on decreasing arguments
   , lvars      :: ![LocSymbol]                   -- ^ Variables that should be checked in the environment they are used
   , lazy       :: !(S.HashSet LocSymbol)         -- ^ Ignore Termination Check in these Functions
-  -- , axioms     :: !(S.HashSet LocSymbol)         -- ^ Binders to turn into SMT axioms
   , reflects   :: !(S.HashSet LocSymbol)         -- ^ Binders to reflect
   , autois     :: !(M.HashMap LocSymbol (Maybe Int))  -- ^ Automatically instantiate axioms in these Functions with maybe specified fuel
   , hmeas      :: !(S.HashSet LocSymbol)         -- ^ Binders to turn into measures using haskell definitions

--- a/tests/import/lib/T1112.hs
+++ b/tests/import/lib/T1112.hs
@@ -1,0 +1,17 @@
+
+{-@ LIQUID "--higherorder"    @-}
+{-@ LIQUID "--exact-data-con" @-}
+
+module T1112 where
+
+import ProdDef
+
+{-@ axiomatize leqProd @-}
+leqProd :: Eq (f p)
+        => (f p -> f p -> Bool) -> (g p -> g p -> Bool)
+        -> Product f g p -> Product f g p -> Bool
+leqProd leqFP leqGP (Product x1 y1) (Product x2 y2) =
+  if x1 == x2
+    then leqGP y1 y2
+    else leqFP x1 x2
+{-# INLINE leqProd #-}

--- a/tests/import/lib/T1112.hs
+++ b/tests/import/lib/T1112.hs
@@ -4,7 +4,9 @@
 
 module T1112 where
 
-import ProdDef
+import T1112Lib
+
+{-@ data Product @-}
 
 {-@ axiomatize leqProd @-}
 leqProd :: Eq (f p)

--- a/tests/import/lib/T1112Lib.hs
+++ b/tests/import/lib/T1112Lib.hs
@@ -1,0 +1,3 @@
+module T1112Lib where
+
+data Product f g p = Product (f p) (g p) deriving Eq


### PR DESCRIPTION
When checking a module `Client` with `--exact-data-con`, 
automatically "lift" or "reflect" all the `TyCon`s that are used 
in *reflected* functions inside `Client`, _even_ when the `Library` 
defining the `TyCon` does not use `--exact-data-con` 
(or is generally unavailable for analysis.)

Fixes #1112 

See the above issue for a use case.

Of course, we cannot lift some primitive `TyCon` like `Bool` and tuples.