### PR TITLE
Install git & ssh before checking out the code on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,9 @@ jobs:
     docker:
       - image: fpco/stack-build:lts
     steps:
+      - run: apt-get update && apt-get install -y z3 git ssh
       - checkout
       - add_ssh_keys
-      - run: apt-get update && apt-get install -y z3 git ssh
       #- run: find .git
       #- run: sed -i '/fixpoint.git/a fetch = +refs/pull/*/head:refs/remotes/origin/pr/*' .git/modules/liquid-fixpoint/config
       - run: git submodule sync


### PR DESCRIPTION
@nikivazou This should hopefully fix for good #1566 by installing `ssh` and `git` sooner before we _actually_ checkout the code and therefore the wrong submodule.

This should also fix #1608 and if it does not let me know, I will take another look at this!