### PR TITLE
Add Support for `Char` Literals

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,16 +1,3 @@
-
-## T1095 
-
-size A = 10 
-size _ = 20 
-
-## jp-strict
-
-See slack
-
-https://gist.github.com/ranjitjhala/9e79513f63acbc5ab6c9ed0c0d811cac
-
-
 ### CallStack/Error
 
 The use of `Prelude.error` gives a crazy performance hit

--- a/include/GHC/Prim.spec
+++ b/include/GHC/Prim.spec
@@ -1,25 +1,21 @@
 module spec GHC.Prim where
 
-embed GHC.Prim.Int#  as int
-embed GHC.Prim.Word# as int
-embed GHC.Prim.Addr# as Str
-
+embed GHC.Prim.Int#     as int
+embed GHC.Prim.Word#    as int
+embed GHC.Prim.Addr#    as Str
 embed GHC.Prim.Double#  as real
+embed GHC.Prim.Char#    as Char
 
 measure addrLen :: GHC.Prim.Addr# -> GHC.Types.Int
 
 assume GHC.Types.D# :: x:GHC.Prim.Double# -> {v: GHC.Types.Double | v = (x :: real) }
 assume GHC.Types.I# :: x:GHC.Prim.Int# -> {v: GHC.Types.Int | v = (x :: int) }
+assume GHC.Types.C# :: x:GHC.Prim.Char# -> {v: GHC.Types.Char | v = (x :: Char) }
 assume GHC.Prim.+#  :: x:GHC.Prim.Int# -> y:GHC.Prim.Int# -> {v: GHC.Prim.Int# | v = x + y}
 assume GHC.Prim.-#  :: x:GHC.Prim.Int# -> y:GHC.Prim.Int# -> {v: GHC.Prim.Int# | v = x - y}
-assume GHC.Prim.==# :: x:GHC.Prim.Int# -> y:GHC.Prim.Int#
-                    -> {v:GHC.Prim.Int# | ((v = 1) <=> x = y)}
-assume GHC.Prim.>=# :: x:GHC.Prim.Int# -> y:GHC.Prim.Int# 
-                    -> {v:GHC.Prim.Int# | ((v = 1) <=> x >= y)}
-assume GHC.Prim.<=# :: x:GHC.Prim.Int# -> y:GHC.Prim.Int# 
-                    -> {v:GHC.Prim.Int# | ((v = 1) <=> x <= y)}
-assume GHC.Prim.<#  :: x:GHC.Prim.Int# -> y:GHC.Prim.Int# 
-                    -> {v:GHC.Prim.Int# | ((v = 1) <=> x < y)}
-assume GHC.Prim.>#  :: x:GHC.Prim.Int# -> y:GHC.Prim.Int# 
-                    -> {v:GHC.Prim.Int# | ((v = 1) <=> x > y)}
+assume GHC.Prim.==# :: x:GHC.Prim.Int# -> y:GHC.Prim.Int# -> {v:GHC.Prim.Int# | v = 1 <=> x = y}
+assume GHC.Prim.>=# :: x:GHC.Prim.Int# -> y:GHC.Prim.Int# -> {v:GHC.Prim.Int# | v = 1 <=> x >= y}
+assume GHC.Prim.<=# :: x:GHC.Prim.Int# -> y:GHC.Prim.Int# -> {v:GHC.Prim.Int# | v = 1 <=> x <= y}
+assume GHC.Prim.<#  :: x:GHC.Prim.Int# -> y:GHC.Prim.Int# -> {v:GHC.Prim.Int# | v = 1 <=> x < y}
+assume GHC.Prim.>#  :: x:GHC.Prim.Int# -> y:GHC.Prim.Int# -> {v:GHC.Prim.Int# | v = 1 <=> x > y}
 

--- a/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -32,6 +32,7 @@ import           Literal
 import           IdInfo
 import qualified Data.List                             as L
 import           Data.Maybe                            (listToMaybe) 
+import qualified Data.Text                             as T
 import           Data.Text.Encoding
 import           Data.Text.Encoding.Error
 import           TysWiredIn
@@ -447,7 +448,8 @@ mkLit (MachWord64 n)   = mkI n
 mkLit (MachFloat  n)   = mkR n
 mkLit (MachDouble n)   = mkR n
 mkLit (LitInteger n _) = mkI n
-mkLit (MachStr s)      = mkS s
+mkLit (MachStr    s)   = mkS s
+mkLit (MachChar   c)   = mkC c 
 mkLit _                = Nothing -- ELit sym sort
 
 mkI :: Integer -> Maybe Expr
@@ -458,6 +460,10 @@ mkR                    = Just . ECon . F.R . fromRational
 
 mkS :: ByteString -> Maybe Expr
 mkS                    = Just . ESym . SL  . decodeUtf8With lenientDecode
+
+mkC :: Char -> Maybe Expr
+mkC                    = Just . ECon . (`F.L` char)  . T.singleton 
+  where char           = FTC F.charFTyCon
 
 ignoreVar :: Id -> Bool
 ignoreVar i = simpleSymbolVar i `elem` ["I#", "D#"]

--- a/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -33,6 +33,7 @@ import           IdInfo
 import qualified Data.List                             as L
 import           Data.Maybe                            (listToMaybe) 
 import qualified Data.Text                             as T
+import qualified Data.Char 
 import           Data.Text.Encoding
 import           Data.Text.Encoding.Error
 import           TysWiredIn
@@ -462,8 +463,10 @@ mkS :: ByteString -> Maybe Expr
 mkS                    = Just . ESym . SL  . decodeUtf8With lenientDecode
 
 mkC :: Char -> Maybe Expr
-mkC                    = Just . ECon . (`F.L` char)  . T.singleton 
-  where char           = FTC F.charFTyCon
+mkC                    = Just . ECon . (`F.L` F.charSort)  . repr 
+  where 
+    -- repr            = T.singleton 
+    repr               = T.pack . show . Data.Char.ord 
 
 ignoreVar :: Id -> Bool
 ignoreVar i = simpleSymbolVar i `elem` ["I#", "D#"]

--- a/tests/neg/T1286.hs
+++ b/tests/neg/T1286.hs
@@ -1,0 +1,7 @@
+module Example where
+
+{-@ fails :: {v:Bool | v} @-}
+fails =  'a' == 'b'
+
+{-@ ok :: {v:Bool | v} @-}
+ok = "a" == "a"

--- a/tests/pos/T1286.hs
+++ b/tests/pos/T1286.hs
@@ -1,0 +1,7 @@
+module Example where
+
+{-@ fails :: {v:Bool | v} @-}
+fails =  'a' == 'a'
+
+{-@ ok :: {v:Bool | v} @-}
+ok = "a" == "a"


### PR DESCRIPTION
Encode `Char` literals like `'a'` and `'b'` in liquid-fixpoint, 
respectively as `Lit "97" Char` and `Lit "98" Char`, which in turn,
represents them to the SMT solver simply as `97` and `98`, which 
suffices to check equality etc. as in `tests/{pos,neg}/CharLiterals.hs`

Fixes #1286 

Matching PR for https://github.com/ucsd-progsys/liquid-fixpoint/pull/360