### PR TITLE
Add span-support in JSON

### DIFF
--- a/src/Language/Haskell/Liquid/UX/ACSS.hs
+++ b/src/Language/Haskell/Liquid/UX/ACSS.hs
@@ -10,6 +10,7 @@ module Language.Haskell.Liquid.UX.ACSS (
   ) where
 
 import Prelude hiding (error)
+import qualified SrcLoc 
 
 import Language.Haskell.HsColour.Anchors
 import Language.Haskell.HsColour.Classify as Classify
@@ -22,13 +23,16 @@ import qualified Data.HashMap.Strict as M
 import Data.List   (find, isPrefixOf, findIndex, elemIndices, intercalate)
 import Data.Char   (isSpace)
 import Text.Printf
+import Text.PrettyPrint.HughesPJ            (Doc) 
 import Language.Haskell.Liquid.GHC.Misc
 import Language.Haskell.Liquid.Types.Errors (panic, impossible)
+import Language.Haskell.Liquid.Types.Types  (AnnInfo) 
 
-data AnnMap  = Ann {
-    types  :: M.HashMap Loc (String, String) -- ^ Loc -> (Var, Type)
-  , errors :: [(Loc, Loc, String)]           -- ^ List of error intervals
-  , status :: !Status
+data AnnMap  = Ann 
+  { types   :: M.HashMap Loc (String, String) -- ^ Loc -> (Var, Type)
+  , errors  :: [(Loc, Loc, String)]           -- ^ List of error intervals
+  , status  :: !Status
+  , sptypes :: ![(SrcLoc.RealSrcSpan, (String, String)) ]-- ^ Type information with spans
   }
 
 data Status = Safe | Unsafe | Error | Crash
@@ -93,7 +97,7 @@ annotTokenise baseLoc tx (src, annm) = zipWith (\(x,y) z -> (x,y,z)) toks annots
     linWidth   = length $ show $ length $ lines src
 
 spanAnnot :: Int -> AnnMap -> Loc -> Annotation
-spanAnnot w (Ann ts es _) span = A t e b
+spanAnnot w (Ann ts es _ _) span = A t e b
   where
     t = fmap snd (M.lookup span ts)
     e = fmap (\_ -> "ERROR") $ find (span `inRange`) [(x,y) | (x,y,_) <- es]
@@ -177,7 +181,7 @@ splitSrcAndAnns ::  String -> (String, AnnMap)
 splitSrcAndAnns s =
   let ls = lines s in
   case findIndex (breakS ==) ls of
-    Nothing -> (s, Ann M.empty [] Safe)
+    Nothing -> (s, Ann M.empty [] Safe mempty)
     Just i  -> (src, ann)
                where (codes, _:mname:annots) = splitAt i ls
                      ann   = annotParse mname $ dropWhile isSpace $ unlines annots
@@ -198,7 +202,7 @@ breakS :: [Char]
 breakS = "MOUSEOVER ANNOTATIONS"
 
 annotParse :: String -> String -> AnnMap
-annotParse mname s = Ann (M.fromList ts) [(x,y,"") | (x,y) <- es] Safe
+annotParse mname s = Ann (M.fromList ts) [(x,y,"") | (x,y) <- es] Safe mempty
   where
     (ts, es)       = partitionEithers $ parseLines mname 0 $ lines s
 
@@ -235,8 +239,9 @@ parseLines _ i _
   = panic Nothing $ "Error Parsing Annot Input on Line: " ++ show i
 
 instance Show AnnMap where
-  show (Ann ts es _ ) =  "\n\n" ++ (concatMap ppAnnotTyp $ M.toList ts)
-                                ++ (concatMap ppAnnotErr [(x,y) | (x,y,_) <- es])
+  show (Ann ts es _ _) =  "\n\n" 
+                      ++ (concatMap ppAnnotTyp $ M.toList ts)
+                      ++ (concatMap ppAnnotErr [(x,y) | (x,y,_) <- es])
 
 ppAnnotTyp :: (PrintfArg t, PrintfType t1) => (Loc, (t, String)) -> t1
 ppAnnotTyp (L (l, c), (x, s))     = printf "%s\n%d\n%d\n%d\n%s\n\n\n" x l c (length $ lines s) s

--- a/src/Language/Haskell/Liquid/UX/ACSS.hs
+++ b/src/Language/Haskell/Liquid/UX/ACSS.hs
@@ -26,7 +26,7 @@ import Text.Printf
 import Text.PrettyPrint.HughesPJ            (Doc) 
 import Language.Haskell.Liquid.GHC.Misc
 import Language.Haskell.Liquid.Types.Errors (panic, impossible)
-import Language.Haskell.Liquid.Types.Types  (AnnInfo) 
+import Language.Haskell.Liquid.Types        (AnnInfo) 
 
 data AnnMap  = Ann 
   { types   :: M.HashMap Loc (String, String) -- ^ Loc -> (Var, Type)

--- a/src/Language/Haskell/Liquid/UX/ACSS.hs
+++ b/src/Language/Haskell/Liquid/UX/ACSS.hs
@@ -23,10 +23,10 @@ import qualified Data.HashMap.Strict as M
 import Data.List   (find, isPrefixOf, findIndex, elemIndices, intercalate)
 import Data.Char   (isSpace)
 import Text.Printf
-import Text.PrettyPrint.HughesPJ            (Doc) 
+-- import Text.PrettyPrint.HughesPJ            (Doc) 
 import Language.Haskell.Liquid.GHC.Misc
 import Language.Haskell.Liquid.Types.Errors (panic, impossible)
-import Language.Haskell.Liquid.Types        (AnnInfo) 
+-- import Language.Haskell.Liquid.Types        (AnnInfo) 
 
 data AnnMap  = Ann 
   { types   :: M.HashMap Loc (String, String) -- ^ Loc -> (Var, Type)

--- a/src/Language/Haskell/Liquid/UX/ACSS.hs
+++ b/src/Language/Haskell/Liquid/UX/ACSS.hs
@@ -23,10 +23,8 @@ import qualified Data.HashMap.Strict as M
 import Data.List   (find, isPrefixOf, findIndex, elemIndices, intercalate)
 import Data.Char   (isSpace)
 import Text.Printf
--- import Text.PrettyPrint.HughesPJ            (Doc) 
 import Language.Haskell.Liquid.GHC.Misc
 import Language.Haskell.Liquid.Types.Errors (panic, impossible)
--- import Language.Haskell.Liquid.Types        (AnnInfo) 
 
 data AnnMap  = Ann 
   { types   :: M.HashMap Loc (String, String) -- ^ Loc -> (Var, Type)

--- a/src/Language/Haskell/Liquid/UX/Annotate.hs
+++ b/src/Language/Haskell/Liquid/UX/Annotate.hs
@@ -448,8 +448,8 @@ instance ToJSON ACSS.AnnMap where
     where 
       toJ (sp, (x,t)) = object [ "start" .= toJSON (srcSpanStartLoc sp) 
                                , "stop"  .= toJSON (srcSpanEndLoc   sp) 
-                               , "var"   .= toJSON x 
-                               , "type"  .= toJSON t 
+                               , "ident" .= toJSON x 
+                               , "ann"  .= toJSON t 
                                ] 
                       
 annErrors :: ACSS.AnnMap -> AnnErrors

--- a/src/Language/Haskell/Liquid/UX/Annotate.hs
+++ b/src/Language/Haskell/Liquid/UX/Annotate.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE TypeSynonymInstances       #-}
 {-# LANGUAGE FlexibleInstances          #-}
 
-{- LIQUID "--diffcheck" @-}
 
 ---------------------------------------------------------------------------
 -- | This module contains the code that uses the inferred types to generate
@@ -14,10 +13,8 @@
 -- 3. JSON files for the web-demo etc.
 ---------------------------------------------------------------------------
 
-
 module Language.Haskell.Liquid.UX.Annotate
-  ( specAnchor
-  , mkOutput
+  ( mkOutput
   , annotate
   , tokeniseWithLoc
   , annErrors
@@ -67,7 +64,7 @@ import           Language.Haskell.Liquid.Types.RefType
 import           Language.Haskell.Liquid.UX.Errors            ()
 import           Language.Haskell.Liquid.UX.Tidy
 import           Language.Haskell.Liquid.Types                hiding (Located(..), Def(..))
-import           Language.Haskell.Liquid.Types.Specifications
+-- import           Language.Haskell.Liquid.Types.Specifications
 
 
 -- | @output@ creates the pretty printed output
@@ -230,7 +227,12 @@ cssHTML css = unlines
 --   annotations.
 
 mkAnnMap :: Config -> ErrorResult -> AnnInfo Doc -> ACSS.AnnMap
-mkAnnMap cfg res ann     = ACSS.Ann (mkAnnMapTyp cfg ann) (mkAnnMapErr res) (mkStatus res)
+mkAnnMap cfg res ann     = ACSS.Ann 
+                             { ACSS.types   = mkAnnMapTyp cfg ann 
+                             , ACSS.errors  = mkAnnMapErr res 
+                             , ACSS.status  = mkStatus res 
+                             , ACSS.sptypes = mkAnnMapBinders cfg ann
+                             }
 
 mkStatus :: FixResult t -> ACSS.Status
 mkStatus (Safe)          = ACSS.Safe
@@ -255,8 +257,7 @@ cinfoErr e = case pos e of
 mkAnnMapTyp :: Config -> AnnInfo Doc -> M.HashMap Loc (String, String)
 mkAnnMapTyp cfg z = M.fromList $ map (first srcSpanStartLoc) $ mkAnnMapBinders cfg z
 
-mkAnnMapBinders :: Config
-                -> AnnInfo Doc -> [(SrcLoc.RealSrcSpan, (String, String))]
+mkAnnMapBinders :: Config -> AnnInfo Doc -> [(SrcLoc.RealSrcSpan, (String, String))]
 mkAnnMapBinders cfg (AI m)
   = map (second bindStr . head . sortWith (srcSpanEndCol . fst))
   $ groupWith (lineCol . fst) locBinds
@@ -423,6 +424,9 @@ instance ToJSON AnnErrors where
                                    , "message" .= toJSON (dropErrorLoc s)
                                    ]
 
+
+
+
 dropErrorLoc :: String -> String
 dropErrorLoc msg
   | null msg' = msg
@@ -436,11 +440,18 @@ instance (Show k, ToJSON a) => ToJSON (Assoc k a) where
       tshow        = T.pack . show
 
 instance ToJSON ACSS.AnnMap where
-  toJSON a = object [ "types"  .= toJSON (annTypes    a)
-                    , "errors" .= toJSON (annErrors   a)
-                    , "status" .= toJSON (ACSS.status a)
+  toJSON a = object [ "types"   .= toJSON (annTypes     a)
+                    , "errors"  .= toJSON (annErrors    a)
+                    , "status"  .= toJSON (ACSS.status  a)
+                    , "sptypes" .= (toJ <$> ACSS.sptypes a) 
                     ]
-
+    where 
+      toJ (sp, (x,t)) = object [ "start" .= toJSON (srcSpanStartLoc sp) 
+                               , "stop"  .= toJSON (srcSpanEndLoc   sp) 
+                               , "var"   .= toJSON x 
+                               , "type"  .= toJSON t 
+                               ] 
+                      
 annErrors :: ACSS.AnnMap -> AnnErrors
 annErrors = AnnErrors . ACSS.errors
 


### PR DESCRIPTION
Fixes #1352 

This now produces JSON that has a field `sptypes` that is an array of annotations as shown below.

```.json
"sptypes":[
      {
         "start":{
            "line":1,
            "column":1
         },
         "ann":"GHC.Types.Module",
         "ident":"Abs.$trModule",
         "stop":{
            "line":1,
            "column":1
         }
      },
      {
         "start":{
            "line":4,
            "column":1
         },
         "ann":"(GHC.Num.Num a, GHC.Classes.Ord a) => a -> a",
         "ident":"Abs.absN",
         "stop":{
            "line":4,
            "column":5
         }
      },
      {
         "start":{
            "line":4,
            "column":6
         },
         "ann":"a",
         "ident":"x",
         "stop":{
            "line":4,
            "column":7
         }
      },
      {
         "start":{
            "line":4,
            "column":10
         },
         "ann":"GHC.Types.Bool",
         "ident":"lq_anf$##7205759403792801910",
         "stop":{
            "line":4,
            "column":35
         }
      },
      {
         "start":{
            "line":4,
            "column":13
         },
         "ann":"GHC.Types.Bool",
         "ident":"lq_anf$##7205759403792801909",
         "stop":{
            "line":4,
            "column":18
         }
      },
      {
         "start":{
            "line":4,
            "column":15
         },
         "ann":"x1:a -> x2:a -> {v : GHC.Types.Bool | v <=> x1 > x2}",
         "ident":"_",
         "stop":{
            "line":4,
            "column":16
         }
      },
      {
         "start":{
            "line":4,
            "column":32
         },
         "ann":"{VV : a | VV == x}",
         "ident":"x",
         "stop":{
            "line":4,
            "column":34
         }
      },
      {
         "start":{
            "line":7,
            "column":1
         },
         "ann":"GHC.Types.Int -> GHC.Types.Int",
         "ident":"Abs.absI",
         "stop":{
            "line":7,
            "column":5
         }
      },
      {
         "start":{
            "line":7,
            "column":6
         },
         "ann":"GHC.Types.Int",
         "ident":"x",
         "stop":{
            "line":7,
            "column":7
         }
      },
      {
         "start":{
            "line":7,
            "column":10
         },
         "ann":"GHC.Types.Bool",
         "ident":"lq_anf$##7205759403792801918",
         "stop":{
            "line":7,
            "column":35
         }
      },
      {
         "start":{
            "line":7,
            "column":13
         },
         "ann":"GHC.Types.Bool",
         "ident":"lq_anf$##7205759403792801917",
         "stop":{
            "line":7,
            "column":18
         }
      },
      {
         "start":{
            "line":7,
            "column":15
         },
         "ann":"x1:GHC.Types.Int -> x2:GHC.Types.Int -> {v : GHC.Types.Bool | v <=> x1 > x2}",
         "ident":"_",
         "stop":{
            "line":7,
            "column":16
         }
      },
      {
         "start":{
            "line":7,
            "column":32
         },
         "ann":"{v : GHC.Types.Int | v == x}",
         "ident":"x",
         "stop":{
            "line":7,
            "column":34
         }
      },
      {
         "start":{
            "line":12,
            "column":1
         },
         "ann":"GHC.Integer.Type.Integer",
         "ident":"Abs.x0",
         "stop":{
            "line":12,
            "column":3
         }
      },
      {
         "start":{
            "line":12,
            "column":6
         },
         "ann":"GHC.Integer.Type.Integer -> GHC.Integer.Type.Integer",
         "ident":"_",
         "stop":{
            "line":12,
            "column":10
         }
      },
      {
         "start":{
            "line":13,
            "column":1
         },
         "ann":"GHC.Types.Int",
         "ident":"Abs.x1",
         "stop":{
            "line":13,
            "column":3
         }
      },
      {
         "start":{
            "line":13,
            "column":6
         },
         "ann":"{v : GHC.Types.Int -> GHC.Types.Int | v == absI}",
         "ident":"_",
         "stop":{
            "line":13,
            "column":10
         }
      },
      {
         "start":{
            "line":13,
            "column":12
         },
         "ann":"GHC.Types.Int",
         "ident":"lq_anf$##7205759403792801920",
         "stop":{
            "line":13,
            "column":14
         }
      }
   ]
```