### PR TITLE
Make all equational combinators return their right-hand side.

### DIFF
--- a/include/Language/Haskell/Liquid/NewProofCombinators.hs
+++ b/include/Language/Haskell/Liquid/NewProofCombinators.hs
@@ -98,7 +98,7 @@ data QED = Admit | QED
 infixl 3 ===
 {-@ (===) :: x:a -> y:{a | y == x} -> {v:a | v == x && v == y} @-}
 (===) :: a -> a -> a
-x === _  = x
+_ === y  = y
 
 infixl 3 =<=
 {-@ (=<=) :: x:a -> y:{a | x <= y} -> {v:a | v == y} @-}
@@ -122,7 +122,7 @@ _ =>= y  = y
 infixl 3 ==?
 {-@ (==?) :: x:a -> y:a -> {v:_ | x == y} -> {v:a | v == x && v == y} @-}
 (==?) :: a -> a -> b -> a
-(==?) x _ _ = x
+(==?) _ y _ = y
 
 infixl 3 =<=?
 {-@ (=<=?) :: x:a -> y:a -> {v:_ | x <= y} -> {v:a | v == y} @-}
@@ -152,7 +152,7 @@ f ? y = f y
 infixl 3 ==!
 {-@ assume (==!) :: x:a -> y:a -> {v:a | v == x && v == y} @-}
 (==!) :: a -> a -> a
-(==!) x _ = x
+(==!) _ y = y
 
 
 -- | To summarize:
@@ -178,13 +178,13 @@ instance (a~b) => OptEq a (Proof -> b) where
 {-@ instance OptEq a (Proof -> b) where
   ==. :: x:a -> y:a -> {v:Proof | x == y} -> {v:b | v ~~ x && v ~~ y}
   @-}
-  (==.) x _ _ = x
+  (==.) _ y _ = y
 
 instance (a~b) => OptEq a b where
 {-@ instance OptEq a b where
   ==. :: x:a -> y:{a| x == y} -> {v:b | v ~~ x && v ~~ y }
   @-}
-  (==.) x _ = x
+  (==.) _ y = y
 
 -------------------------------------------------------------------------------
 -- | * Combining Proof Certificates -------------------------------------------


### PR DESCRIPTION
From a proof standpoint, these definitions are equivalent. However, defining the equality combinators to return their right hand side has two advantages:

1. It makes defining optimized functions using the equality combinators more natural. This way, we can write
```haskell
foo = correctButInefficientDefinition
```
and then use the operators to refine it:
```haskell
foo = correctButInefficientDefinition
      === simplifiedDefinition
      === optimizedDefinition
```
and end up with `foo` having the optimized definition.

2. It brings the definitions in line with the inequality combinators, which all return their right hand sides.