### PR TITLE
Drop binders with PredTy from DataCtors

### DIFF
--- a/src/Language/Haskell/Liquid/Constraint/Init.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Init.hs
@@ -69,7 +69,7 @@ initEnv info
        let f0'   = if notruetypes $ getConfig sp then [] else f0''
        f1       <- refreshArgs'   defaults                            -- default TOP reftype      (for all vars)
        f1'      <- refreshArgs' $ makedcs dcsty                       -- data constructors
-       f2       <- (refreshArgs' $ assm info)                           -- assumed refinements      (for imported vars)
+       f2       <- refreshArgs' $ assm info                           -- assumed refinements      (for imported vars)
        f3       <- refreshArgs' $ vals gsAsmSigs sp                   -- assumed refinedments     (with `assume`)
        f40      <- makeExactDc <$> (refreshArgs' $ vals gsCtors sp)   -- constructor refinements  (for measures)
        f5       <- refreshArgs' $ vals gsInSigs sp                    -- internal refinements     (from Haskell measures)

--- a/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -25,7 +25,7 @@ import           Language.Haskell.Liquid.GHC.TypeRep
 import qualified Var
 import           Coercion
 import qualified Pair
-
+-- import qualified Text.Printf as Printf
 import qualified CoreSyn                               as C
 import           Literal
 import           IdInfo
@@ -456,7 +456,11 @@ _simpleSymbolVar' :: Id -> Symbol
 _simpleSymbolVar' = simplesymbol --symbol . {- showPpr . -} getName
 
 isErasable :: Id -> Bool
-isErasable v = isPrefixOfSym (symbol ("$"      :: String)) (simpleSymbolVar v)
+isErasable v = isPrefixOfSym (symbol ("$" :: String)) (simpleSymbolVar v)
+  -- where
+    -- v         = F.tracepp _msg v0
+    -- _msg      = Printf.printf "isErasable: isCoVar %s = %s" (showPpr v0) (show $ isCoVar v0)
+
 
 isANF :: Id -> Bool
 isANF      v = isPrefixOfSym (symbol ("lq_anf" :: String)) (simpleSymbolVar v)
@@ -544,5 +548,6 @@ instance Simplify C.CoreBind where
 
 instance Simplify C.CoreAlt where
   simplify (c, xs, e) = (c, xs, simplify e)
-
+    -- where xs   = F.tracepp _msg xs0
+    --      _msg = "isCoVars? " ++ F.showpp [(x, isCoVar x, varType x) | x <- xs0]
   inline p (c, xs, e) = (c, xs, inline p e)

--- a/src/Language/Haskell/Liquid/Types/PredType.hs
+++ b/src/Language/Haskell/Liquid/Types/PredType.hs
@@ -74,7 +74,7 @@ dataConPSpecType dc dcp = [ (workX, workT), (wrapX, wrapT) ]
     wrapT               = dcWrapSpecType dc dcp
     workX               = dataConWorkId dc            -- this is the weird one for GADTs
     wrapX               = dataConWrapId dc            -- this is what the user expects to see
-    isVanilla           = F.notracepp ("IS-Vanilla: " ++ showpp dc) $ isVanillaDataCon dc
+    isVanilla           = {- F.notracepp ("IS-Vanilla: " ++ showpp dc) $ -} isVanillaDataCon dc
 
 dcWorkSpecType :: DataCon -> SpecType -> SpecType
 dcWorkSpecType c wrT    = fromRTypeRep (meetWorkWrapRep c wkR wrR)

--- a/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -141,8 +141,8 @@ strengthenDataConType (x, t) = (x, fromRTypeRep trep {ty_res = tres})
 dataConArgs :: SpecRep -> ([Symbol], [SpecType])
 dataConArgs trep = unzip [ (x, t) | (x, t) <- zip xs ts, isValTy t]
   where
-    -- xs           = ty_binds trep
-    xs           = zipWith (\_ i -> (symbol ("x" ++ show i))) (ty_args trep) [1..]
+    xs           = ty_binds trep
+    -- xs           = zipWith (\_ i -> (symbol ("x" ++ show i))) (ty_args trep) [1..]
     ts           = ty_args trep
     isValTy      = not . isPredType . toType
 


### PR DESCRIPTION
With GADTs, GADT often adds extra parameters, corresponding to `PredTy` which are things like 

https://downloads.haskell.org/~ghc/8.2.1/docs/html/libraries/ghc-8.2.1/Type.html#t:PredType

We don't want those binders to appear inside the singleton refinements for data constructors, and this PR filters those around.
