### PR TITLE
cabal.project: update to ghc 8.6.4

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,7 +3,6 @@
 
 packages: .
           ./liquid-fixpoint
-          ./text-format
 
 package liquid-fixpoint
   flags: devel
@@ -11,4 +10,4 @@ package liquid-fixpoint
 package liquidhaskell
   flags: devel
 
-with-compiler: ghc-8.4.3
+with-compiler: ghc-8.6.4


### PR DESCRIPTION
Adapt the name of the compiler and drop the non-existent reference to the local copy of `text-format`.