### PR TITLE
Delete duplicate `build-type` stanza in .cabal file

### DIFF
--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -1,7 +1,6 @@
 Name:                liquidhaskell
 Version:             0.8.2.2
 Copyright:           2010-17 Ranjit Jhala & Niki Vazou & Eric L. Seidel, University of California, San Diego.
-build-type:          Simple
 Synopsis:            Liquid Types for Haskell
 Description:         Liquid Types for Haskell.
 Homepage:            https://github.com/ucsd-progsys/liquidhaskell


### PR DESCRIPTION
`cabal-install-2.1` warns you about this:

```
The field "build-type" is specified more than once at positions 4:1, 13:1
```