### PR TITLE
New Proof Combinators

### DIFF
--- a/include/Language/Haskell/Liquid/NewProofCombinators.hs
+++ b/include/Language/Haskell/Liquid/NewProofCombinators.hs
@@ -5,8 +5,7 @@
 
 module NewProofCombinators (
 
-  -- Attention! the operators Admitted and (==?) are 
-  -- UNSAFE: they should not belong the final proof term
+  -- ATTENTION! `Admitted` and `(==!)` are UNSAFE: they should not belong the final proof term
 
   -- * Proof is just a () alias 
   Proof
@@ -18,12 +17,11 @@ module NewProofCombinators (
   , (?)
 
   -- * These two operators check all intermediate equalities 
-  , (==!) -- proof of equality is implicit eg. x ==! y
-  , (==:) -- proof of equality is explitic eg. x ==: y ? p
+  , (===) -- proof of equality is implicit eg. x === y
+  , (==?) -- proof of equality is explitic eg. x ==? y ? p
 
   -- Uncheck operator used only for proof debugging
-  
-  , (==?) -- x ==? y always succeds 
+  , (==!) -- x ==! y always succeds 
 
   -- * The below operator does not check intermediate equalities
   --   but takes optional proof argument.
@@ -85,48 +83,53 @@ data QED = Admitted | QED
 
 -- | Implicit equality
 
--- x ==! y returns the proof certificate that 
+-- x === y returns the proof certificate that 
 -- result value is equal to both x and y
 -- when y == x (as assumed by the operator's precondition) 
 
-infixl 3 ==!
-{-@ (==!) :: x:a -> y:{a | y == x} -> {v:a | v == x && v == y} @-} 
-(==!) :: a -> a -> a 
-x ==! _  = x
+infixl 3 ===
+{-@ (===) :: x:a -> y:{a | y == x} -> {v:a | v == x && v == y} @-} 
+(===) :: a -> a -> a 
+x === _  = x
 
+-------------------------------------------------------------------------------
 -- | Explicit equality
--- `x ==: y ? p` returns the proof certificate that 
--- result value is equal to both x and y
--- when y == x is explicitely asserted by the proof term p
+-- 	`x ==? y ? p` 
+--   returns the proof certificate that result value is equal to both x and y
+--   when y == x is explicitely asserted by the proof term p
+-------------------------------------------------------------------------------
 
-infixl 3 ==:
-{-@ (==:) :: x:a -> y:a -> {v:Proof | x == y} -> {v:a | v == x && v == y} @-} 
-(==:) :: a -> a -> Proof -> a 
-(==:) x _ _ = x
+infixl 3 ==?
+{-@ (==?) :: x:a -> y:a -> {v:Proof | x == y} -> {v:a | v == x && v == y} @-} 
+(==?) :: a -> a -> Proof -> a 
+(==?) x _ _ = x
 
--- where `?` is basically Haskell's $ and is used for the right precedence
+-------------------------------------------------------------------------------
+-- | `?` is basically Haskell's $ and is used for the right precedence
+-------------------------------------------------------------------------------
 
 infixl 3 ?
 (?) :: (Proof -> a) -> Proof -> a
 f ? y = f y
 
 
+-------------------------------------------------------------------------------
 -- | Assumed equality
--- `x ==? y ` returns the admitted proof certificate that 
--- result value is equal to both x and y
+-- 	`x ==! y ` 
+--   returns the admitted proof certificate that result value is equals x and y
+-------------------------------------------------------------------------------
 
-infixl 3 ==?
-{-@ assume (==?) :: x:a -> y:a -> {v:a | v == x && v == y} @-} 
-(==?) :: a -> a -> a 
-(==?) x _ = x
+infixl 3 ==!
+{-@ assume (==!) :: x:a -> y:a -> {v:a | v == x && v == y} @-} 
+(==!) :: a -> a -> a 
+(==!) x _ = x
 
 
--- Example: See ListExamples 
-
--- In short: 
--- - (==?) is only for proof debuging
--- - (==:) requires explicit proof term
--- - (==!) does not require explicit proof term
+-- | To summarize: 
+--
+-- 	- (==!) is *only* for proof debuging
+--	- (===) does not require explicit proof term
+-- 	- (==?) requires explicit proof term
 
 -------------------------------------------------------------------------------
 -- | * Unchecked Proof Certificates -------------------------------------------

--- a/include/Language/Haskell/Liquid/NewProofCombinators.hs
+++ b/include/Language/Haskell/Liquid/NewProofCombinators.hs
@@ -5,29 +5,29 @@
 
 module NewProofCombinators (
 
-  -- ATTENTION! `Admitted` and `(==!)` are UNSAFE: they should not belong the final proof term
+  -- ATTENTION! `Admit` and `(==!)` are UNSAFE: they should not belong the final proof term
 
-  -- * Proof is just a () alias 
+  -- * Proof is just a () alias
   Proof
-  
-  -- * Proof constructors 
+
+  -- * Proof constructors
   , trivial, unreachable, (***), QED(..)
 
   -- * Proof certificate constructors
   , (?)
 
-  -- * These two operators check all intermediate equalities 
+  -- * These two operators check all intermediate equalities
   , (===) -- proof of equality is implicit eg. x === y
   , (==?) -- proof of equality is explitic eg. x ==? y ? p
 
   -- Uncheck operator used only for proof debugging
-  , (==!) -- x ==! y always succeds 
+  , (==!) -- x ==! y always succeds
 
   -- * The below operator does not check intermediate equalities
   --   but takes optional proof argument.
   , (==.)
 
-  -- * Combining Proofs 
+  -- * Combining Proofs
   , (&&&)
 
 ) where
@@ -54,54 +54,54 @@ unreachable =  ()
 -- All proof terms are deleted at runtime.
 {- RULE "proofs are irrelevant" forall (p :: Proof). p = () #-}
 
--- | proof casting 
+-- | proof casting
 -- | `x *** QED`: x is a proof certificate* strong enough for SMT to prove your theorem
--- | `x *** Admitted`: x is an unfinished proof
+-- | `x *** Admit`: x is an unfinished proof
 
-infixl 3 *** 
-{-@ assume (***) :: a -> p:QED -> { if (isAdmitted p) then false else true } @-}
-(***) :: a -> QED -> Proof 
+infixl 3 ***
+{-@ assume (***) :: a -> p:QED -> { if (isAdmit p) then false else true } @-}
+(***) :: a -> QED -> Proof
 _ *** _ = ()
 
-data QED = Admitted | QED    
+data QED = Admit | QED
 
-{-@ measure isAdmitted :: QED -> Bool @-}
-{-@ Admitted :: {v:QED | isAdmitted v } @-}
+{-@ measure isAdmit :: QED -> Bool @-}
+{-@ Admit :: {v:QED | isAdmit v } @-}
 
 
 -------------------------------------------------------------------------------
 -- | * Checked Proof Certificates ---------------------------------------------
 -------------------------------------------------------------------------------
 
--- Any (refined) carries proof certificates. 
--- For example 42 :: {v:Int | v == 42} is a certificate that 
--- the value 42 is equal to 42. 
+-- Any (refined) carries proof certificates.
+-- For example 42 :: {v:Int | v == 42} is a certificate that
+-- the value 42 is equal to 42.
 -- But, this certificate will not really be used to proof any fancy theorems.
 
 -- Below we provide a number of equational operations
--- that constuct proof certificates. 
+-- that constuct proof certificates.
 
 -- | Implicit equality
 
--- x === y returns the proof certificate that 
+-- x === y returns the proof certificate that
 -- result value is equal to both x and y
--- when y == x (as assumed by the operator's precondition) 
+-- when y == x (as assumed by the operator's precondition)
 
 infixl 3 ===
-{-@ (===) :: x:a -> y:{a | y == x} -> {v:a | v == x && v == y} @-} 
-(===) :: a -> a -> a 
+{-@ (===) :: x:a -> y:{a | y == x} -> {v:a | v == x && v == y} @-}
+(===) :: a -> a -> a
 x === _  = x
 
 -------------------------------------------------------------------------------
 -- | Explicit equality
--- 	`x ==? y ? p` 
+-- 	`x ==? y ? p`
 --   returns the proof certificate that result value is equal to both x and y
 --   when y == x is explicitely asserted by the proof term p
 -------------------------------------------------------------------------------
 
 infixl 3 ==?
-{-@ (==?) :: x:a -> y:a -> {v:Proof | x == y} -> {v:a | v == x && v == y} @-} 
-(==?) :: a -> a -> Proof -> a 
+{-@ (==?) :: x:a -> y:a -> {v:Proof | x == y} -> {v:a | v == x && v == y} @-}
+(==?) :: a -> a -> Proof -> a
 (==?) x _ _ = x
 
 -------------------------------------------------------------------------------
@@ -115,17 +115,17 @@ f ? y = f y
 
 -------------------------------------------------------------------------------
 -- | Assumed equality
--- 	`x ==! y ` 
+-- 	`x ==! y `
 --   returns the admitted proof certificate that result value is equals x and y
 -------------------------------------------------------------------------------
 
 infixl 3 ==!
-{-@ assume (==!) :: x:a -> y:a -> {v:a | v == x && v == y} @-} 
-(==!) :: a -> a -> a 
+{-@ assume (==!) :: x:a -> y:a -> {v:a | v == x && v == y} @-}
+(==!) :: a -> a -> a
 (==!) x _ = x
 
 
--- | To summarize: 
+-- | To summarize:
 --
 -- 	- (==!) is *only* for proof debuging
 --	- (===) does not require explicit proof term
@@ -136,7 +136,7 @@ infixl 3 ==!
 -------------------------------------------------------------------------------
 
 -- The above operators check each intermediate proof step.
--- The operator `==.` below accepts an optional proof term 
+-- The operator `==.` below accepts an optional proof term
 -- argument, but does not check intermediate steps.
 
 infixl 3 ==.
@@ -162,4 +162,4 @@ instance (a~b) => OptEq a b where
 
 
 (&&&) :: Proof -> Proof -> Proof
-x &&& _ = x 
+x &&& _ = x

--- a/include/Language/Haskell/Liquid/NewProofCombinators.hs
+++ b/include/Language/Haskell/Liquid/NewProofCombinators.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE IncoherentInstances   #-}
 
-module NewProofCombinators (
+module Language.Haskell.Liquid.NewProofCombinators (
 
   -- ATTENTION! `Admit` and `(==!)` are UNSAFE: they should not belong the final proof term
 


### PR DESCRIPTION
@nikivazou I have rejiggered the proof combinators to make 
them easier to remember.

1. **Checked Eq** `x === y` means check `x` and `y` are equal,
2. **Certified Eq** `x ==? y  ? pf` means `x` and `y` are equal because of `pf`,
3. **Unchecked Eq** `x ==! y` means "trust me", `x` equals `y` (UNSAFE).

I want to use `==?` because we use `?` for the _"because"_ and its easier to remember.
Similarly `===` means really check this equality, and `==!` is "danger" (indicated by the `!`) 

😄 
 