### PR TITLE
Restore git hash at cmdline

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,35 +1,5 @@
 # TODO
 
-## PLE-OPT 
-
-      ExactGADT5.hs:                          FAIL (0.80s)
-      BinahQuery.hs:                          FAIL (0.93s)
-      STLCB0.hs:                              FAIL (1.64s)
-      STLCB1.hs:                              FAIL (2.59s)
-      T1302b.hs:                              FAIL (0.85s)
-
-
-
-
-
-
-- [x] Don't generate KVars inside "proofs" [somehow causes proofs to fail]
-- []  Only run INSTANTIATE/PLE on constraints with a concrete LHS?
-- []  Fancy TRIE to do INCREMENTAL PLE.
-
-
-```
-$ time stack exec -- fixpoint ple-overhead.bfq --allowho --eliminate=some
-
-Safe
-        0.29 real         0.26 user         0.13 sys
-
-$ time stack exec -- fixpoint ple-overhead.bfq --allowho --eliminate=some --rewrite
-
-Safe
-        0.54 real         0.53 user         0.18 sys
-```
-
 
 ## CallStack/Error
 

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -179,6 +179,7 @@ library
                     , liquid-fixpoint      >= 0.8.0.0
                     , mtl                  >= 2.1
                     , optparse-simple
+                    , githash
                     , parsec               >= 3.1
                     , pretty               >= 1.1
                     , syb                  >= 0.4.4

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -6,8 +6,6 @@
 {-# LANGUAGE TypeSynonymInstances      #-}
 {-# OPTIONS_GHC -fno-cse #-}
 
-{-@ LIQUID "--diff"     @-}
-
 -- | This module contains all the code needed to output the result which
 --   is either: `SAFE` or `WARNING` with some reasonable error message when
 --   something goes wrong. All forms of errors/exceptions should go through
@@ -49,6 +47,7 @@ import System.Environment
 import System.Console.CmdArgs.Explicit
 import System.Console.CmdArgs.Implicit     hiding (Loud)
 import System.Console.CmdArgs.Text
+import GitHash 
 
 import Data.List                           (nub)
 
@@ -446,6 +445,7 @@ copyright :: String
 copyright = concat $ concat
   [ ["LiquidHaskell "]
   , [$(simpleVersion Meta.version)]
+  , [gitInfo]
   -- , [" (" ++ _commitCount ++ " commits)" | _commitCount /= ("1"::String) &&
   --                                          _commitCount /= ("UNKNOWN" :: String)]
   , ["\nCopyright 2013-19 Regents of the University of California. All Rights Reserved.\n"]
@@ -453,7 +453,24 @@ copyright = concat $ concat
   where
     _commitCount = $gitCommitCount
 
--- NOTE [searchpath]
+gitInfo :: String
+gitInfo  = msg
+  where
+    giTry  = $$tGitInfoCwdTry
+    msg    = case giTry of
+               Left _   -> " no git information"
+               Right gi -> gitMsg gi
+    
+gitMsg :: GitInfo -> String
+gitMsg gi = concat
+  [ " [", giBranch gi, "@", giHash gi
+  , " (", giCommitDate gi, ")"
+  -- , " (", show (giCommitCount gi), " commits in HEAD)"
+  , "] "
+  ]
+
+
+-- [NOTE:searchpath]
 -- 1. we used to add the directory containing the file to the searchpath,
 --    but this is bad because GHC does NOT do this, and it causes spurious
 --    "duplicate module" errors in the following scenario


### PR DESCRIPTION
Somehow the upgrade to GHC 8.6 caused the git-hash to disappear, c.f.

   https://github.com/fpco/optparse-simple/issues/13

This PR restores it by directly using the `githash` package, so you now get, e.g.

```
rjhala@borscht ~/r/s/liquidhaskell (ple2)> stack exec -- liquid tests/pos/Abs.hs
LiquidHaskell Version 0.8.6.0 [ple2@1c96fbc0e46f842e641683b3215701c9fd6c2fdc (Wed Apr 17 08:43:47 2019 -0700)]
Copyright 2013-19 Regents of the University of California. All Rights Reserved.
...

**** RESULT: SAFE **************************************************************
```