### PR TITLE
Ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,22 @@ To additionally turn on _proof by logical evaluation_ use the option
 
 You can see many examples of proofs by logical evaluation in `benchmarks/popl18/ple/pos`
 
+This flag is **global** and will symbolically evaluate all the terms that appear in the specifications.
+
+As an alternative, the `liquidinstanceslocal` flag has local behavior. [See](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/benchmarks/proofautomation/pos/Unification.hs)
+
+```
+{-@ LIQUID "--automatic-instances=liquidinstanceslocal" @-}
+```
+
+will only evaluate terms appearing in the specifications
+of the function `theorem`, in the function `theorem` is
+annotated for automatic instantiation using the following
+liquid annotation
+
+```
+{-@ automatic-instances theorem @-}
+```
 
 Incremental Checking
 --------------------
@@ -333,6 +349,22 @@ By default, the inferred types will have fully qualified module names.
 To use unqualified names, much easier to read, use:
 
     --short-names
+
+Disabling Checks on Functions
+-----------------------------
+
+You can _disable_ checking of a particular function (e.g. because it is unsafe,
+or somehow not currently outside the scope of LH) by using the `ignore` directive.
+
+For example,
+
+```haskell
+{-@ ignore foo @-}
+```
+
+will _disable_ the checking of the code for the top-level binder `foo`.
+
+See `tests/pos/Ignores.hs` for an example.
 
 
 Totality Check
@@ -1080,7 +1112,7 @@ The above definition
     then the auto generated singleton type is overwritten.
 
 Inlines 
--------------------
+-------
 
 The `inline`  lets you use a Haskell function in a type specification. 
 
@@ -1432,25 +1464,3 @@ Suppose that the current version of Liquid Haskell is `A.B.C.D`:
 
 + The `A` component shall be updated at the sole discretion of the project owners.
 
-Proof Automation
-----------------
-The `liquidinstances` automatically generates proof terms using symbolic evaluation. [See](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/benchmarks/proofautomation/pos/MonoidList.hs).
-
-```
-{-@ LIQUID "--automatic-instances=liquidinstances" @-}
-```
-
-This flag is **global** and will symbolically evaluation all the terms that appear in the specifications.
-
-As an alternative, the `liquidinstanceslocal` flag has local behavior. [See](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/benchmarks/proofautomation/pos/Unification.hs)
-
-```
-{-@ LIQUID "--automatic-instances=liquidinstanceslocal" @-}
-```
-
-will only evaluate terms appearing in the specifications of the function `theorem`, in the function `theorem` is annotated
-for automatic instantiation using the following liquid annotation
-
-```
-{-@ automatic-instances theorem @-}
-```

--- a/include/GHC/Base.spec
+++ b/include/GHC/Base.spec
@@ -25,8 +25,12 @@ fst (a,b) = a
 measure snd :: (a,b) -> b
 snd (a,b) = b
 
-qualif Fst(v:a, y:b): (v = (fst y))
-qualif Snd(v:a, y:b): (v = (snd y))
+// qualif Fst(v:a, y:b): (v = (fst y))
+// qualif Snd(v:a, y:b): (v = (snd y))
+
+qualif Fst(__v:a, __y:b): (__v = (fst __y))
+qualif Snd(__v:a, __y:b): (__v = (snd __y))
+
 
 invariant {v: [a] | len v >= 0 }
 map       :: (a -> b) -> xs:[a] -> {v: [b] | len v == len xs}

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -519,6 +519,7 @@ emptySpec cfg = SP
   , gsQualifiers = mempty
   , gsADTs       = mempty
   , gsTgtVars    = mempty
+  , gsIgnoreVars = mempty
   , gsDecr       = mempty
   , gsTexprs     = mempty
   , gsNewTypes   = mempty
@@ -549,12 +550,15 @@ makeGhcSpec0 :: Config
              -> GhcSpec
              -> BareM GhcSpec
 makeGhcSpec0 cfg defVars exports name adts ignoreVars sp = do
-  targetVars <- makeTargetVars name defVars (checks cfg) ignoreVars
-  return      $ sp { gsConfig  = cfg
-                   , gsExports = exports
-                   , gsTgtVars = targetVars
-                   , gsADTs    = adts
-                   }
+  targetVars <- makeTargetVars name defVars (checks cfg) 
+  igVars     <- makeIgnoreVars name defVars ignoreVars 
+  return      $ sp 
+    { gsConfig     = cfg
+    , gsExports    = exports
+    , gsTgtVars    = targetVars
+    , gsADTs       = adts
+    , gsIgnoreVars = igVars 
+    }
 
 makeGhcSpec1 :: [(Symbol, Var)]
              -> [Var]

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -430,7 +430,7 @@ makeGhcSpec' cfg file cbs fiTcs tcs instenv vars defVars exports specs0 = do
   syms2    <- symbolVarMap (varInModule name) (vars ++ map fst cs') fSyms
   let syms  = syms0 ++ syms1 ++ syms2
   let su    = mkSubst [ (x, mkVarExpr v) | (x, v) <- syms ]
-  makeGhcSpec0 cfg defVars exports name adts (emptySpec cfg)
+  makeGhcSpec0 cfg defVars exports name adts (Ms.ignores fullSpec) (emptySpec cfg) 
     >>= makeGhcSpec1 syms vars defVars embs tyi exports name sigs (recSs ++ asms) cs'  ms' cms' su
     >>= makeGhcSpec2 invs ntys ialias measures su syms
     >>= makeGhcSpec3 (datacons ++ cls) tycons embs syms
@@ -545,15 +545,16 @@ makeGhcSpec0 :: Config
              -> NameSet
              -> ModName
              -> [F.DataDecl]
+             -> S.HashSet LocSymbol
              -> GhcSpec
              -> BareM GhcSpec
-makeGhcSpec0 cfg defVars exports name adts sp
-  = do targetVars <- makeTargetVars name defVars $ checks cfg
-       return      $ sp { gsConfig  = cfg
-                        , gsExports = exports
-                        , gsTgtVars = targetVars
-                        , gsADTs    = adts
-                        }
+makeGhcSpec0 cfg defVars exports name adts ignoreVars sp = do
+  targetVars <- makeTargetVars name defVars (checks cfg) ignoreVars
+  return      $ sp { gsConfig  = cfg
+                   , gsExports = exports
+                   , gsTgtVars = targetVars
+                   , gsADTs    = adts
+                   }
 
 makeGhcSpec1 :: [(Symbol, Var)]
              -> [Var]

--- a/src/Language/Haskell/Liquid/Bare/Spec.hs
+++ b/src/Language/Haskell/Liquid/Bare/Spec.hs
@@ -192,14 +192,15 @@ makeTargetVars :: ModName -> [Var] -> [String] -> BareM [Var]
 makeTargetVars name vars checkVars = do 
   env          <- gets hscEnv
   checkNames   <- mkNames env name (dummyLoc . prefix <$> checkVars)
+  return        [ v | v <- vars, varName v `elem` checkNames ] 
+  where
+    prefix s    = qualifySymbol (F.symbol name) (F.symbol s)
   -- _ignoreNames <- mkNames env (S.toList ignoreVars)
   -- checkNames  <- liftIO $ concatMapM (lookupName env name (Just NS.varName)) (dummyLoc . prefix <$> checkVars)
   -- ignoreNames <- liftIO $ concatMapM (lookupName env name (Just NS.varName)) (S.toList ignoreVars)
   -- let vars' = if null checkNames then vars else filter ((`elem` checkNames) . varName) vars 
   -- return [ v | v <- vars', varName v `notElem` ignoreNames ]
-  return        [ v | v <- vars, varName v `elem` checkNames ] 
-  where
-    prefix s    = qualifySymbol (F.symbol name) (F.symbol s)
+
     
 mkNames :: HscTypes.HscEnv -> ModName -> [LocSymbol] -> BareM [Name.Name]
 mkNames env name = liftIO . concatMapM (lookupName env name (Just NS.varName))

--- a/src/Language/Haskell/Liquid/Bare/Spec.hs
+++ b/src/Language/Haskell/Liquid/Bare/Spec.hs
@@ -15,6 +15,7 @@ module Language.Haskell.Liquid.Bare.Spec (
   , makeDefs
   , makeHMeas, makeHInlines
   , makeTExpr
+  , makeIgnoreVars
   , makeTargetVars
   , makeAssertSpec
   , makeAssumeSpec
@@ -35,6 +36,8 @@ import           Prelude                                    hiding (error)
 import           TyCon
 import           Var
 
+import qualified Name 
+import qualified HscTypes 
 import qualified OccName as NS
 import           Control.Monad.Except
 import           Control.Monad.State
@@ -179,18 +182,27 @@ varsAfter f s lvs
 --------------------------------------------------------------------------------
 -- | API: Bare Refinement Types ------------------------------------------------
 --------------------------------------------------------------------------------
-makeTargetVars :: ModName -> [Var] -> [String] -> S.HashSet LocSymbol -> BareM [Var]
-makeTargetVars name vars checkVars ignoreVars = do 
+makeIgnoreVars :: ModName -> [Var] -> S.HashSet LocSymbol -> BareM [Var]
+makeIgnoreVars name vars ignores = do 
+  env         <- gets hscEnv 
+  ignoreNames <- mkNames env name (S.toList ignores)
+  return        [ v | v <- vars, varName v `elem` ignoreNames ] 
+
+makeTargetVars :: ModName -> [Var] -> [String] -> BareM [Var]
+makeTargetVars name vars checkVars = do 
   env          <- gets hscEnv
-  checkNames   <- mkNames env (dummyLoc . prefix <$> checkVars)
-  ignoreNames  <- mkNames env (S.toList ignoreVars)
+  checkNames   <- mkNames env name (dummyLoc . prefix <$> checkVars)
+  -- _ignoreNames <- mkNames env (S.toList ignoreVars)
   -- checkNames  <- liftIO $ concatMapM (lookupName env name (Just NS.varName)) (dummyLoc . prefix <$> checkVars)
   -- ignoreNames <- liftIO $ concatMapM (lookupName env name (Just NS.varName)) (S.toList ignoreVars)
-  let vars' = if null checkNames then vars else filter ((`elem` checkNames) . varName) vars 
-  return [ v | v <- vars', varName v `notElem` ignoreNames ]
+  -- let vars' = if null checkNames then vars else filter ((`elem` checkNames) . varName) vars 
+  -- return [ v | v <- vars', varName v `notElem` ignoreNames ]
+  return        [ v | v <- vars, varName v `elem` checkNames ] 
   where
-    mkNames env = liftIO . concatMapM (lookupName env name (Just NS.varName))
     prefix s    = qualifySymbol (F.symbol name) (F.symbol s)
+    
+mkNames :: HscTypes.HscEnv -> ModName -> [LocSymbol] -> BareM [Name.Name]
+mkNames env name = liftIO . concatMapM (lookupName env name (Just NS.varName))
 
 makeAssertSpec :: ModName -> Config -> [Var] -> [Var] -> (ModName, Ms.BareSpec)
                -> BareM [(ModName, Var, LocSpecType)]

--- a/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -729,6 +729,19 @@ showCBs untidy
   | untidy    = Out.showSDocDebug unsafeGlobalDynFlags . ppr . tidyCBs
   | otherwise = showPpr
 
+
+ignoreCoreBinds :: [Var] -> [CoreBind] -> [CoreBind]
+ignoreCoreBinds vs cbs 
+  | null vs         = cbs 
+  | otherwise       = concatMap go cbs
+  where
+    go :: CoreBind -> [CoreBind]
+    go b@(NonRec x _) 
+      | x `elem` vs = [] 
+      | otherwise   = [b] 
+    go (Rec xes)    = [Rec (filter ((`notElem` vs) . fst) xes)]
+
+
 findVarDef :: Symbol -> [CoreBind] -> Maybe (Var, CoreExpr)
 findVarDef x cbs = case xCbs of
                      (NonRec v def   : _ ) -> Just (v, def)

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -40,7 +40,7 @@ import           Language.Haskell.Liquid.Types.RefType (applySolution)
 import           Language.Haskell.Liquid.UX.Errors
 import           Language.Haskell.Liquid.UX.CmdLine
 import           Language.Haskell.Liquid.UX.Tidy
-import           Language.Haskell.Liquid.GHC.Misc (showCBs) -- howPpr)
+import           Language.Haskell.Liquid.GHC.Misc (showCBs, ignoreCoreBinds) -- howPpr)
 import           Language.Haskell.Liquid.GHC.Interface
 import           Language.Haskell.Liquid.Constraint.Generate
 import           Language.Haskell.Liquid.Constraint.ToFixpoint
@@ -142,10 +142,11 @@ newPrune cfg cbs tgt info
   | not (null vs) = return . Right $ [DC.thin cbs sp vs]
   | timeBinds cfg = return . Right $ [DC.thin cbs sp [v] | v <- exportedVars info ]
   | diffcheck cfg = maybeEither cbs <$> DC.slice tgt cbs sp
-  | otherwise     = return  (Left cbs)
+  | otherwise     = return $ Left (ignoreCoreBinds ignores cbs)
   where
-    vs            = gsTgtVars sp
-    sp            = spec    info
+    ignores       = gsIgnoreVars sp 
+    vs            = gsTgtVars    sp
+    sp            = spec       info
 
 -- topLevelBinders :: GhcSpec -> [Var]
 -- topLevelBinders = map fst . tySigs

--- a/src/Language/Haskell/Liquid/Measure.hs
+++ b/src/Language/Haskell/Liquid/Measure.hs
@@ -78,6 +78,7 @@ data Spec ty bndr  = Spec
   , hmeas      :: !(S.HashSet LocSymbol)         -- ^ Binders to turn into measures using haskell definitions
   , hbounds    :: !(S.HashSet LocSymbol)         -- ^ Binders to turn into bounds using haskell definitions
   , inlines    :: !(S.HashSet LocSymbol)         -- ^ Binders to turn into logic inline using haskell definitions
+  , ignores    :: !(S.HashSet LocSymbol)         -- ^ Binders to ignore during checking; that is DON't check the corebind. 
   , autosize   :: !(S.HashSet LocSymbol)         -- ^ Type Constructors that get automatically sizing info
   , pragmas    :: ![Located String]              -- ^ Command-line configurations passed in through source
   , cmeasures  :: ![Measure ty ()]               -- ^ Measures attached to a type-class
@@ -173,6 +174,7 @@ instance Monoid (Spec ty bndr) where
            , hmeas      = S.union   (hmeas    s1)  (hmeas    s2)
            , hbounds    = S.union   (hbounds  s1)  (hbounds  s2)
            , inlines    = S.union   (inlines  s1)  (inlines  s2)
+           , ignores    = S.union   (ignores  s1)  (ignores  s2)
            , autosize   = S.union   (autosize s1)  (autosize s2)
            , bounds     = M.union   (bounds   s1)  (bounds   s2)
            , defs       = M.union   (defs     s1)  (defs     s2)
@@ -204,6 +206,7 @@ instance Monoid (Spec ty bndr) where
            , reflects   = S.empty
            , hbounds    = S.empty
            , inlines    = S.empty
+           , ignores    = S.empty
            , autosize   = S.empty
            , pragmas    = []
            , cmeasures  = []

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -873,6 +873,7 @@ data Pspec ty ctor
   | HMeas   LocSymbol
   | Reflect LocSymbol
   | Inline  LocSymbol
+  | Ignore  LocSymbol
   | ASize   LocSymbol
   | HBound  LocSymbol
   | PBound  (Bound ty Expr)
@@ -956,6 +957,7 @@ mkSpec name xs         = (name,) $ Measure.qualifySpec (symbol name) Measure.Spe
   , Measure.reflects   = S.fromList [s | Reflect s <- xs]
   , Measure.hmeas      = S.fromList [s | HMeas  s <- xs]
   , Measure.inlines    = S.fromList [s | Inline s <- xs]
+  , Measure.ignores    = S.fromList [s | Ignore s <- xs]
   , Measure.autosize   = S.fromList [s | ASize  s <- xs]
   , Measure.hbounds    = S.fromList [s | HBound s <- xs]
   , Measure.defs       = M.fromList [d | Define d <- xs]
@@ -981,6 +983,7 @@ specP
     <|> (reserved "infixr"        >> liftM BFix    infixrP  )
     <|> (reserved "infix"         >> liftM BFix    infixP   )
     <|> (fallbackSpecP "inline"     (liftM Inline  inlineP  ))
+    <|> (fallbackSpecP "ignore"     (liftM Ignore  inlineP  ))
 
     <|> (fallbackSpecP "bound"    (((liftM PBound  boundP   )
                                 <|> (liftM HBound  hboundP  ))))

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -356,6 +356,7 @@ data GhcSpec = SP
                                                  -- e.g tests/pos/qualTest.hs
   , gsADTs       :: ![F.DataDecl]                -- ^ ADTs extracted from Haskell 'data' definitions
   , gsTgtVars    :: ![Var]                       -- ^ Top-level Binders To Verify (empty means ALL binders)
+  , gsIgnoreVars :: ![Var]                       -- ^ Top-level Binders To NOT Verify (empty means ALL binders)
   , gsDecr       :: ![(Var, [Int])]              -- ^ Lexicographically ordered size witnesses for termination
   , gsTexprs     :: ![(Var, [F.Located Expr])]     -- ^ Lexicographically ordered expressions for termination
   , gsNewTypes   :: ![(TyCon, LocSpecType)]      -- ^ Mapping of 'newtype' type constructors with their refined types.

--- a/src/Language/Haskell/Liquid/Types.hs
+++ b/src/Language/Haskell/Liquid/Types.hs
@@ -332,8 +332,8 @@ type Qualifier = F.Qualifier
 -- | The following is the overall type for /specifications/ obtained from
 -- parsing the target source and dependent libraries
 
-data GhcSpec = SP {
-    gsTySigs   :: ![(Var, LocSpecType)]          -- ^ Asserted Reftypes
+data GhcSpec = SP 
+  { gsTySigs   :: ![(Var, LocSpecType)]          -- ^ Asserted Reftypes
   , gsAsmSigs  :: ![(Var, LocSpecType)]          -- ^ Assumed Reftypes
   , gsInSigs   :: ![(Var, LocSpecType)]          -- ^ Auto generated Signatures
   , gsCtors    :: ![(Var, LocSpecType)]          -- ^ Data Constructor Measure Sigs

--- a/tests/pos/Ignores.hs
+++ b/tests/pos/Ignores.hs
@@ -1,0 +1,8 @@
+module Ignores where 
+
+inc :: Int -> Int 
+inc x = x - 1 
+
+{-@ inc :: Nat -> Nat @-}
+
+{-@ ignore inc @-}

--- a/tests/pos/Ignores.hs
+++ b/tests/pos/Ignores.hs
@@ -1,8 +1,7 @@
 module Ignores where 
 
+{-@ ignore inc @-}
+{-@ inc :: Nat -> Nat @-}
 inc :: Int -> Int 
 inc x = x - 1 
 
-{-@ inc :: Nat -> Nat @-}
-
-{-@ ignore inc @-}

--- a/tests/todo/false.hs
+++ b/tests/todo/false.hs
@@ -1,12 +1,8 @@
-module Foo where
 
-{-@ LIQUID "--no-termination" @-}
-{-@ LIQUID "--native" @-}
+{-@ diverge :: Int -> {false} @-}
+{-@ lazy diverge @-}
+diverge :: Int -> Int 
+diverge n = diverge n
 
-{-@ foo :: {v:a | false} @-}
-foo  = foo
-
-
-nat :: Int
-{-@ nat :: Nat @-}
-nat = 42
+{-@ one_eq_two :: { 1 == 2 } @-}
+one_eq_two = diverge 0


### PR DESCRIPTION
Add an `{-@ ignore foo @-}` annotation to explicitly disable checking the body for function `foo`.