### PR TITLE
add refinement for function valued selector

### DIFF
--- a/src/Language/Haskell/Liquid/Bare/DataType.hs
+++ b/src/Language/Haskell/Liquid/Bare/DataType.hs
@@ -662,7 +662,7 @@ makeRecordSelectorSigs env name = checkRecordSelectorSigs . concatMap makeOne
   where
   makeOne (Loc l l' dcp)
     | null fls                    --    no field labels
-    || any (isFunTy . snd) args   -- OR function-valued fields
+    || any (isFunTy . snd) args && not (higherOrderFlag env)   -- OR function-valued fields
     || dcpIsGadt dcp              -- OR GADT style datcon
     = []
     | otherwise 

--- a/tests/pos/T1544.hs
+++ b/tests/pos/T1544.hs
@@ -1,0 +1,17 @@
+{-@ LIQUID "--reflection"    @-}
+module T1544 where
+
+{-@ data ThingMM = ThingMM {f :: Int -> Int, fprop :: v:Int -> {f v >= 0}} @-}
+data ThingMM =
+  ThingMM
+    { f :: Int -> Int
+    , fprop :: Int -> ()
+    }
+
+{-@ fieldLemmaPat :: t:ThingMM -> v:Int -> {f t v >= 0} @-}
+fieldLemmaPat :: ThingMM -> Int -> ()
+fieldLemmaPat (ThingMM _ fprop) i = const () $ fprop i
+
+{-@ fieldLemmaSel :: t:ThingMM -> v:Int -> {f t v >= 0} @-}
+fieldLemmaSel :: ThingMM -> Int -> ()
+fieldLemmaSel t i = const () $ fprop t i


### PR DESCRIPTION
With reflection enabled, we might want to refine a function valued field and invoke the selector to propagate the refinements. The selector is currently not properly generated and the proof would go through only if we extract the field using pattern matching:
```haskell
{-@ data ThingMM = ThingMM {f :: Int -> Int, fprop :: v:Int -> {f v >= 0}} @-}

data ThingMM =
  ThingMM
    { f :: Int -> Int
    , fprop :: Int -> ()
    }

{-@ safe' :: t:ThingMM -> v:Int -> {f t v >= 0} @-}
safe' :: ThingMM -> Int -> ()
safe' (ThingMM _ fprop) i = const () $ fprop i

-- should be safe
{-@ unsafe :: t:ThingMM -> v:Int -> {f t v >= 0} @-}
unsafe :: ThingMM -> Int -> ()
unsafe t i = const () $ fprop t i
```