### PR TITLE
Drop only dictionaries of type Eq, Ord, Numerical, and ~

### DIFF
--- a/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -178,7 +178,7 @@ axiomType s t = AT to (reverse xts) res
     (to, (_,xts, Just res)) = runState (go t) (1,[], Nothing)
     go (RAllT a t r) = RAllT a <$> go t <*> return r 
     go (RAllP p t) = RAllP p <$> go t 
-    go (RFun x tx t r) | isClassType tx = (\t' -> RFun x tx t' r) <$> go t
+    go (RFun x tx t r) | isEmbeddedClass tx = (\t' -> RFun x tx t' r) <$> go t
     go (RFun x tx t r) = do 
       (i,bs,res) <- get 
       let x' = unDummy x i 

--- a/src/Language/Haskell/Liquid/Constraint/Split.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Split.hs
@@ -249,7 +249,7 @@ splitC (SubC γ t1'@(RAllT α1 t1 _) t2'@(RAllT α2 t2 _))
           (Just (x1, _), Just (x2, _)) -> F.mkSubst [(x1, F.EVar x2)]
           _                            -> F.mkSubst []
 
-splitC (SubC _ (RApp c1 _ _ _) (RApp c2 _ _ _)) | isClass c1 && c1 == c2
+splitC (SubC _ (RApp c1 _ _ _) (RApp c2 _ _ _)) | isEmbeddedDict c1 && c1 == c2
   = return []
 
 splitC (SubC γ t1@(RApp _ _ _ _) t2@(RApp _ _ _ _))

--- a/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
+++ b/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
@@ -184,7 +184,7 @@ specTypeToLogic es e t
 
 
     su           = F.mkSubst $ zip xs es
-    (cls, nocls) = L.partition (isClassType.snd) $ zip (ty_binds trep) (ty_args trep)
+    (cls, nocls) = L.partition (isEmbeddedClass.snd) $ zip (ty_binds trep) (ty_args trep)
                  :: ([(F.Symbol, SpecType)], [(F.Symbol, SpecType)])
     (xs, ts)     = unzip nocls :: ([F.Symbol], [SpecType])
 

--- a/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -19,7 +19,7 @@ module Language.Haskell.Liquid.GHC.Misc where
 import           Class                                      (classKey)
 import           Data.String
 import qualified Data.List as L
-import           PrelNames                                  (fractionalClassKeys)
+import           PrelNames                                  (fractionalClassKeys, itName, ordClassKey, numericClassKeys, eqClassKey)
 import           FamInstEnv
 import           Debug.Trace
 -- import qualified ConLike                                    as Ghc
@@ -56,7 +56,7 @@ import           TcRnDriver
 
 
 import           RdrName
-import           Type                                       (expandTypeSynonyms, isClassPred, isEqPred, liftedTypeKind)
+import           Type                                       (expandTypeSynonyms, isClassPred, isEqPred, liftedTypeKind, tyConAppTyCon_maybe)
 import           TyCoRep
 import           Var
 import           IdInfo
@@ -218,6 +218,9 @@ unTickExpr x                  = x
 
 isFractionalClass :: Class -> Bool
 isFractionalClass clas = classKey clas `elem` fractionalClassKeys
+
+isOrdClass :: Class -> Bool
+isOrdClass clas = classKey clas == ordClassKey
 
 --------------------------------------------------------------------------------
 -- | Pretty Printers -----------------------------------------------------------
@@ -802,6 +805,47 @@ binders (Rec xes)    = fst <$> xes
 
 expandVarType :: Var -> Type
 expandVarType = expandTypeSynonyms . varType
+
+--------------------------------------------------------------------------------
+-- | The following functions test if a `CoreExpr` or `CoreVar` can be
+--   embedded in logic. With type-class support, we can no longer erase
+--   such expressions arbitrarily.
+--------------------------------------------------------------------------------
+isEmbeddedDictExpr :: CoreExpr -> Bool
+isEmbeddedDictExpr = isEmbeddedDictType . CoreUtils.exprType
+
+isEmbeddedDictVar :: Var -> Bool
+isEmbeddedDictVar v = F.notracepp msg . isEmbeddedDictType . varType $ v
+  where
+    msg     =  "isGoodCaseBind v = " ++ show v
+
+isEmbeddedDictType :: Type -> Bool
+isEmbeddedDictType = anyF [isOrdPred, isNumericPred, isEqPred, isPrelEqPred]
+
+-- unlike isNumCls, isFracCls, these two don't check if the argument's
+-- superclass is Ord or Num. I believe this is the more predictable behavior
+
+isPrelEqPred :: Type -> Bool
+isPrelEqPred ty = case tyConAppTyCon_maybe ty of
+  Just tyCon -> isPrelEqTyCon tyCon
+  _          -> False
+
+
+isPrelEqTyCon :: TyCon -> Bool
+isPrelEqTyCon tc = tc `hasKey` eqClassKey
+
+isOrdPred :: Type -> Bool
+isOrdPred ty = case tyConAppTyCon_maybe ty of
+  Just tyCon -> tyCon `hasKey` ordClassKey
+  _          -> False
+
+-- Not just Num, but Fractional, Integral as well
+isNumericPred :: Type -> Bool
+isNumericPred ty = case tyConAppTyCon_maybe ty of
+  Just tyCon -> getUnique tyCon `elem` numericClassKeys
+  _          -> False
+
+
 --------------------------------------------------------------------------------
 -- | The following functions test if a `CoreExpr` or `CoreVar` are just types
 --   in disguise, e.g. have `PredType` (in the GHC sense of the word), and so

--- a/src/Language/Haskell/Liquid/LawInstances.hs
+++ b/src/Language/Haskell/Liquid/LawInstances.hs
@@ -90,6 +90,6 @@ splitTypeConstraints :: [(F.Symbol, SpecType)] -> ([(F.Symbol, SpecType)], [(F.S
 splitTypeConstraints = go []  
   where  
     go cs (b@(_x, RApp c _ _ _):ts) 
-      | isClass c
+      | isEmbeddedDict c
       = go (b:cs) ts 
     go cs r = (reverse cs, map (\(x, t) -> (x, shiftVV t x)) r)

--- a/src/Language/Haskell/Liquid/Measure.hs
+++ b/src/Language/Haskell/Liquid/Measure.hs
@@ -261,7 +261,7 @@ mapArgumens lc t1 t2 = go xts1' xts2'
     xts1' = dropWhile canDrop xts1
     xts2' = dropWhile canDrop xts2
 
-    canDrop (_, t) = isClassType t || isEqType t
+    canDrop (_, t) = isEmbeddedClass t
 
     go xs ys
       | length xs == length ys && and (zipWith (==) (toRSort . snd <$> xts1') (toRSort . snd <$> xts2'))

--- a/src/Language/Haskell/Liquid/Types/Fresh.hs
+++ b/src/Language/Haskell/Liquid/Types/Fresh.hs
@@ -91,7 +91,7 @@ trueRefType (RImpF _ t t' _)
 trueRefType (RFun _ t t' _)
   = rFun <$> fresh <*> true t <*> true t'
 
-trueRefType (RApp c ts _  _) | isClass c
+trueRefType (RApp c ts _  _) | isEmbeddedDict c
   = rRCls c <$> mapM true ts
 
 trueRefType (RApp c ts rs r)
@@ -144,7 +144,7 @@ refreshRefType (RFun b t t' _)
   | b == F.dummySymbol = rFun <$> fresh <*> refresh t <*> refresh t'
   | otherwise          = rFun     b     <$> refresh t <*> refresh t'
 
-refreshRefType (RApp rc ts _ _) | isClass rc
+refreshRefType (RApp rc ts _ _) | isEmbeddedDict rc
   = return $ rRCls rc ts
 
 refreshRefType (RApp rc ts rs r)

--- a/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -150,7 +150,7 @@ dataConArgs trep = unzip [ (x, t) | (x, t) <- zip xs ts, isValTy t]
   where
     xs           = ty_binds trep
     ts           = ty_args trep
-    isValTy      = not . GM.isPredType . toType
+    isValTy      = not . GM.isEmbeddedDictType . toType
 
 
 pdVar :: PVar t -> Predicate


### PR DESCRIPTION
Once typeclass support is properly implemented, we should no longer drop dictionaries (term level) and class constraints (type level), with the exception of  Eq, Ord, Numerical (Num, Integral, etc.).
While tests for class-laws would definitely break, I want use this PR to see if there's anything else that will be broken that I did not expect.