### PR TITLE
T1601

### DIFF
--- a/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
+++ b/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
@@ -47,7 +47,7 @@ fixConfig tgt cfg = def
   , FC.ginteractive     = ginteractive       cfg
   , FC.noslice          = noslice           cfg
   , FC.rewriteAxioms    = Config.allowPLE   cfg
-  , FC.etaElim          = not (exactDC cfg)
+  , FC.etaElim          = False -- not (exactDC cfg) -- SEE: https://github.com/ucsd-progsys/liquidhaskell/issues/1601
   , FC.extensionality   = extensionality    cfg 
   }
 

--- a/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
+++ b/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
@@ -47,7 +47,7 @@ fixConfig tgt cfg = def
   , FC.ginteractive     = ginteractive       cfg
   , FC.noslice          = noslice           cfg
   , FC.rewriteAxioms    = Config.allowPLE   cfg
-  , FC.etaElim          = False -- not (exactDC cfg) -- SEE: https://github.com/ucsd-progsys/liquidhaskell/issues/1601
+  , FC.etaElim          = not (exactDC cfg) && extensionality cfg -- SEE: https://github.com/ucsd-progsys/liquidhaskell/issues/1601
   , FC.extensionality   = extensionality    cfg 
   }
 

--- a/tests/pos/T1560.hs
+++ b/tests/pos/T1560.hs
@@ -1,5 +1,6 @@
 {-@ LIQUID "--ple"        @-}
 {-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--extensionality" @-}
 
 module T1560 where 
 

--- a/tests/pos/T1560B.hs
+++ b/tests/pos/T1560B.hs
@@ -1,5 +1,6 @@
 {-@ LIQUID "--ple"        @-}
 {-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--extensionality" @-}
 
 module T1560 where 
 


### PR DESCRIPTION
Fixes #1601 by disabling `elimEta` which is currently buggy. The PR guards `elimEta` under the _highly experimental_ `extensionality` flag. We can revisit the defaults when @nikivazou addresses the issue.

