### PR TITLE
Backport GHC differential D4388 to Desugar.

### DIFF
--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -62,6 +62,10 @@ Flag include
   Description: use in-tree include directory
   Default:     False
 
+Flag deterministic-profiling
+  Description: Support building against GHC with https://phabricator.haskell.org/D4388 backported
+  Default:     False
+
 Executable liquid
   default-language: Haskell98
   Build-Depends: base >=4.8.1.0 && <5
@@ -281,6 +285,8 @@ Library
      hs-source-dirs: devel
    if flag(devel)
      ghc-options: -Werror
+   if flag(deterministic-profiling)
+     cpp-options: -DDETERMINISTIC_PROFILING
    Default-Extensions: PatternGuards
 
 test-suite test

--- a/src/Language/Haskell/Liquid/Desugar/DsExpr.hs
+++ b/src/Language/Haskell/Liquid/Desugar/DsExpr.hs
@@ -383,8 +383,14 @@ dsExpr (HsSCC _ cc expr@(L loc _)) = do
       then do
         mod_name <- getModule
         count <- goptM Opt_ProfCountEntries
+#ifdef DETERMINISTIC_PROFILING
+        let nm = sl_fs cc
+        flavour <- ExprCC <$> getCCIndexM nm
+        Tick (ProfNote (mkUserCC nm mod_name loc flavour) count True)
+#else
         uniq <- newUnique
         Tick (ProfNote (mkUserCC (sl_fs cc) mod_name loc uniq) count True)
+#endif
                <$> dsLExpr expr
       else dsLExpr expr
 


### PR DESCRIPTION
This allows liquidhaskell to build with the new CostCentre interface.

Note that the referenced change is not going to be backported to an official GHC 8.2 release and may not make it into an official 8.4 release, but it is in the pipeline to be included in GHC 8.2 and 8.4 provided with nixpkgs, as it fixes an otherwise unworkaroundable blocker in doing distributed builds with nix and GHC and profiling libs. I doubt this PR will be desired as-is, it seems like there are three different paths here:

1. Do nothing for now, and once liquidhaskell is bumped to GHC 8.6 this will have to get fixed one way or another
2. Bump liquidhaskell to track GHC 8.6 now
3. Add a cabal flag or similar to switch between the current and new code paths depending on whether D4388 is applied to ghc or not.

Please let me know which path you'd like to take.