### PR TITLE
Do not substitute bound variables on qualification

### DIFF
--- a/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -411,12 +411,11 @@ substEnv :: (F.Subable a) => Env -> ModName -> F.SourcePos -> [F.Symbol] -> a ->
 substEnv env name l bs = F.substa (qualifySymbol env name l bs) 
 
 instance Qualify SpecType where 
-  qualify = substFreeEnv           
+  qualify x1 x2 x3 x4 x5 = emapReft (substFreeEnv x1 x2 x3) x4 x5            
 
 instance Qualify BareType where 
-  qualify = substFreeEnv 
+  qualify x1 x2 x3 x4 x5 = emapReft (substFreeEnv x1 x2 x3) x4 x5 
 
--- Do not substitute variables bound e.g. by function types
 substFreeEnv :: (F.Subable a) => Env -> ModName -> F.SourcePos -> [F.Symbol] -> a -> a 
 substFreeEnv env name l bs = F.substf (F.EVar . qualifySymbol env name l bs) 
 

--- a/tests/pos/T1636.hs
+++ b/tests/pos/T1636.hs
@@ -1,0 +1,25 @@
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
+
+module Qualify where 
+
+data RA a  = RA  
+
+
+{-@ type RRA a E1 E2 = {v:RA a | E1 == E2} @-}
+
+
+{-@ assume eqRTCtx :: f:a -> g:a  -> RRA a {f} {g} -> ctx:(a -> b) -> RRA b {ctx f} {ctx g}  @-}
+eqRTCtx ::  a -> a -> RA a -> (a -> b) -> RA b
+eqRTCtx _f _g _pf _ctx = undefined  
+
+fEqG0BadDomain :: Integer -> RA Integer
+fEqG0BadDomain x = RA
+
+{-@ reflect f @-}
+f :: Integer -> Integer 
+f x = x + 1 
+
+{-@ reflect g @-}
+g :: Integer -> Integer 
+g x = x + 1 


### PR DESCRIPTION
`tests/pos/T1636.hs` was before crashing because in `eqRTCtx` the bounded `f` and `g` were qualified and renamed to the reflected `f` and `g` functions. 