### PR TITLE
Add support for Bags/Multisets

### DIFF
--- a/docs/blog/2017-12-15-splitting-and-splicing-intervals-I.lhs
+++ b/docs/blog/2017-12-15-splitting-and-splicing-intervals-I.lhs
@@ -301,7 +301,7 @@ that the above is a _correct_ implementation of a Set library.
 
 Is it even _possible_, let alone _easier_ to do that with LH?
 
-[demo]:              http://goto.ucsd.edu/~rjhala/liquid/haskell/demo/#?demo=IntervalSets.hs
+[demo]:              http://goto.ucsd.edu:8090/index.html#?demo=IntervalSets.hs
 [intersect-good]:    https://github.com/antalsz/hs-to-coq/blob/8f84d61093b7be36190142c795d6cd4496ef5aed/examples/intervals/Proofs.v#L370-L439
 [union-good]:        https://github.com/antalsz/hs-to-coq/blob/b7efc7a8dbacca384596fc0caf65e62e87ef2768/examples/intervals/Proofs_Function.v#L319-L382
 [subtract-good]:     https://github.com/antalsz/hs-to-coq/blob/8f84d61093b7be36190142c795d6cd4496ef5aed/examples/intervals/Proofs.v#L565-L648

--- a/include/CoreToLogic.lg
+++ b/include/CoreToLogic.lg
@@ -24,6 +24,7 @@ define GHC.Types.True                 = (true)
 
 define Data.Map.Base.insert k v m     = (Map_store m k v)
 define Data.Map.Base.select k v       = (Map_select m k)
+define Data.Map.Base.union  m1 m2     = (Map_union  m1 m2)
 
 define Language.Haskell.Liquid.String.stringEmp = (stringEmp)
 define Data.RString.RString.stringEmp = (stringEmp)

--- a/include/CoreToLogic.lg
+++ b/include/CoreToLogic.lg
@@ -8,7 +8,6 @@ define Data.Set.Base.member x xs      = (Set_mem x xs)
 define Data.Set.Base.isSubsetOf x y   = (Set_sub x y)
 define Data.Set.Base.elems xs         = (listElts xs)
 
-
 define Data.Set.Internal.singleton x      = (Set_sng x)
 define Data.Set.Internal.union x y        = (Set_cup x y)
 define Data.Set.Internal.intersection x y = (Set_cap x y)
@@ -22,10 +21,10 @@ define Data.Set.Internal.elems xs         = (listElts xs)
 
 define GHC.Types.True                 = (true)
 
-define Language.Haskell.Liquid.Bag.empty     = (Map_default 0)
 define Language.Haskell.Liquid.Bag.get k m   = (Map_select m k)
 define Language.Haskell.Liquid.Bag.put k m   = (Map_store m k (1 + (Map_select m k)))
 define Language.Haskell.Liquid.Bag.union m n = (Map_union  m n)
+define Language.Haskell.Liquid.Bag.empty     = (Map_default 0)
 
 define Data.Map.Base.insert k v m     = (Map_store m k v)
 define Data.Map.Base.select k v       = (Map_select m k)

--- a/include/CoreToLogic.lg
+++ b/include/CoreToLogic.lg
@@ -20,11 +20,15 @@ define Data.Set.Internal.isSubsetOf x y   = (Set_sub x y)
 define Data.Set.Internal.elems xs         = (listElts xs)
 
 
-define GHC.Types.True                 = (true) 
+define GHC.Types.True                 = (true)
+
+define Language.Haskell.Liquid.Bag.empty     = (Map_default 0)
+define Language.Haskell.Liquid.Bag.get k m   = (Map_select m k)
+define Language.Haskell.Liquid.Bag.put k m   = (Map_store m k (1 + (Map_select m k)))
+define Language.Haskell.Liquid.Bag.union m n = (Map_union  m n)
 
 define Data.Map.Base.insert k v m     = (Map_store m k v)
 define Data.Map.Base.select k v       = (Map_select m k)
-define Data.Map.Base.union  m1 m2     = (Map_union  m1 m2)
 
 define Language.Haskell.Liquid.String.stringEmp = (stringEmp)
 define Data.RString.RString.stringEmp = (stringEmp)

--- a/include/Data/Set.spec
+++ b/include/Data/Set.spec
@@ -6,6 +6,7 @@ embed Data.Set.Set as Set_Set
 // -- | Logical Set Operators: Interpreted "natively" by the SMT solver -------------------------
 // ----------------------------------------------------------------------------------------------
 
+
 // union
 measure Set_cup  :: (Data.Set.Set a) -> (Data.Set.Set a) -> (Data.Set.Set a)
 

--- a/include/Language/Haskell/Liquid/Bag.hs
+++ b/include/Language/Haskell/Liquid/Bag.hs
@@ -1,0 +1,19 @@
+module Language.Haskell.Liquid.Bag where
+
+import qualified Data.Map as M
+
+{-@ embed Map as Map_t @-}
+
+type Bag a = M.Map a Int
+
+empty :: Bag k
+empty = M.empty
+
+get :: (Ord k) => k -> Bag k -> Int
+get k m = M.findWithDefault 0 k m
+
+put :: (Ord k) => k -> Bag k -> Bag k
+put k m = M.insert k (1 + get k m) m
+
+union :: (Ord k) => Bag k -> Bag k -> Bag k
+union m1 m2 = M.union m1 m2

--- a/include/Language/Haskell/Liquid/Bag.hs
+++ b/include/Language/Haskell/Liquid/Bag.hs
@@ -2,18 +2,26 @@ module Language.Haskell.Liquid.Bag where
 
 import qualified Data.Map as M
 
-{-@ embed Map as Map_t @-}
+{-@ embed   M.Map as Map_t                                  @-}
+{-@ measure Map_default :: Int -> Bag a                     @-}
+{-@ measure Map_union   :: Bag a -> Bag a -> Bag a          @-}
+{-@ measure Map_select  :: M.Map k v -> k -> v              @-}
+{-@ measure Map_store   :: M.Map k v -> k -> v -> M.Map k v @-}
 
 type Bag a = M.Map a Int
 
+{-@ assume empty :: {v:Bag k | v = Map_default 0} @-}
 empty :: Bag k
 empty = M.empty
 
+{-@ assume get :: (Ord k) => k:k -> b:Bag k -> {v:Nat | v = Map_select b k}  @-}
 get :: (Ord k) => k -> Bag k -> Int
 get k m = M.findWithDefault 0 k m
 
+{-@ assume put :: (Ord k) => k:k -> b:Bag k -> {v:Bag k | v = Map_store b k (1 + (Map_select b k))} @-}
 put :: (Ord k) => k -> Bag k -> Bag k
 put k m = M.insert k (1 + get k m) m
 
+{-@ assume union :: (Ord k) => m1:Bag k -> m2:Bag k -> {v:Bag k | v = Map_union m1 m2} @-}
 union :: (Ord k) => Bag k -> Bag k -> Bag k
 union m1 m2 = M.union m1 m2

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -152,6 +152,7 @@ Library
    hs-source-dirs:  src, include
    Exposed-Modules: LiquidHaskell,
                     Language.Haskell.Liquid.Prelude,
+                    Language.Haskell.Liquid.Bag,
                     Language.Haskell.Liquid.ProofCombinators,
                     Language.Haskell.Liquid.Foreign,
                     Language.Haskell.Liquid.List,

--- a/src/Language/Haskell/Liquid/Bare/Lookup.hs
+++ b/src/Language/Haskell/Liquid/Bare/Lookup.hs
@@ -5,7 +5,6 @@
 
 module Language.Haskell.Liquid.Bare.Lookup (
     GhcLookup(..)
---   , lookupGhcThing
   , lookupGhcVar
   , lookupGhcTyCon
   , lookupGhcDnTyCon
@@ -233,11 +232,13 @@ ghcSymbolString :: F.Symbol -> String
 ghcSymbolString = T.unpack . fst . T.breakOn "##" . symbolText
 -- ghcSymbolString = symbolString . dropModuleUnique
 
+--------------------------------------------------------------------------------
 -- | It's possible that we have already resolved the 'Name' we are looking for,
 -- but have had to turn it back into a 'String', e.g. to be used in an 'Expr',
 -- as in @{v:Ordering | v = EQ}@. In this case, the fully-qualified 'Name'
 -- (@GHC.Types.EQ@) will likely not be in scope, so we store our own mapping of
 -- fully-qualified 'Name's to 'Var's and prefer pulling 'Var's from it.
+--------------------------------------------------------------------------------
 lookupGhcVar :: GhcLookup a => a -> BareM Var
 lookupGhcVar x = do
   env <- gets varEnv

--- a/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -80,15 +80,6 @@ resolveSym _ ls@(Loc _ _ s) = do
     then return ls
     else resolveCtor ls
 
-    -- nv <- gets (typeAliases . rtEnv)
-         -- case M.lookup s env of
-           -- Nothing | isCon s -> resolveCtor ls
-                                -- -- do v <- lookupGhcVar ls
-                                -- --   let qs = symbol v
-                                -- --   addSym (qs, v)
-                                -- --   return $ Loc l l' qs
-           -- _                 -> return ls
-
 resolveCtor :: LocSymbol -> BareM LocSymbol
 resolveCtor ls = do
   env1 <- gets propSyms

--- a/tests/pos/ListISort-bag.hs
+++ b/tests/pos/ListISort-bag.hs
@@ -1,0 +1,21 @@
+module ListSort where
+
+import qualified Language.Haskell.Liquid.Bag as B
+
+{-@ type OList a = [a]<{\fld v -> v >= fld}> @-}
+
+{-@ insertSort    :: (Ord a) => xs:[a] -> {v : OList a | bag v = bag xs} @-}
+insertSort        :: (Ord a) => [a] -> [a]
+insertSort []     = []
+insertSort (x:xs) = insert x (insertSort xs)
+
+{-@ insert      :: (Ord a) => x:a -> xs: OList a -> {v: OList a | bag v = B.put x (bag xs) } @-}
+insert y []     = [y]
+insert y (x:xs)
+  | y <= x    	= y : x : xs
+  | otherwise 	= x : insert y xs
+
+{-@ measure bag @-}
+bag :: (Ord a) => [a] -> B.Bag a
+bag []     = B.empty
+bag (x:xs) = B.put x (bag xs)

--- a/tests/pos/MergeSort-bag.hs
+++ b/tests/pos/MergeSort-bag.hs
@@ -1,0 +1,59 @@
+------------------------------------------------------------------------------
+-- | An implementation of Merge Sort, where LH verifies
+--   * termination, and that
+--   * the output is an ordered permutation of the input.
+------------------------------------------------------------------------------
+
+module MergeSort (bag, sort) where
+
+import qualified Language.Haskell.Liquid.Bag as B
+
+{-@ measure bag @-}
+bag :: (Ord a) => [a] -> B.Bag a
+bag []     = B.empty
+bag (x:xs) = B.put x (bag xs)
+
+{-@ type OList a    = [a]<{\fld v -> (v >= fld)}>       @-}
+{-@ type OListN a N = {v:OList a | len v == N}          @-}
+{-@ type OListBag a B = {v:OList a | bag v == B} @-}
+
+--------------------------------------------------------------------------------
+-- | The top level `sort` function. Proved:
+--    *  ordered, and
+--    *  same multi-set as the input.
+--------------------------------------------------------------------------------
+{-@ sort :: (Ord a) => xs:[a] -> OListBag a (bag xs) @-}
+sort :: Ord a => [a] -> [a]
+sort []   = []
+sort [x]  = [x]
+sort xs   = merge (sort xs1) (sort xs2)
+  where
+    (xs1, xs2) = split xs
+
+--------------------------------------------------------------------------------
+-- | The `split` function breaks its list into two `Halves`:
+--------------------------------------------------------------------------------
+{-@ split :: xs:[a] -> Halves a xs @-}
+split :: [a] -> ([a], [a])
+split (x:(y:zs)) = (x:xs, y:ys) where (xs, ys) = split zs
+split xs         = (xs, [])
+
+
+-- | A type describing two `Halves` of a list `Xs`
+{-@ type Halves a Xs = {v: (Half a Xs, Half a Xs) | len (fst v) + len (snd v) = len Xs
+                                                  && B.union (bag (fst v)) (bag (snd v)) == bag Xs}
+  @-}
+
+-- | Each `Half` is empty or smaller than the input:
+{-@ type Half a Xs  = {v:[a] | (len v > 1) => (len v < len Xs)} @-}
+
+--------------------------------------------------------------------------------
+-- | Finally, the `merge` function combines two ordered lists.
+--------------------------------------------------------------------------------
+{-@ merge :: Ord a => xs:OList a -> ys:OList a -> OListBag a (B.union (bag xs) (bag ys)) / [(len xs + len ys)] @-}
+merge :: Ord a => [a] -> [a] ->  [a]
+merge xs []         = xs
+merge [] ys         = ys
+merge (x:xs) (y:ys)
+  | x <= y          = x : merge xs (y:ys)
+  | otherwise       = y : merge (x:xs) ys

--- a/tests/pos/MergeSort-bag.hs
+++ b/tests/pos/MergeSort-bag.hs
@@ -40,8 +40,7 @@ split xs         = (xs, [])
 
 
 -- | A type describing two `Halves` of a list `Xs`
-{-@ type Halves a Xs = {v: (Half a Xs, Half a Xs) | len (fst v) + len (snd v) = len Xs
-                                                  && B.union (bag (fst v)) (bag (snd v)) == bag Xs}
+{-@ type Halves a Xs = {v: (Half a Xs, Half a Xs) | len (fst v) + len (snd v) = len Xs && B.union (bag (fst v)) (bag (snd v)) == bag Xs}
   @-}
 
 -- | Each `Half` is empty or smaller than the input:

--- a/tests/pos/bag.hs
+++ b/tests/pos/bag.hs
@@ -2,16 +2,16 @@ module BagTest where
 
 import Language.Haskell.Liquid.Bag as B
 
-{- measure elems @-}
-elems :: (Ord a) => [a] -> B.Bag a
-elems []     = B.empty
-elems (x:xs) = B.put x (elems xs)
+{-@ measure bag @-}
+bag :: (Ord a) => [a] -> B.Bag a
+bag []     = B.empty
+bag (x:xs) = B.put x (bag xs)
 
 {-@ prop0 :: x:_ -> TT @-}
 prop0 :: Int -> Bool
 prop0 x = (B.get x a == 2)
   where
-    a   = B.bag [x, x, x + 1]
+    a   = bag [x, x, x + 1]
 
 {-@ prop1 :: x:_ -> TT @-}
 prop1 :: Int -> Bool

--- a/tests/pos/bag.hs
+++ b/tests/pos/bag.hs
@@ -1,0 +1,28 @@
+module BagTest where
+
+import qualified Data.Set as S
+import Language.Haskell.Liquid.Bag as B
+
+{-@ measure elems @-}
+elems :: (Ord a) => [a] -> B.Bag a
+elems []     = B.empty
+elems (x:xs) = B.put x (elems xs)
+
+{-@ prop0 :: x:_ -> TT @-}
+prop0 :: Int -> Bool
+prop0 x = (B.get x a == 2)
+  where
+    a   = elems [x, x, x + 1]
+
+{-@ prop1 :: x:_ -> TT @-}
+prop1 :: Int -> Bool
+prop1 x = (B.get (x + 1) a == 1)
+  where
+    a   = elems [x, x, x + 1]
+
+{-@ prop2 :: x:_ -> y:_ -> TT @-}
+prop2 :: Int -> Int -> Bool
+prop2 x y = (a == b)
+  where
+    a     = elems [x, y, x]
+    b     = elems [y, x, x]

--- a/tests/pos/bag.hs
+++ b/tests/pos/bag.hs
@@ -1,9 +1,8 @@
 module BagTest where
 
-import qualified Data.Set as S
 import Language.Haskell.Liquid.Bag as B
 
-{-@ measure elems @-}
+{- measure elems @-}
 elems :: (Ord a) => [a] -> B.Bag a
 elems []     = B.empty
 elems (x:xs) = B.put x (elems xs)
@@ -12,17 +11,17 @@ elems (x:xs) = B.put x (elems xs)
 prop0 :: Int -> Bool
 prop0 x = (B.get x a == 2)
   where
-    a   = elems [x, x, x + 1]
+    a   = B.bag [x, x, x + 1]
 
 {-@ prop1 :: x:_ -> TT @-}
 prop1 :: Int -> Bool
 prop1 x = (B.get (x + 1) a == 1)
   where
-    a   = elems [x, x, x + 1]
+    a   = bag [x, x, x + 1]
 
 {-@ prop2 :: x:_ -> y:_ -> TT @-}
 prop2 :: Int -> Int -> Bool
 prop2 x y = (a == b)
   where
-    a     = elems [x, y, x]
-    b     = elems [y, x, x]
+    a     = bag [x, y, x]
+    b     = bag [y, x, x]


### PR DESCRIPTION
See:

The basic library is defined in:

- `include/Language/Haskell/Liquid/Bag.hs`

For some example clients see:

- `tests/{pos, neg}/bag.hs`           
- `tests/{pos, neg}/bag1.hs`
- `tests/pos/ListISort-bag.hs`
- `tests/pos/MergeSort-bag.hs` 

Matching PR for https://github.com/ucsd-progsys/liquid-fixpoint/pull/351