### PR TITLE
Suppress all other output for '--json'

### DIFF
--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -243,9 +243,11 @@ test-suite test
                   , optparse-applicative >= 0.11
                   , process              >= 1.2
                   , stm                  >= 2.4
+                  , string-conv          >= 0.1
                   , tagged               >= 0.7.3
                   , tasty                >= 0.10
                   , tasty-ant-xml
+                  , tasty-golden         >= 2.0.0
                   , tasty-hunit          >= 0.9
                   , tasty-rerun          >= 1.1
                   , text

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -80,14 +80,14 @@ runLiquid :: MbEnv -> Config -> IO (ExitCode, MbEnv)
 --------------------------------------------------------------------------------
 runLiquid mE cfg  = do 
   reals <- realTargets mE cfg (files cfg)
-  putStrLn $ showpp (text "Targets:" <+> vcat (text <$> reals))
+  whenNormal $ putStrLn $ showpp (text "Targets:" <+> vcat (text <$> reals))
   checkTargets cfg mE reals
 
 checkTargets :: Config -> MbEnv -> [FilePath] -> IO (ExitCode, MbEnv)
 checkTargets cfg  = go 
   where
     go env []     = return (ExitSuccess, env)
-    go env (f:fs) = do colorPhaseLn Loud ("[Checking: " ++ f ++ "]") ""
+    go env (f:fs) = do whenLoud $ colorPhaseLn Loud ("[Checking: " ++ f ++ "]") ""
                        (ec, env') <- runLiquidTargets env cfg [f] 
                        case ec of 
                          ExitSuccess -> go env' fs

--- a/tests/golden/json_output.golden
+++ b/tests/golden/json_output.golden
@@ -1,0 +1,2 @@
+RESULT
+[{"start":{"line":9,"column":1},"stop":{"line":9,"column":12},"message":"Error: Liquid Type Mismatch\n  Inferred type\n    VV : {v : GHC.Types.Int | v == 7}\n \n  not a subtype of Required type\n    VV : {VV : GHC.Types.Int | VV mod 2 == 0}\n "}]

--- a/tests/golden/json_output.hs
+++ b/tests/golden/json_output.hs
@@ -1,0 +1,41 @@
+module Main where
+
+{-@ type Even = {v:Int | v mod 2 = 0} @-}
+
+{-@ weAreEven :: [Even] @-}
+weAreEven     = [(0-10), (0-4), 0, 2, 666]
+
+{-@ notEven :: Even @-}
+notEven = 7
+
+{-@ isEven :: n:Nat -> {v:Bool | (v <=> (n mod 2 == 0))} @-}
+isEven   :: Int -> Bool
+isEven 0 = True
+isEven 1 = False
+isEven n = not (isEven (n-1))
+
+{-@ evens :: n:Nat -> [Even] @-}
+evens n = [i | i <- range 0 n, isEven i]
+
+{-@ range :: lo:Int -> hi:Int -> [{v:Int | (lo <= v && v < hi)}] / [hi -lo] @-}
+range lo hi
+  | lo < hi   = lo : range (lo+1) hi
+  | otherwise = []
+
+{-@ shift :: [Even] -> Even -> [Even] @-}
+shift xs k = [x + k | x <- xs]
+
+{-@ double :: [Nat] -> [Even] @-}
+double xs = [x + x | x <- xs]
+
+
+
+---
+
+notEven    :: Int
+weAreEven  :: [Int]
+shift      :: [Int] -> Int -> [Int]
+double     :: [Int] -> [Int]
+range      :: Int -> Int -> [Int]
+
+main = putStrLn "hello"


### PR DESCRIPTION
Fixes #1562.

In order to fix the issue I have taken @alanz 's expected output and converted it into a [golden test](https://ro-che.info/articles/2017-12-04-golden-tests) via [tasty-golden](https://hackage.haskell.org/package/tasty-golden-2.3.2/docs/Test-Tasty-Golden.html), to make sure that in the future regressions of this kind are caught. There is probably an argument for generalising `goldenTest`, but we can do that in the future without premature generalisation.

On a side note, I have resisted the temptation of making sweeping changes (and therefore I have added only the minimal amount of code necessary to fix the issue) but it seems to me like we could benefit from rationalising a little bit our logging interface: at the moment we have a lots of different ways to do logging, and some of them rely on a mutable, [global-level](https://hackage.haskell.org/package/cmdargs-0.10.18/docs/src/System-Console-CmdArgs-Verbosity.html#ref) (cfr. `ref`) verbosity setting.

Maybe if we had a more uniform logging interface which is the only one we are allowed to use (not from an effect point of view but mostly as a developer API contract) perhaps that would make things cleaner, but it's obviously a bit of refactoring work I have decided not to pursue without discussion first 😉 
  