### PR TITLE
fix for #1423

### DIFF
--- a/src/Language/Haskell/Liquid/Types/PredType.hs
+++ b/src/Language/Haskell/Liquid/Types/PredType.hs
@@ -129,6 +129,7 @@ meetWorkWrapRep c workR wrapR
   = workR { ty_binds = xs ++ (ty_binds wrapR)
           , ty_args  = ts ++ zipWith strengthenRType ts' (ty_args wrapR)
           , ty_res   = strengthenRType (ty_res workR)    (ty_res  wrapR)
+          , ty_preds = ty_preds wrapR
           }
   | otherwise
   = panic (Just (getSrcSpan c)) errMsg


### PR DESCRIPTION
This is a patch for #1423 but not sure it will take us far in GADTs. 
The issue is that user-defined data refinements refine the wrapper data constructors. 
In case analysis the worker data constructor is used. 

In most cases these two are the same and everything is smooth (in that the Abstract Refinements and in general the type specs are the same for both). 
With GADTs these two might not be the same. Up to now the worker had no abstract refinements and thus the crash. This fix ports the abstract refinements of the wrapper to the worker and for this example it is fine since the fields on the data constructor are not actually using the abstract refinement. But in the general case, where the abstract refinement is actually used, this could get unsound. 
A sound alternative to this fix would be to disallow data refinements in all data types whose wrapper and worker are not the same. 