### PR TITLE
make functor a generic class for #1619

### DIFF
--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -1458,14 +1458,13 @@ isPLETerm γ
 
 -- | @isGenericVar@ determines whether the @RTyVar@ has no class constraints
 isGenericVar :: RTyVar -> SpecType -> Bool
-isGenericVar α t =  all (\(c, α') -> (α'/=α) || isOrd c || isEq c ) (classConstrs t)
+isGenericVar α t =  all (\(c, α') -> (α'/=α) || isGenericClass c ) (classConstrs t)
   where 
     classConstrs t = [(c, ty_var_value α')
                         | (c, ts) <- tyClasses t
                         , t'      <- ts
                         , α'      <- freeTyVars t']
-    isOrd          = (ordClassName ==) . className
-    isEq           = (eqClassName ==) . className
+    isGenericClass c = className c `elem` [ordClassName, eqClassName, functorClassName]
 
 -- instance MonadFail CG where 
 --  fail msg = panic Nothing msg

--- a/tests/pos/T1619.hs
+++ b/tests/pos/T1619.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE Rank2Types #-}
+
+{-@ data Label<label :: User -> Bool> where @-}
+data Label
+data User
+data Tagged l a = Tag a
+data MyFunctor f = MyFunctor { myFmap :: forall a b. (a -> b) -> f a -> f b }
+
+instance Functor (Tagged l) where
+  fmap = fmapTagged
+
+taggedFunctor :: MyFunctor (Tagged l)
+taggedFunctor = MyFunctor fmapTagged
+
+fmapTagged :: (a -> b) -> Tagged l a -> Tagged l b
+fmapTagged f (Tag x) = Tag (f x)
+
+{-@
+myFmapPreservesLabel :: forall <label :: User -> Bool>.
+(a -> b) -> Tagged (Label<label>) a -> Tagged (Label<label>) b
+@-}
+myFmapPreservesLabel :: (a -> b) -> Tagged Label a -> Tagged Label b
+myFmapPreservesLabel = myFmap taggedFunctor
+
+{-@
+fmapPreservesLabel :: forall <label :: User -> Bool>.
+(a -> b) -> Tagged (Label<label>) a -> Tagged (Label<label>) b
+@-}
+fmapPreservesLabel :: (a -> b) -> Tagged Label a -> Tagged Label b
+fmapPreservesLabel = fmap


### PR DESCRIPTION
So, in @rosekunkel 's example, the abstract refinement `label` was defaulted to true because `Functor` is not "generic", so no fresh type was created. 

@rosekunkel this fixes your issue, but if you want to have similar behavior on other type classes, you should make a similar edit and add, e.g., applicative, monads, etc in the generic set, like I did. 

@ranjitjhala I am not entirely sure that Functor (and the rest type constructors) are generic. It would be cool to formalize what generic means for such constructors. But the truth is, we are being too strict by not refreshing at all non generic types. I suspect we need to refresh the inner parts of the type (as here) but not the top level refinements. 

Anyway, this should unblock Rose. 