### PR TITLE
Replace prune unsorted

### DIFF
--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -725,7 +725,7 @@ isSymbolOfVar x v = x == symbol' v
 
 measureTypeToInv :: Bare.Env -> ModName -> (LocSymbol, (Ghc.Var, LocSpecType)) -> ((Maybe Ghc.Var, LocSpecType), Maybe UnSortedExpr)
 measureTypeToInv env name (x, (v, t)) 
-  = tracepp "measureTypeToInv" $ ((Just v, t {val = Bare.qualifyTop env name (F.loc x) mtype}), usorted)
+  = notracepp "measureTypeToInv" $ ((Just v, t {val = Bare.qualifyTop env name (F.loc x) mtype}), usorted)
   where
     trep = toRTypeRep (val t)
     ts   = ty_args  trep

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -674,21 +674,22 @@ makeSpecData src env sigEnv measEnv sig specs = SpData
                        , let tt  = Bare.plugHoles sigEnv name (Bare.LqTV x) t 
                    ]
   , gsMeas       = [ (F.symbol x, uRType <$> t) | (x, t) <- measVars ] 
-  , gsMeasures   = Bare.qualifyTopDummy env name <$> (F.notracepp "MEASURES-1" $ ms1 ++ ms2)
+  , gsMeasures   = Bare.qualifyTopDummy env name <$> (ms1 ++ ms2)
   , gsInvariants = Misc.nubHashOn (F.loc . snd) invs 
   , gsIaliases   = concatMap (makeIAliases env sigEnv) (M.toList specs)
+  , gsUnsorted   = usI ++ (concatMap msUnSorted $ concatMap measures specs)
   }
   where
     measVars     = Bare.meSyms      measEnv -- ms'
                 ++ Bare.meClassSyms measEnv -- cms' 
                 ++ Bare.varMeasures env
-    measures     = Bare.meMeasureSpec measEnv  
-    ms1          = M.elems (Ms.measMap measures)
-    ms2          =          Ms.imeas   measures
+    measuresSp   = Bare.meMeasureSpec measEnv  
+    ms1          = M.elems (Ms.measMap measuresSp)
+    ms2          =          Ms.imeas   measuresSp
     mySpec       = M.lookupDefault mempty name specs
     name         = giTargetMod      src
-    invs         = makeMeasureInvariants env name sig mySpec
-                ++ concat (makeInvariants env sigEnv <$> M.toList specs)
+    (minvs,usI)  = makeMeasureInvariants env name sig mySpec
+    invs         = minvs ++ concat (makeInvariants env sigEnv <$> M.toList specs)
 
 makeIAliases :: Bare.Env -> Bare.SigEnv -> (ModName, BareSpec) -> [(LocSpecType, LocSpecType)]
 makeIAliases env sigEnv (name, spec)
@@ -706,14 +707,15 @@ makeInvariants env sigEnv (name, spec) =
     , let t = Bare.cookSpecType env sigEnv name Bare.GenTV bt
   ]
 
-makeMeasureInvariants :: Bare.Env -> ModName -> GhcSpecSig -> Ms.BareSpec -> [(Maybe Ghc.Var, LocSpecType)]
+makeMeasureInvariants :: Bare.Env -> ModName -> GhcSpecSig -> Ms.BareSpec 
+                      -> ([(Maybe Ghc.Var, LocSpecType)], [UnSortedExpr])
 makeMeasureInvariants env name sig mySpec 
-  = measureTypeToInv env name <$> [(x, (y, ty)) | x <- xs, (y, ty) <- sigs
-                                       , isSymbolOfVar (val x) y ]
+  = mapSnd Mb.catMaybes $ 
+    unzip (measureTypeToInv env name <$> [(x, (y, ty)) | x <- xs, (y, ty) <- sigs
+                                         , isSymbolOfVar (val x) y ])
   where 
     sigs = gsTySigs sig 
     xs   = S.toList (Ms.hmeas  mySpec) 
-
 
 isSymbolOfVar :: Symbol -> Ghc.Var -> Bool
 isSymbolOfVar x v = x == symbol' v
@@ -721,26 +723,41 @@ isSymbolOfVar x v = x == symbol' v
     symbol' :: Ghc.Var -> Symbol
     symbol' = GM.dropModuleNames . symbol . Ghc.getName
 
-measureTypeToInv :: Bare.Env -> ModName -> (LocSymbol, (Ghc.Var, LocSpecType)) -> (Maybe Ghc.Var, LocSpecType)
-measureTypeToInv env name (x, (v, t)) = (Just v, t {val = Bare.qualifyTop env name (F.loc x) mtype})
+measureTypeToInv :: Bare.Env -> ModName -> (LocSymbol, (Ghc.Var, LocSpecType)) -> ((Maybe Ghc.Var, LocSpecType), Maybe UnSortedExpr)
+measureTypeToInv env name (x, (v, t)) 
+  = tracepp "measureTypeToInv" $ ((Just v, t {val = Bare.qualifyTop env name (F.loc x) mtype}), usorted)
   where
     trep = toRTypeRep (val t)
     ts   = ty_args  trep
     args = ty_binds trep
     res  = ty_res   trep
+    z    = last args
+    tz   = last ts
+    usorted = if isSimpleADT tz then Nothing else ((mapFst (:[])) <$> mkReft (dummyLoc $ F.symbol v) z tz res)
     mtype
       | null ts 
       = uError $ ErrHMeas (GM.sourcePosSrcSpan $ loc t) (pprint x) "Measure has no arguments!"
       | otherwise 
-      = mkInvariant x (last args) (last ts) res 
+      = mkInvariant x z tz res 
+    isSimpleADT (RApp _ ts _ _) = all isRVar ts 
+    isSimpleADT _               = False 
 
 mkInvariant :: LocSymbol -> Symbol -> SpecType -> SpecType -> SpecType
 mkInvariant x z t tr = strengthen (top <$> t) (MkUReft reft mempty mempty)
       where
-        Reft (v, p)    = toReft $ Mb.fromMaybe mempty $ stripRTypeBase tr
-        su             = mkSubst [(v, mkEApp x [EVar v])]
-        reft           = Reft (v, subst su p')
-        p'             = pAnd $ filter (\e -> z `notElem` syms e) $ conjuncts p
+        reft  = Mb.maybe mempty Reft mreft
+        mreft = mkReft x z t tr 
+
+
+mkReft :: LocSymbol -> Symbol -> SpecType -> SpecType -> Maybe (Symbol, Expr)
+mkReft x z t tr 
+  | Just q <- stripRTypeBase tr
+  = let Reft (v, p) = toReft q
+        su          = mkSubst [(v, mkEApp x [EVar v])]
+        p'          = pAnd $ filter (\e -> z `notElem` syms e) $ conjuncts p
+    in  Just (v, subst su p')
+mkReft _ _ _ _  
+  = Nothing 
 
 
 -- REBARE: formerly, makeGhcSpec3
@@ -810,7 +827,7 @@ knownWiredTyCons env name = filter isKnown wiredTyCons
 makeMeasEnv :: Bare.Env -> Bare.TycEnv -> Bare.SigEnv -> Bare.ModSpecs -> Bare.MeasEnv 
 -------------------------------------------------------------------------------------------
 makeMeasEnv env tycEnv sigEnv specs = Bare.MeasEnv 
-  { meMeasureSpec = measures 
+  { meMeasureSpec = F.notracepp "meMEASURES" measures 
   , meClassSyms   = cms' 
   , meSyms        = ms' 
   , meDataCons    = F.notracepp "meDATACONS" cs' 

--- a/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -120,8 +120,8 @@ checkGhcSpec :: [(ModName, Ms.BareSpec)]
 checkGhcSpec specs env cbs sp = Misc.applyNonNull (Right sp) Left errors
   where
     errors           =  mapMaybe (checkBind allowHO "measure"      emb tcEnv env) (gsMeas       (gsData sp))
-                     ++ condNull False -- NV TODO: check consistency with templates
-                        (mapMaybe (checkBind allowHO "constructor"  emb tcEnv env) (gsCtors      (gsData sp)))
+                     ++ condNull noPrune 
+                        (mapMaybe (checkBind allowHO "constructor"  emb tcEnv env) (txCtors $ gsCtors      (gsData sp)))
                      ++ mapMaybe (checkBind allowHO "assume"       emb tcEnv env) (gsAsmSigs    (gsSig sp))
                      ++ checkTySigs         allowHO cbs            emb tcEnv env                (gsSig sp)
                      -- ++ mapMaybe (checkTerminationExpr             emb       env) (gsTexprs     (gsSig  sp)) 
@@ -152,7 +152,9 @@ checkGhcSpec specs env cbs sp = Misc.applyNonNull (Right sp) Left errors
     clsSigs sp       = [ (v, t) | (v, t) <- gsTySigs sp, isJust (isClassOpId_maybe v) ]
     sigs             = gsTySigs (gsSig sp) ++ gsAsmSigs (gsSig sp) ++ gsCtors (gsData sp)
     allowHO          = higherOrderFlag sp
-    -- noPrune          = not (pruneFlag sp)
+    noPrune          = not (pruneFlag sp)
+    txCtors ts       = [(v, fmap (fmap (fmap (F.filterUnMatched temps))) t) | (v,t) <- ts]
+    temps            = F.makeTemplates $ gsUnsorted $ gsData sp
     -- env'             = L.foldl' (\e (x, s) -> insertSEnv x (RR s mempty) e) env wiredSortedSyms
 
 

--- a/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -530,7 +530,7 @@ checkMeasures :: F.TCEmb TyCon -> F.SEnv F.SortedReft -> [Measure SpecType DataC
 checkMeasures emb env = concatMap (checkMeasure emb env)
 
 checkMeasure :: F.TCEmb TyCon -> F.SEnv F.SortedReft -> Measure SpecType DataCon -> [Error]
-checkMeasure emb γ (M name@(Loc src _ n) sort body _)
+checkMeasure emb γ (M name@(Loc src _ n) sort body _ _)
   = [ txerror e | Just e <- checkMBody γ emb name sort <$> body ]
   where
     txerror = ErrMeas (GM.sourcePosSrcSpan src) (pprint n)

--- a/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -120,8 +120,8 @@ checkGhcSpec :: [(ModName, Ms.BareSpec)]
 checkGhcSpec specs env cbs sp = Misc.applyNonNull (Right sp) Left errors
   where
     errors           =  mapMaybe (checkBind allowHO "measure"      emb tcEnv env) (gsMeas       (gsData sp))
-                     ++ condNull noPrune
-                       (mapMaybe (checkBind allowHO "constructor"  emb tcEnv env) (gsCtors      (gsData sp)))
+                     ++ condNull False -- NV TODO: check consistency with templates
+                        (mapMaybe (checkBind allowHO "constructor"  emb tcEnv env) (gsCtors      (gsData sp)))
                      ++ mapMaybe (checkBind allowHO "assume"       emb tcEnv env) (gsAsmSigs    (gsSig sp))
                      ++ checkTySigs         allowHO cbs            emb tcEnv env                (gsSig sp)
                      -- ++ mapMaybe (checkTerminationExpr             emb       env) (gsTexprs     (gsSig  sp)) 
@@ -152,7 +152,7 @@ checkGhcSpec specs env cbs sp = Misc.applyNonNull (Right sp) Left errors
     clsSigs sp       = [ (v, t) | (v, t) <- gsTySigs sp, isJust (isClassOpId_maybe v) ]
     sigs             = gsTySigs (gsSig sp) ++ gsAsmSigs (gsSig sp) ++ gsCtors (gsData sp)
     allowHO          = higherOrderFlag sp
-    noPrune          = not (pruneFlag sp)
+    -- noPrune          = not (pruneFlag sp)
     -- env'             = L.foldl' (\e (x, s) -> insertSEnv x (RR s mempty) e) env wiredSortedSyms
 
 

--- a/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -105,6 +105,7 @@ makeUnSorted t defs
     ta = go $ Ghc.expandTypeSynonyms t
 
     go (Ghc.ForAllTy _ t) = go t 
+    go (Ghc.FunTy p t) | Ghc.isClassPred p = go t 
     go (Ghc.FunTy t _)    = t 
     go t                  = t -- this should never happen!
 

--- a/src/Language/Haskell/Liquid/Constraint/Env.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Env.hs
@@ -184,17 +184,14 @@ addCGEnv tx γ (_, x, t') = do
   let t  = tx $ normalize idx t'
   let l  = getLocation γ
   let γ' = γ { renv = insertREnv x t (renv γ) }
-  pflag <- pruneRefs <$> get
-  is    <- if True -- // || allowHOBinders || isBase t
-            then (:) <$> addBind l x (rTypeSortedReft' pflag γ' t) <*> addClassBind γ' l t
-            else return []
+  tem   <- getTemplates 
+  is    <- (:) <$> addBind l x (rTypeSortedReft' γ' tem t) <*> addClassBind γ' l t
   return $ γ' { fenv = insertsFEnv (fenv γ) is }
 
 rTypeSortedReft' :: (PPrint r, F.Reftable r, SubsTy RTyVar RSort r, F.Reftable (RTProp RTyCon RTyVar r))
-                 => Bool -> CGEnv -> RRType r -> F.SortedReft
-rTypeSortedReft' pflag γ
-  | pflag     = pruneUnsortedReft (feEnv $ fenv γ) . f
-  | otherwise = f
+                 => CGEnv -> F.Templates -> RRType r -> F.SortedReft
+rTypeSortedReft' γ t 
+  = pruneUnsortedReft (feEnv $ fenv γ) t . f
   where
     f         = rTypeSortedReft (emb γ)
 
@@ -250,10 +247,8 @@ addEEnv γ (x,t')= do
   let t  = addRTyConInv (invs γ) $ normalize idx t'
   let l  = getLocation γ
   let γ' = γ { renv = insertREnv x t (renv γ) }
-  pflag <- pruneRefs <$> get
-  is    <- if True -- // allowHOBinders || isBase t
-            then (:) <$> addBind l x (rTypeSortedReft' pflag γ' t) <*> addClassBind γ' l t
-            else return []
+  tem   <- getTemplates
+  is    <- (:) <$> addBind l x (rTypeSortedReft' γ' tem t) <*> addClassBind γ' l t
   modify (\s -> s { ebinds = ebinds s ++ (snd <$> is)})
   return $ γ' { fenv = insertsFEnv (fenv γ) is }
 

--- a/src/Language/Haskell/Liquid/Constraint/Init.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Init.hs
@@ -282,7 +282,7 @@ initCGI cfg info = CGInfo {
   , autoSize   = gsAutosize tspc
   , allowHO    = higherOrderFlag cfg
   , ghcI       = info
-  , unsorted   = F.notracepp "UNSORTED" $ gsUnsorted $ gsData spc
+  , unsorted   = F.notracepp "UNSORTED" $ F.makeTemplates $ gsUnsorted $ gsData spc
   }
   where
     tce        = gsTcEmbeds nspc 

--- a/src/Language/Haskell/Liquid/Constraint/Init.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Init.hs
@@ -282,6 +282,7 @@ initCGI cfg info = CGInfo {
   , autoSize   = gsAutosize tspc
   , allowHO    = higherOrderFlag cfg
   , ghcI       = info
+  , unsorted   = F.notracepp "UNSORTED" $ gsUnsorted $ gsData spc
   }
   where
     tce        = gsTcEmbeds nspc 

--- a/src/Language/Haskell/Liquid/Constraint/Types.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Types.hs
@@ -50,6 +50,8 @@ module Language.Haskell.Liquid.Constraint.Types
   , removeInvariant, restoreInvariant, makeRecInvariants
 
   , addArgument, addArguments
+
+  , getTemplates
   ) where
 
 import Prelude hiding (error)
@@ -211,8 +213,16 @@ data CGInfo = CGInfo
   , allowHO    :: !Bool
   , ghcI       :: !GhcInfo
   , dataConTys :: ![(Var, SpecType)]           -- ^ Refined Types of Data Constructors
-  , unsorted   :: ![UnSortedExpr]              -- ^ Potentially unsorted expressions
+  , unsorted   :: !F.Templates                 -- ^ Potentially unsorted expressions
   }
+
+
+getTemplates :: CG F.Templates
+getTemplates = do 
+  fg     <- pruneRefs <$> get
+  ts     <- unsorted  <$> get
+  return $ if fg then F.anything else ts 
+       
 
 instance PPrint CGInfo where
   pprintTidy = pprCGInfo

--- a/src/Language/Haskell/Liquid/Constraint/Types.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Types.hs
@@ -211,6 +211,7 @@ data CGInfo = CGInfo
   , allowHO    :: !Bool
   , ghcI       :: !GhcInfo
   , dataConTys :: ![(Var, SpecType)]           -- ^ Refined Types of Data Constructors
+  , unsorted   :: ![UnSortedExpr]              -- ^ Potentially unsorted expressions
   }
 
 instance PPrint CGInfo where

--- a/src/Language/Haskell/Liquid/Measure.hs
+++ b/src/Language/Haskell/Liquid/Measure.hs
@@ -19,6 +19,7 @@ module Language.Haskell.Liquid.Measure (
   , mkM, mkMSpec, mkMSpec'
   , dataConTypes
   , defRefType
+  , bodyPred
   ) where
 
 import           DataCon
@@ -47,10 +48,10 @@ import           Language.Haskell.Liquid.Types.Specs
 import           Language.Haskell.Liquid.UX.Tidy
 
 
-mkM ::  LocSymbol -> ty -> [Def ty bndr] -> MeasureKind -> Measure ty bndr
-mkM name typ eqns kind
+mkM ::  LocSymbol -> ty -> [Def ty bndr] -> MeasureKind -> UnSortedExprs -> Measure ty bndr
+mkM name typ eqns kind u
   | all ((name ==) . measure) eqns
-  = M name typ eqns kind
+  = M name typ eqns kind u
   | otherwise
   = panic Nothing $ "invalid measure definition for " ++ show name
 

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -1262,7 +1262,7 @@ hmeasureP = do
        ty <- locParserP genBareTypeP
        whiteSpace
        eqns <- grabs $ measureDefP (rawBodyP <|> tyBodyP ty)
-       return (Meas $ Measure.mkM b ty eqns MsMeasure))
+       return (Meas $ Measure.mkM b ty eqns MsMeasure mempty))
     <|> (return (HMeas b))
     )
 
@@ -1271,13 +1271,13 @@ measureP = do
   (x, ty) <- tyBindP
   whiteSpace
   eqns    <- grabs $ measureDefP (rawBodyP <|> tyBodyP ty)
-  return   $ Measure.mkM x ty eqns MsMeasure
+  return   $ Measure.mkM x ty eqns MsMeasure mempty
 
 -- | class measure
 cMeasureP :: Parser (Measure (Located BareType) ())
 cMeasureP
   = do (x, ty) <- tyBindP
-       return $ Measure.mkM x ty [] MsClass
+       return $ Measure.mkM x ty [] MsClass mempty 
 
 iMeasureP :: Parser (Measure (Located BareType) LocSymbol)
 iMeasureP = measureP

--- a/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -116,6 +116,7 @@ data GhcSpecData = SpData
   , gsInvariants :: ![(Maybe Var, LocSpecType)]   -- ^ Data type invariants from measure definitions, e.g forall a. {v: [a] | len(v) >= 0}
   , gsIaliases   :: ![(LocSpecType, LocSpecType)] -- ^ Data type invariant aliases 
   , gsMeasures   :: ![Measure SpecType DataCon]   -- ^ Measure definitions
+  , gsUnsorted   :: ![UnSortedExpr]
   }
 
 data GhcSpecNames = SpNames 

--- a/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/src/Language/Haskell/Liquid/Types/Types.hs
@@ -181,7 +181,7 @@ module Language.Haskell.Liquid.Types.Types (
 
   -- * Measures
   , Measure (..)
-  , UnSortedExprs (..), UnSortedExpr (..)
+  , UnSortedExprs, UnSortedExpr
   , MeasureKind (..)
   , CMeasure (..)
   , Def (..)
@@ -2044,7 +2044,7 @@ instance F.PPrint a => F.PPrint (Def t a) where
       cbsd = parens (F.pprintTidy k c <-> hsep (F.pprintTidy k `fmap` (fst <$> bs)))
 
 instance (F.PPrint t, F.PPrint a) => F.PPrint (Measure t a) where
-  pprintTidy k (M n s eqs _ u) =  F.pprintTidy k n <+> {- parens (pprintTidy k (loc n)) <+> -} "::" <+> F.pprintTidy k s
+  pprintTidy k (M n s eqs _ _) =  F.pprintTidy k n <+> {- parens (pprintTidy k (loc n)) <+> -} "::" <+> F.pprintTidy k s
                                   $$ vcat (F.pprintTidy k `fmap` eqs)
 
 

--- a/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/src/Language/Haskell/Liquid/Types/Types.hs
@@ -1990,7 +1990,7 @@ data Measure ty ctor = M
   , msUnSorted :: !UnSortedExprs -- potential unsorted expressions used at measure denifinitions
   } deriving (Data, Typeable, Generic, Functor)
 
-type UnSortedExprs = [UnSortedExpr]
+type UnSortedExprs = [UnSortedExpr] -- mempty = []
 type UnSortedExpr  = ([F.Symbol], F.Expr)
 
 data MeasureKind 

--- a/tests/pos/ListKeys.hs
+++ b/tests/pos/ListKeys.hs
@@ -1,14 +1,16 @@
-{-@ LIQUID "--pruneunsorted" @-}
+{- LIQUID "--pruneunsorted" @-}
 
 module Foo () where
-import Data.Set (Set(..)) 
+import Data.Set (Set(..), empty, union, singleton) 
 
-{-@  measure listKeys :: [(k, v)] -> (Set k) 
-    listKeys([])   = {v | Set_emp v }
-    listKeys(x:xs) = {v | v = (Set_cup (Set_sng (fst x)) (listKeys xs)) }
+{-@  measure listKeys @-}
+listKeys :: Ord k => [(k, v)] -> Set k 
+listKeys [] = empty 
+listKeys (x:xs) = singleton (myfst x) `union` listKeys xs 
 
-@-}
-
+{-@ measure myfst @-}
+myfst :: (a,b) -> a 
+myfst (x,_) = x 
 
 {-@ getFsts :: ys:[(a, b)] -> {v : [a] | listElts v = listKeys ys } @-}
 getFsts ::[(a, b)] ->  [a]


### PR DESCRIPTION
The `prune-unsorted` flag is not needed to allow "unsorted" predicates; look tests/pos/ListKeys.hs

Unsorted predicates generate unsorted templates and refinements that match these templates and are unsorted are filtered out. 