### PR TITLE
Fix Show for RTAlias

### DIFF
--- a/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -1623,10 +1623,10 @@ shiftVV t _
 -- MOVE TO TYPES
 instance (Show tv, Show ty) => Show (RTAlias tv ty) where
   show (RTA n as xs t) =
-    printf "type %s %s %s = %s -- defined at %s" (symbolString n)
+    printf "type %s %s %s = %s" (symbolString n)
       (unwords (show <$> as))
       (unwords (show <$> xs))
-      (show t) 
+      (show t)
 
 --------------------------------------------------------------------------------
 -- | From Old Fixpoint ---------------------------------------------------------


### PR DESCRIPTION
Ran into a small issue with the definition of `show` while doing some debugging.

It looks like the format string has one more argument than necessary, resulting in an error
```
printf: argument list ended prematurely
```

The error appears to be introduced in: https://github.com/ucsd-progsys/liquidhaskell/commit/99754dbcd48c58f6ed7326d878bb8b4f97cd197b#diff-5fc4ae8750cd8b70894d6a005369102f
