### PR TITLE
Refine the type of `Data.String.fromString` spec

### DIFF
--- a/include/Data/String.spec
+++ b/include/Data/String.spec
@@ -5,4 +5,4 @@ measure stringlen :: a -> GHC.Types.Int
 Data.String.fromString
     ::  forall a. Data.String.IsString a
     =>  i : [GHC.Types.Char]
-    ->  { o : a | len i == stringlen o }
+    ->  { o : a | i ~~ o && len i == stringlen o }


### PR DESCRIPTION
Refine the type of `Data.String.fromString` to say that the value returned is equal to the input string