### PR TITLE
Data.Time.Calendar.spec: provide a more accurate type for 'gregorianMonthLength'

### DIFF
--- a/include/Data/Time/Calendar.spec
+++ b/include/Data/Time/Calendar.spec
@@ -8,4 +8,4 @@ fromGregorian :: Integer -> NumericMonth -> NumericDayOfMonth -> Day
 
 toGregorian :: Day -> (Integer,NumericMonth,NumericDayOfMonth)
 
-gregorianMonthLength :: Integer -> Int -> { x:Nat | 28 <= x && x <= 31 }
+gregorianMonthLength :: Integer -> NumericMonth -> { x:Nat | 28 <= x && x <= 31 }


### PR DESCRIPTION
Minor fix.