### PR TITLE
flag polymorphic instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,16 @@ To allow reasoning about function extensionality use the `extensionality flag`. 
 {-@ LIQUID "--extensionality" @-}
 ```
 
+
+Fast Checking
+-------------
+
+The option `--fast` or `--nopolyinfer` greatly recudes verification time, can also reduces precision of type checking. 
+It, per module, deactivates inference of refinements during 
+instantiation of polymorphic type variables. 
+It is suggested to use on theorem proving style when reflected 
+functions are trivially refined. 
+
 Incremental Checking
 --------------------
 

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -824,7 +824,9 @@ consE γ e'@(App e a@(Type τ))
          Just (x, _) -> return $ maybe (checkUnbound γ e' x tt a) (F.subst1 tt . (x,)) (argType τ)
          Nothing     -> return tt
   where 
-    isPos α = not (extensionality (getConfig γ)) || rtv_is_pol (ty_var_info α)
+    isPos α =   not (nopolyinfer (getConfig γ)) && 
+              ( not (extensionality (getConfig γ)) 
+              || rtv_is_pol (ty_var_info α))
 
 consE γ e'@(App e a) | Just aDict <- getExprDict γ a
   = case dhasinfo (dlookup (denv γ) aDict) (getExprFun γ e) of

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -1456,6 +1456,8 @@ isGeneric γ α t = isGenericVar α t && not (isPLETerm γ)
 -- | @isPLETerm γ@ returns @True@ if the "currrent" top-level binder in γ has PLE enabled.
 isPLETerm :: CGEnv -> Bool  
 isPLETerm γ 
+  | proofLogicEval $ getConfig $ γ
+  = True 
   | Just x <- cgVar γ = {- F.tracepp ("isPLEVar:" ++ F.showpp x) $ -} isPLEVar (giSpec . cgInfo $ γ) x 
   | otherwise         = False 
 

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -815,7 +815,9 @@ consE _ (Lit c)
 
 consE γ e'@(App e a@(Type τ))
   = do RAllT α te _ <- checkAll ("Non-all TyApp with expr", e) γ <$> consE γ e
-       t            <- if isPos α && isGeneric γ (ty_var_value α) te then freshTy_type TypeInstE e τ else trueTy τ
+       t            <- if not (nopolyinfer (getConfig γ)) && isPos α && isGenericVar (ty_var_value α) te 
+                         then freshTy_type TypeInstE e τ 
+                         else trueTy τ
        addW          $ WfC γ t
        t'           <- refreshVV t
        tt0          <- instantiatePreds γ e' (subsTyVar_meet' (ty_var_value α, t') te)
@@ -824,9 +826,7 @@ consE γ e'@(App e a@(Type τ))
          Just (x, _) -> return $ maybe (checkUnbound γ e' x tt a) (F.subst1 tt . (x,)) (argType τ)
          Nothing     -> return tt
   where 
-    isPos α =   not (nopolyinfer (getConfig γ)) && 
-              ( not (extensionality (getConfig γ)) 
-              || rtv_is_pol (ty_var_info α))
+    isPos α = not (extensionality (getConfig γ)) || rtv_is_pol (ty_var_info α)
 
 consE γ e'@(App e a) | Just aDict <- getExprDict γ a
   = case dhasinfo (dlookup (denv γ) aDict) (getExprFun γ e) of
@@ -1448,18 +1448,6 @@ exprLoc _                       = Nothing
 isType :: Expr CoreBndr -> Bool
 isType (Type _)                 = True
 isType a                        = eqType (exprType a) predType
-
--- | @isGeneric@ determines whether the @RTyVar@ CAN and SHOULD be instantiated in a refined manner.
-isGeneric :: CGEnv -> RTyVar -> SpecType -> Bool
-isGeneric γ α t = isGenericVar α t && not (isPLETerm γ)
-
--- | @isPLETerm γ@ returns @True@ if the "currrent" top-level binder in γ has PLE enabled.
-isPLETerm :: CGEnv -> Bool  
-isPLETerm γ 
-  | proofLogicEval $ getConfig $ γ
-  = True 
-  | Just x <- cgVar γ = {- F.tracepp ("isPLEVar:" ++ F.showpp x) $ -} isPLEVar (giSpec . cgInfo $ γ) x 
-  | otherwise         = False 
 
 -- | @isGenericVar@ determines whether the @RTyVar@ has no class constraints
 isGenericVar :: RTyVar -> SpecType -> Bool

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -346,7 +346,7 @@ config = cmdArgsMode $ Config {
   , nopolyinfer
     = def 
         &= help "No inference of polymorphic type application. Gives imprecision, but speedup."
-        &= name "nopolyinfer"
+        &= name "fast"
 
   , reflection 
     = def 

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -343,6 +343,11 @@ config = cmdArgsMode $ Config {
         &= help "Enable extensional interpretation of function equality"
         &= name "extensionality"
 
+  , nopolyinfer
+    = def 
+        &= help "No inference of polymorphic type application. Gives imprecision, but speedup."
+        &= name "nopolyinfer"
+
   , reflection 
     = def 
         &= help "Enable reflection of Haskell functions and theorem proving" 
@@ -591,6 +596,7 @@ defConfig = Config
   , proofLogicEvalLocal = False
   , reflection        = False
   , extensionality    = False 
+  , nopolyinfer       = False
   , compileSpec       = False
   , noCheckImports    = False
   , typedHoles        = False

--- a/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/src/Language/Haskell/Liquid/UX/Config.hs
@@ -88,6 +88,7 @@ data Config = Config
   , oldPLE          :: Bool        -- ^ Enable proof-by-logical-evaluation
   , proofLogicEvalLocal  :: Bool   -- ^ Enable proof-by-logical-evaluation locally, per function
   , extensionality  :: Bool        -- ^ Enable extensional interpretation of function equality 
+  , nopolyinfer     :: Bool        -- ^ No inference of polymorphic type application. 
   , reflection      :: Bool        -- ^ Allow "reflection"; switches on "--higherorder" and "--exactdc"
   , compileSpec     :: Bool        -- ^ Only "compile" the spec -- into .bspec file -- don't do any checking. 
   , noCheckImports  :: Bool        -- ^ Do not check the transitive imports  


### PR DESCRIPTION
Most equational style proofs are not using the advantages polymorphic inference (esp. the ones that reason about trivially refined functions). But these proofs still pay the inference extra time. 
In this PR I flag the polymorphic inference feature. 
The example I am working on drops from ` 379.96 s` to `5.66 s`. 