### PR TITLE
Make structural termination checker argument-order-agnostic.

### DIFF
--- a/src/Language/Haskell/Liquid/Termination/Structural.hs
+++ b/src/Language/Haskell/Liquid/Termination/Structural.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DeriveGeneric       #-}
 
 module Language.Haskell.Liquid.Termination.Structural (terminationVars) where
 
@@ -14,15 +15,18 @@ import VarSet
 
 import           Text.PrettyPrint.HughesPJ hiding ((<>)) 
 import qualified Data.HashSet  as S
+import Data.Hashable (Hashable)
+import GHC.Generics (Generic)
+import Data.Maybe (mapMaybe)
 
 terminationVars :: GhcInfo -> [Var]
-terminationVars = resultVars . terminationCheck 
+terminationVars = resultVars . terminationCheck
 
-resultVars :: Result -> [Var]
-resultVars OK         = [] 
+resultVars :: Result a -> [Var]
+resultVars (OK _)       = []
 resultVars (Error es) = teVar <$> es 
 
-terminationCheck :: GhcInfo -> Result 
+terminationCheck :: GhcInfo -> Result ()
 terminationCheck info 
   | isStruct  = mconcat $ map (checkBind cbs) (allRecBinds cbs)
   | otherwise = mconcat $ map (checkBind cbs) (S.toList $ gsStTerm $ gsTerm $ giSpec info)
@@ -32,37 +36,38 @@ terminationCheck info
 
 ------------------------------------------------------------------------------------------
 
-data Result = OK | Error [TermError]
+data Result a = OK a | Error [TermError]
 
 data TermError = TE 
   { teVar   :: !Var
   , teError :: !UserError 
   }
 
-mkError :: Var -> Doc -> Result
+mkError :: Var -> Doc -> Result a
 mkError fun expl = Error [mkTermError fun expl] 
 
-mkTermError :: Var -> Doc -> TermError 
+mkTermError :: Var -> Doc -> TermError
 mkTermError fun expl = TE 
   { teVar   = fun 
   , teError = ErrStTerm (getSrcSpan fun) (text $ showPpr fun) expl
   }
 
-instance Monoid Result where
-  mempty  = OK
+instance Monoid a => Monoid (Result a) where
+  mempty  = OK mempty
   mappend = (<>)
 
-instance Semigroup Result where
-  OK       <> e        = e
-  e        <> OK       = e
+instance Semigroup a => Semigroup (Result a) where
+  OK x     <> OK y     = OK (x <> y)
+  OK _     <> e        = e
+  e        <> OK _     = e
   Error e1 <> Error e2 = Error (e1 ++ e2)
 
 -- resultToDoc :: Result -> Output Doc
 -- resultToDoc OK        = mempty
 -- resultToDoc (Error x) = mempty { o_result = Unsafe x }
 
-checkBind :: [CoreBind] -> Var -> Result
-checkBind cbs x = maybe OK isStructurallyRecursiveGroup (findRecBind cbs x)
+checkBind :: [CoreBind] -> Var -> Result ()
+checkBind cbs x = maybe (OK ()) isStructurallyRecursiveGroup (findRecBind cbs x)
 
 allRecBinds :: [CoreBind] -> [Var]
 allRecBinds cbs = concat[ fst <$> xes |  Rec xes <- cbs ]
@@ -76,16 +81,19 @@ findRecBind (Rec xes:_)    y | y `elem` (fst <$> xes)
 findRecBind (_:xes) y
   = findRecBind xes y
 
-isStructurallyRecursiveGroup :: [(Var,CoreExpr)] -> Result
+isStructurallyRecursiveGroup :: [(Var,CoreExpr)] -> Result ()
 isStructurallyRecursiveGroup xes = mconcat (isStructurallyRecursive funs <$> xes)
   where funs = mkVarSet (map fst xes)
 
-isStructurallyRecursive :: VarSet -> (Var, CoreExpr) -> Result
+isStructurallyRecursive :: VarSet -> (Var, CoreExpr) -> Result ()
 isStructurallyRecursive funs (fun, rhs)
   | null xs
   = mkError fun (text "The definition has no value parameters.")
   | otherwise
-  = check (Env (mkError fun) funs (map initParam xs)) [] body
+  = let env = Env (mkError fun) funs (map initParam xs) in
+      case check env [] body of
+        OK calls -> structDecreasing env calls
+        Error err -> Error err
   where
     (_ts, xs, body) = collectTyAndValBinders rhs
 
@@ -97,14 +105,14 @@ data Param = Param
 initParam :: Var -> Param
 initParam x = Param (unitVarSet x) emptyVarSet
 
-data Env = Env
-    { retErr   :: Doc -> Result -- ^ How to signal erros
-    , funs     :: VarSet        -- ^ Which functions are interesting
-    , params   :: [Param]       -- ^ Parameters
+data Env a = Env
+    { retErr   :: Doc -> Result a  -- ^ How to signal erros
+    , funs     :: VarSet           -- ^ Which functions are interesting
+    , params   :: [Param]          -- ^ Parameters
     }
 
 
-shadow :: Env -> [Var] -> Env
+shadow :: Env a -> [Var] -> Env a
 shadow (Env retErr funs params) vs
     = Env retErr (funs `delVarSetList` vs) (map shadowParam params)
   where
@@ -113,8 +121,8 @@ shadow (Env retErr funs params) vs
 
 envAddSubterms :: CoreExpr -- ^ the scrutinee variable
                -> [Var]    -- ^ the variables that are subterms
-               -> Env
-               -> Env
+               -> Env a
+               -> Env a
 envAddSubterms (Tick _ e) vs env = envAddSubterms e vs env
 envAddSubterms (Cast e _) vs env = envAddSubterms e vs env
 envAddSubterms (Var v)    vs env = env { params = map paramAddSubterms (params env) }
@@ -124,13 +132,11 @@ envAddSubterms (Var v)    vs env = env { params = map paramAddSubterms (params e
                        | otherwise = p
 envAddSubterms _ _ env = env
 
-check :: Env -> [CoreArg] -> CoreExpr -> Result
+check :: Env (S.HashSet Call) -> [CoreArg] -> CoreExpr -> Result (S.HashSet Call)
 check env args = \case
     Var fun | not (fun `elemVarSet` funs env) -> mempty
-            | isGoodArgs (params env) args  -> mempty
-            | [] <- args -> retErr env $ text "Unsaturated call to" <+> (text $ showPpr fun)
-            | otherwise  -> retErr env $ text "Non-structural recursion in call" <+>
-                                        (text $ showPpr (mkApps (Var fun) args))
+            | length args < length (params env) -> retErr env $ text "Unsaturated call to" <+> (text $ showPpr fun)
+            | otherwise -> OK $ S.singleton $ getStructArgs (showPpr $ mkApps (Var fun) args) $ zip (params env) args
 
     App e a | isTypeArg a ->                   check env args e
             | otherwise   -> check env [] a <> check env (a:args) e
@@ -154,14 +160,59 @@ check env args = \case
     Coercion{} -> mempty
     Type{}     -> mempty
 
--- This is where we check a function call.
--- We go through the list of arguments as long as they are equal
--- to the original parameter. If we find one that is smaller, great. Otherwise,
--- fail.
-isGoodArgs :: [Param] -> [CoreArg] -> Bool
-isGoodArgs ps     (Cast e _ : as) = isGoodArgs ps (e : as)
-isGoodArgs ps     (Tick _ e : as) = isGoodArgs ps (e : as)
-isGoodArgs (p:ps) (Var v : as)
-    | v `elemVarSet` origParam p = isGoodArgs ps as
-    | v `elemVarSet` subterms p  = True -- yay!
-isGoodArgs _ _ = False
+data Call = Call
+  { callSource :: String
+  , candidateArgs :: S.HashSet Int
+  , decreasingArgs :: S.HashSet Int
+  } deriving (Eq, Show, Generic)
+
+instance Hashable Call
+
+-- This is where we  check a function call. We go through  the list of arguments
+-- and find the  indices of those which are decreasing.  Note that this approach
+-- is only guaranteed to  work when the arguments to the  function are named, so
+-- e.g.
+-- foo (x:xs) (y:ys) = foo xs (y:ys)
+-- won't necessarily work, but
+-- foo (x:xs) yys@(y:ys) = foo xs yys
+-- will.
+getStructArgs :: String -> [(Param, CoreArg)] -> Call
+getStructArgs src args =
+  let (ca, da) = getStructArgs' 0 args in Call src ca da
+  where
+    getStructArgs' _ [] = (S.empty, S.empty)
+    getStructArgs' i ((p, Cast e _) : args) = getStructArgs' i ((p, e) : args)
+    getStructArgs' i ((p, Tick _ e) : args) = getStructArgs' i ((p, e) : args)
+    getStructArgs' i ((p, Var v) : args)
+      | v `elemVarSet` origParam p = (S.singleton i, S.empty) <> getStructArgs' (i + 1) args
+      | v `elemVarSet` subterms p = (S.singleton i, S.singleton i) <> getStructArgs' (i + 1) args
+      | otherwise = getStructArgs' (i + 1) args
+    getStructArgs' i (_ : args) = getStructArgs' (i + 1) args
+
+-- Check if there is some way to lexicographically order the arguments so that
+-- they are structurally decreasing. Essentially, in order for there to be, we
+-- must be able to find some argument which is always either unchanged or
+-- decreasing. We can then remove every call where that argument is decreasing
+-- and recurse.
+structDecreasing :: Env () -> S.HashSet Call -> Result ()
+structDecreasing env calls
+  | S.null calls = mempty
+  | not $ S.null nonDecCalls = raiseErr nonDecCalls
+  | otherwise =
+      let ca = commonArgs calls in
+        if S.null ca then
+          raiseErr calls
+        else
+          structDecreasing env $ (S.fromList . mapMaybe (removeDecreasing ca) . S.toList) calls
+  where
+    raiseErr calls =
+      retErr env $ text "Non-structural recursion in calls" <+>
+      (text $ showPpr (S.map callSource calls))
+    nonDecCalls = S.filter (S.null . decreasingArgs) calls
+    commonArgs calls = foldl1 S.intersection (S.map candidateArgs calls)
+    removeDecreasing args call
+      | S.null (decreasingArgs call `S.difference` args) = Nothing
+      | otherwise = Just $ call
+        { candidateArgs = candidateArgs call `S.difference` args
+        , decreasingArgs = decreasingArgs call `S.difference` args
+        }

--- a/tests/terminate/pos/Ackermann.hs
+++ b/tests/terminate/pos/Ackermann.hs
@@ -1,0 +1,17 @@
+module Ackermann where
+
+data Peano = Z | S Peano
+
+ack :: Peano -> Peano -> Peano
+ack Z n = S n
+ack (S m) Z = ack m (S Z)
+ack sm@(S m) (S n) = ack m (ack sm n)
+
+ackFlipped :: Peano -> Peano -> Peano
+ackFlipped n Z = S n
+ackFlipped Z (S m) = ackFlipped (S Z) m
+ackFlipped (S n) sm@(S m) = ackFlipped (ackFlipped n sm) m
+
+-- This case is redundant, but without it LH can't determine that this function
+-- is total. See https://github.com/ucsd-progsys/liquidhaskell/issues/1396
+ackFlipped _ _ = error "unreachable"

--- a/tests/terminate/pos/Lexicographic.hs
+++ b/tests/terminate/pos/Lexicographic.hs
@@ -1,0 +1,31 @@
+module Lexicographic where
+
+foo012 (x:xs) ys     zs     = 1 + foo012 xs ys zs
+foo012 []     (y:ys) zs     = 1 + foo012 [] ys zs
+foo012 []     []     (z:zs) = 1 + foo012 [] [] zs
+foo012 []     []     []     = 0
+
+foo021 (x:xs) zs     ys     = 1 + foo021 xs zs ys
+foo021 []     zs     (y:ys) = 1 + foo021 [] zs ys
+foo021 []     (z:zs) []     = 1 + foo021 [] zs []
+foo021 []     []     []     = 0
+
+foo102 ys     (x:xs) zs     = 1 + foo102 ys xs zs
+foo102 (y:ys) []     zs     = 1 + foo102 ys [] zs
+foo102 []     []     (z:zs) = 1 + foo102 [] [] zs
+foo102 []     []     []     = 0
+
+foo120 ys     zs     (x:xs) = 1 + foo120 ys zs xs
+foo120 (y:ys) zs     []     = 1 + foo120 ys zs []
+foo120 []     (z:zs) []     = 1 + foo120 [] zs []
+foo120 []     []     []     = 0
+
+foo201 zs     (x:xs) ys     = 1 + foo201 zs xs ys
+foo201 zs     []     (y:ys) = 1 + foo201 zs [] ys
+foo201 (z:zs) []     []     = 1 + foo201 zs [] []
+foo201 []     []     []     = 0
+
+foo210 zs     ys     (x:xs) = 1 + foo210 zs ys xs
+foo210 zs     (y:ys) []     = 1 + foo210 zs ys []
+foo210 (z:zs) []     []     = 1 + foo210 zs [] []
+foo210 []     []     []     = 0

--- a/tests/terminate/pos/LocalTermExpr.hs
+++ b/tests/terminate/pos/LocalTermExpr.hs
@@ -18,3 +18,20 @@ myfoo = foo 5 True
     foo :: Int -> Bool -> Bool
     foo 0 _ = True
     foo n b = foo (n-1) b
+
+mysumFlipped xs = go 0 0
+  where
+    i = 0
+    n = length xs
+    {-@ go :: _ -> i:_ -> _ / [n - i] @-}
+    go acc i
+      | i >= n    = acc
+      | otherwise = go (acc + xs !! i) (i+1)
+
+myfooFlipped = foo True 5
+  where
+    n = False
+    {-@ foo :: b:_ -> n:{_ | n >= 0 && b} -> {v:_ | n >= 0 && b} / [n] @-}
+    foo :: Bool -> Int -> Bool
+    foo _ 0 = True
+    foo b n = foo b (n-1)

--- a/tests/terminate/pos/StructSecondArg.hs
+++ b/tests/terminate/pos/StructSecondArg.hs
@@ -1,0 +1,5 @@
+data Peano = Z | S Peano
+
+addToInt :: Int -> Peano -> Int
+addToInt n Z     = n
+addToInt n (S p) = addToInt (n + 1) p

--- a/tests/terminate/pos/list00.hs
+++ b/tests/terminate/pos/list00.hs
@@ -7,3 +7,12 @@ lref = go []
 {-@ go :: _ -> xs:_ -> _ / [len xs] @-}
 go acc []     = acc 
 go acc (x:xs) = go (x:acc) xs 
+
+lmapFlipped [] f     = []
+lmapFlipped (x:xs) f = f x : lmapFlipped xs f
+
+lrefFlipped = (\x -> goFlipped x [])
+
+{-@ goFlipped :: xs:_ -> _ -> _ / [len xs] @-}
+goFlipped [] acc = acc
+goFlipped (x:xs) acc = goFlipped xs (x:acc)

--- a/tests/terminate/pos/list01.hs
+++ b/tests/terminate/pos/list01.hs
@@ -8,3 +8,10 @@ revL                = go N
     go acc N        = acc
     go acc (C x xs) = go (C x acc) xs
 
+mapLFlipped N f = N
+mapLFlipped (C x xs) f = C (f x) (mapLFlipped xs f)
+
+revLFlipped x = go x N
+  where
+    go N acc = acc
+    go (C x xs) acc = go xs (C x acc)


### PR DESCRIPTION
Fixes https://github.com/ucsd-progsys/liquidhaskell/issues/1381.

This will likely cause some regression in error messages, at least until https://github.com/ucsd-progsys/liquidhaskell/issues/1396 is fixed. Also, there are still some structurally-recursive programs that this won't be able to check, I'll make a new issue for that limitation (but it has a very simple workaround).