### PR TITLE
Flag the scope of outer binders in inner refinements

### DIFF
--- a/benchmarks/esop2013-submission/Base.hs
+++ b/benchmarks/esop2013-submission/Base.hs
@@ -1,4 +1,6 @@
 {-@ LIQUID "--prune-unsorted" @-}
+{-@ LIQUID "--bscope"         @-}
+
 {-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__
 -- LIQUID {- LANGUAGE DeriveDataTypeable, StandaloneDeriving -}

--- a/benchmarks/text-0.11.2.3/Data/Text.hs
+++ b/benchmarks/text-0.11.2.3/Data/Text.hs
@@ -1,6 +1,6 @@
-{-@ LIQUID "--pruneunsorted" @-}
+{-@ LIQUID "--pruneunsorted"     @-}
 {-@ LIQUID "--no-pattern-inline" @-}
-
+{-@ LIQUID "--bscope"            @-}
 
 {-# LANGUAGE BangPatterns, CPP, MagicHash, Rank2Types, UnboxedTuples #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}

--- a/src/Language/Haskell/Liquid/Bare/Misc.hs
+++ b/src/Language/Haskell/Liquid/Bare/Misc.hs
@@ -77,7 +77,7 @@ freeSymbols xs' xts yts ivs =  [ lx | lx <- Misc.sortNub $ zs ++ zs' ++ zs'' , n
 freeSyms :: (F.Reftable r, TyConable c) => Located (RType c tv r) -> [LocSymbol]
 freeSyms ty    = [ F.atLoc ty x | x <- tySyms ]
   where
-    tySyms     = Misc.sortNub $ concat $ efoldReft (\_ _ -> True) (\_ _ -> []) (\_ -> []) (const ()) f (const id) F.emptySEnv [] (val ty)
+    tySyms     = Misc.sortNub $ concat $ efoldReft (\_ _ -> True) False (\_ _ -> []) (\_ -> []) (const ()) f (const id) F.emptySEnv [] (val ty)
     f γ _ r xs = let F.Reft (v, _) = F.toReft r in
                  [ x | x <- F.syms r, x /= v, not (x `F.memberSEnv` γ)] : xs
 

--- a/src/Language/Haskell/Liquid/Constraint/Fresh.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Fresh.hs
@@ -106,7 +106,7 @@ addKuts _x t = modify $ \s -> s { kuts = mappend (F.KS ks) (kuts s)   }
        | otherwise  = {- F.tracepp ("addKuts: " ++ showpp _x) -} ks'
 
 specTypeKVars :: SpecType -> [F.KVar]
-specTypeKVars = foldReft (\ _ r ks -> (kvars $ ur_reft r) ++ ks) []
+specTypeKVars = foldReft False (\ _ r ks -> (kvars $ ur_reft r) ++ ks) []
 
 --------------------------------------------------------------------------------
 trueTy  :: Type -> CG SpecType

--- a/src/Language/Haskell/Liquid/Constraint/Split.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Split.hs
@@ -255,7 +255,7 @@ splitC (SubC _ (RApp c1 _ _ _) (RApp c2 _ _ _)) | isClass c1 && c1 == c2
 splitC (SubC γ t1@(RApp _ _ _ _) t2@(RApp _ _ _ _))
   = do (t1',t2') <- unifyVV t1 t2
        cs    <- bsplitC γ t1' t2'
-       γ'    <- γ `extendEnvWithVV` t1'
+       γ'    <- return γ -- `extendEnvWithVV` t1'
        let RApp c t1s r1s _ = t1'
        let RApp _ t2s r2s _ = t2'
        let isapplied = True -- TC.tyConArity (rtc_tc c) == length t1s

--- a/src/Language/Haskell/Liquid/Constraint/Split.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Split.hs
@@ -84,7 +84,7 @@ splitW (WfC γ t@(RVar _ _))
 
 splitW (WfC γ t@(RApp _ ts rs _))
   =  do ws    <- bsplitW γ t
-        γ'    <- γ `extendEnvWithVV` t
+        γ'    <- if bscope (getConfig γ) then γ `extendEnvWithVV` t else return γ
         ws'   <- concat <$> mapM (splitW . WfC γ') ts
         ws''  <- concat <$> mapM (rsplitW γ)       rs
         return $ ws ++ ws' ++ ws''
@@ -255,7 +255,7 @@ splitC (SubC _ (RApp c1 _ _ _) (RApp c2 _ _ _)) | isClass c1 && c1 == c2
 splitC (SubC γ t1@(RApp _ _ _ _) t2@(RApp _ _ _ _))
   = do (t1',t2') <- unifyVV t1 t2
        cs    <- bsplitC γ t1' t2'
-       γ'    <- return γ -- `extendEnvWithVV` t1'
+       γ'    <- if (bscope (getConfig γ)) then γ `extendEnvWithVV` t1' else return γ
        let RApp c t1s r1s _ = t1'
        let RApp _ t2s r2s _ = t2'
        let isapplied = True -- TC.tyConArity (rtc_tc c) == length t1s

--- a/src/Language/Haskell/Liquid/Types/Fresh.hs
+++ b/src/Language/Haskell/Liquid/Types/Fresh.hs
@@ -284,4 +284,4 @@ refreshHoles' (x,t)
          | otherwise = return r
 
 noHoles :: (F.Reftable r, TyConable c) => RType c tv r -> Bool
-noHoles = and . foldReft (\_ r bs -> not (hasHole r) : bs) []
+noHoles = and . foldReft False (\_ r bs -> not (hasHole r) : bs) []

--- a/src/Language/Haskell/Liquid/Types/PredType.hs
+++ b/src/Language/Haskell/Liquid/Types/PredType.hs
@@ -391,7 +391,7 @@ substRCon msg (_, RProp ss t1@(RApp c1 ts1 rs1 r1)) t2@(RApp c2 ts2 rs2 _) πs r
 
     su = F.mkSubst $ zipWith (\s1 s2 -> (s1, F.EVar s2)) (rvs t1) (rvs t2)
 
-    rvs      = foldReft (\_ r acc -> rvReft r : acc) []
+    rvs      = foldReft False (\_ r acc -> rvReft r : acc) []
     rvReft r = let F.Reft(s,_) = F.toReft r in s
 
 substRCon msg su t _ _        = {- panic Nothing -} errorP "substRCon: " $ msg ++ " " ++ showpp (su, t)

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -155,6 +155,10 @@ config = cmdArgsMode $ Config {
     = def &= help "Enable gradual refinement type checking"
           &= name "gradual"
 
+ , bscope
+    = def &= help "scope of the outer binders on the inner refinements"
+          &= name "bscope"
+
  , gdepth
     = 1
     &= help ("Size of gradual conretizations, 1 by default")
@@ -538,6 +542,7 @@ defConfig = Config
   , rankNTypes        = False 
   , noclasscheck      = False 
   , gradual           = False
+  , bscope            = False 
   , gdepth            = 1
   , ginteractive      = False
   , totalHaskell      = def -- True 

--- a/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/src/Language/Haskell/Liquid/UX/Config.hs
@@ -45,6 +45,7 @@ data Config = Config
   -- , structuralTerm :: Bool       -- ^ use structural termination checker
   , nostructuralterm :: Bool    -- ^ disable structural termination check
   , gradual        :: Bool       -- ^ enable gradual type checking
+  , bscope         :: Bool       -- ^ scope of the outer binders on the inner refinements
   , gdepth         :: Int        -- ^ depth of gradual concretization
   , ginteractive   :: Bool       -- ^ interactive gradual solving
   , totalHaskell   :: Bool       -- ^ Check for termination and totality, Overrides no-termination flags

--- a/tests/neg/PairMeasure.hs
+++ b/tests/neg/PairMeasure.hs
@@ -1,5 +1,7 @@
 module Foo () where
 
+{-@ LIQUID "--bscope" @-}
+
 {-@ measure getfst :: (a, b) -> a
     getfst (x, y) = x
   @-}

--- a/tests/pos/PairMeasure.hs
+++ b/tests/pos/PairMeasure.hs
@@ -2,6 +2,7 @@
 -- TAG: measure
 
 module Foo () where
+{-@ LIQUID "--bscope" @-}
 
 {-@ measure getfst :: (a, b) -> a
     getfst (x, y) = x

--- a/tests/pos/PairMeasure0.hs
+++ b/tests/pos/PairMeasure0.hs
@@ -1,5 +1,7 @@
 module Foo () where
 
+{-@ LIQUID "--bscope" @-}
+
 {-@ measure getfst :: (a, b) -> a
     getfst (x, y) = x
   @-}

--- a/tests/pos/T1074.hs
+++ b/tests/pos/T1074.hs
@@ -1,4 +1,5 @@
 -- see https://github.com/ucsd-progsys/liquidhaskell/issues/1074
+{-@ LIQUID "--bscope"         @-}
 
 module Blank where
 

--- a/tests/pos/maybe4.hs
+++ b/tests/pos/maybe4.hs
@@ -1,5 +1,7 @@
 module Foo () where
 
+{-@ LIQUID "--bscope" @-}
+
 {-@ goo   :: lo:{v0a: Maybe {v:a | ((isJust v0a) && (v = (fromJust v0a)))} | true } 
           -> hi:{v0b: Maybe {v:a | ((isJust v0b) && (v = (fromJust v0b)))} | (((isJust(lo) && isJust(v0b)) => (fromJust(v0b) >= fromJust(lo)))) }   
           -> Bool 

--- a/tests/pos/selfList.hs
+++ b/tests/pos/selfList.hs
@@ -1,5 +1,7 @@
 module Foo () where
 
+{-@ LIQUID "--bscope" @-}
+
 import Data.Set (Set(..)) 
 
 {-@ include <selfList.hquals> @-}

--- a/tests/pos/transpose.hs
+++ b/tests/pos/transpose.hs
@@ -1,5 +1,6 @@
 {-@ LIQUID "--no-termination" @-}
 {-@ LIQUID "--prune-unsorted" @-}
+{-@ LIQUID "--bscope"         @-}
 
 module Tx (transpose, transpose', transpose'') where
 

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -530,7 +530,7 @@ extraOptions dir test = mappend (dirOpts dir) (testOpts test)
         , "-iinclude"
         )
       , ( "benchmarks/text-0.11.2.3"
-        , "--no-check-imports -i../bytestring-0.9.2.1 -i../bytestring-0.9.2.1/include -i../../include"
+        , "--bscope --no-check-imports -i../bytestring-0.9.2.1 -i../bytestring-0.9.2.1/include -i../../include"
         )
       , ( "benchmarks/vector-0.10.0.1"
         , "-i."


### PR DESCRIPTION
Before, in the below `RApp`

```
{out:T {in:a | rin } | rout}
```

the binder `out` was in scope for the refinement `rin`.  (More, the refinement `rout` was in the SMT environment when checking subtyping of the inner types). 

This behavior is weird because type checking smaller types relies on typechecking bigger (which sound break various induction assumptions of type checking). But, 1/ I have not found a formalization of refinement type checking of type constructors with type arguments, 2/ I cannot think of any unsoundness caused by this scoping and 3/ we use it in LH, e.g., to type pairs as [`{v0 : ({v:a | v = (getfst v0)}, b) | true }`](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/PairMeasure0.hs#L7).

So, I suggest we flag this behavior with the `bscope` flag introduced here. 
