### PR TITLE
Hacking around GHC name lookup

### DIFF
--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -306,8 +306,7 @@ makeLiftedSpec1 file name lSpec0 xts axs invs
   = liftIO $ saveLiftedSpec file name lSpec1
   where
     xbs    = [ (varLocSym x       , specToBare <$> t) | (x, t) <- xts  ]
-    -- xinvs  = [ (Just (varLocSym x), specToBare <$> t) | (Just x, t) <- invs ]
-    xinvs  = [ ((varLocSym <$>x), specToBare <$> t) | (x, t) <- invs ]
+    xinvs  = [ ((varLocSym <$> x) , specToBare <$> t) | (x, t) <- invs ]
     lSpec1 = lSpec0 { Ms.asmSigs    = xbs
                     , Ms.reflSigs   = F.notracepp "REFL-SIGS" xbs
                     , Ms.axeqs      = axs

--- a/src/Language/Haskell/Liquid/Bare/Lookup.hs
+++ b/src/Language/Haskell/Liquid/Bare/Lookup.hs
@@ -167,18 +167,6 @@ safeParseIdentifier :: HscEnv -> String -> IO (SrcLoc.Located RdrName)
 safeParseIdentifier env s = hscParseIdentifier env s `Ex.catch` handle
   where
     handle = uError . head . sourceErrors ("GHC error in safeParseIdentifier: " ++ s)
-    -- s      = fixWorkId s0
-
-{- 
-fixWorkId :: String -> String 
--- fixWorkId s   = ".$W" --> "."
-fixWorkId s   = L.intercalate "." (reverse (w' : ws)) 
-  where 
-    w'        = if "$W" `L.isPrefixOf` w then drop 2 w else w
-    w:ws      = reverse (splitDots s) 
-    splitDots = words . map (\c -> if c == '.' then ' ' else c) 
--}
-
 
 symbolLookupEnvOrig :: HscEnv -> ModName -> Maybe NameSpace -> F.Symbol -> IO [Name]
 symbolLookupEnvOrig env mod namespace s

--- a/src/Language/Haskell/Liquid/Bare/Lookup.hs
+++ b/src/Language/Haskell/Liquid/Bare/Lookup.hs
@@ -6,6 +6,7 @@
 module Language.Haskell.Liquid.Bare.Lookup (
     GhcLookup(..)
   , lookupGhcVar
+  , lookupGhcWrkVar
   , lookupGhcTyCon
   , lookupGhcDnTyCon
   , lookupGhcDataCon
@@ -72,13 +73,13 @@ instance GhcLookup Name where
 
 instance GhcLookup FieldLabel where
   lookupName e m ns = lookupName e m ns . flSelector
-  srcSpan           = srcSpan . flSelector
+  srcSpan           = srcSpan           . flSelector
 
 instance F.Symbolic FieldLabel where
   symbol = F.symbol . flSelector
 
 instance GhcLookup DataName where
-  lookupName e m ns = lookupName e m ns . dataNameSymbol
+  lookupName e m ns = lookupName e m ns .  dataNameSymbol
   srcSpan           = GM.fSrcSpanSrcSpan . F.srcSpan
 
 lookupGhcThing :: (GhcLookup a, PPrint b) => String -> (TyThing -> Maybe (Int, b)) -> Maybe NameSpace -> a -> BareM b
@@ -166,6 +167,18 @@ safeParseIdentifier :: HscEnv -> String -> IO (SrcLoc.Located RdrName)
 safeParseIdentifier env s = hscParseIdentifier env s `Ex.catch` handle
   where
     handle = uError . head . sourceErrors ("GHC error in safeParseIdentifier: " ++ s)
+    -- s      = fixWorkId s0
+
+{- 
+fixWorkId :: String -> String 
+-- fixWorkId s   = ".$W" --> "."
+fixWorkId s   = L.intercalate "." (reverse (w' : ws)) 
+  where 
+    w'        = if "$W" `L.isPrefixOf` w then drop 2 w else w
+    w:ws      = reverse (splitDots s) 
+    splitDots = words . map (\c -> if c == '.' then ' ' else c) 
+-}
+
 
 symbolLookupEnvOrig :: HscEnv -> ModName -> Maybe NameSpace -> F.Symbol -> IO [Name]
 symbolLookupEnvOrig env mod namespace s
@@ -225,7 +238,6 @@ ghcSplitModuleName x = (mkModuleName $ ghcSymbolString m, mkTcOcc $ ghcSymbolStr
 
 ghcSymbolString :: F.Symbol -> String
 ghcSymbolString = T.unpack . fst . T.breakOn "##" . F.symbolText
--- ghcSymbolString = symbolString . dropModuleUnique
 
 --------------------------------------------------------------------------------
 -- | It's possible that we have already resolved the 'Name' we are looking for,
@@ -234,7 +246,7 @@ ghcSymbolString = T.unpack . fst . T.breakOn "##" . F.symbolText
 -- (@GHC.Types.EQ@) will likely not be in scope, so we store our own mapping of
 -- fully-qualified 'Name's to 'Var's and prefer pulling 'Var's from it.
 --------------------------------------------------------------------------------
-lookupGhcVar :: GhcLookup a => a -> BareM Var
+lookupGhcVar :: (GhcLookup a) => a -> BareM Var
 lookupGhcVar x = do
   env <- gets varEnv
   case M.lookup (F.symbol x) env of
@@ -245,6 +257,31 @@ lookupGhcVar x = do
     fv (AnId x)                   = Just (0, x)
     fv (AConLike (RealDataCon x)) = Just (1, dataConWorkId x)
     fv _                          = Nothing
+
+-- | Specialized version of the above to deal with 'WorkerId' of the form 
+--   'Foo.$WCtor' which crash the GHC parser. Sigh.
+
+lookupGhcWrkVar :: F.LocSymbol -> BareM Var
+lookupGhcWrkVar wx = 
+  lookupGhcThing "variable" fv (Just varName) x `catchError` \_ ->
+  lookupGhcThing "variable or data constructor" fv (Just dataName) x
+  where
+    x                             = F.notracepp msg (fixWorkSymbol <$> wx)
+    msg                           = "lookupGhcWrkVar wx = " ++ F.showpp wx
+    fv (AnId z)                   = Just (0, z)
+    fv (AConLike (RealDataCon z)) = Just (1, dataConWorkId z)
+    fv _                          = Nothing
+
+fixWorkSymbol :: F.Symbol -> F.Symbol 
+fixWorkSymbol s   = maybe s reQual (F.stripPrefix wrkPrefix x) 
+  where
+    isQual        = F.lengthSym m > 0
+    reQual z
+      | isQual    = GM.qualifySymbol m z 
+      | otherwise = z 
+    (m, x)        = GM.splitModuleName s 
+    wrkPrefix     = "$W"
+
 
 lookupGhcDnTyCon :: String -> DataName -> BareM TyCon
 lookupGhcDnTyCon src (DnName s)
@@ -299,35 +336,12 @@ lookupGhcTyCon src s = do
     err = "type constructor or class\n " ++ src
 
 lookupGhcDataCon :: Located F.Symbol -> BareM DataCon
-lookupGhcDataCon dc = case lookupWiredDataCon (val dc) of
+lookupGhcDataCon dc = case lookupWiredDataCon (F.notracepp "lookupGhcDatacon" $ val dc) of
                         Just x  -> return x
                         Nothing -> lookupGhcDataCon' dc
 
 lookupWiredDataCon :: F.Symbol ->  Maybe DataCon
 lookupWiredDataCon x = M.lookup x wiredDataCons 
-
-{-                         
-lookupWiredDataCon dc 
-  | Just n <- isTupleDC dc
-  = Just (tupleDataCon Boxed n)
-  | dc == "[]"
-  = Just nilDataCon
-  | dc == ":"
-  = Just consDataCon
-  | dc == "GHC.Base.Nothing"
-  = Just nothingDataCon
-  | dc == "GHC.Base.Just"
-  = Just justDataCon
-  | otherwise
-  = Nothing
-
-isTupleDC :: F.Symbol -> Maybe Int
-isTupleDC zs
-  | "(," `isPrefixOfSym` zs
-  = Just $ lengthSym zs - 1
-  | otherwise
-  = Nothing
--}
 
 wiredDataCons :: M.HashMap F.Symbol DataCon 
 wiredDataCons = M.fromList 

--- a/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -14,13 +14,10 @@ import           Var
 import           Control.Monad.State
 import           Data.Char                           (isUpper)
 import           Text.Parsec.Pos
-
 import qualified Data.HashMap.Strict                 as M
-
--- import           Language.Fixpoint.Misc              (traceShow)
--- import qualified Language.Fixpoint.Types.Names       as F -- (prims, unconsSym)
 import qualified Language.Fixpoint.Types            as F -- (prims, unconsSym)
 import           Language.Fixpoint.Types (Expr(..), Sort(..))
+import qualified Language.Haskell.Liquid.GHC.Misc   as GM 
 import           Language.Haskell.Liquid.Misc        (secondM, third3M)
 import           Language.Haskell.Liquid.Types
 import           Language.Haskell.Liquid.Bare.Env
@@ -82,18 +79,18 @@ resolveCtor ls = do
     Nothing  -> resolveCtorVar ls
 
 resolveCtorVar :: LocSymbol -> BareM LocSymbol
-resolveCtorVar ls = do
+resolveCtorVar ls = do 
   v <- lookupGhcVar ls
   let qs = F.symbol v
   addSym (qs, v)
-  return $ F.atLoc ls qs
-  -- Loc l l' qs
+  return (F.atLoc ls qs)
 
 isSpecialSym :: F.Symbol -> BareM Bool
 isSpecialSym s = do
   env0 <- gets (typeAliases . rtEnv)
-  return $ or [s `elem` F.prims, M.member s env0]
-
+  return $ or [s `elem` F.prims
+              , M.member s env0
+              , GM.isWorker s ]
 
 addSym :: MonadState BareEnv m => (F.Symbol, Var) -> m ()
 addSym (x, v) = modify $ \be -> be { varEnv = M.insert x v (varEnv be) } --  `L.union` [x] } -- TODO: OMG THIS IS THE SLOWEST THING IN THE WORLD!

--- a/src/Language/Haskell/Liquid/Bare/Spec.hs
+++ b/src/Language/Haskell/Liquid/Bare/Spec.hs
@@ -162,7 +162,7 @@ varSymbols f vs = concatMapM go
     locVar v    = (getSourcePos v, v)
     go (s, ns)  = case M.lookup (val s) lvs of
                     Just lvs -> return  ((, ns) <$> varsAfter f s lvs)
-                    Nothing  -> ((:[]) . (,ns)) <$> lookupGhcVar (F.tracepp "varSymbols" s)
+                    Nothing  -> ((:[]) . (,ns)) <$> lookupGhcVar s
 
 varsAfter :: ([b] -> [b]) -> Located a -> [(F.SourcePos, b)] -> [b]
 varsAfter f s lvs

--- a/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -18,6 +18,7 @@ module Language.Haskell.Liquid.GHC.Misc where
 
 import           Class                                      (classKey)
 import           Data.String
+import qualified Data.List as L
 import           PrelNames                                  (fractionalClassKeys)
 import           FamInstEnv
 import           Debug.Trace
@@ -495,7 +496,6 @@ symbolTyCon x i n = stringTyCon x i (symbolString n)
 symbolTyVar :: Symbol -> TyVar
 symbolTyVar n = stringTyVar (symbolString n)
 
-
 localVarSymbol ::  Var -> Symbol
 localVarSymbol v
   | us `isSuffixOfSym` vs = vs
@@ -505,7 +505,9 @@ localVarSymbol v
     vs                    = exportedVarSymbol v 
 
 exportedVarSymbol :: Var -> Symbol
-exportedVarSymbol = symbol . getName            
+exportedVarSymbol x = notracepp msg . symbol . getName $ x            
+  where 
+    msg = "exportedVarSymbol: " ++ showPpr x 
 
 qualifiedNameSymbol :: Name -> Symbol
 qualifiedNameSymbol n = symbol $ concatFS [modFS, occFS, uniqFS]
@@ -675,6 +677,13 @@ isDictionary = isPrefixOfSym "$f" . dropModuleNames . symbol
 
 isInternal :: Symbolic a => a -> Bool
 isInternal   = isPrefixOfSym "$"  . dropModuleNames . symbol
+
+isWorker :: Symbolic a => a -> Bool 
+isWorker s = notracepp ("isWorkerSym: s = " ++ ss) $ "$W" `L.isInfixOf` ss 
+  where 
+    ss     = symbolString (symbol s)
+
+
 
 stripParens :: T.Text -> T.Text
 stripParens t = fromMaybe t (strip t)


### PR DESCRIPTION
With GADTs etc, we have to resolve names that look like `Model.$WUserVerkey` which really should be `Model.UserVerkey`, as the former name crashes the GHC lookup parser. This works around that. Hopefully.