### PR TITLE
fix name resolution for dots

### DIFF
--- a/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -645,7 +645,10 @@ unQualifySymbol sym
   | otherwise             = (Nothing, sym) 
 
 splitModuleNameExact :: F.Symbol -> (F.Symbol, F.Symbol)
-splitModuleNameExact x = (GM.takeModuleNames x, GM.dropModuleNames x)
+splitModuleNameExact x' = myTracepp ("splitModuleNameExact for " ++ F.showpp x) 
+                          (GM.takeModuleNames x, GM.dropModuleNames x)
+  where
+    x = GM.stripParensSym x' 
 
 errResolve :: PJ.Doc -> String -> LocSymbol -> UserError 
 errResolve k msg lx = ErrResolve (GM.fSrcSpan lx) k (F.pprint (F.val lx)) (PJ.text msg) 

--- a/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -647,21 +647,20 @@ dropModuleNamesCorrect = F.symbol . go . F.symbolText
              Nothing -> s
 
 takeModuleNames  :: Symbol -> Symbol
-takeModuleNames = F.symbol . go T.empty . F.symbolText
+takeModuleNames  = F.symbol . go [] . F.symbolText
   where
     go acc s = case T.uncons s of
                 Just (c,tl) -> if isUpper c && T.any (== '.') tl
-                                 then go (getModule s) $ snd $ fromJust $ T.uncons $ T.dropWhile (/= '.') s
-                                 else acc 
-                Nothing -> acc 
-    getModule s = T.snoc (T.takeWhile (/= '.') s) '.'
+                                 then go (getModule s:acc) $ snd $ fromJust $ T.uncons $ T.dropWhile (/= '.') s
+                                 else T.intercalate "." (reverse acc) 
+                Nothing -> T.intercalate "." (reverse acc) 
+    getModule s = T.takeWhile (/= '.') s
 
 {- 
-takeModuleNames  = mungeNames initName sepModNames "takeModuleNames: "
+takeModuleNamesOld  = mungeNames initName sepModNames "takeModuleNames: "
   where
     initName msg = symbol . T.intercalate "." . safeInit msg
 -}
-
 dropModuleUnique :: Symbol -> Symbol
 dropModuleUnique = mungeNames headName sepUnique   "dropModuleUnique: "
   where

--- a/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -630,9 +630,12 @@ dropModuleNamesAndUnique :: Symbol -> Symbol
 dropModuleNamesAndUnique = dropModuleUnique . dropModuleNames
 
 dropModuleNames  :: Symbol -> Symbol
+dropModuleNames = dropModuleNamesCorrect 
+{- 
 dropModuleNames = mungeNames lastName sepModNames "dropModuleNames: "
  where
    lastName msg = symbol . safeLast msg
+-}
 
 dropModuleNamesCorrect  :: Symbol -> Symbol
 dropModuleNamesCorrect = F.symbol . go . F.symbolText
@@ -644,15 +647,25 @@ dropModuleNamesCorrect = F.symbol . go . F.symbolText
              Nothing -> s
 
 takeModuleNames  :: Symbol -> Symbol
+takeModuleNames = F.symbol . go T.empty . F.symbolText
+  where
+    go acc s = case T.uncons s of
+                Just (c,tl) -> if isUpper c && T.any (== '.') tl
+                                 then go (getModule s) $ snd $ fromJust $ T.uncons $ T.dropWhile (/= '.') s
+                                 else acc 
+                Nothing -> acc 
+    getModule s = T.snoc (T.takeWhile (/= '.') s) '.'
+
+{- 
 takeModuleNames  = mungeNames initName sepModNames "takeModuleNames: "
   where
     initName msg = symbol . T.intercalate "." . safeInit msg
+-}
 
 dropModuleUnique :: Symbol -> Symbol
 dropModuleUnique = mungeNames headName sepUnique   "dropModuleUnique: "
   where
     headName msg = symbol . safeHead msg
-
 
 cmpSymbol :: Symbol -> Symbol -> Bool
 cmpSymbol coreSym logicSym

--- a/tests/import/lib/ReflectLib3.hs
+++ b/tests/import/lib/ReflectLib3.hs
@@ -1,4 +1,4 @@
-{-@ LIQUID "--exact-data-con"                      @-}
+{-@ LIQUID "--reflection"                      @-}
 {-@ LIQUID "--automatic-instances=liquidinstances" @-}
 
 module ReflectLib3 where

--- a/tests/neg/NameResolution.hs
+++ b/tests/neg/NameResolution.hs
@@ -1,6 +1,6 @@
 module Fixme where
 
-import Prelude hiding ((==))
+import Prelude hiding ((==), (++))
 import Language.Haskell.Liquid.Equational 
 
 
@@ -22,3 +22,6 @@ foo _
   ==.. 2 
 
 
+{-@ (++) :: a -> a -> a @-}
+(++) :: a -> a -> a 
+x ++ _ = x 

--- a/tests/neg/NameResolution.hs
+++ b/tests/neg/NameResolution.hs
@@ -1,0 +1,24 @@
+module Fixme where
+
+import Prelude hiding ((==))
+import Language.Haskell.Liquid.Equational 
+
+
+{-@ bar :: () -> Int @-}
+bar :: () -> Int
+bar _
+  =   1 
+  ==. 2 
+
+
+{-@ (==..) :: x:a -> y:{a | x == y} -> {v:a | v == y && v == x} @-}
+(==..) :: a -> a -> a 
+_ ==.. x = x
+
+{-@ foo :: () -> Int @-}
+foo :: () -> Int
+foo _
+  =   1 
+  ==.. 2 
+
+


### PR DESCRIPTION
Seems that `==.` was not checking intermediate steps because name resolution was wrong and it was ignoring the spec of `==.`. This PR fixes it. 