### PR TITLE
Fix parsing of `[]`

### DIFF
--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -324,7 +324,7 @@ bareTypeBracesP = do
                return $ Right ct
                      ))
            <|>
-            (try(do
+            (do
                     x  <- symbolP
                     _ <- colon
                     -- NOSUBST i  <- freshIntP
@@ -335,17 +335,15 @@ bareTypeBracesP = do
                     -- su replaces any use of x in the balance of the expression with the unique val
                     -- NOSUBST let xi = intSymbol x i
                     -- NOSUBST let su v = if v == x then xi else v
-                    return $ Left $ PC (PcExplicit x) $ t (Reft (x, ra)) ))
-           <|> do t <- ((RHole . uTop . Reft . ("VV",)) <$> (refasHoleP <* spaces))
-                  return (Left $ nullPC t)
-            )) <|> try (helper holeOrPreds) <|> helper predP
+                    return $ Left $ PC (PcExplicit x) $ t (Reft (x, ra)) )
+            )) <|> try (helper holeOrPredsP) <|> helper predP
   case t of
     Left l -> return l
     Right ct -> do
       PC _sb tt <- btP
       return $ nullPC $ rrTy ct tt
   where
-    holeOrPreds
+    holeOrPredsP
       = (reserved "_" >> return hole)
      <|> try (pAnd <$> brackets (sepBy predP semi))
     helper p = braces $ do

--- a/tests/parser/pos/ReflectedInfix.hs
+++ b/tests/parser/pos/ReflectedInfix.hs
@@ -1,0 +1,20 @@
+module ReflectedInfix where
+{-@ LIQUID "--higherorder"    @-}
+{-@ LIQUID "--exact-data-con" @-}
+
+import Language.Haskell.Liquid.ProofCombinators 
+import Prelude hiding ((++))
+
+{-@ infix ++ @-}
+{-@ reflect ++ @-}
+(++) :: [a]-> [a] -> [a] 
+[] ++ ys = ys 
+(x:xs) ++ ys = x : (xs ++ ys)
+
+{-@ appendNilId :: xs:[a] -> { xs ++ [] = xs } @-}
+appendNilId :: [a] -> Proof
+appendNilId xs = undefined 
+
+{-@ nilAppendId :: xs:[a] -> { [] ++ xs = xs } @-}
+nilAppendId :: [a] -> Proof
+nilAppendId xs = undefined 


### PR DESCRIPTION
Fixes https://github.com/ucsd-progsys/liquidhaskell/issues/1421

This pull request fixes the parsing of annotations like:
```
{-@ nilAppendId :: xs:[a] -> { [] ++ xs = xs } @-}
```
It seems that `refasHoleP` eagerly accepted `[]` as a list of empty predicates, thus  `bareTypeBracesP` failed because of the extra `++ xs = xs` inside the braces. This fix works by back-tracking that failure, and then rechecking the inside of the braces as a single predicate `predP`.