### PR TITLE
Include commit count (and revision) in version info

### DIFF
--- a/devel/Paths_liquidhaskell.hs
+++ b/devel/Paths_liquidhaskell.hs
@@ -1,12 +1,18 @@
 {-# LANGUAGE TemplateHaskell #-}
+
 module Paths_liquidhaskell where
 
 import Language.Haskell.TH
 import System.Directory
 import System.FilePath
+import Data.Version (Version, makeVersion)
 
 getDataFileName :: FilePath -> IO FilePath
 getDataFileName f = do
   let loc = $(do { loc <- location; f <- runIO (canonicalizePath (loc_filename loc)); litE (stringL f); })
   let root = takeDirectory (takeDirectory loc)
   return (root </> f)
+
+-- | dummy version (devel only)
+version :: Version
+version = makeVersion [0,0,0,0]

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -148,6 +148,7 @@ Library
                 , QuickCheck >= 2.7
                 , ghc-prim
                 , hpc >= 0.6
+                , optparse-simple
 
    hs-source-dirs:  src, include
    Exposed-Modules: LiquidHaskell,

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -148,6 +148,7 @@ Library
                 , QuickCheck >= 2.7
                 , ghc-prim
                 , hpc >= 0.6
+                , gitrev
                 , optparse-simple
 
    hs-source-dirs:  src, include

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -442,7 +442,13 @@ envCfg = do
     l       = newPos "ENVIRONMENT" 0 0
 
 copyright :: String
-copyright = "LiquidHaskell v" ++ myVersion ++ " Copyright 2013-17 Regents of the University of California. All Rights Reserved.\n"
+copyright = concat $ concat
+  [ ["LiquidHaskell "]
+  , [myVersion]
+  , [" (" ++ commitCount ++ " commits)" | commitCount /= ("1"::String) &&
+                                          commitCount /= ("UNKNOWN" :: String)]
+  , [" Copyright 2013-17 Regents of the University of California. All Rights Reserved.\n"]
+  ]
   where
     myVersion = $(simpleVersion Meta.version)
     -- CIRCLE HASSLES: myVersion = showVersion version

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -40,6 +40,7 @@ import Control.Monad
 import Data.Maybe
 import Data.Aeson (encode)
 import qualified Data.ByteString.Lazy.Char8 as B
+import Development.GitRev (gitCommitCount)
 import Options.Applicative.Simple (simpleVersion)
 import qualified Paths_liquidhaskell as Meta
 import System.Directory
@@ -445,6 +446,7 @@ copyright = "LiquidHaskell v" ++ myVersion ++ " Copyright 2013-17 Regents of the
   where
     myVersion = $(simpleVersion Meta.version)
     -- CIRCLE HASSLES: myVersion = showVersion version
+    commitCount = $gitCommitCount
 
 -- NOTE [searchpath]
 -- 1. we used to add the directory containing the file to the searchpath,

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -444,14 +444,12 @@ envCfg = do
 copyright :: String
 copyright = concat $ concat
   [ ["LiquidHaskell "]
-  , [myVersion]
+  , [$(simpleVersion Meta.version)]
   , [" (" ++ commitCount ++ " commits)" | commitCount /= ("1"::String) &&
                                           commitCount /= ("UNKNOWN" :: String)]
   , [" Copyright 2013-17 Regents of the University of California. All Rights Reserved.\n"]
   ]
   where
-    myVersion = $(simpleVersion Meta.version)
-    -- CIRCLE HASSLES: myVersion = showVersion version
     commitCount = $gitCommitCount
 
 -- NOTE [searchpath]

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleInstances         #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TemplateHaskell           #-}
 {-# LANGUAGE TupleSections             #-}
 {-# LANGUAGE TypeSynonymInstances      #-}
 {-# OPTIONS_GHC -fno-cse #-}
@@ -39,6 +40,8 @@ import Control.Monad
 import Data.Maybe
 import Data.Aeson (encode)
 import qualified Data.ByteString.Lazy.Char8 as B
+import Options.Applicative.Simple (simpleVersion)
+import qualified Paths_liquidhaskell as Meta
 import System.Directory
 import System.Exit
 import System.Environment
@@ -440,8 +443,7 @@ envCfg = do
 copyright :: String
 copyright = "LiquidHaskell v" ++ myVersion ++ " Copyright 2013-17 Regents of the University of California. All Rights Reserved.\n"
   where
-    myVersion :: String
-    myVersion = "0.8.2.2"
+    myVersion = $(simpleVersion Meta.version)
     -- CIRCLE HASSLES: myVersion = showVersion version
 
 -- NOTE [searchpath]


### PR DESCRIPTION
- [x] Remove the `version` magic number
- [x] Add commit count (and revision) in version info

Now, `liquid` says:

```bash
$ stack exec -- liquid
LiquidHaskell Version 0.8.2.2, Git revision bc9c3c64cf2be0a65ad7bfc1804152bd5a7f7cfc (8377 commits) Copyright 2013-17 Regents of the University of California. All Rights Reserved.
```

Currently implementation was change `Language.Haskell.Liquid.UX.CmdLine` for the better, but I think that it should be implemented `src/Liquid.hs`, if as possible.
Because, `TH` is expanded at compile time, and then `library` is not always compiled.

## references

- [Main.hs in stack](https://github.com/commercialhaskell/stack/blob/master/src/main/Main.hs#L122)
- [optparse-simple pkg](https://www.stackage.org/haddock/lts-10.3/optparse-simple-0.1.0/Options-Applicative-Simple.html#)
- [gitrev pkg](https://www.stackage.org/lts-10.3/package/gitrev-1.3.1)