### PR TITLE
Change function application syntax

### DIFF
--- a/benchmarks/text-0.11.2.3/Data/Text/Array.hs
+++ b/benchmarks/text-0.11.2.3/Data/Text/Array.hs
@@ -250,14 +250,13 @@ unsafeIndexFQ = undefined
 
 {-@ unsafeIndexB :: a:Array -> o:AValidO a -> l:AValidL o a
                  -> i:{v:Int | Btwn v o (o + l)}
-                 -> {v:Word16 | (if (v >= 56320 && v <= 57343)
-                                 then ((numchars(a, o, (i - o )+1)
-                                     = (1 + numchars(a, o, (i-o)-1)))
-                                    && (numchars(a, o, (i-o-1)) >= 0)
-                                    && (((i-o)-1) >= 0))
-                                 else ((numchars(a, o, (i-o)+1)
-                                     = (1 + numchars(a, o, i-o)))
-                                    && (numchars(a, o, (i-o)) >= 0)))}
+                 -> {v:Word16 | (
+  if (v >= 56320 && v <= 57343)
+  then ( (numchars a o ((i - o)+1)) = (1 + (numchars a o ((i-o)-1)))
+    && ( (numchars a o (i-o-1)) >= 0)
+    && ( ((i-o)-1) >= 0))
+  else ( ((numchars a o ((i-o)+1)) = (1 + (numchars a o (i-o))))
+    && ( (numchars a o (i-o)) >= 0)))}
   @-}
 unsafeIndexB :: Array -> Int -> Int -> Int -> Word16
 unsafeIndexB a o l i = let x = unsafeIndex a i
@@ -265,14 +264,12 @@ unsafeIndexB a o l i = let x = unsafeIndex a i
 
 {-@ unsafeIndexBQ :: x:Word16 -> a:Array -> o:Int -> i:Int
                   -> {v:Bool | (v <=>
-                                (if ((x >= 56320) && (x <= 57343))
-                                 then ((numchars(a, o, (i-o)+1)
-                                     = (1 + numchars(a, o, (i-o)-1)))
-                                    && (numchars(a, o, (i-o-1)) >= 0)
-                                    && (((i-o)-1) >= 0))
-                                 else ((numchars(a, o, (i-o)+1)
-                                     = (1 + numchars(a, o, i-o)))
-                                    && (numchars(a, o, (i-o)) >= 0))))}
+  if (x >= 56320 && x <= 57343)
+  then ( (numchars a o ((i - o)+1)) = (1 + (numchars a o ((i-o)-1)))
+    && ( (numchars a o (i-o-1)) >= 0)
+    && ( ((i-o)-1) >= 0))
+  else ( ((numchars a o ((i-o)+1)) = (1 + (numchars a o (i-o))))
+    && ( (numchars a o (i-o)) >= 0)))}
   @-}
 unsafeIndexBQ :: Word16 -> Array -> Int -> Int -> Bool
 unsafeIndexBQ = undefined

--- a/benchmarks/text-0.11.2.3/Data/Text/Internal.hs
+++ b/benchmarks/text-0.11.2.3/Data/Text/Internal.hs
@@ -89,7 +89,7 @@ import Language.Haskell.Liquid.Prelude
   @-}
 
 {-@ measure tlength :: Text -> Int
-    tlength (Text a o l) = numchars(a,o,l)
+    tlength (Text a o l) = numchars a o l
   @-}
 
 {-@ type IncrTList a = [a]<{\x y -> (tlength x) < (tlength y)}> @-}

--- a/tests/neg/meas9.hs
+++ b/tests/neg/meas9.hs
@@ -6,7 +6,7 @@ import Data.Set (Set(..))
 myid []     = []
 myid (x:xs) = x : myid xs
 
-{-@ myapp :: xs:[a] -> ys:[a] -> {v:[a] | listElts(v) = Set_cup(listElts(xs), listElts(xs))} @-}
+{-@ myapp :: xs:[a] -> ys:[a] -> {v:[a] | listElts(v) = Set_cup (listElts xs) (listElts xs) } @-}
 myapp :: [a] -> [a] -> [a]
 myapp []     ys = ys
 myapp (x:xs) ys = x : myapp xs ys


### PR DESCRIPTION
Liquid Haskell currently parses `f (x, y)` as `(f x) y`. This will no longer work if https://github.com/ucsd-progsys/liquid-fixpoint/pull/405 is merged. This PR updates some tests to use the normal Haskell function application syntax.