### PR TITLE
Resolve Multiple Data-declarations 

### DIFF
--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -708,7 +708,8 @@ makeGhcSpecCHOP1 cfg specs embs syms = do
   let tyi          = qualifyRTyCon (qualifySymbol syms) <$> makeTyConInfo tycons
   datacons        <- makePluggedDataCons embs tyi (concat dcs ++ wiredDataCons)
   let tds          = [(name, tc, dd) | (name, tc, _, Just dd) <- tcDds]
-  let adts         = makeDataDecls cfg embs tds datacons
+  myName          <- modName <$> get
+  let adts         = makeDataDecls cfg embs myName tds datacons
   dm              <- gets dcEnv
   _               <- setDataDecls adts
   let dcSelectors  = concatMap (makeMeasureSelectors cfg dm) $ F.notracepp "CHOP1-datacons" datacons

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -700,7 +700,6 @@ makeGhcSpecCHOP1
            , M.HashMap TyCon RTyCon
            , [F.DataDecl]
            )
-
 makeGhcSpecCHOP1 cfg specs embs syms = do
   (tcDds, dcs)    <- mconcat <$> mapM makeConTypes specs
   let tcs          = [(x, y) | (_, x, y, _)       <- tcDds]

--- a/src/Language/Haskell/Liquid/Bare/DataType.hs
+++ b/src/Language/Haskell/Liquid/Bare/DataType.hs
@@ -95,12 +95,12 @@ makeDataDecls :: Config -> F.TCEmb TyCon
               -> [(DataCon, Located DataConP)]
               -> [F.DataDecl]
 makeDataDecls cfg tce tds ds
-  | makeDecls = [ makeFDataDecls tce tc dd ctors
-                | (tc, (dd, ctors)) <- groupDataCons tds' (F.tracepp "makeDataDecls-DATACONS" ds) ]
+  | makeDecls = [ makeFDataDecls tce tc dd (F.notracepp "Make-Decl-CTORS" ctors)
+                | (tc, (dd, ctors)) <- groupDataCons tds' ds ]
   | otherwise = []
   where
     makeDecls = exactDC cfg && not (noADT cfg)
-    tds'      = indexTyConDecls tds --[ (tc, (d, t)) | (_, tc, (d, t)) <- F.tracepp "makeDataDecls-TYCONS" tds ]
+    tds'      = F.notracepp "makeDataDecls-TYCONS" $ indexTyConDecls tds --[ (tc, (d, t)) | (_, tc, (d, t)) <- F.tracepp "makeDataDecls-TYCONS" tds ]
 
 -- [NOTE:Orphan-TyCons]
 

--- a/src/Language/Haskell/Liquid/Bare/DataType.hs
+++ b/src/Language/Haskell/Liquid/Bare/DataType.hs
@@ -116,8 +116,6 @@ makeDataDecls cfg tce name tds ds
           - otherwise you can avoid importing the definition
             and hence, unsafely pass its invariants!
 
-      That said ...
-
       So, 'resolveTyConDecls' implements the following protocol:
 
       (a) If there is a "Home" definition,
@@ -125,6 +123,11 @@ makeDataDecls cfg tce name tds ds
 
       (b) If there are ONLY "orphan" definitions,
           then pick the one from module being analyzed.
+
+      We COULD relax to allow for exactly one orphan `DataUser` definition
+      which is the one that should be selected, but that seems like a
+      slippery slope, as you can avoid importing the definition
+      and hence, unsafely pass its invariants! (Feature not bug?)
 
 -}
 resolveTyCons :: ModName -> [(ModName, TyCon, DataPropDecl)]
@@ -140,7 +143,7 @@ resolveDecls :: ModName -> TyCon -> Misc.ListNE (ModName, DataPropDecl)
              -> Maybe (ModName, DataPropDecl)
 resolveDecls mName tc mds  = Misc.firstMaybes $ (`L.find` mds) <$> [ isHomeDef , isMyDef]
   where
-    isMyDef                = (mName ==)             . fst 
+    isMyDef                = (mName ==)             . fst
     isHomeDef              = (tcHome ==) . F.symbol . fst
     tcHome                 = GM.takeModuleNames (F.symbol tc)
 

--- a/src/Language/Haskell/Liquid/Bare/Spec.hs
+++ b/src/Language/Haskell/Liquid/Bare/Spec.hs
@@ -91,7 +91,7 @@ makeClasses cmod cfg vs (mod, spec) = inModule mod $ mapM mkClass $ Ms.classes s
                  let sts = [(val s, unClass $ val t) | (s, _)    <- ms
                                                      | (_, _, t) <- vts]
                  let t   = rCls tc as'
-                 let dcp = DataConP l αs [] [] (val <$> ss') (reverse sts) t False l'
+                 let dcp = DataConP l αs [] [] (val <$> ss') (reverse sts) t False (F.symbol mod) l'
                  return ((dc,dcp),vts)
 
 makeQualifiers :: (ModName, Ms.Spec ty bndr)

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -1405,7 +1405,7 @@ dataDeclP = do
 
 emptyDecl :: LocSymbol -> SourcePos -> Maybe SizeFun -> DataDecl
 emptyDecl x pos fsize
-  = D x [] [] [] [] pos fsize Nothing
+  = D x [] [] [] [] pos fsize Nothing DataReflected
 
 dataDeclBodyP :: SourcePos -> LocSymbol -> Maybe SizeFun -> Parser DataDecl
 dataDeclBodyP pos x fsize = do
@@ -1413,7 +1413,7 @@ dataDeclBodyP pos x fsize = do
   ps         <- predVarDefsP
   (pTy, dcs) <- dataCtorsP
   whiteSpace
-  return      $ D x ts ps [] dcs pos fsize pTy
+  return      $ D x ts ps [] dcs pos fsize pTy DataUser
 
 dataCtorsP :: Parser (Maybe BareType, [DataCtor])
 dataCtorsP

--- a/src/Language/Haskell/Liquid/Types/PredType.hs
+++ b/src/Language/Haskell/Liquid/Types/PredType.hs
@@ -63,7 +63,7 @@ mkRTyCon tc (TyConP _ αs' ps _ tyvariance predvariance size)
     pvs' = subts (zip αs' τs) <$> ps
 
 dataConPSpecType :: DataCon -> DataConP -> SpecType
-dataConPSpecType dc (DataConP _ vs ps ls cs yts rt _ _)
+dataConPSpecType dc (DataConP _ vs ps ls cs yts rt _ _ _)
   = mkArrow makeVars ps ls ts' rt'
   where
     (xs, ts) = unzip $ reverse yts
@@ -90,13 +90,14 @@ instance Show TyConP where
  show = showpp -- showSDoc . ppr
 
 instance PPrint DataConP where
-  pprintTidy k (DataConP _ vs ps ls cs yts t isGadt _)
-     =  (parens $ hsep (punctuate comma (pprintTidy k <$> vs)))  
+  pprintTidy k (DataConP _ vs ps ls cs yts t isGadt mname _)
+     =  (parens $ hsep (punctuate comma (pprintTidy k <$> vs)))
     <+> (parens $ hsep (punctuate comma (pprintTidy k <$> ps)))
     <+> (parens $ hsep (punctuate comma (pprintTidy k <$> ls)))
     <+> (parens $ hsep (punctuate comma (pprintTidy k <$> cs)))
     <+> (parens $ hsep (punctuate comma (pprintTidy k <$> yts)))
     <+> (pprintTidy k isGadt)
+    <+> (pprintTidy k mname)
     <+>  pprintTidy k t
 
 instance Show DataConP where

--- a/src/Language/Haskell/Liquid/WiredIn.hs
+++ b/src/Language/Haskell/Liquid/WiredIn.hs
@@ -119,8 +119,8 @@ wiredTyDataCons = (concat tcs, mapSnd dummyLoc <$> concat dcs)
 
 listTyDataCons :: ([(TyCon, TyConP)] , [(DataCon, DataConP)])
 listTyDataCons   = ( [(c, TyConP l0 [RTV tyv] [p] [] [Covariant] [Covariant] (Just fsize))]
-                   , [(nilDataCon , DataConP l0 [RTV tyv] [p] [] [] [] lt False l0)
-                     ,(consDataCon, DataConP l0 [RTV tyv] [p] [] [] cargs  lt  False l0)])
+                   , [(nilDataCon , DataConP l0 [RTV tyv] [p] [] [] [] lt False wiredInName l0)
+                     ,(consDataCon, DataConP l0 [RTV tyv] [p] [] [] cargs  lt  False wiredInName l0)])
     where
       l0         = dummyPos "LH.Bare.listTyDataCons"
       c          = listTyCon
@@ -137,9 +137,12 @@ listTyDataCons   = ( [(c, TyConP l0 [RTV tyv] [p] [] [Covariant] [Covariant] (Ju
       cargs      = [(xs, xst), (x, xt)]
       fsize      = SymSizeFun (dummyLoc "len")
 
+wiredInName :: Symbol
+wiredInName = "WiredIn"
+
 tupleTyDataCons :: Int -> ([(TyCon, TyConP)] , [(DataCon, DataConP)])
 tupleTyDataCons n = ( [(c, TyConP l0 (RTV <$> tyvs) ps [] tyvarinfo pdvarinfo Nothing)]
-                    , [(dc, DataConP l0 (RTV <$> tyvs) ps [] []  cargs  lt False l0)])
+                    , [(dc, DataConP l0 (RTV <$> tyvs) ps [] []  cargs  lt False wiredInName l0)])
   where
     tyvarinfo     = replicate n     Covariant
     pdvarinfo     = replicate (n-1) Covariant

--- a/tests/import/lib/T1117.hs
+++ b/tests/import/lib/T1117.hs
@@ -1,8 +1,10 @@
 {-@ LIQUID "--higherorder"        @-}
 {-@ LIQUID "--exactdc"            @-}
-module Bug where
 
-import Aux
+module T1117 where
+
+import T1117Lib 
+
 import Language.Haskell.Liquid.ProofCombinators
 
 {-@ axiomatize leqU1 @-}

--- a/tests/import/lib/T1117.hs
+++ b/tests/import/lib/T1117.hs
@@ -1,0 +1,24 @@
+{-@ LIQUID "--higherorder"        @-}
+{-@ LIQUID "--exactdc"            @-}
+module Bug where
+
+import Aux
+import Language.Haskell.Liquid.ProofCombinators
+
+{-@ axiomatize leqU1 @-}
+leqU1 :: U1 p -> U1 p -> Bool
+leqU1 _ _ = True
+
+{-@ leqU1Refl :: x:U1 p -> { leqU1 x x } @-}
+leqU1Refl :: U1 p -> Proof
+leqU1Refl U1 = leqU1 U1 U1 ==. True *** QED
+
+{-@ axiomatize leqProd @-}
+leqProd :: Eq (f p)
+        => (f p -> f p -> Bool) -> (g p -> g p -> Bool)
+        -> Product f g p -> Product f g p -> Bool
+leqProd leqFP leqGP (Product x1 y1) (Product x2 y2) =
+  if x1 == x2
+    then leqGP y1 y2
+    else leqFP x1 x2
+{-# INLINE leqProd #-}

--- a/tests/import/lib/T1117Lib.hs
+++ b/tests/import/lib/T1117Lib.hs
@@ -1,0 +1,8 @@
+{-@ LIQUID "--higherorder"        @-}
+{-@ LIQUID "--exactdc"            @-}
+
+module T1117Lib where
+
+data U1 p = U1
+
+data Product f g p = Product (f p) (g p)

--- a/tests/import/lib/T1118.hs
+++ b/tests/import/lib/T1118.hs
@@ -1,0 +1,25 @@
+{-@ LIQUID "--higherorder"        @-}
+{-@ LIQUID "--exactdc"            @-}
+module T1118 where
+
+import T1118Lib2 
+import T1118Lib1
+import Language.Haskell.Liquid.ProofCombinators
+
+{-@ axiomatize leqU1 @-}
+leqU1 :: U1 p -> U1 p -> Bool
+leqU1 _ _ = True
+
+{-@ leqU1Refl :: x:U1 p -> { leqU1 x x } @-}
+leqU1Refl :: U1 p -> Proof
+leqU1Refl U1 = leqU1 U1 U1 ==. True *** QED
+
+{-@ axiomatize leqProd @-}
+leqProd :: Eq (f p)
+        => (f p -> f p -> Bool) -> (g p -> g p -> Bool)
+        -> Product f g p -> Product f g p -> Bool
+leqProd leqFP leqGP (Product x1 y1) (Product x2 y2) =
+  if x1 == x2
+    then leqGP y1 y2
+    else leqFP x1 x2
+{-# INLINE leqProd #-}

--- a/tests/import/lib/T1118Lib1.hs
+++ b/tests/import/lib/T1118Lib1.hs
@@ -1,0 +1,7 @@
+{-@ LIQUID "--higherorder"        @-}
+{-@ LIQUID "--exactdc"            @-}
+module T1118Lib1 where
+
+import T1118Lib2 
+
+{-@ data Product @-}

--- a/tests/import/lib/T1118Lib2.hs
+++ b/tests/import/lib/T1118Lib2.hs
@@ -1,0 +1,4 @@
+module T1118Lib2 where
+
+data U1 p = U1
+data Product f g p = Product (f p) (g p)


### PR DESCRIPTION
Fixes #1117 

We can end up with multiple data-declarations if we automatically reflect data types (as in `--exact-data-con` / ADT mode.) 

Consequently, we need to "resolve" the definitions to get a SINGLE definition. 

See the `[NOTE:Orphan-TyCons]` in `Bare/DataType.hs` for details.
