### PR TITLE
Simplify Flags needed for Theorem Proving

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,17 @@ To enable theorem proving, e.g. as [described here](https://ucsd-progsys.github.
 use the option 
 
 ```haskell
-    {-@ LIQUID "--no-termination" @-}
+    {-@ LIQUID "--reflection" @-}
 ```
+
+To additionally turn on _proof by logical evaluation_ use the option
+
+```haskell
+    {-@ LIQUID "--reflection" @-}
+```
+
+You can see many examples of proofs by logical evaluation in `benchmarks/popl18/ple/pos`
+
 
 Incremental Checking
 --------------------

--- a/README.md
+++ b/README.md
@@ -184,20 +184,36 @@ LiquidHaskell supports several command line options, to configure the
 checking. Each option can be passed in at the command line, or directly
 added to the source file via:
 
+```haskell
     {-@ LIQUID "option-within-quotes" @-}
+```
 
 for example, to disable termination checking (see below)
 
+```haskell
     {-@ LIQUID "--no-termination" @-}
+```
 
 You may also put command line options in the environment variable
 `LIQUIDHASKELL_OPTS`. For example, if you add the line:
 
+```
     LIQUIDHASKELL_OPTS="--diff"
+```
 
 to your `.bashrc` then, by default, all files will be
 *incrementally checked* unless you run with the overriding
 `--full` flag (see below).
+
+Theorem Proving 
+---------------
+
+To enable theorem proving, e.g. as [described here](https://ucsd-progsys.github.io/liquidhaskell-blog/tags/reflection.html)
+use the option 
+
+```haskell
+    {-@ LIQUID "--no-termination" @-}
+```
 
 Incremental Checking
 --------------------
@@ -205,35 +221,43 @@ Incremental Checking
 LiquidHaskell supports *incremental* checking where each run only checks
 the part of the program that has been modified since the previous run.
 
+```
     $ liquid --diff foo.hs
+```
 
-Each run of `liquid` saves the file to a `.bak` file and the *subsequent*
-run
+Each run of `liquid` saves the file to a `.bak` file and the *subsequent* run
+
     + does a `diff` to see what has changed w.r.t. the `.bak` file
     + only generates constraints for the `[CoreBind]` corresponding to the
        changed top-level binders and their transitive dependencies.
 
 The time savings are quite significant. For example:
 
+```
     $ time liquid --notermination -i . Data/ByteString.hs > log 2>&1
 
     real	7m3.179s
     user	4m18.628s
     sys	    0m21.549s
+```
 
 Now if you go and tweak the definition of `spanEnd` on line 1192 and re-run:
 
+```
     $ time liquid -d --notermination -i . Data/ByteString.hs > log 2>&1
 
     real	0m11.584s
     user	0m6.008s
     sys	    0m0.696s
+```
 
 The diff is only performed against **code**, i.e. if you only change
 specifications, qualifiers, measures, etc. `liquid -d` will not perform
 any checks. In this case, you may specify individual definitions to verify:
 
+```
     $ liquid -b bar -b baz foo.hs
+```
 
 This will verify `bar` and `baz`, as well as any functions they use.
 

--- a/README.md
+++ b/README.md
@@ -573,30 +573,43 @@ To deactivate this automatic measure definition, and speed up verification, you 
 
 
 Prune Unsorted Predicates
--------------------------
+--------------------------
 
-Consider a measure over lists of integers
+The `--prune-unsorted` flag is needed when using *measures over specialized instances* of ADTs. 
 
+For example, consider a measure over lists of integers
+
+```haskell
     sum :: [Int] -> Int
     sum [] = 0
     sum (x:xs) = 1 + sum xs
+```
 
 This measure will translate into strengthening the types of list constructors
 
+```
     [] :: {v:[Int] | sum v = 0 }
     (:) :: x:Int -> xs:[Int] -> {v:[Int] | sum v = x + sum xs}
+```
 
 But what if our list is polymorphic `[a]` and later instantiate to list of ints?
-The hack we do right now is to strengthen the polymorphic list with the `sum` information
+The workaround we have right now is to strengthen the polymorphic list with the 
+`sum` information
 
+```
     [] :: {v:[a] | sum v = 0 }
     (:) :: x:a -> xs:[a] -> {v:[a] | sum v = x + sum xs}
+```
 
-But for non numeric `a`s, expressions like `x + sum xs` is unsorted causing the logic to crash.
-We use the flag `--prune-unsorted` to prune away unsorted expressions (like `x + sum xs`) in the logic.
+But for non numeric `a`s, refinements like `x + sum xs` are ill-sorted! 
+
+We use the flag `--prune-unsorted` to prune away unsorted expressions 
+(like `x + sum xs`) inside refinements.
 
 
+```
     liquid --prune-unsorted test.hs
+```
 
 
 Case Expansion

--- a/benchmarks/popl18/ple/pos/AlphaEquivalence.hs
+++ b/benchmarks/popl18/ple/pos/AlphaEquivalence.hs
@@ -1,7 +1,5 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
-{-@ LIQUID "--alphaequivalence"  @-}
-{-@ LIQUID "--betaequivalence"  @-}
+{-@ LIQUID "--reflection"       @-}
+{-@ LIQUID "--alphaequivalence" @-}
 
 {-# LANGUAGE IncoherentInstances   #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/benchmarks/popl18/ple/pos/Append.hs
+++ b/benchmarks/popl18/ple/pos/Append.hs
@@ -1,8 +1,5 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
-{-@ LIQUID "--higherorderqs" @-}
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
-
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 
 {-# LANGUAGE IncoherentInstances   #-}
 {-# LANGUAGE FlexibleContexts      #-}

--- a/benchmarks/popl18/ple/pos/ApplicativeId.hs
+++ b/benchmarks/popl18/ple/pos/ApplicativeId.hs
@@ -1,9 +1,5 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
-{-@ LIQUID "--higherorderqs" @-}
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
-
-
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 
 {-# LANGUAGE IncoherentInstances   #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/benchmarks/popl18/ple/pos/ApplicativeList.hs
+++ b/benchmarks/popl18/ple/pos/ApplicativeList.hs
@@ -1,8 +1,5 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
-{-@ LIQUID "--no-adt" @-}
-
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 
 {-# LANGUAGE IncoherentInstances   #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/benchmarks/popl18/ple/pos/ApplicativeMaybe.hs
+++ b/benchmarks/popl18/ple/pos/ApplicativeMaybe.hs
@@ -1,8 +1,5 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
-
-
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 
 {-# LANGUAGE IncoherentInstances   #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/benchmarks/popl18/ple/pos/BasicLambdas.hs
+++ b/benchmarks/popl18/ple/pos/BasicLambdas.hs
@@ -1,8 +1,4 @@
-
-{-@ LIQUID "--higherorder"      @-}
-{-@ LIQUID "--exact-data-cons" @-}
-
-{- LIQUID "--automatic-instances=liquidinstances" @-}
+{-@ LIQUID "--reflection" @-}
 
 module BasicLambda where
 

--- a/benchmarks/popl18/ple/pos/Compose.hs
+++ b/benchmarks/popl18/ple/pos/Compose.hs
@@ -1,7 +1,5 @@
-{-@ LIQUID "--higherorder"     @-}
-
-{-@ LIQUID "--exact-data-cons" @-}
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 
 module Compose where
 

--- a/benchmarks/popl18/ple/pos/Euclide.hs
+++ b/benchmarks/popl18/ple/pos/Euclide.hs
@@ -1,6 +1,5 @@
-{-@ LIQUID "--higherorder"      @-}
-{-@ LIQUID "--exact-data-cons" @-}
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 
 module Euclide where
 

--- a/benchmarks/popl18/ple/pos/FoldrUniversal.hs
+++ b/benchmarks/popl18/ple/pos/FoldrUniversal.hs
@@ -1,9 +1,8 @@
 -- | Universal property of foldr a la Zombie
 -- | cite : http://www.seas.upenn.edu/~sweirich/papers/congruence-extended.pdf
 
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
+{-@ LIQUID "--reflection"     @-}
+{-@ LIQUID "--ple"     @-}
 
 module FoldrUniversal where
 

--- a/benchmarks/popl18/ple/pos/FunctionEquality101.hs
+++ b/benchmarks/popl18/ple/pos/FunctionEquality101.hs
@@ -1,8 +1,5 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
-{-@ LIQUID "--betaequivalence"  @-}
-
-{- LIQUID "--automatic-instances=liquidinstances" @-}
+{-@ LIQUID "--reflection"      @-}
+{-@ LIQUID "--betaequivalence" @-}
 
 {-# LANGUAGE IncoherentInstances   #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/benchmarks/popl18/ple/pos/FunctorId.hs
+++ b/benchmarks/popl18/ple/pos/FunctorId.hs
@@ -1,9 +1,5 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
-{-@ LIQUID "--higherorderqs" @-}
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
-
-
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 
 {-# LANGUAGE IncoherentInstances   #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/benchmarks/popl18/ple/pos/FunctorList.hs
+++ b/benchmarks/popl18/ple/pos/FunctorList.hs
@@ -1,9 +1,5 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
-{-@ LIQUID "--higherorderqs" @-}
-
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
-
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 
 {-# LANGUAGE IncoherentInstances   #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/benchmarks/popl18/ple/pos/FunctorMaybe.hs
+++ b/benchmarks/popl18/ple/pos/FunctorMaybe.hs
@@ -1,9 +1,5 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
-{-@ LIQUID "--higherorderqs" @-}
-
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
-
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 
 {-# LANGUAGE IncoherentInstances   #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/benchmarks/popl18/ple/pos/Lists.hs
+++ b/benchmarks/popl18/ple/pos/Lists.hs
@@ -1,8 +1,5 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
-
-
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 
 module Lists where
 

--- a/benchmarks/popl18/ple/pos/MapFusion.hs
+++ b/benchmarks/popl18/ple/pos/MapFusion.hs
@@ -1,9 +1,5 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
-{-@ LIQUID "--higherorderqs" @-}
-
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
-
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 
 {-# LANGUAGE IncoherentInstances #-}
 {-# LANGUAGE FlexibleContexts    #-}

--- a/benchmarks/popl18/ple/pos/Maybe.hs
+++ b/benchmarks/popl18/ple/pos/Maybe.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--reflection"     @-}
 
 
 {-# LANGUAGE IncoherentInstances   #-}

--- a/benchmarks/popl18/ple/pos/MonadId.hs
+++ b/benchmarks/popl18/ple/pos/MonadId.hs
@@ -1,7 +1,6 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 {-@ LIQUID "--betaequivalence" @-}
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
 
 
 {-# LANGUAGE IncoherentInstances   #-}

--- a/benchmarks/popl18/ple/pos/MonadList.hs
+++ b/benchmarks/popl18/ple/pos/MonadList.hs
@@ -1,8 +1,7 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 {-@ LIQUID "--betaequivalence"  @-}
 
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
 
 
 {-# LANGUAGE IncoherentInstances   #-}

--- a/benchmarks/popl18/ple/pos/MonadMaybe.hs
+++ b/benchmarks/popl18/ple/pos/MonadMaybe.hs
@@ -1,13 +1,9 @@
-{-@ LIQUID "--higherorder"      @-}
-{-@ LIQUID "--exact-data-cons"  @-}
+{-@ LIQUID "--reflection"        @-}
+{-@ LIQUID "--ple"               @-}
+{-@ LIQUID "--betaequivalence"   @-}
 
-{-@ LIQUID "--alphaequivalence" @-}
-{-@ LIQUID "--betaequivalence"  @-}
-
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
-
-{-# LANGUAGE IncoherentInstances   #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE IncoherentInstances #-}
+{-# LANGUAGE FlexibleContexts    #-}
 module MonadMaybe where
 
 import Prelude hiding (return, Maybe(..))

--- a/benchmarks/popl18/ple/pos/MonoidList.hs
+++ b/benchmarks/popl18/ple/pos/MonoidList.hs
@@ -1,8 +1,5 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
-{-@ LIQUID "--higherorderqs" @-}
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
-{-@ LIQUID "--no-adt" @-}
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 
 module MonoidList where
 

--- a/benchmarks/popl18/ple/pos/MonoidMaybe.hs
+++ b/benchmarks/popl18/ple/pos/MonoidMaybe.hs
@@ -1,6 +1,5 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 
 module MonoidMaybe where
 

--- a/benchmarks/popl18/ple/pos/NormalForm.hs
+++ b/benchmarks/popl18/ple/pos/NormalForm.hs
@@ -1,5 +1,5 @@
-{-@ LIQUID "--higherorder"      @-}
-{-@ LIQUID "--exact-data-cons"  @-}
+{-@ LIQUID "--reflection"      @-}
+
 {-@ LIQUID "--alphaequivalence" @-}
 {-@ LIQUID "--betaequivalence"  @-}
 {-@ LIQUID "--normalform"       @-} 

--- a/benchmarks/popl18/ple/pos/OverviewListInfix.hs
+++ b/benchmarks/popl18/ple/pos/OverviewListInfix.hs
@@ -1,9 +1,5 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
-{-@ LIQUID "--maxparams=10"  @-}
-{-@ LIQUID "--higherorderqs" @-}
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
-
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 
 {-# LANGUAGE IncoherentInstances #-}
 {-# LANGUAGE FlexibleContexts    #-}

--- a/benchmarks/popl18/ple/pos/Peano.hs
+++ b/benchmarks/popl18/ple/pos/Peano.hs
@@ -1,14 +1,9 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
-{-@ LIQUID "--higherorderqs" @-}
-
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 
 module Peano where
 
 import Prelude hiding (plus)
-
--- import Proves
 
 import Language.Haskell.Liquid.ProofCombinators
 
@@ -20,10 +15,9 @@ plusComm  :: Peano -> Peano -> Proof
 plusSuccR :: Peano -> Peano -> Proof
 
 
-
 data Peano = Z | S Peano
 
-{-@ data Peano [toInt] = Z | S {prev :: Peano} @-}
+{-@ data Peano [toInt] @-} 
 
 {-@ measure toInt @-}
 toInt :: Peano -> Int

--- a/benchmarks/popl18/ple/pos/Solver.hs
+++ b/benchmarks/popl18/ple/pos/Solver.hs
@@ -5,8 +5,8 @@
 -- | Should use cases and auto translate like in the paper's theory
 -- | Also, &&, not and rest logical operators are not in scope in the axioms
 
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--reflection"     @-}
+
 {-@ LIQUID "--pruneunsorted"   @-}
 
 

--- a/benchmarks/popl18/ple/pos/Unification.hs
+++ b/benchmarks/popl18/ple/pos/Unification.hs
@@ -5,10 +5,7 @@
 -- nonlinear-cuts (i.e. they add new cut vars that require qualifiers.) why?
 -- where? switch off non-lin-cuts in higher-order mode?
 
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
-{-@ LIQUID "--eliminate=all"   @-}
-
+{-@ LIQUID "--reflection"      @-}
 {-@ LIQUID "--automatic-instances=liquidinstanceslocal" @-}
 
 module Unify where
@@ -37,7 +34,6 @@ unify TBot TBot
   = Just Emp
 unify t1@(TVar i) t2
   | not (S.member i (freeVars t2))
-  -- ORIG = Just (C (P i t2) Emp `byTheorem` theoremVar t2 i)
   = Just (C (P i t2) Emp) `byTheorem` theoremVar t2 i
 unify t1 t2@(TVar i)
   | not (S.member i (freeVars t1))
@@ -46,7 +42,6 @@ unify t1 t2@(TVar i)
 unify (TFun t11 t12) (TFun t21 t22)
   = case unify t11 t21 of
       Just θ1 -> case unify (apply θ1 t12) (apply θ1 t22) of
-		    -- Just θ2 -> Just (append θ2 θ1 `byTheorem` theoremFun t11 t12 t21 t22 θ1 θ2)
 		   Just θ2 -> Just (append θ2 θ1) `byTheorem` theoremFun t11 t12 t21 t22 θ1 θ2
                    Nothing -> Nothing
       _       -> Nothing

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -157,7 +157,7 @@ config = cmdArgsMode $ Config {
           &= name "trust-sizes"
 
  , gradual
-    = def &= help "Enable gradual refinementtype checking"
+    = def &= help "Enable gradual refinement type checking"
           &= name "gradual"
 
  , gdepth
@@ -354,6 +354,9 @@ config = cmdArgsMode $ Config {
     = False &= help "Enable Proof-by-Logical-Evaluation"
         &= name "ple"
 
+  , reflection 
+    = False &= help "Enable reflection of Haskell functions and theorem proving" 
+        &= name "reflection"
  } &= verbosity
    &= program "liquid"
    &= help    "Refinement Types for Haskell"
@@ -565,6 +568,7 @@ defConfig = Config { files             = def
                    , noslice              = False
                    , noLiftedImport       = False
                    , proofLogicEval       = False
+                   , reflection           = False
                    }
 
 ------------------------------------------------------------------------

--- a/tests/neg/ReflectDefault.hs
+++ b/tests/neg/ReflectDefault.hs
@@ -1,0 +1,21 @@
+
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
+{-@ LIQUID "--no-case-expand" @-}
+
+module ReflectDefault where 
+
+data Thing = A | B | C | D 
+
+{-@ reflect foo @-}
+foo :: Thing -> Int
+foo A = 0 
+foo D = 10
+foo _ = 1 
+
+{-@ thmOK :: {foo C == 1} @-}
+thmOK = ()
+
+{-@ thmBAD :: {foo A == 1} @-}
+thmBAD = ()
+

--- a/tests/pos/ReflectDefault.hs
+++ b/tests/pos/ReflectDefault.hs
@@ -1,0 +1,18 @@
+
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
+{-@ LIQUID "--no-case-expand" @-}
+
+module ReflectDefault where 
+
+data Thing = A | B | C | D 
+
+{-@ reflect foo @-}
+foo :: Thing -> Int
+foo A = 0 
+foo D = 10
+foo _ = 1 
+
+{-@ thmOK :: {foo C == 1} @-}
+thmOK = ()
+


### PR DESCRIPTION
Fixes https://github.com/ucsd-progsys/liquidhaskell/issues/1262

Please *do not* use `--higherorder` or `--exact-data-cons` anymore.

Instead use:

* `--reflection`  (which switches on `--higherorder` and `--exactdc`)
* `--ple` (which switches on `automaticinstances=liquidinstances`)

See examples in `benchmarks/popl18/ple/pos` for example.