### PR TITLE
add structural termination flag

### DIFF
--- a/src/Language/Haskell/Liquid/Termination/Structural.hs
+++ b/src/Language/Haskell/Liquid/Termination/Structural.hs
@@ -22,6 +22,8 @@ import qualified Data.HashSet                           as S
 
 
 terminationCheck :: GhcInfo -> Output Doc 
+terminationCheck info | structuralTerm (getConfig info)
+                      = mconcat $ map (resultToDoc . checkBind (cbs info)) (allRecBinds $ cbs info)
 terminationCheck info = mconcat $ map (resultToDoc . checkBind (cbs info)) (S.toList $ gsStTerm $ spec info)
 
 
@@ -40,6 +42,9 @@ resultToDoc (Error x) = mempty {o_result = Unsafe x }
 checkBind :: [CoreBind] -> Var -> Result
 checkBind cbs x = maybe OK isStructurallyRecursiveGroup (findRecBind cbs x)
 
+
+allRecBinds :: [CoreBind] -> [Var]
+allRecBinds cbs = concat[ fst <$> xes |  Rec xes <- cbs ] 
 
 findRecBind :: [CoreBind] -> Var -> Maybe [(Var,CoreExpr)]
 findRecBind [] _ = Nothing

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -150,6 +150,10 @@ config = cmdArgsMode $ Config {
     = def &= help "Disable Termination Check"
           &= name "no-termination-check"
 
+ , structuralTerm
+    = def &= help "Structural Termination Check"
+          &= name "structural-termination"
+
  , nostructuralT
     = def &= help "Trust that size functions are inductive"
           &= name "trust-sizes"
@@ -522,6 +526,7 @@ defConfig = Config
   , checks            = def
   , noCheckUnknown    = def
   , notermination     = def
+  , structuralTerm    = False 
   , nostructuralT     = def 
   , gradual           = False
   , gdepth            = 1

--- a/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/src/Language/Haskell/Liquid/UX/Config.hs
@@ -42,6 +42,7 @@ data Config = Config
   , checks         :: [String]   -- ^ set of binders to check
   , noCheckUnknown :: Bool       -- ^ whether to complain about specifications for unexported and unused values
   , notermination  :: Bool       -- ^ disable termination check
+  , structuralTerm :: Bool       -- ^ use only structural termination checker
   , nostructuralT  :: Bool       -- ^ disable structural termination check
   , gradual        :: Bool       -- ^ enable gradual type checking
   , gdepth         :: Int        -- ^ depth of gradual concretization
@@ -162,4 +163,4 @@ totalityCheck' :: Config -> Bool
 totalityCheck' cfg = (not (nototality cfg)) || totalHaskell cfg
 
 terminationCheck' :: Config -> Bool
-terminationCheck' cfg = totalHaskell cfg || not (notermination cfg)
+terminationCheck' cfg = (totalHaskell cfg || not (notermination cfg)) && (not (structuralTerm cfg))

--- a/tests/todo/T1278.hs
+++ b/tests/todo/T1278.hs
@@ -1,0 +1,10 @@
+{-@ LIQUID "--structural" @-}
+
+module Term where
+
+data List a = Nil | Cons a (List a)
+
+sz :: List a -> Int
+sz Nil = 0
+sz (Cons _ Nil) = 1
+sz (Cons _ (Cons _ l)) = 2 + sz l


### PR DESCRIPTION
Using `--structural` flag, the structural termination checker is used to check all functions. 

Initial purpose of the flag: let @nomeata develop the structural termination checker. e.g., the added [example](https://github.com/ucsd-progsys/liquidhaskell/commit/560e5b78820ca5e43b1febeb5c5c5b1a12b6a5b3#diff-c79be91fc15879ad54fbfa50c647251f) now fails. 