### PR TITLE
Parse function composition

### DIFF
--- a/include/Data/Tuple.spec
+++ b/include/Data/Tuple.spec
@@ -1,4 +1,4 @@
 module spec Data.Tuple where
 
-fst :: x:(a,b) -> {v:a | v = (fst x)}
-snd :: x:(a,b) -> {v:b | v = (snd x)}
+fst :: {f:(x:(a,b) -> {v:a | v = (fst x)}) | f == fst }
+snd :: {f:(x:(a,b) -> {v:b | v = (snd x)}) | f == snd }

--- a/include/GHC/Base.spec
+++ b/include/GHC/Base.spec
@@ -18,6 +18,11 @@ len (y:ys) = 1 + len ys
 // null []     = true 
 // null (y:ys) = false
 
+
+// WiredIn in Language.Haskell.Liquid.Types.Names
+measure liquidCompose :: (b -> c) -> (a -> b) -> a -> c
+(.) :: {o3:(f:(b -> c) -> {o2: (g:(a -> b) -> {o1: (x:a -> {o:c | o == liquidCompose f g x && o == f (g x)}) | o1 == liquidCompose f g}) | o2 == liquidCompose f}) | o3 = liquidCompose }
+
 measure fst :: (a, b) -> a
 fst (a, b) = a
 

--- a/include/GHC/Base.spec
+++ b/include/GHC/Base.spec
@@ -18,11 +18,6 @@ len (y:ys) = 1 + len ys
 // null []     = true 
 // null (y:ys) = false
 
-
-// WiredIn in Language.Haskell.Liquid.Types.Names
-measure liquidCompose :: (b -> c) -> (a -> b) -> a -> c
-(.) :: {o3:(f:(b -> c) -> {o2: (g:(a -> b) -> {o1: (x:a -> {o:c | o == liquidCompose f g x && o == f (g x)}) | o1 == liquidCompose f g}) | o2 == liquidCompose f}) | o3 = liquidCompose }
-
 measure fst :: (a, b) -> a
 fst (a, b) = a
 

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -431,6 +431,7 @@ makeSpecRefl cfg src menv specs env name sig tycEnv = SpRefl
   , gsMyAxioms   = F.notracepp "gsMyAxioms" myAxioms 
   , gsReflects   = F.notracepp "gsReflects" (lawMethods ++ filter (isReflectVar rflSyms) sigVars ++ wReflects)
   , gsHAxioms    = F.notracepp "gsHAxioms" xtes 
+  , gsWiredReft  = wReflects
   }
   where
     wReflects    = Bare.wiredReflects cfg env name sig
@@ -916,7 +917,7 @@ makeLiftedSpec src _env refl sData sig qual myRTE lSpec0 = lSpec0
     xbs           = toBare <$> reflTySigs 
     sigVars       = S.difference defVars reflVars
     defVars       = S.fromList (giDefVars src)
-    reflTySigs    = [(x, t) | (x,t,_) <- gsHAxioms refl]
+    reflTySigs    = [(x, t) | (x,t,_) <- gsHAxioms refl, x `notElem` gsWiredReft refl]
     reflVars      = S.fromList (fst <$> reflTySigs)
     -- myAliases fld = M.elems . fld $ myRTE 
     srcF          = giTarget src 

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -157,7 +157,7 @@ makeGhcSpec0 cfg src lmap mspecs = SP
     myRTE    = myRTEnv       src env sigEnv rtEnv  
     qual     = makeSpecQual cfg env tycEnv measEnv rtEnv specs 
     sData    = makeSpecData  src env sigEnv measEnv sig specs 
-    refl     = makeSpecRefl  src measEnv specs env name sig tycEnv 
+    refl     = makeSpecRefl  cfg src measEnv specs env name sig tycEnv 
     laws     = makeSpecLaws env sigEnv (gsTySigs sig ++ gsAsmSigs sig) measEnv specs 
     sig      = makeSpecSig cfg name specs env sigEnv   tycEnv measEnv (giCbs src)
     measEnv  = makeMeasEnv      env tycEnv sigEnv       specs 
@@ -421,21 +421,22 @@ makeSpecLaws env sigEnv sigs menv specs = SpLaws
   }
 
 ------------------------------------------------------------------------------------------
-makeSpecRefl :: GhcSrc -> Bare.MeasEnv -> Bare.ModSpecs -> Bare.Env -> ModName -> GhcSpecSig -> Bare.TycEnv 
+makeSpecRefl :: Config -> GhcSrc -> Bare.MeasEnv -> Bare.ModSpecs -> Bare.Env -> ModName -> GhcSpecSig -> Bare.TycEnv 
              -> GhcSpecRefl 
 ------------------------------------------------------------------------------------------
-makeSpecRefl src menv specs env name sig tycEnv = SpRefl 
+makeSpecRefl cfg src menv specs env name sig tycEnv = SpRefl 
   { gsLogicMap   = lmap 
   , gsAutoInst   = makeAutoInst env name mySpec 
   , gsImpAxioms  = concatMap (Ms.axeqs . snd) (M.toList specs)
   , gsMyAxioms   = F.notracepp "gsMyAxioms" myAxioms 
-  , gsReflects   = F.notracepp "gsReflects" (lawMethods ++ filter (isReflectVar rflSyms) sigVars)
+  , gsReflects   = F.notracepp "gsReflects" (lawMethods ++ filter (isReflectVar rflSyms) sigVars ++ wReflects)
   , gsHAxioms    = F.notracepp "gsHAxioms" xtes 
   }
   where
+    wReflects    = Bare.wiredReflects cfg env name sig
     lawMethods   = F.notracepp "Law Methods" $ concatMap Ghc.classMethods (fst <$> Bare.meCLaws menv) 
     mySpec       = M.lookupDefault mempty name specs 
-    xtes         = Bare.makeHaskellAxioms src env tycEnv name lmap sig mySpec
+    xtes         = Bare.makeHaskellAxioms cfg src env tycEnv name lmap sig mySpec
     myAxioms     = [ Bare.qualifyTop env name (F.loc lt) (e {eqName = symbol x}) | (x, lt, e) <- xtes]  
     rflSyms      = S.fromList (getReflects specs)
     sigVars      = F.notracepp "SIGVARS" $ (fst3 <$> xtes)            -- reflects
@@ -460,9 +461,11 @@ getReflects  = fmap val . S.toList . S.unions . fmap (names . snd) . M.toList
 ------------------------------------------------------------------------------------------
 addReflSigs :: GhcSpecRefl -> GhcSpecSig -> GhcSpecSig
 ------------------------------------------------------------------------------------------
-addReflSigs refl sig = sig { gsAsmSigs = reflSigs ++ gsAsmSigs sig }
+addReflSigs refl sig = sig { gsAsmSigs = reflSigs ++ filter notReflected (gsAsmSigs sig) }
   where 
-    reflSigs         = [ (x, t) | (x, t, _) <- gsHAxioms refl ]   
+    reflSigs        = [ (x, t) | (x, t, _) <- gsHAxioms refl ]   
+    reflected       = fst <$> reflSigs
+    notReflected xt = (fst xt) `notElem` reflected
 
 makeAutoInst :: Bare.Env -> ModName -> Ms.BareSpec -> M.HashMap Ghc.Var (Maybe Int)
 makeAutoInst env name spec = Misc.hashMapMapKeys (Bare.lookupGhcVar env name "Var") (Ms.autois spec)

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -41,6 +41,7 @@ import           Text.PrettyPrint.HughesPJ.Compat       ((<+>))
 import           Language.Fixpoint.Types                hiding (panic, SVar, DDecl, DataDecl, DataCtor (..), Error, R, Predicate)
 import           Language.Haskell.Liquid.GHC.Misc
 import           Language.Haskell.Liquid.Types          
+import           Language.Haskell.Liquid.Types.Names (functionComposisionSymbol)          
 import qualified Language.Fixpoint.Misc                 as Misc      
 import qualified Language.Haskell.Liquid.Misc           as Misc
 import qualified Language.Haskell.Liquid.Measure        as Measure
@@ -80,9 +81,11 @@ hsSpecificationP modName specComments specQuotes =
 
 initPStateWithList :: PState
 initPStateWithList 
-  = initPState { empList  = Just (EVar ("GHC.Types.[]" :: Symbol))
-               , singList = Just (\e -> EApp (EApp (EVar ("GHC.Types.:"  :: Symbol)) e) (EVar ("GHC.Types.[]" :: Symbol)))
+  = (initPState composeFun)
+               { empList    = Just (EVar ("GHC.Types.[]" :: Symbol))
+               , singList   = Just (\e -> EApp (EApp (EVar ("GHC.Types.:"  :: Symbol)) e) (EVar ("GHC.Types.[]" :: Symbol)))
                }
+  where composeFun = Just $ EVar functionComposisionSymbol
 
 --------------------------------------------------------------------------
 specSpecificationP  :: SourceName -> String -> Either Error (ModName, Measure.BareSpec)

--- a/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/src/Language/Haskell/Liquid/Types/Names.hs
@@ -1,5 +1,5 @@
 module Language.Haskell.Liquid.Types.Names
-  (lenLocSymbol, anyTypeSymbol) where
+  (lenLocSymbol, anyTypeSymbol, functionComposisionSymbol) where
 
 import Language.Fixpoint.Types
 
@@ -9,3 +9,8 @@ lenLocSymbol = dummyLoc $ symbol ("autolen" :: String)
 
 anyTypeSymbol :: Symbol
 anyTypeSymbol = symbol ("GHC.Prim.Any" :: String)
+
+
+--  defined in include/GHC/Base.hs
+functionComposisionSymbol :: Symbol
+functionComposisionSymbol = symbol ("liquidCompose" :: String)

--- a/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/src/Language/Haskell/Liquid/Types/Names.hs
@@ -13,4 +13,4 @@ anyTypeSymbol = symbol ("GHC.Prim.Any" :: String)
 
 --  defined in include/GHC/Base.hs
 functionComposisionSymbol :: Symbol
-functionComposisionSymbol = symbol ("liquidCompose" :: String)
+functionComposisionSymbol = symbol ("GHC.Base.." :: String)

--- a/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -135,6 +135,7 @@ data GhcSpecRefl = SpRefl
   , gsMyAxioms   :: ![F.Equation]                     -- ^ Axioms from my reflected functions
   , gsReflects   :: ![Var]                            -- ^ Binders for reflected functions
   , gsLogicMap   :: !LogicMap
+  , gsWiredReft  :: ![Var]
   }
 
 data GhcSpecLaws = SpLaws 

--- a/src/Language/Haskell/Liquid/WiredIn.hs
+++ b/src/Language/Haskell/Liquid/WiredIn.hs
@@ -64,7 +64,7 @@ isWiredInName :: F.Symbol -> Bool
 isWiredInName x = x `S.member` wiredInNames
 
 wiredInNames :: S.HashSet F.Symbol
-wiredInNames = S.fromList [ "head", "tail", "fst", "snd", "len" ]
+wiredInNames = S.fromList [ "head", "tail", "fst", "snd", "len"]
 
 isWiredInShape :: F.LocSymbol -> Bool
 isWiredInShape x = any (`F.isPrefixOfSym` (val x)) [F.anfPrefix, F.tempPrefix, dcPrefix]

--- a/tests/pos/T1547.hs
+++ b/tests/pos/T1547.hs
@@ -1,0 +1,7 @@
+{-@ LIQUID "--reflection" @-}
+
+module Foo where
+
+{-@ myfst :: () -> {v:((a,b) -> a) | v == fst } @-}
+myfst :: () -> (a,b) -> a 
+myfst _ = fst 

--- a/tests/pos/T1547.hs
+++ b/tests/pos/T1547.hs
@@ -1,6 +1,6 @@
 {-@ LIQUID "--reflection" @-}
 
-module Foo where
+module T1547 where
 
 {-@ myfst :: () -> {v:((a,b) -> a) | v == fst } @-}
 myfst :: () -> (a,b) -> a 

--- a/tests/pos/T1548.hs
+++ b/tests/pos/T1548.hs
@@ -6,6 +6,18 @@ module T1548 where
 import Language.Haskell.Liquid.Equational 
 
 
+example :: (b -> d) -> a -> b -> Proof
+{-@ example :: g:(b -> d) -> a:a -> b:b -> { snd (second g (a,b)) == snd (a,g b) } @-}
+example g a b  
+  =   snd (second g (a,b)) 
+  ==. snd (a,g b)
+  *** QED 
+
+hFun :: (b -> d)  -> Proof
+{-@ hFun :: g:(b -> d) -> { snd . second g == g . snd } @-}
+hFun g = extensionality (snd . second g) (g . snd) (h g)
+
+
 h :: (b -> d) -> (a,b) -> Proof
 {-@ h :: g:(b -> d) -> p:(a,b) -> { (snd . second g) (p) == (g . snd) (p) } @-}
 h g p =   (snd . second g) p
@@ -28,3 +40,9 @@ sndSecond g (a,b)
   ==. g b
   ==. g (snd (a,b))
   *** QED
+
+
+
+extensionality :: (a -> b) -> (a -> b) -> (a -> ()) -> ()  
+{-@ assume extensionality :: f:(a -> b) -> g:(a -> b) -> (x:a -> {f x == g x}) ->  {f == g}  @-}
+extensionality _ _ _ = ()

--- a/tests/pos/T1548.hs
+++ b/tests/pos/T1548.hs
@@ -1,0 +1,30 @@
+{-@ LIQUID "--reflection" @-}
+
+
+module T1548 where
+
+import Language.Haskell.Liquid.Equational 
+
+
+h :: (b -> d) -> (a,b) -> Proof
+{-@ h :: g:(b -> d) -> p:(a,b) -> { (snd . second g) (p) == (g . snd) (p) } @-}
+h g p =   (snd . second g) p
+      ==. snd (second g p)
+          ? sndSecond g p
+      ==. g (snd p)
+      ==. (g . snd) p
+      *** QED
+
+
+{-@ reflect second @-}
+second :: (b -> d) -> ((a,b) -> (a,d))
+second g (a,b) = (a, g b)
+
+{-@ sndSecond :: g:(b -> d) -> p:(a,b) -> { snd (second g p) == g (snd p) } @-}
+sndSecond :: (b -> d) -> (a,b) -> Proof
+sndSecond g (a,b)
+  =   snd (second g (a,b))
+  ==. snd (a,g b)
+  ==. g b
+  ==. g (snd (a,b))
+  *** QED


### PR DESCRIPTION
Function Composition is properly parsed in refinements. e.g., you can write https://github.com/ucsd-progsys/liquidhaskell/blob/768e5ef799b0dee4ce2d3ea02ebe155d7079073f/tests/pos/T1548.hs#L10

There are two things to be addressed in different PR: 
1) In `(g . snd) (p)` the argument (here `p`) needs to be in parenthesis. This is a general limitation of our parser: when the function is not a variable, the argument needs to be parenthesized. 

2) More importantly, the definition of Haskell's function composition is hardcoded. See comment below