### PR TITLE
fix for #1593

### DIFF
--- a/src/Language/Haskell/Liquid/GHC/Play.hs
+++ b/src/Language/Haskell/Liquid/GHC/Play.hs
@@ -14,7 +14,7 @@ import TyCoRep hiding (substTysWith)
 import DataCon
 
 import TyCon
-import Type      (tyConAppArgs_maybe, tyConAppTyCon_maybe, binderVar)
+import Type      (tyConAppArgs_maybe, tyConAppTyCon_maybe, binderVar, isFunTy)
 import PrelNames (isStringClassName)
 
 import           Control.Arrow       ((***))
@@ -131,6 +131,8 @@ mapType f = go
 
 
 stringClassArg :: Type -> Maybe Type
+stringClassArg t | isFunTy t 
+  = Nothing
 stringClassArg t
   = case (tyConAppTyCon_maybe t, tyConAppArgs_maybe t) of
       (Just c, Just [t]) | isStringClassName == tyConName c

--- a/tests/pos/T1593.hs
+++ b/tests/pos/T1593.hs
@@ -1,0 +1,16 @@
+{-@ LIQUID "--reflection"     @-}
+
+-- not ok
+data Thing0 m = Thing
+  { t0 :: (m Int -> Int) -> Int
+  }
+
+-- not ok
+data Thing1 m = Thing1
+  { t1 :: (Int -> m Int) -> Int
+  }
+
+-- ok
+data Thing2 m = Thing2
+  { t2 :: Int -> m Int -> Int
+  }


### PR DESCRIPTION
It seems that `tyConAppTyCon_maybe t` or `tyConAppArgs_maybe t` crashes when called with `m Int -> Int` on ghc-8.6.5. 

@yiyunliu, since you have established error reporting communication with ghc, you might mention that, but the guard adding in this branch fixes your #1593. 