### PR TITLE
[WIP] Allow len for vector measure.

### DIFF
--- a/include/Data/Vector.spec
+++ b/include/Data/Vector.spec
@@ -4,21 +4,20 @@ import GHC.Base
 
 data variance Data.Vector.Vector covariant
 
-
 measure vlen    :: forall a. (Data.Vector.Vector a) -> Int
 
-invariant       {v: Data.Vector.Vector a | 0 <= vlen v } 
+invariant       {v: Data.Vector.Vector a | 0 <= vlen v && 0 <= len v }
 
-assume !           :: forall a. x:(Data.Vector.Vector a) -> vec:{v:Nat | v < vlen x } -> a 
+assume !           :: forall a. x:(Data.Vector.Vector a) -> vec:{ v:Nat | v < vlen x && v < len x } -> a
 
-assume unsafeIndex :: forall a. x:(Data.Vector.Vector a) -> vec:{v:Nat | v < vlen x } -> a 
+assume unsafeIndex :: forall a. x:(Data.Vector.Vector a) -> vec:{ v:Nat | v < vlen x && v < len x } -> a
 
-assume fromList  :: forall a. x:[a] -> {v: Data.Vector.Vector a  | vlen v = len x }
+assume fromList    :: forall a. x:[a] -> { v: Data.Vector.Vector a  | vlen v = len x && len v = len x }
 
-assume length    :: forall a. x:(Data.Vector.Vector a) -> {v : Nat | v = vlen x }
+assume length      :: forall a. x:(Data.Vector.Vector a) -> { v : Nat | v = vlen x && v = len x }
 
-assume replicate :: n:Nat -> a -> {v:Data.Vector.Vector a | vlen v = n} 
+assume replicate   :: n:Nat -> a -> { v:Data.Vector.Vector a | vlen v = n && len v = n }
 
-assume imap :: (Nat -> a -> b) -> x:(Data.Vector.Vector a) -> {y:Data.Vector.Vector b | vlen y = vlen x }
+assume imap        :: (Nat -> a -> b) -> x:(Data.Vector.Vector a) -> { y:Data.Vector.Vector b | vlen y = vlen x && len y = len x }
 
-assume map :: (a -> b) -> x:(Data.Vector.Vector a) -> {y:Data.Vector.Vector b | vlen y = vlen x }
+assume map         :: (a -> b) -> x:(Data.Vector.Vector a) -> { y:Data.Vector.Vector b | vlen y = vlen x && len y = len x }


### PR DESCRIPTION
See #1170

For backward-compatibility, I have left `vlen`.

```haskell
assume ! :: forall a. x:(Data.Vector.Vector a) -> vec:{v:Nat | v < vlen x || v < len x } -> a
```

Is this correct? And, What should I do about the test case?