### PR TITLE
Move printing LH copyright outside getOpts

### DIFF
--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -61,6 +61,7 @@ liquid :: [String] -> IO b
 --------------------------------------------------------------------------------
 liquid args = do 
   cfg     <- getOpts args 
+  printLiquidHaskellBanner
   (ec, _) <- runLiquid Nothing cfg
   exitWith ec
 

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -29,6 +29,9 @@ module Language.Haskell.Liquid.UX.CmdLine (
    -- * Diff check mode
    , diffcheck
 
+   -- * Show info about this version of LiquidHaskell
+   , printLiquidHaskellBanner
+
 ) where
 
 import Prelude hiding (error)
@@ -391,9 +394,12 @@ getOpts as = do
                          as
   cfg    <- fixConfig cfg1
   when (json cfg) $ setVerbosity Quiet
-  whenNormal $ putStrLn copyright
   withSmtSolver cfg
 
+-- | Shows the LiquidHaskell banner, that includes things like the copyright, the
+-- git commit and the version.
+printLiquidHaskellBanner :: IO ()
+printLiquidHaskellBanner = whenNormal $ putStrLn copyright
 
 cmdArgsRun' :: Mode (CmdArgs a) -> [String] -> IO a
 cmdArgsRun' md as


### PR DESCRIPTION
Previously `getOpts` was dealing with two concerns: parsing the command line arguments and printing the LH's "banner", which included things like the version, the git commit and the copyright.

This commit moves this printing outside `getOpts`, so that in the future we will have more fine-grained control over that.

More specifically, when using the source plugin, this banner would be printed each time we call `getOpts`, which will be once per module, which is a bit visually-heavy, especially when trying to wrap `ghc` to act as the new executable as part of `adinapoli/source-plugin`.