### PR TITLE
Remove --c-files from extraOptions

### DIFF
--- a/tests/test.hs
+++ b/tests/test.hs
@@ -502,10 +502,10 @@ extraOptions dir test = mappend (dirOpts dir) (testOpts test)
   where
     dirOpts = flip (Map.findWithDefault mempty) $ Map.fromList
       [ ( "benchmarks/bytestring-0.9.2.1"
-        , "-iinclude --c-files=cbits/fpstring.c"
+        , "-iinclude"
         )
       , ( "benchmarks/text-0.11.2.3"
-        , "--no-check-imports -i../bytestring-0.9.2.1 -i../bytestring-0.9.2.1/include --c-files=../bytestring-0.9.2.1/cbits/fpstring.c -i../../include --c-files=cbits/cbits.c"
+        , "--no-check-imports -i../bytestring-0.9.2.1 -i../bytestring-0.9.2.1/include -i../../include"
         )
       , ( "benchmarks/vector-0.10.0.1"
         , "-i."


### PR DESCRIPTION
Fixes #1586.

This commit removes the `--c-files` options from `extraOptions`, as this was
causing symbols to be loaded twice by the linker when running the tests
via Cabal.