### PR TITLE
Fix cvc4 URL

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,7 @@ To run `liquid` you need to install:
 Download and install *at least one* of
 
 + [Z3](https://github.com/Z3Prover/z3/releases) or [Microsoft official binary](https://www.microsoft.com/en-us/download/details.aspx?id=52270)
-+ [CVC4](http://cvc4.cs.nyu.edu/)
++ [CVC4](http://cvc4.cs.stanford.edu/web/)
 + [MathSat](http://mathsat.fbk.eu/download.html)
 
 Note: It should be findable from PATH. LiquidHaskell is executing it as a child process.

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ To run a different solver (supporting SMTLIB2) do:
 
 Currently, LiquidHaskell supports
 
-+ [CVC4](http://cvc4.cs.nyu.edu/)
++ [CVC4](http://cvc4.cs.stanford.edu/web/)
 + [MathSat](http://mathsat.fbk.eu/download.html )
 
 To use these solvers, you must install the corresponding binaries

--- a/docs/slides/plpv14/lhs/00_Index.lhs
+++ b/docs/slides/plpv14/lhs/00_Index.lhs
@@ -38,7 +38,7 @@ Install
   <br>
 
   + `http://z3.codeplex.com`
-  + `http://cvc4.cs.nyu.edu`
+  + `http://cvc4.cs.stanford.edu/web/`
   + `http://mathsat.fbk.eu`
 
 </div>

--- a/docs/slides/plpv14/lhs/00_Index.lhs.markdown
+++ b/docs/slides/plpv14/lhs/00_Index.lhs.markdown
@@ -38,7 +38,7 @@ Install
   <br>
 
   + `http://z3.codeplex.com`
-  + `http://cvc4.cs.nyu.edu`
+  + `http://cvc4.cs.stanford.edu/web/`
   + `http://mathsat.fbk.eu`
 
 </div>


### PR DESCRIPTION
First of all, thanks for LiquidHaskell!

During the installation process, I discovered that `cvc4` URL opened a blank page, so I tried to fix the link everywhere you used it.

Hope this is helpful.