### PR TITLE
Add scripts to plot testsuite perf via gnuplot

### DIFF
--- a/scripts/plot-performance/README.md
+++ b/scripts/plot-performance/README.md
@@ -1,0 +1,31 @@
+## Visualising performance of LH's testsuite
+
+We offer a simple script to generate a gnuplot (under the form of a `.png` file) from `.csv` files
+produced by LH's testuite. It will produce something like this:
+
+![perf-min](https://user-images.githubusercontent.com/442035/78143687-e3f4a480-742e-11ea-9a47-6b1800914a15.png)
+
+### Usage
+
+In order to measure, say, regression between two LH branches, it's first necessary to acquire two `.csv`
+files to compare. For example, suppose you want to measure the performance changes between `develop` and
+a `new-feature` branch. The easiest way is to do something like this:
+
+```
+git checkout develop
+stack build
+stack test -j1 liquidhaskell:test --flag liquidhaskell:include --flag liquidhaskell:devel --test-arguments="-p Micro"
+git checkout new-feature
+stack build
+stack test -j1 liquidhaskell:test --flag liquidhaskell:include --flag liquidhaskell:devel --test-arguments="-p Micro"
+```
+
+After doing so, inside `tests/logs` you will find a bunch of folders named after your hostname, with some
+timestamps. At that point you can simply do:
+
+```
+./chart_perf.sh ../path/to/develop.csv ../path/to/new_feature.csv
+```
+
+The order is _chronological_, i.e. the first csv should be the "before" and the second the "after". After
+you do that, you should hopefully have a `perf.png` image on your filesystem to inspect.

--- a/scripts/plot-performance/chart_perf.sh
+++ b/scripts/plot-performance/chart_perf.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Simple script to plot the performance regression between different testruns in Liquidhaskell.
+# It requires:
+# - gnuplot
+# - Imagemagick
+
+# $1 = before.csv
+# $2 = after.csv
+
+cat $1 | tail -n +5 > before.csv
+cat $2 | tail -n +5 > after.csv
+
+paste before.csv after.csv > combined.csv
+
+gnuplot -p -e "csv_1='before.csv';csv_2='after.csv';csv_3='combined.csv'" perf.gnuplot
+convert -trim -density 300 perf.svg perf.png

--- a/scripts/plot-performance/perf.gnuplot
+++ b/scripts/plot-performance/perf.gnuplot
@@ -1,0 +1,29 @@
+set datafile separator ','
+
+# General config.
+set autoscale
+set bmargin 22    # For some reason using xticlabels adds tons of whitespaces at the end
+set tics font ",4"
+
+# Y (time) axis config
+set ylabel "Time"
+set logscale y 10
+
+# Chart shape
+set style histogram clustered
+set boxwidth 0.75 relative
+set style fill transparent solid 0.5 noborder
+set style histogram gap 0.25
+
+# Grid
+set style line 100 lt 1 lc rgb "grey" lw 0.5 # linestyle for the grid
+set grid ls 100 # enable grid with specific linestyle
+
+# X axis config
+set xtics 1 rotate
+
+set terminal svg enhanced size 2048,1024
+set output 'perf.svg'
+plot csv_2 using 2:xticlabels(1) with boxes lc rgb'red90' axis x1y1 title "after", \
+     csv_3 using 2:xticlabels(1) with boxes lc rgb'blue90' axis x1y1 title "before", \
+     '' u 0:($2+.1):(sprintf("%3.2f",$4-$2)) with labels rotate left font ",4" notitle


### PR DESCRIPTION
This PR adds the simple script I have to plot performance difference between branches as requested by @nikivazou . There is a README that explains how to use it, but it should hopefully be straightforward, provided you have installed `gnuplot` and `ImageMagick` on your machine (both of which are available via `brew` on Mac OS X).

Something I have noticed is that we already had a bunch of scripts for performance reporting (inside `scripts/performance`) which the top-level `README` file even mentions, so I don't know if we should somehow integrate these at some point or simply clarify better the purpose of these scripts to avoid have them bit-rot.

Instructions on how to run the script is provided in the README, and it should generate something like this, if all is well:

![perf-min](https://user-images.githubusercontent.com/442035/78143687-e3f4a480-742e-11ea-9a47-6b1800914a15.png)

Note that this script ingest the data from the testsuite "summary" CSV files, which are not produced as part of a "scientific" benchmark process, but are merely the running time of each test according to `tasty`. This means these numbers can fluctuate quite a bit between runs depending on the load of the OS or the scheduler.