### PR TITLE
Upgrade to GHC 8.4.4

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,40 @@
+{ mkDerivation, aeson, array, base, bifunctors, binary, bytestring
+, Cabal, cereal, cmdargs, containers, data-default, deepseq, Diff
+, directory, exceptions, filepath, fingertree, ghc, ghc-boot
+, ghc-paths, ghc-prim, gitrev, hashable, hpc, hscolour
+, liquid-fixpoint, located-base, mtl, optparse-applicative
+, optparse-simple, parsec, pretty, process, QuickCheck, stdenv, stm
+, syb, tagged, tasty, tasty-ant-xml, tasty-hunit, tasty-rerun
+, template-haskell, temporary, text, text-format, th-lift, time
+, transformers, unordered-containers, vector, z3
+}:
+mkDerivation {
+  pname = "liquidhaskell";
+  version = "0.8.4.0";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  enableSeparateDataOutput = true;
+  libraryHaskellDepends = [
+    aeson array base bifunctors binary bytestring Cabal cereal cmdargs
+    containers data-default deepseq Diff directory exceptions filepath
+    fingertree ghc ghc-boot ghc-paths ghc-prim gitrev hashable hpc
+    hscolour liquid-fixpoint located-base mtl optparse-simple parsec
+    pretty process QuickCheck syb template-haskell temporary text
+    text-format th-lift time transformers unordered-containers vector
+  ];
+  executableHaskellDepends = [
+    base cmdargs deepseq ghc ghc-boot hpc liquid-fixpoint located-base
+    pretty process time
+  ];
+  testHaskellDepends = [
+    array base bytestring containers directory filepath ghc ghc-boot
+    hpc liquid-fixpoint mtl optparse-applicative parsec process stm syb
+    tagged tasty tasty-ant-xml tasty-hunit tasty-rerun template-haskell
+    text time transformers
+  ];
+  testSystemDepends = [ z3 ];
+  homepage = "https://github.com/ucsd-progsys/liquidhaskell";
+  description = "Liquid Types for Haskell";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -109,8 +109,8 @@ Executable liquid
 Library
    Default-Language: Haskell98
    Build-Depends: base >=4.11.1.0 && <5
-                , ghc == 8.4.3
-                , ghc-boot == 8.4.3
+                , ghc == 8.4.4
+                , ghc-boot == 8.4.4
                 , template-haskell >= 2.9
                 , time >= 1.4
                 , array >= 0.5

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,58 @@
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "default", doBenchmark ? false }:
+
+let
+
+  inherit (nixpkgs) pkgs;
+
+  f = { mkDerivation, aeson, array, base, bifunctors, binary
+      , bytestring, Cabal, cereal, cmdargs, containers, data-default
+      , deepseq, Diff, directory, exceptions, filepath, fingertree, ghc
+      , ghc-boot, ghc-paths, ghc-prim, gitrev, hashable, hpc, hscolour
+      , liquid-fixpoint, located-base, mtl, optparse-applicative
+      , optparse-simple, parsec, pretty, process, QuickCheck, stdenv, stm
+      , syb, tagged, tasty, tasty-ant-xml, tasty-hunit, tasty-rerun
+      , template-haskell, temporary, text, text-format, th-lift, time
+      , transformers, unordered-containers, vector, z3
+      }:
+      mkDerivation {
+        pname = "liquidhaskell";
+        version = "0.8.4.0";
+        src = ./.;
+        isLibrary = true;
+        isExecutable = true;
+        enableSeparateDataOutput = true;
+        libraryHaskellDepends = [
+          aeson array base bifunctors binary bytestring Cabal cereal cmdargs
+          containers data-default deepseq Diff directory exceptions filepath
+          fingertree ghc ghc-boot ghc-paths ghc-prim gitrev hashable hpc
+          hscolour liquid-fixpoint located-base mtl optparse-simple parsec
+          pretty process QuickCheck syb template-haskell temporary text
+          text-format th-lift time transformers unordered-containers vector
+        ];
+        executableHaskellDepends = [
+          base cmdargs deepseq ghc ghc-boot hpc liquid-fixpoint located-base
+          pretty process time
+        ];
+        testHaskellDepends = [
+          array base bytestring containers directory filepath ghc ghc-boot
+          hpc liquid-fixpoint mtl optparse-applicative parsec process stm syb
+          tagged tasty tasty-ant-xml tasty-hunit tasty-rerun template-haskell
+          text time transformers
+        ];
+        testSystemDepends = [ z3 ];
+        homepage = "https://github.com/ucsd-progsys/liquidhaskell";
+        description = "Liquid Types for Haskell";
+        license = stdenv.lib.licenses.bsd3;
+      };
+
+  haskellPackages = if compiler == "default"
+                       then pkgs.haskellPackages
+                       else pkgs.haskell.packages.${compiler};
+
+  variant = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
+
+  drv = variant (haskellPackages.callPackage f {});
+
+in
+
+  if pkgs.lib.inNixShell then drv.env else drv

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
-resolver: lts-12.2
+resolver: lts-12.26
 
 packages:
-- liquid-fixpoint/
+- ../liquid-fixpoint/
 - '.'
 
 extra-deps:


### PR DESCRIPTION
These changes will allow liquidhaskell to build with GHC 8.4.4. I have tested building it with both Stack and Nix/NixOS. You may not be ready for that yet, so feel free to disregard this pull request.

One change I made that may not be what you want: `stack.yaml` now expects to find liquid-fixpoint in `../liquid-fixpoint` instead of `./liquid-fixpoint`. I made that change in my fork because I found nested repositories a bit confusing to work with. It's my understanding that nested repos aren't recommended. However, if you'd like me to undo that, let me know.

There are a lot of changes to default.nix and shell.nix. That's because I'm using the versions that are automatically generated by cabal2nix. I think this will be simpler for others who might work on the package.

For future reference, here's how I generated those files.

```
cabal2nix . > default.nix
cabal2nix . --shell > shell.nix
```

