### PR TITLE
Inline (Singleton) Equalities in Error Messages

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,54 @@
+
+# T1258 
+
+
+Right now, `liquid tests/todo/T1258.hs` prints: 
+
+```
+ 20 | prop = f B C === E *** QED
+             ^^^^^^^^^^^
+
+   Inferred type
+     VV : {v : Baz | v == T1258.E}
+
+   not a subtype of Required type
+     VV : {VV : Baz | VV == ?a}
+
+   In Context
+     ?a : {?a : Baz | ?a == T1258.f T1258.B T1258.C}
+```
+
+lets get it to print 
+
+```
+ 20 | prop = f B C === E *** QED
+             ^^^^^^^^^^^
+
+   Inferred type
+     VV : {v : Baz | v == T1258.E}
+
+   not a subtype of Required type
+     VV : {VV : Baz | VV == T1258.f T1258.B T1258.C}
+```
+
+and then, when `--short-names` is on, to print 
+
+```
+ s20 | prop = f B C === E *** QED
+             ^^^^^^^^^^^
+
+   Inferred type
+     VV : {v : Baz | v == E}
+
+   not a subtype of Required type
+     VV : {VV : Baz | VV == f B C}
+```
+
+
+
 # T1173 
 
 * borscht-2017-08-24T18-14-25/summary.csv vs. DEVELOP?
-
 
 
 # 3 Failures moved in tests/DependentHaskell/todo

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -268,11 +268,10 @@ uniqNub xs = M.elems $ M.fromList [ (index x, x) | x <- xs ]
 
 reflectedTyCons :: Config -> TCEmb TyCon -> [CoreBind] -> Ms.BareSpec -> [TyCon]
 reflectedTyCons cfg embs cbs spec
-  | exactDC cfg = filter (not . isEmbedded embs)
-                $ concatMap varTyCons
-                $ reflectedVars spec cbs
-
-  | otherwise   = []
+  | exactDCFlag cfg = filter (not . isEmbedded embs)
+                    $ concatMap varTyCons
+                    $ reflectedVars spec cbs
+  | otherwise       = []
 
 -- | We cannot reflect embedded tycons (e.g. Bool) as that gives you a sort
 --   conflict: e.g. what is the type of is-True? does it take a GHC.Types.Bool
@@ -459,14 +458,6 @@ addRTEnv spec = do
   rt <- rtEnv <$> get
   return $ spec { gsRTAliases = rt }
 
--- RJ: AAAAAAARGHHH: this is duplicate of RT.strengthenDataConType
--- // _makeExactDataCons :: ModName -> Config -> [Var] -> GhcSpec -> BareM GhcSpec
--- // _makeExactDataCons _n cfg vs spec
-  -- // | exactDC cfg = return $ spec { gsTySigs = gsTySigs spec ++ xts}
-  -- // | otherwise   = return   spec
-  -- // where
-    -- // xts         = makeDataConCtor <$> filter f vs
-    -- // f v         = GM.isDataConId v
 
 varInModule :: (Show a, Show a1) => a -> a1 -> Bool
 varInModule n v = L.isPrefixOf (show n) $ show v

--- a/src/Language/Haskell/Liquid/Bare/DataType.hs
+++ b/src/Language/Haskell/Liquid/Bare/DataType.hs
@@ -184,7 +184,7 @@ makeDataDecls cfg tce name tds ds
                 ]
   | otherwise = []
   where
-    makeDecls = exactDC cfg && not (noADT cfg)
+    makeDecls = exactDCFlag cfg && not (noADT cfg)
     tds'      = resolveTyCons name tds
 
 -- [NOTE:Orphan-TyCons]
@@ -566,7 +566,7 @@ ofBDataCtor name l l' tc αs ps ls πs (DataCtor c _ xts res) = do
   let t0'       = F.notracepp ("dataConResultTy c' = " ++ show c' ++ " res' = " ++ show res') $ dataConResultTy c' αs t0 res'
   cfg          <- gets beConfig
   let (yts, ot) = F.notracepp ("OFBDataCTOR: " ++ show c' ++ " " ++ show (isVanillaDataCon c', res') ++ " " ++ show isGadt)
-                $ qualifyDataCtor (exactDC cfg && not isGadt) name dLoc (zip xs ts', t0')
+                $ qualifyDataCtor (exactDCFlag cfg && not isGadt) name dLoc (zip xs ts', t0')
   let zts       = zipWith (normalizeField c') [1..] (reverse yts)
 
   let usedTvs   = S.fromList (ty_var_value <$> concatMap RT.freeTyVars (t0':ts'))

--- a/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -74,13 +74,13 @@ import           Language.Haskell.Liquid.Bare.ToBare
 makeHaskellDataDecls :: Config -> ModName -> Ms.BareSpec -> [TyCon] -> [DataDecl]
 --------------------------------------------------------------------------------
 makeHaskellDataDecls cfg name spec tcs
-  | exactDC cfg = mapMaybe tyConDataDecl
-                . F.notracepp "makeHaskellDataDecls-1"
-                . zipMap   (hasDataDecl name spec . fst)
-                . liftableTyCons
-                . filter isReflectableTyCon
-                $ tcs
-  | otherwise   = []
+  | exactDCFlag cfg = mapMaybe tyConDataDecl
+                    . F.notracepp "makeHaskellDataDecls-1"
+                    . zipMap   (hasDataDecl name spec . fst)
+                    . liftableTyCons
+                    . filter isReflectableTyCon
+                    $ tcs
+  | otherwise       = []
 
 
 isReflectableTyCon :: TyCon -> Bool
@@ -240,8 +240,8 @@ meetLoc t1 t2 = t1 {val = val t1 `meet` val t2}
 
 makeMeasureSelectors :: Config -> DataConMap -> (DataCon, Located DataConP) -> [Measure SpecType DataCon]
 makeMeasureSelectors cfg dm (dc, Loc l l' (DataConP _ _vs _ps _ _ xts _resTy isGadt _ _))
-  = (Misc.condNull (exactDC cfg) $ checker : catMaybes (go' <$> fields)) --  internal measures, needed for reflection
- ++ (Misc.condNull (autofields)  $           catMaybes (go  <$> fields)) --  user-visible measures.
+  = (Misc.condNull (exactDCFlag cfg) $ checker : catMaybes (go' <$> fields)) --  internal measures, needed for reflection
+ ++ (Misc.condNull (autofields)      $           catMaybes (go  <$> fields)) --  user-visible measures.
   where
     autofields = not (isGadt || noMeasureFields cfg)
     go ((x, t), i)

--- a/src/Language/Haskell/Liquid/Constraint/Init.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Init.hs
@@ -93,7 +93,7 @@ initEnv info
     vals f       = map (mapSnd val) . f
     mapSndM f    = \(x,y) -> ((x,) <$> f y)
     makedcs      = map strengthenDataConType
-    makeExactDc dcs = if exactDC (getConfig info) then makedcs dcs else dcs
+    makeExactDc dcs = if exactDCFlag info then makedcs dcs else dcs
     is autoinv   = mkRTyConInv    (gsInvariants sp ++ ((Nothing,) <$> autoinv))
 
 makeDataConTypes :: Var -> CG (Var, SpecType)

--- a/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -349,7 +349,7 @@ locNamedThing x = F.Loc l lE x
     lE         = getSourcePosE x
 
 namedLocSymbol :: (F.Symbolic a, NamedThing a) => a -> F.Located F.Symbol
-namedLocSymbol d = {- dropModuleNamesAndUnique . -} F.symbol <$> locNamedThing d
+namedLocSymbol d = F.symbol <$> locNamedThing d
 
 varLocInfo :: (Type -> a) -> Var -> F.Located a
 varLocInfo f x = f . varType <$> locNamedThing x

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -196,14 +196,14 @@ solveCs cfg tgt cgi info names = do
   finfo            <- cgInfoFInfo info cgi
   F.Result r sol _ <- solve (fixConfig tgt cfg) finfo
   let resErr        = applySolution sol . cinfoError . snd <$> r
-  resModel_        <- fmap (e2u sol) <$> getModels info cfg resErr
-  let resModel      = resModel_  `addErrors` (e2u sol <$> logErrors cgi)
+  resModel_        <- fmap (e2u cfg sol) <$> getModels info cfg resErr
+  let resModel      = resModel_  `addErrors` (e2u cfg sol <$> logErrors cgi)
   let out0          = mkOutput cfg resModel sol (annotMap cgi)
   return            $ out0 { o_vars    = names    }
                            { o_result  = resModel }
 
-e2u :: F.FixSolution -> Error -> UserError
-e2u s = fmap F.pprint . tidyError s
+e2u :: Config -> F.FixSolution -> Error -> UserError
+e2u cfg s = fmap F.pprint . tidyError cfg s
 
 -- writeCGI tgt cgi = {-# SCC "ConsWrite" #-} writeFile (extFileName Cgi tgt) str
 --   where

--- a/src/Language/Haskell/Liquid/Misc.hs
+++ b/src/Language/Haskell/Liquid/Misc.hs
@@ -293,3 +293,13 @@ fstByRank rkvs = [ (r, k, v) | (k, rvs) <- krvss, let (r, v) = getFst rvs ]
 
 sortOn :: (Ord b) => (a -> b) -> [a] -> [a]
 sortOn f = L.sortBy (compare `on` f)
+
+{- mapEither :: (a -> Either b c) -> [a] -> ([b], [c])
+mapEither f []     = ([], [])
+mapEither f (x:xs) = case f x of 
+                       Left y  -> (y:ys, zs)
+                       Right z -> (ys, z:zs)
+                     where 
+                       (ys, zs) = mapEither f xs 
+-}
+

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -21,8 +21,9 @@
 module Language.Haskell.Liquid.Types (
 
   -- * Options
-    Config (..)
-  , HasConfig (..)
+    module Language.Haskell.Liquid.UX.Config
+  --   Config (..)
+  -- , HasConfig (..)
 
   -- * Ghc Information
   , GhcInfo (..)

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -22,8 +22,6 @@ module Language.Haskell.Liquid.Types (
 
   -- * Options
     module Language.Haskell.Liquid.UX.Config
-  --   Config (..)
-  -- , HasConfig (..)
 
   -- * Ghc Information
   , GhcInfo (..)

--- a/src/Language/Haskell/Liquid/Types/Errors.hs
+++ b/src/Language/Haskell/Liquid/Types/Errors.hs
@@ -541,10 +541,17 @@ ppReqInContext td tA tE c
                 , text "VV :" <+> pprintTidy td tA]
       , nests 2 [ text "not a subtype of Required type"
                 , text "VV :" <+> pprintTidy td tE]
-      , nests 2 [ text "In Context"
-                , vsep (map (uncurry (pprintBind td)) (M.toList c))
-                ]
+      , ppContext td c 
       ]
+
+ppContext :: PPrint t => Tidy -> M.HashMap Symbol t -> Doc 
+ppContext td c
+  | 0 < length xts = nests 2 [ text "In Context"
+                             , vsep (map (uncurry (pprintBind td)) xts)
+                             ]
+  | otherwise      = empty 
+  where 
+    xts            = M.toList c 
 
 pprintBind :: PPrint t => Tidy -> Symbol -> t -> Doc
 pprintBind td v t = pprintTidy td v <+> char ':' <+> pprintTidy td t

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -556,22 +556,16 @@ defConfig = Config { files             = def
                    , counterExamples   = False
                    , timeBinds         = False
                    , untidyCore        = False
-                   -- , noEliminate       = False
                    , eliminate         = FC.Some
                    , noPatternInline   = False
                    , noSimplifyCore    = False
                    , nonLinCuts        = True
                    , autoInstantiate   = def
-                   -- , proofMethod       = def
-                   -- , fuel              = defFuel
                    , debugInstantionation = False
                    , noslice              = False
                    , noLiftedImport       = False
                    , proofLogicEval       = False
                    }
-
--- defFuel :: Int
--- defFuel = 2
 
 ------------------------------------------------------------------------
 -- | Exit Function -----------------------------------------------------

--- a/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/src/Language/Haskell/Liquid/UX/Config.hs
@@ -143,8 +143,8 @@ expandFlag :: (HasConfig t) => t -> Bool
 expandFlag = not . nocaseexpand . getConfig
 
 exactDCFlag :: (HasConfig t) => t -> Bool
-exactDCFlag _ = True 
--- exactDCFlag = exactDC . getConfig 
+-- exactDCFlag _ = True 
+exactDCFlag = exactDC . getConfig 
 
 hasOpt :: (HasConfig t) => t -> (Config -> Bool) -> Bool
 hasOpt t f = f (getConfig t)

--- a/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/src/Language/Haskell/Liquid/UX/Config.hs
@@ -7,6 +7,14 @@ module Language.Haskell.Liquid.UX.Config (
      Config (..)
    , HasConfig (..)
    , allowPLE, allowLocalPLE, allowGlobalPLE
+   , patternFlag
+   , higherOrderFlag
+   , pruneFlag
+   , expandFlag
+   , exactDCFlag
+   , hasOpt
+   , totalityCheck
+   , terminationCheck 
    ) where
 
 import Prelude hiding (error)
@@ -17,8 +25,8 @@ import GHC.Generics
 import System.Console.CmdArgs
 
 -- NOTE: adding strictness annotations breaks the help message
-data Config = Config {
-    files          :: [FilePath] -- ^ source files to check
+data Config = Config 
+  { files          :: [FilePath] -- ^ source files to check
   , idirs          :: [FilePath] -- ^ path to directory for including specs
   , diffcheck      :: Bool       -- ^ check subset of binders modified (+ dependencies) since last check
   , linear         :: Bool       -- ^ uninterpreted integer multiplication and division
@@ -76,15 +84,12 @@ data Config = Config {
   , noSimplifyCore  :: Bool       -- ^ simplify GHC core before constraint-generation
   , nonLinCuts      :: Bool       -- ^ treat non-linear kvars as cuts
   , autoInstantiate :: Instantiate -- ^ How to instantiate axioms
-  -- NO-TRIGGER , proofMethod     :: ProofMethod -- ^ How to create automatic instances
-  -- NO-TRIGGER , fuel            :: Int         -- ^ Fuel for axiom instantiation
   , debugInstantionation :: Bool   -- ^ Debug Instantiation
   , noslice         :: Bool        -- ^ Disable non-concrete KVar slicing
   , noLiftedImport  :: Bool        -- ^ Disable loading lifted specifications (for "legacy" libs)
   , proofLogicEval  :: Bool        -- ^ Enable proof-by-logical-evaluation
   } deriving (Generic, Data, Typeable, Show, Eq)
 
--- NO-TRIGGER instance Serialize ProofMethod
 instance Serialize Instantiate
 instance Serialize SMTSolver
 instance Serialize Config
@@ -94,11 +99,6 @@ data Instantiate
   | LiquidInstances
   | LiquidInstancesLocal
   deriving (Eq, Data, Typeable, Generic)
-
--- NO-TRIGGER data ProofMethod
--- NO-TRIGGER   = Rewrite
--- NO-TRIGGER   | AllMethods
--- NO-TRIGGER   deriving (Eq, Data, Typeable, Generic)
 
 allowPLE :: Config -> Bool
 allowPLE cfg
@@ -113,13 +113,6 @@ allowLocalPLE :: Config -> Bool
 allowLocalPLE cfg
   =  proofLogicEval  cfg
   || autoInstantiate cfg == LiquidInstancesLocal
-
--- NO-TRIGGER instance Default ProofMethod where
-  -- NO-TRIGGER def = Rewrite
--- NO-TRIGGER
--- NO-TRIGGER instance Show ProofMethod where
-  -- NO-TRIGGER show Rewrite    = "rewrite"
-  -- NO-TRIGGER show AllMethods = "all"
 
 instance Default Instantiate where
   def = NoInstances
@@ -137,26 +130,30 @@ instance HasConfig  Config where
 class HasConfig t where
   getConfig :: t -> Config
 
-  patternFlag :: t -> Bool
-  patternFlag = not . noPatternInline . getConfig
+patternFlag :: (HasConfig t) => t -> Bool
+patternFlag = not . noPatternInline . getConfig
 
-  higherOrderFlag :: t -> Bool
-  higherOrderFlag = higherorder . getConfig
+higherOrderFlag :: (HasConfig t) => t -> Bool
+higherOrderFlag = higherorder . getConfig
 
-  pruneFlag :: t -> Bool
-  pruneFlag = pruneUnsorted . getConfig
+pruneFlag :: (HasConfig t) => t -> Bool
+pruneFlag = pruneUnsorted . getConfig
 
-  expandFlag :: t -> Bool
-  expandFlag = not . nocaseexpand . getConfig
+expandFlag :: (HasConfig t) => t -> Bool
+expandFlag = not . nocaseexpand . getConfig
 
-  hasOpt :: t -> (Config -> Bool) -> Bool
-  hasOpt t f = f (getConfig t)
+exactDCFlag :: (HasConfig t) => t -> Bool
+exactDCFlag _ = True 
+-- exactDCFlag = exactDC . getConfig 
 
-  totalityCheck :: t -> Bool
-  totalityCheck = totalityCheck' . getConfig
+hasOpt :: (HasConfig t) => t -> (Config -> Bool) -> Bool
+hasOpt t f = f (getConfig t)
 
-  terminationCheck :: t -> Bool
-  terminationCheck = terminationCheck' . getConfig
+totalityCheck :: (HasConfig t) => t -> Bool
+totalityCheck = totalityCheck' . getConfig
+
+terminationCheck :: (HasConfig t) => t -> Bool
+terminationCheck = terminationCheck' . getConfig
 
 totalityCheck' :: Config -> Bool
 totalityCheck' cfg = (not (nototality cfg)) || totalHaskell cfg

--- a/src/Language/Haskell/Liquid/UX/Errors.hs
+++ b/src/Language/Haskell/Liquid/UX/Errors.hs
@@ -5,12 +5,7 @@
 -- | This module contains the functions related to @Error@ type,
 -- in particular, to @tidyError@ using a solution, and @pprint@ errors.
 
--- TODO: move this into Tidy.
-
-module Language.Haskell.Liquid.UX.Errors
-  ( -- * Cleanup an Error
-    tidyError
- ) where
+module Language.Haskell.Liquid.UX.Errors ( tidyError ) where
 
 import           Control.Arrow                       (second)
 import qualified Data.HashMap.Strict                 as M
@@ -31,11 +26,16 @@ type Ctx  = M.HashMap F.Symbol SpecType
 type CtxM = M.HashMap F.Symbol (WithModel SpecType)
 
 ------------------------------------------------------------------------
-tidyError :: F.FixSolution -> Error -> Error
+tidyError :: Config -> F.FixSolution -> Error -> Error
 ------------------------------------------------------------------------
-tidyError sol
-  = fmap (tidySpecType F.Full)
+tidyError cfg sol
+  = fmap (tidySpecType (configTidy cfg)) 
   . tidyErrContext sol
+
+configTidy :: Config -> F.Tidy 
+configTidy cfg 
+  | shortNames cfg = F.Lossy 
+  | otherwise      = F.Full 
 
 tidyErrContext :: F.FixSolution -> Error -> Error
 tidyErrContext _ e@(ErrSubType {})

--- a/src/Language/Haskell/Liquid/UX/Errors.hs
+++ b/src/Language/Haskell/Liquid/UX/Errors.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections     #-}
 
 -- | This module contains the functions related to @Error@ type,
 -- in particular, to @tidyError@ using a solution, and @pprint@ errors.
@@ -16,68 +17,70 @@ import qualified Data.HashMap.Strict                 as M
 import qualified Data.HashSet                        as S
 import           Data.Hashable
 import           Data.Maybe                          (maybeToList)
-import           Language.Fixpoint.Types             hiding (Error, SrcSpan, shiftVV)
+import qualified Language.Fixpoint.Types             as F -- hiding (Error, SrcSpan, shiftVV)
 import           Language.Haskell.Liquid.Types.RefType
 import           Language.Haskell.Liquid.Transforms.Simplify
 import           Language.Haskell.Liquid.UX.Tidy
 import           Language.Haskell.Liquid.Types
-import           Language.Haskell.Liquid.Misc        (single)
+import qualified Language.Haskell.Liquid.Misc as Misc 
+import qualified Language.Fixpoint.Misc       as Misc 
 
 -- import Debug.Trace
 
-type Ctx = M.HashMap Symbol SpecType
-type CtxM = M.HashMap Symbol (WithModel SpecType)
+type Ctx  = M.HashMap F.Symbol SpecType
+type CtxM = M.HashMap F.Symbol (WithModel SpecType)
 
 ------------------------------------------------------------------------
-tidyError :: FixSolution -> Error -> Error
+tidyError :: F.FixSolution -> Error -> Error
 ------------------------------------------------------------------------
 tidyError sol
-  = fmap (tidySpecType Full)
+  = fmap (tidySpecType F.Full)
   . tidyErrContext sol
 
-tidyErrContext :: FixSolution -> Error -> Error
+tidyErrContext :: F.FixSolution -> Error -> Error
 tidyErrContext _ e@(ErrSubType {})
-  = e { ctx = c', tact = subst θ tA, texp = subst θ tE }
+  = e { ctx = c', tact = F.subst θ tA, texp = F.subst θ tE }
     where
       (θ, c') = tidyCtx xs $ ctx e
-      xs      = syms tA ++ syms tE
+      xs      = F.syms tA ++ F.syms tE
       tA      = tact e
       tE      = texp e
 
 tidyErrContext _ e@(ErrSubTypeModel {})
-  = e { ctxM = c', tactM = fmap (subst θ) tA, texp = fmap (subst θ) tE }
+  = e { ctxM = c', tactM = fmap (F.subst θ) tA, texp = fmap (F.subst θ) tE }
     where
       (θ, c') = tidyCtxM xs $ ctxM e
-      xs      = syms tA ++ syms tE
+      xs      = F.syms tA ++ F.syms tE
       tA      = tactM e
       tE      = texp e
 
 tidyErrContext _ e@(ErrAssType {})
-  = e { ctx = c', cond = subst θ p }
+  = e { ctx = c', cond = F.subst θ p }
     where
       m       = ctx e
       (θ, c') = tidyCtx xs m
-      xs      = syms p
+      xs      = F.syms p
       p       = cond e
 
 tidyErrContext _ e
   = e
 
 --------------------------------------------------------------------------------
-tidyCtx       :: [Symbol] -> Ctx -> (Subst, Ctx)
+tidyCtx       :: [F.Symbol] -> Ctx -> (F.Subst, Ctx)
 --------------------------------------------------------------------------------
-tidyCtx xs m  = (θ, M.fromList yts)
+tidyCtx xs m   = (θ1 `mappend` θ2, M.fromList yts)
   where
-    yts       = [tBind x $ tidySpecType Full t | (x, t) <- xts]
-    (θ, xts)  = tidyTemps $ second stripReft <$> tidyREnv xs m
-    tBind x t = (x', shiftVV t x') where x' = tidySymbol x
+    yts        = [tBind x (tidySpecType F.Full t) | (x, t) <- xt2s]
+    (θ2, xt2s) = tidyTemps xt1s -- [ (x, stripReft t) | (x, t) <- xt1s ] 
+    (θ1, xt1s) = tidyREnv xs m 
+    tBind x t  = (x', shiftVV t x') where x' = F.tidySymbol x
 
-tidyCtxM       :: [Symbol] -> CtxM -> (Subst, CtxM)
+tidyCtxM       :: [F.Symbol] -> CtxM -> (F.Subst, CtxM)
 tidyCtxM xs m  = (θ, M.fromList yts)
   where
     yts       = [tBind x t | (x, t) <- xts]
     (θ, xts)  = tidyTemps $ second (fmap stripReft) <$> tidyREnvM xs m
-    tBind x t = (x', fmap (\t -> shiftVV t x') t) where x' = tidySymbol x
+    tBind x t = (x', fmap (\t -> shiftVV t x') t) where x' = F.tidySymbol x
 
 
 stripReft     :: SpecType -> SpecType
@@ -92,18 +95,39 @@ stripRType st = (t', ro)
     ro        = stripRTypeBase  t
     t         = simplifyBounds st
 
-tidyREnv      :: [Symbol] -> Ctx -> [(Symbol, SpecType)]
-tidyREnv xs m = [(x, t) | x <- xs', t <- maybeToList (M.lookup x m), ok t]
+tidyREnv :: [F.Symbol] -> Ctx -> (F.Subst, [(F.Symbol, SpecType)])
+tidyREnv xs m   = (θ, second (F.subst θ) <$> zts) -- [(z, F.subst θ t) | (z, t) <- zts]) 
+  where 
+    θ           = mconcat [ F.mkSubst [(y, e)] | (y, e) <- yes ]
+    (yes, zts)  = Misc.mapEither isInline xts 
+    xts         = sliceREnv xs m
+
+isInline :: (a, SpecType) -> Either (a, F.Expr) (a, SpecType) 
+isInline (x, t) = either (Left . (x,)) (Right . (x,)) (isInline' t) 
+
+isInline' :: SpecType -> Either F.Expr SpecType 
+isInline' t = case ro of 
+                Nothing -> Right t' 
+                Just rr -> case F.isSingletonReft (ur_reft rr) of 
+                             Just e  -> Left e
+                             Nothing -> Right (strengthen t' rr) 
+              where 
+                  (t', ro) = stripRType t 
+
+
+
+sliceREnv :: [F.Symbol] -> Ctx -> [(F.Symbol, SpecType)]
+sliceREnv xs m = [(x, t) | x <- xs', t <- maybeToList (M.lookup x m), ok t]
   where
     xs'       = expandFix deps xs
-    deps y    = maybe [] (syms . rTypeReft) (M.lookup y m)
+    deps y    = maybe [] (F.syms . rTypeReft) (M.lookup y m)
     ok        = not . isFunTy
 
-tidyREnvM      :: [Symbol] -> CtxM -> [(Symbol, WithModel SpecType)]
+tidyREnvM      :: [F.Symbol] -> CtxM -> [(F.Symbol, WithModel SpecType)]
 tidyREnvM xs m = [(x, t) | x <- xs', t <- maybeToList (M.lookup x m), ok t]
   where
     xs'       = expandFix deps xs
-    deps y    = maybe [] (syms . rTypeReft . dropModel) (M.lookup y m)
+    deps y    = maybe [] (F.syms . rTypeReft . dropModel) (M.lookup y m)
     ok        = not . isFunTy . dropModel
 
 expandFix :: (Eq a, Hashable a) => (a -> [a]) -> [a] -> [a]
@@ -114,19 +138,19 @@ expandFix f               = S.toList . go S.empty
       | x `S.member` seen = go seen xs
       | otherwise         = go (S.insert x seen) (f x ++ xs)
 
-tidyTemps     :: (Subable t) => [(Symbol, t)] -> (Subst, [(Symbol, t)])
+tidyTemps     :: (F.Subable t) => [(F.Symbol, t)] -> (F.Subst, [(F.Symbol, t)])
 tidyTemps xts = (θ, [(txB x, txTy t) | (x, t) <- xts])
   where
     txB  x    = M.lookupDefault x x m
-    txTy      = subst θ
+    txTy      = F.subst θ
     m         = M.fromList yzs
-    θ         = mkSubst [(y, EVar z) | (y, z) <- yzs]
+    θ         = F.mkSubst [(y, F.EVar z) | (y, z) <- yzs]
     yzs       = zip ys niceTemps
     ys        = [ x | (x,_) <- xts, isTmpSymbol x]
 
-niceTemps     :: [Symbol]
+niceTemps     :: [F.Symbol]
 niceTemps     = mkSymbol <$> xs ++ ys
   where
-    mkSymbol  = symbol . ('?' :)
-    xs        = single   <$> ['a' .. 'z']
+    mkSymbol  = F.symbol . ('?' :)
+    xs        = Misc.single <$> ['a' .. 'z']
     ys        = ("a" ++) <$> [show n | n <- [0 ..]]

--- a/src/Language/Haskell/Liquid/UX/Tidy.hs
+++ b/src/Language/Haskell/Liquid/UX/Tidy.hs
@@ -124,7 +124,6 @@ tidyLocalRefas k = mapReft (txStrata . txReft' k)
     isTmp x                       = any (`isPrefixOfSym` x) [anfPrefix, "ds_"]
     txStr                         = filter (not . isSVar)
 
-
 tidyEqual :: SpecType -> SpecType
 tidyEqual = mapReft txReft
   where 

--- a/src/Language/Haskell/Liquid/UX/Tidy.hs
+++ b/src/Language/Haskell/Liquid/UX/Tidy.hs
@@ -111,7 +111,7 @@ tidySymbols k t = substa (shortSymbol . tidySymbol) $ mapBind dropBind t
   where
     xs          = S.fromList (syms t)
     dropBind x  = if x `S.member` xs then tidySymbol x else nonSymbol
-    shortSymbol = if k == Lossy then dropModuleNames else id
+    shortSymbol = if (tracepp "shortSymbol k" k) == Lossy then dropModuleNames else id
 
 tidyLocalRefas   :: Tidy -> SpecType -> SpecType
 tidyLocalRefas k = mapReft (txStrata . txReft' k)

--- a/src/Language/Haskell/Liquid/UX/Tidy.hs
+++ b/src/Language/Haskell/Liquid/UX/Tidy.hs
@@ -107,11 +107,14 @@ tidyVV r@(Reft (va,_))
     isJunk    = isPrefixOfSym "x"
 
 tidySymbols :: Tidy -> SpecType -> SpecType
-tidySymbols k t = substa (shortSymbol . tidySymbol) $ mapBind dropBind t
+tidySymbols k t = substa (shortSymbol k . tidySymbol) $ mapBind dropBind t
   where
     xs          = S.fromList (syms t)
     dropBind x  = if x `S.member` xs then tidySymbol x else nonSymbol
-    shortSymbol = if (tracepp "shortSymbol k" k) == Lossy then dropModuleNames else id
+
+shortSymbol :: Tidy -> Symbol -> Symbol 
+shortSymbol Lossy = dropModuleNames 
+shortSymbol _     = id 
 
 tidyLocalRefas   :: Tidy -> SpecType -> SpecType
 tidyLocalRefas k = mapReft (txStrata . txReft' k)

--- a/tests/errors/InlineSubExp0.hs
+++ b/tests/errors/InlineSubExp0.hs
@@ -1,0 +1,21 @@
+
+-- https://github.com/ucsd-progsys/liquidhaskell/issues/1258
+
+{-@ LIQUID "--exact-data-con" @-}
+{-@ LIQUID "--short-names"    @-} 
+
+module T1258 where 
+
+import Language.Haskell.Liquid.NewProofCombinators 
+
+data Foo = A | B
+data Bar = C | D
+data Baz = E | F
+
+{-@ reflect f @-}
+f :: Foo -> Bar -> Baz
+f B C = F
+f _ _ = E
+
+{-@ prop :: {f B C == F} @-}
+prop = f B C === E *** QED  

--- a/tests/errors/InlineSubExp1.hs
+++ b/tests/errors/InlineSubExp1.hs
@@ -1,0 +1,26 @@
+
+-- https://github.com/ucsd-progsys/liquidhaskell/issues/1258
+
+{-@ LIQUID "--exact-data-con" @-}
+{-@ LIQUID "--short-names"    @-}
+
+module T1258 where 
+
+import Language.Haskell.Liquid.NewProofCombinators 
+
+data Foo = A | B
+data Bar = C | D
+data Baz = E | F | G 
+
+{-@ reflect f @-}
+f :: Foo -> Bar -> Baz
+f B C = F
+f A D = E
+f _ _ = G 
+
+{-@ reflect g @-}
+g :: Foo -> Bar 
+g A = C 
+g _ = D 
+
+test = f B (g A) === f A D *** QED  

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -168,6 +168,10 @@ errorTests = group "Error-Messages"
   , errorTest "tests/errors/BadData1.hs"            2 "`Main.EntityField` is not the type constructor for `BlobXVal`"
   , errorTest "tests/errors/BadData2.hs"            2 "`Boo.Hog` is not the type constructor for `Cuthb`"
   , errorTest "tests/errors/T1140.hs"               2 "Specified type does not refine Haskell type for `Blank.foo`"
+  , errorTest "tests/errors/InlineSubExp0.hs"       1 "== f B C"
+  , errorTest "tests/errors/InlineSubExp1.hs"       1 "== f B (g A)"
+
+
   ]
 
 unitTests :: IO TestTree


### PR DESCRIPTION
Fixes #1258 

For example,  `liquid tests/errors/InlineSubExp1.hs` now fails with

```
 /Users/rjhala/research/stack/liquidhaskell/tests/errors/InlineSubExp1.hs:26:22-26: Error: Liquid Type Mismatch

 26 | test = f B (g A) === f A D *** QED
                           ^^^^^

   Inferred type
     VV : {v : Baz | v == f A D}

   not a subtype of Required type
     VV : {VV : Baz | VV == f B (g A)}
```

instead of scattering the facts across temporary binders e.g. as shown below 

<img width="349" alt="screen shot 2018-03-29 at 12 24 55 pm" src="https://user-images.githubusercontent.com/1650232/38109226-463c0258-334c-11e8-9662-fa90d31e6cf7.png">


