### PR TITLE
Optimize Windows builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,11 +22,6 @@ install:
 - z3 --version
 
 build_script:
-# Test build liquid-fixpoint
-- cd liquid-fixpoint
-- echo "" | stack --no-terminal build --copy-bins --local-bin-path ..
-- cd ..
-
 # Build LiquidHaskell
 - echo "" | stack --no-terminal build --copy-bins --local-bin-path .
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,5 @@
 platform: x64
 
-# Caching larger than 1GB will fail the build on Free AppVeyor account
-cache:
-# - C:\Users\appveyor\AppData\Roaming\stack\
-- C:\Users\appveyor\AppData\Local\Programs\stack\x86_64-windows\
-
 init:
 - git --version
   


### PR DESCRIPTION
Cache removed for now and use liquid target to build liquid-fixpoint.
This resulted in <50min build times. This should fix the problem with AppVeyor timeout on 1 hour.