### PR TITLE
Allow tests to be run via stack or cabal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ css/
 *.smt2
 .liquid
 .dir-locals.el
+.tasty-rerun-log


### PR DESCRIPTION
Fixes #1584.

This commit introduces a new test option called '--liquid-runner' that defaults to `stack exec -- liquid` as before but allow users to override the command which will eventually run `liquid`.

Doing so allows Cabal users to pass something like `cabal new-exec liquid -- ` to the test executable, for example running this:

```
/path/to/test --liquid-runner 'cabal new-exec liquid -- '
```

As I was at it, I have also switched from `LineBuffering` to `NoBuffering` in the implementation of `mkTest`, as that should be pretty harmless and generally recommended for these kind of long-running tests.