### PR TITLE
Adding information that is saving hours of newcomers

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,10 +10,11 @@ To run `liquid` you need to install:
 
 Download and install *at least one* of
 
-+ [Z3](https://github.com/Z3Prover/z3/releases)
++ [Z3](https://github.com/Z3Prover/z3/releases) or [Microsoft official binary|https://www.microsoft.com/en-us/download/details.aspx?id=52270]
 + [CVC4](http://cvc4.cs.nyu.edu/)
 + [MathSat](http://mathsat.fbk.eu/download.html)
 
+Note: It should be findable from PATH. LiquidHaskell is executing it as a child process.
 
 ## Step 2: Install `liquid` via Package Manager
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Requirements
 
 LiquidHaskell requires (in addition to the cabal dependencies)
 
-- SMTLIB2 compatible solver
+- SMTLIB2 compatible solver installed and its executable found on PATH
 
 How To Clone, Build and Install
 -------------------------------


### PR DESCRIPTION
I have tried to build a few SMT solvers, like Z3 and CVC. It's not trivial under Windows 10 on a non-clean installations. Then I found ready to install Z3 binary from Microsoft at last. But for some reason it doesn't add its *bin* folder to PATH. And I had first to figure out how LiquidHaskell interact with SMT solvers (I'm a newcomer). With reading the code I found that it spawns child process of solvers that should be found on PATH. If I have this written in instructions it would save me hours of time and hours invested in learning LiquidHaskell instead. So I propose those changes to the manual.