### PR TITLE
Automatically Check Imported Modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,33 +1,32 @@
 # Changes
 
-## NEXT 
+## NEXT 0.8.6.0
 
-## 0.8.6.0
+- Automatically check (transitive) dependencies
+- Built with GHC 8.6.4
+- Structural termination checker (on by default)
+- Support for specifying class-laws and that they hold on instances
+- Bug fixes for PLE
+- Need to run LH on imported libs (with source) first; can use `--compile-spec` to avoid checking.
 
-- Built with GHC 8.6.4 
-- Structural termination checker (used by default)
-- Support for specifying class-laws and that they hold on instances 
-- Bug fixes for PLE 
-- Need to run LH on imported libs (with source) first; can use `--compile-spec` to avoid checking. 
+## 0.8.4.0
 
-## 0.8.4.0 
-
-- Support for GHC 8.4.3 
+- Support for GHC 8.4.3
 - Significant restructuring of `Bare` front-end to shrink dependency on GHC-API
 
 ## 0.8.2.2
 
-- Support for GHC 8.2.2 
+- Support for GHC 8.2.2
 
 - Support for GADTs and TypeFamilies, see
-	- `tests/{pos,neg}/ExactGADT*.hs` 
+	- `tests/{pos,neg}/ExactGADT*.hs`
 
-- Add support for Bags/Multisets, see 
+- Add support for Bags/Multisets, see
 	- `tests/pos/bag.hs`
 	- `tests/neg/bag.hs`
 	- `tests/pos/ListISort-bag.hs`
 
-- Add support for *inductive predicates* see 
+- Add support for *inductive predicates* see
 	- `tests/pos/IndEven.hs`
 	- `tests/pos/IndPerm.hs`
 	- `tests/pos/IndStar.hs`

--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,8 @@ Given:
 
 Invariant
 
-
+     Data/Text/Unsafe.hs:        FAIL (2.69s)
+     Data/Text/Fusion/Common.hs: FAIL (5.73s)
 
 ## CallStack/Error
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,15 @@
 # TODO
 
+## Build
+
+Given:
+
+- Target  = D.hs
+- Imports = A.hs, B.hs, C.hs
+
+Invariant
+
+
 
 ## CallStack/Error
 

--- a/benchmarks/text-0.11.2.3/Data/Text/Fusion.hs
+++ b/benchmarks/text-0.11.2.3/Data/Text/Fusion.hs
@@ -1,8 +1,8 @@
 {-@ LIQUID "--prune-unsorted" @-}
+{-@ LIQUID "--eliminate=none" @-}
 
 {-# LANGUAGE BangPatterns, MagicHash #-}
 
-{-@ LIQUID "--eliminate=none" @-}
 
 -- |
 -- Module      : Data.Text.Fusion

--- a/benchmarks/text-0.11.2.3/Data/Text/Fusion/Common.hs
+++ b/benchmarks/text-0.11.2.3/Data/Text/Fusion/Common.hs
@@ -967,6 +967,8 @@ countCharI a (Stream next s0 _len) = loop 0 s0
                  | otherwise -> loop i s'
 {-# INLINE [0] countCharI #-}
 
+{-@ assume error :: String -> a @-}
+
 streamError :: String -> String -> a
 streamError func msg = P.error $ "Data.Text.Fusion.Common." ++ func ++ ": " ++ msg
 

--- a/benchmarks/text-0.11.2.3/Data/Text/Unsafe.hs
+++ b/benchmarks/text-0.11.2.3/Data/Text/Unsafe.hs
@@ -46,10 +46,10 @@ import Language.Haskell.Liquid.Prelude
 -- the programmer to provide a proof that the 'Text' is non-empty.
 {-@ unsafeHead :: TextNE -> Char @-}
 unsafeHead :: Text -> Char
-unsafeHead (Text arr off _len)
+unsafeHead (Text arr off xlen)
     | m < 0xD800 || m > 0xDBFF = unsafeChr m
     | otherwise                = chr2 m n
-    where m = A.unsafeIndexF arr off _len off
+    where m = A.unsafeIndexF arr off xlen off
           {-@ lazyvar n @-}
           n = A.unsafeIndex arr (off+1)
 {-# INLINE unsafeHead #-}
@@ -96,13 +96,13 @@ data Iter = Iter {-# UNPACK #-} !Char {-# UNPACK #-} !Int
                     <= (tlength t)))}
   @-}
 iter :: Text -> Int -> Iter
-iter (Text arr off _len) i
+iter (Text arr off xlen) i
     | m < 0xD800 || m > 0xDBFF = Iter (unsafeChr m) 1
     | otherwise                = let k = j + 1
                                      n = A.unsafeIndex arr k
                                  in
                                  Iter (chr2 m n) 2
-  where m = A.unsafeIndexF arr off _len j
+  where m = A.unsafeIndexF arr off xlen j
         j = off + i
         {- lazyvar n @-}
         -- n = A.unsafeIndex arr k
@@ -121,10 +121,10 @@ iter (Text arr off _len) i
                            <= (tlength t)))}
   @-}
 iter_ :: Text -> Int -> Int
-iter_ (Text arr off _len) i | m < 0xD800 || m > 0xDBFF = 1
+iter_ (Text arr off xlen) i | m < 0xD800 || m > 0xDBFF = 1
                             | otherwise                = 2
 --LIQUID   where m = A.unsafeIndex arr (off+i)
-  where m = A.unsafeIndexF arr off _len (off+i)
+  where m = A.unsafeIndexF arr off xlen (off+i)
 {-# INLINE iter_ #-}
 
 -- | /O(1)/ Iterate one step backwards through a UTF-16 array,
@@ -140,13 +140,13 @@ iter_ (Text arr off _len) i | m < 0xD800 || m > 0xDBFF = 1
 --LIQUID reverseIter :: Text -> Int -> (Char,Int)
 --LIQUID reverseIter (Text arr off _len) i
 reverseIter :: Text -> Int -> (Char,Int)
-reverseIter (Text arr off _len) i
+reverseIter (Text arr off xlen) i
     | m < 0xDC00 || m > 0xDFFF = (unsafeChr m, neg 1)
     | otherwise                = let k = j - 1
                                      n = A.unsafeIndex arr k
                                  in
                                   (chr2 n m,    neg 2)
-  where m = A.unsafeIndexB arr off _len j
+  where m = A.unsafeIndexB arr off xlen j
         {- lazyvar n @-}
         -- n = A.unsafeIndex arr k
         j = off + i
@@ -170,7 +170,7 @@ lengthWord16 (Text _arr _off len) = len
 -- | /O(1)/ Unchecked take of 'k' 'Word16's from the front of a 'Text'.
 {-@ takeWord16 :: k:Nat -> {v:Text | (k <= (tlen v))} -> {v:Text | (tlen v) = k} @-}
 takeWord16 :: Int -> Text -> Text
-takeWord16 k (Text arr off _len) = Text arr off k
+takeWord16 k (Text arr off xlen) = Text arr off k
 {-# INLINE takeWord16 #-}
 
 -- | /O(1)/ Unchecked drop of 'k' 'Word16's from the front of a 'Text'.

--- a/include/Data/Set.spec
+++ b/include/Data/Set.spec
@@ -36,9 +36,9 @@ measure Set_sub  :: (Data.Set.Internal.Set a) -> (Data.Set.Internal.Set a) -> GH
 // -- | Refined Types for Data.Set Operations --------------------------------------------------
 // ---------------------------------------------------------------------------------------------
 
-isSubsetOf    :: (GHC.Classes.Ord a) => x:(Data.Set.Internal.Set a) -> y:(Data.Set.Internal.Set a) -> {v:Bool | v <=> Set_sub x y}
-member        :: (GHC.Classes.Ord a) => x:a -> xs:(Data.Set.Internal.Set a) -> {v:Bool | v <=> Set_mem x xs}
-null          :: (GHC.Classes.Ord a) => xs:(Data.Set.Internal.Set a) -> {v:Bool | v <=> Set_emp xs}
+isSubsetOf    :: (GHC.Classes.Ord a) => x:(Data.Set.Internal.Set a) -> y:(Data.Set.Internal.Set a) -> {v:GHC.Types.Bool | v <=> Set_sub x y}
+member        :: (GHC.Classes.Ord a) => x:a -> xs:(Data.Set.Internal.Set a) -> {v:GHC.Types.Bool | v <=> Set_mem x xs}
+null          :: (GHC.Classes.Ord a) => xs:(Data.Set.Internal.Set a) -> {v:GHC.Types.Bool | v <=> Set_emp xs}
 
 empty         :: {v:(Data.Set.Internal.Set a) | Set_emp v}
 singleton     :: x:a -> {v:(Data.Set.Internal.Set a) | v = (Set_sng x)}

--- a/include/Data/Set.spec
+++ b/include/Data/Set.spec
@@ -25,7 +25,6 @@ measure Set_emp   :: (Data.Set.Internal.Set a) -> GHC.Types.Bool
 // empty set
 measure Set_empty :: forall a. GHC.Types.Int -> (Data.Set.Internal.Set a)
 
-
 // membership test
 measure Set_mem  :: a -> (Data.Set.Internal.Set a) -> GHC.Types.Bool
 

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -72,14 +72,14 @@ loadLiftedSpec cfg srcF
                else (warnMissingLiftedSpec srcF specF >> return Nothing)
       Ex.evaluate lSp
 
-errMissingSpec :: FilePath -> FilePath -> UserError 
-errMissingSpec srcF specF = ErrNoSpec Ghc.noSrcSpan (text srcF) (text specF)
-
 warnMissingLiftedSpec :: FilePath -> FilePath -> IO () 
 warnMissingLiftedSpec srcF specF = do 
   incDir <- Misc.getIncludeDir 
   unless (Misc.isIncludeFile incDir srcF)
     $ Ex.throw (errMissingSpec srcF specF) 
+
+errMissingSpec :: FilePath -> FilePath -> UserError 
+errMissingSpec srcF specF = ErrNoSpec Ghc.noSrcSpan (text srcF) (text specF)
 
 -- saveLiftedSpec :: FilePath -> ModName -> Ms.BareSpec -> IO ()
 saveLiftedSpec :: GhcSrc -> GhcSpec -> IO () 

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -22,6 +22,7 @@ module Language.Haskell.Liquid.Bare (
   ) where
 
 import           Prelude                                    hiding (error)
+import           Control.Monad                              (unless)
 import qualified Control.Exception                          as Ex
 import qualified Data.Binary                                as B
 import qualified Data.Maybe                                 as Mb
@@ -77,9 +78,8 @@ errMissingSpec srcF specF = ErrNoSpec Ghc.noSrcSpan (text srcF) (text specF)
 warnMissingLiftedSpec :: FilePath -> FilePath -> IO () 
 warnMissingLiftedSpec srcF specF = do 
   incDir <- Misc.getIncludeDir 
-  if Misc.isIncludeFile incDir srcF 
-    then return () 
-    else Ex.throw (errMissingSpec srcF specF) 
+  unless (Misc.isIncludeFile incDir srcF)
+    $ Ex.throw (errMissingSpec srcF specF) 
 
 -- saveLiftedSpec :: FilePath -> ModName -> Ms.BareSpec -> IO ()
 saveLiftedSpec :: GhcSrc -> GhcSpec -> IO () 

--- a/src/Language/Haskell/Liquid/GHC/Interface.hs
+++ b/src/Language/Haskell/Liquid/GHC/Interface.hs
@@ -112,13 +112,15 @@ import qualified Debug.Trace as Debug
  -}
 --------------------------------------------------------------------------------
 realTargets :: Maybe HscEnv -> Config -> [FilePath] -> IO [FilePath] 
-realTargets  mbEnv cfg tgtFs = do 
-  incDir   <- Misc.getIncludeDir 
-  allFs    <- orderTargets mbEnv cfg tgtFs
-  let srcFs = filter (not . Misc.isIncludeFile incDir) allFs
-  realFs   <- filterM check srcFs
-  dir      <- getCurrentDirectory
-  return      (makeRelative dir <$> realFs)
+realTargets  mbEnv cfg tgtFs 
+  | noCheckImports cfg = return tgtFs
+  | otherwise          = do 
+    incDir   <- Misc.getIncludeDir 
+    allFs    <- orderTargets mbEnv cfg tgtFs
+    let srcFs = filter (not . Misc.isIncludeFile incDir) allFs
+    realFs   <- filterM check srcFs
+    dir      <- getCurrentDirectory
+    return      (makeRelative dir <$> realFs)
   where 
     check f    = not <$> skipTarget tgts f 
     tgts       = S.fromList tgtFs

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -75,7 +75,6 @@ liquidConstraints cfg = do
     Right (gs, _) -> 
       return $ Left $ map generateConstraints gs
 
-
 --------------------------------------------------------------------------------
 runLiquid :: MbEnv -> Config -> IO (ExitCode, MbEnv)
 --------------------------------------------------------------------------------
@@ -86,18 +85,6 @@ runLiquid mE cfg  = orderTargets mE cfg (files cfg) >>= go mE
                        case ec of 
                          ExitSuccess -> go env' fs
                          _           -> return (ec, env')
-
---------------------------------------------------------------------------------
-{- | @orderTargets mE cfg targets@ uses `Interface.configureGhcTargets` to return a list of files
-
-       [i1, i2, ... ] ++ [f1, f2, ...]
-
-     1. where each file only (transitively imports) preceding ones; 
-     2. `f1..` are a permutation of the original `targets`;
- -}
---------------------------------------------------------------------------------
-orderTargets :: MbEnv -> Config -> [FilePath] -> IO [FilePath]
-orderTargets _ _ fs = return fs -- undefined
 
 --------------------------------------------------------------------------------
 -- | @runLiquid@ checks a *target-list* of files, ASSUMING that we have 

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -78,13 +78,21 @@ liquidConstraints cfg = do
 --------------------------------------------------------------------------------
 runLiquid :: MbEnv -> Config -> IO (ExitCode, MbEnv)
 --------------------------------------------------------------------------------
-runLiquid mE cfg  = orderTargets mE cfg (files cfg) >>= go mE
-  where 
+runLiquid mE cfg  = do 
+  reals <- realTargets mE cfg (files cfg)
+  putStrLn $ showpp (text "Targets:" <+> vcat (text <$> reals))
+  checkTargets cfg mE reals
+
+checkTargets :: Config -> MbEnv -> [FilePath] -> IO (ExitCode, MbEnv)
+checkTargets cfg  = go 
+  where
     go env []     = return (ExitSuccess, env)
-    go env (f:fs) = do (ec, env') <- runLiquidTargets env cfg [f] 
+    go env (f:fs) = do colorPhaseLn Loud ("[Checking: " ++ f ++ "]") ""
+                       (ec, env') <- runLiquidTargets env cfg [f] 
                        case ec of 
                          ExitSuccess -> go env' fs
                          _           -> return (ec, env')
+
 
 --------------------------------------------------------------------------------
 -- | @runLiquid@ checks a *target-list* of files, ASSUMING that we have 

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -58,7 +58,10 @@ type MbEnv = Maybe HscEnv
 --------------------------------------------------------------------------------
 liquid :: [String] -> IO b
 --------------------------------------------------------------------------------
-liquid args = getOpts args >>= runLiquid Nothing >>= exitWith . fst
+liquid args = do 
+  cfg     <- getOpts args 
+  (ec, _) <- runLiquid Nothing cfg
+  exitWith ec
 
 --------------------------------------------------------------------------------
 liquidConstraints :: Config -> IO (Either [CGInfo] ExitCode) 
@@ -72,20 +75,45 @@ liquidConstraints cfg = do
     Right (gs, _) -> 
       return $ Left $ map generateConstraints gs
 
---------------------------------------------------------------------------------
--- | This fellow does the real work
+
 --------------------------------------------------------------------------------
 runLiquid :: MbEnv -> Config -> IO (ExitCode, MbEnv)
 --------------------------------------------------------------------------------
-runLiquid mE cfg = do
-  z <- actOrDie $ second Just <$> getGhcInfos mE cfg (files cfg)
+runLiquid mE cfg  = orderTargets mE cfg (files cfg) >>= go mE
+  where 
+    go env []     = return (ExitSuccess, env)
+    go env (f:fs) = do (ec, env') <- runLiquidTargets env cfg [f] 
+                       case ec of 
+                         ExitSuccess -> go env' fs
+                         _           -> return (ec, env')
+
+--------------------------------------------------------------------------------
+{- | @orderTargets mE cfg targets@ uses `Interface.configureGhcTargets` to return a list of files
+
+       [i1, i2, ... ] ++ [f1, f2, ...]
+
+     1. where each file only (transitively imports) preceding ones; 
+     2. `f1..` are a permutation of the original `targets`;
+ -}
+--------------------------------------------------------------------------------
+orderTargets :: MbEnv -> Config -> [FilePath] -> IO [FilePath]
+orderTargets _ _ fs = return fs -- undefined
+
+--------------------------------------------------------------------------------
+-- | @runLiquid@ checks a *target-list* of files, ASSUMING that we have 
+--   already  run LH on ALL the (transitive) home imports -- i.e. other 
+--   imports files for which we have source -- in order to build the .bspec 
+--   files for those specs.
+--------------------------------------------------------------------------------
+runLiquidTargets :: MbEnv -> Config -> [FilePath] -> IO (ExitCode, MbEnv)
+--------------------------------------------------------------------------------
+runLiquidTargets mE cfg targetFiles = do
+  z <- actOrDie $ second Just <$> getGhcInfos mE cfg targetFiles
   case z of
     Left e -> do
-      exitWithResult cfg (files cfg) $ mempty { o_result = e }
+      exitWithResult cfg targetFiles $ mempty { o_result = e }
       return (resultExit e, mE)
     Right (gs, mE') -> do
--- //       | compileSpec cfg -> return (ExitSuccess, mE')
--- //       | otherwise       
       d <- checkMany cfg mempty gs
       return (ec d, mE')
   where

--- a/src/Language/Haskell/Liquid/Misc.hs
+++ b/src/Language/Haskell/Liquid/Misc.hs
@@ -8,7 +8,7 @@ import Control.Monad.State
 
 import Control.Arrow (first)
 import System.FilePath
-import System.Directory   (doesFileExist)
+import System.Directory   (getModificationTime, doesFileExist)
 import System.Environment (getExecutablePath)
 
 import qualified Control.Exception     as Ex --(evaluate, catch, IOException)
@@ -373,3 +373,9 @@ sayReadFile f = do
   -- print ("SAY-READ-FILE: " ++ f)
   res <- readFile f 
   Ex.evaluate res
+
+lastModified :: FilePath -> IO (Maybe UTCTime) 
+lastModified f = do 
+  ex  <- doesFileExist f
+  if ex then Just <$> getModificationTime f
+        else return   Nothing

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -350,6 +350,11 @@ config = cmdArgsMode $ Config {
         &= name "compile-spec"
         &= help "Only compile specifications (into .bspec file); skip verification" 
 
+  , noCheckImports
+    = def 
+        &= name "no-check-imports"
+        &= help "Do not check the transitive imports; only check the target files." 
+
   } &= verbosity
     &= program "liquid"
     &= help    "Refinement Types for Haskell"
@@ -580,6 +585,7 @@ defConfig = Config
   , proofLogicEvalLocal = False
   , reflection        = False
   , compileSpec       = False
+  , noCheckImports    = False
   }
 
 ------------------------------------------------------------------------

--- a/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/src/Language/Haskell/Liquid/UX/Config.hs
@@ -89,7 +89,8 @@ data Config = Config
   , proofLogicEval  :: Bool        -- ^ Enable proof-by-logical-evaluation
   , proofLogicEvalLocal  :: Bool   -- ^ Enable proof-by-logical-evaluation locally, per function
   , reflection      :: Bool        -- ^ Allow "reflection"; switches on "--higherorder" and "--exactdc"
-  , compileSpec     :: Bool       -- ^ Only "compile" the spec -- into .bspec file -- don't do any checking. 
+  , compileSpec     :: Bool        -- ^ Only "compile" the spec -- into .bspec file -- don't do any checking. 
+  , noCheckImports  :: Bool        -- ^ Do not check the transitive imports  
   } deriving (Generic, Data, Typeable, Show, Eq)
 
 -- PLE-OPT instance Serialize Instantiate

--- a/src/Language/Haskell/Liquid/UX/DiffCheck.hs
+++ b/src/Language/Haskell/Liquid/UX/DiffCheck.hs
@@ -143,7 +143,7 @@ assumeSpec sigm sp = sp { gsSig = gsig { gsAsmSigs = M.toList $ M.union sigm ass
     gsig           = gsSig sp
 
 diffVars :: [Int] -> [Def] -> [Var]
-diffVars ls defs'    = tracePpr ("INCCHECK: diffVars lines = " ++ show ls ++ " defs= " ++ show defs) $
+diffVars ls defs'    = -- tracePpr ("INCCHECK: diffVars lines = " ++ show ls ++ " defs= " ++ show defs) $
                          go (L.sort ls) defs
   where
     defs             = L.sort defs'

--- a/tests/import/deps/A.hs
+++ b/tests/import/deps/A.hs
@@ -1,0 +1,9 @@
+module A where
+
+{-@ plus :: x:Int -> y:Int -> {v:Int | v = x + y} @-}
+plus :: Int -> Int -> Int
+plus x y = x + y
+
+test :: String -> (String, String)
+test x = ("test", x)
+

--- a/tests/import/deps/B.hs
+++ b/tests/import/deps/B.hs
@@ -1,0 +1,6 @@
+module B where
+
+{-@ minus :: x:Int -> y:Int -> {v:Int | v = x - y} @-}
+minus :: Int -> Int -> Int
+minus x y = x - y
+

--- a/tests/import/deps/C.hs
+++ b/tests/import/deps/C.hs
@@ -1,0 +1,8 @@
+module C where
+
+import A
+import B
+
+{-@ quux :: x:Int -> y:Int -> z:Int -> {v:Int | v = x + y - z} @-}
+quux :: Int -> Int -> Int -> Int
+quux x y z = x `plus` y `minus` z

--- a/tests/import/deps/D.hs
+++ b/tests/import/deps/D.hs
@@ -1,0 +1,8 @@
+module D where
+
+import qualified C
+
+{-@ gloob :: x:Nat -> Nat @-}
+gloob :: Int -> Int 
+gloob x = C.quux x x x
+

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -497,10 +497,10 @@ extraOptions dir test = mappend (dirOpts dir) (testOpts test)
   where
     dirOpts = flip (Map.findWithDefault mempty) $ Map.fromList
       [ ( "benchmarks/bytestring-0.9.2.1"
-        , "--compile-spec -iinclude --c-files=cbits/fpstring.c"
+        , "-iinclude --c-files=cbits/fpstring.c"
         )
       , ( "benchmarks/text-0.11.2.3"
-        , "--compile-spec -i../bytestring-0.9.2.1 -i../bytestring-0.9.2.1/include --c-files=../bytestring-0.9.2.1/cbits/fpstring.c -i../../include --c-files=cbits/cbits.c"
+        , "--no-check-imports -i../bytestring-0.9.2.1 -i../bytestring-0.9.2.1/include --c-files=../bytestring-0.9.2.1/cbits/fpstring.c -i../../include --c-files=cbits/cbits.c"
         )
       , ( "benchmarks/vector-0.10.0.1"
         , "-i."

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -222,7 +222,7 @@ microTests = group "Micro"
   , mkMicro "basic-neg"      "tests/basic/neg"       (ExitFailure 1)
   , mkMicro "measure-pos"    "tests/measure/pos"     ExitSuccess          -- measPosOrder
   , mkMicro "measure-neg"    "tests/measure/neg"     (ExitFailure 1)
-  , mkMicro "datacon-pos"    "tests/datacon/pos"     ExitSuccess          -- dconPosOrder 
+  , mkMicro "datacon-pos"    "tests/datacon/pos"     ExitSuccess          
   , mkMicro "datacon-neg"    "tests/datacon/neg"     (ExitFailure 1)
   , mkMicro "names-pos"      "tests/names/pos"       ExitSuccess
   , mkMicro "names-neg"      "tests/names/neg"       (ExitFailure 1)
@@ -230,7 +230,7 @@ microTests = group "Micro"
   , mkMicro "reflect-neg"    "tests/reflect/neg"     (ExitFailure 1) 
   , mkMicro "absref-pos"     "tests/absref/pos"      ExitSuccess
   , mkMicro "absref-neg"     "tests/absref/neg"      (ExitFailure 1)
-  , mkMicro "import-lib"     "tests/import/lib"      ExitSuccess          -- impLibOrder 
+  -- , mkMicro "import-lib"     "tests/import/lib"      ExitSuccess       -- NOT disabled; but via CHECK-IMPORTS
   , mkMicro "import-cli"     "tests/import/client"   ExitSuccess
   , mkMicro "class-pos"      "tests/classes/pos"     ExitSuccess
   , mkMicro "class-neg"      "tests/classes/neg"     (ExitFailure 1)        
@@ -266,14 +266,14 @@ benchTests = group "Benchmarks"
   , testGroup "icfp_neg"    <$> odirTests  "benchmarks/icfp15/neg"                icfpIgnored   icfpOrder   (ExitFailure 1)
   ]
 
-_impLibOrder :: Maybe FileOrder 
-_impLibOrder = Just . mkOrder $ [ "T1102_LibZ.hs", "WrapLibCode.hs", "STLib.hs", "T1102_LibY.hs" ]
-
-_dconPosOrder :: Maybe FileOrder 
-_dconPosOrder = Just . mkOrder $ [ "Data02Lib.hs" ]
-
-_measPosOrder :: Maybe FileOrder 
-_measPosOrder = Just . mkOrder $ [ "List00Lib.hs" ]
+-- AUTO-ORDER _impLibOrder :: Maybe FileOrder 
+-- AUTO-ORDER _impLibOrder = Just . mkOrder $ [ "T1102_LibZ.hs", "WrapLibCode.hs", "STLib.hs", "T1102_LibY.hs" ]
+-- AUTO-ORDER 
+-- AUTO-ORDER _dconPosOrder :: Maybe FileOrder 
+-- AUTO-ORDER _dconPosOrder = Just . mkOrder $ [ "Data02Lib.hs" ]
+-- AUTO-ORDER 
+-- AUTO-ORDER _measPosOrder :: Maybe FileOrder 
+-- AUTO-ORDER _measPosOrder = Just . mkOrder $ [ "List00Lib.hs" ]
 
 proverOrder :: Maybe FileOrder 
 proverOrder = Just . mkOrder $ 


### PR DESCRIPTION
If module 

- `C.hs` imports `B.hs` and 
- `B.hs` imports `A.hs` 

then 

```
$ liquid C.hs
```

will now automatically check `A.hs` then `B.hs` and then `C.hs`. Subsequent invocations of the above will *only* check `C.hs` (as long as `A.hs` etc. have not been modified.) Eliminates the need for convoluted Makefiles, and perhaps, the (existing) cabal integration? 

**Disable** with the flag `--no-check-imports` which restores the original behavior, e.g. for backwards compatibility on benchmarks.
