### PR TITLE
Remove ill-sorted Either Specs 

### DIFF
--- a/include/Data/Either.spec
+++ b/include/Data/Either.spec
@@ -1,14 +1,14 @@
 module spec Data.Either where
 
-invariant {v:[Data.Either.Either a b] | (lenRight v >= 0) && (lenRight v <= len v)}
+// invariant {v:[Data.Either.Either a b] | (lenRight v >= 0) && (lenRight v <= len v)}
 
-measure lenRight :: [Data.Either.Either a b] -> GHC.Types.Int
-lenRight (x:xs) = if (isLeft x) then (lenRight xs) else (lenRight xs + 1)
-lenRight ([])   = 0
+// measure lenRight :: [Data.Either.Either a b] -> GHC.Types.Int
+// lenRight (x:xs) = if (isLeft x) then (lenRight xs) else (lenRight xs + 1)
+// lenRight ([])   = 0
 
-measure isLeftHd :: [Data.Either.Either a b] -> Bool 
-isLeftHd (x:xs) = (isLeft x)
-isLeftHd ([])   = false
+// measure isLeftHd :: [Data.Either.Either a b] -> Bool 
+// isLeftHd (x:xs) = (isLeft x)
+// isLeftHd ([])   = false
 
 measure isLeft :: Data.Either.Either a b -> Bool
 isLeft (Left x)  = true


### PR DESCRIPTION
From include/Data/Either.spec 


These trigger the `prune-unsorted` stuff which should really just affect people who use 
these odd measures and not anyone using an `Either`.