### PR TITLE
Add proper version to liquid-* packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ commands:
           name: Dependencies
           command: |
             cabal v2-update
+            cabal v2-clean
             cabal v2-build -j1 all
       - save_cache:
           key: cabal-{{ checksum "liquidhaskell.cabal" }}

--- a/liquid-base/liquid-base.cabal
+++ b/liquid-base/liquid-base.cabal
@@ -100,7 +100,7 @@ library
   build-depends:      base                 == 4.14.0.0
                     , liquid-ghc-prim
                     , liquidhaskell        >= 0.8.10.1
-  default-language:   Haskell98
+  default-language:   Haskell2010
   default-extensions: PackageImports
                       NoImplicitPrelude
   if impl(ghc >= 8.10)

--- a/liquid-base/liquid-base.cabal
+++ b/liquid-base/liquid-base.cabal
@@ -1,5 +1,5 @@
 name:               liquid-base
-version:            0.8.10.1
+version:            4.14.0.0
 synopsis:           Drop-in base replacement for LiquidHaskell
 description:        Drop-in base replacement for LiquidHaskell.
 license:            BSD3
@@ -97,7 +97,7 @@ library
                     Liquid.Prelude.NotReal
                     Prelude
   hs-source-dirs:     src
-  build-depends:      base                 >= 4.11.1.0 && < 5
+  build-depends:      base                 >= 4.14.0.0 && < 5
                     , liquid-ghc-prim
                     , liquidhaskell        >= 0.8.10.1
   default-language:   Haskell98

--- a/liquid-base/liquid-base.cabal
+++ b/liquid-base/liquid-base.cabal
@@ -97,7 +97,7 @@ library
                     Liquid.Prelude.NotReal
                     Prelude
   hs-source-dirs:     src
-  build-depends:      base                 >= 4.14.0.0 && < 5
+  build-depends:      base                 == 4.14.0.0
                     , liquid-ghc-prim
                     , liquidhaskell        >= 0.8.10.1
   default-language:   Haskell98

--- a/liquid-bytestring/liquid-bytestring.cabal
+++ b/liquid-bytestring/liquid-bytestring.cabal
@@ -30,7 +30,7 @@ library
   build-depends:      liquid-base          < 5
                     , bytestring           >= 0.10.10.0 && < 0.11
                     , liquidhaskell        >= 0.8.10.1
-  default-language:   Haskell98
+  default-language:   Haskell2010
   default-extensions: PackageImports
   if impl(ghc >= 8.10)
     ghc-options: -fplugin=LiquidHaskell

--- a/liquid-bytestring/liquid-bytestring.cabal
+++ b/liquid-bytestring/liquid-bytestring.cabal
@@ -1,5 +1,5 @@
 name:               liquid-bytestring
-version:            0.8.10.1
+version:            0.10.10.0
 synopsis:           LiquidHaskell specs for the bytestring package
 description:        LiquidHaskell specs for the bytestring package.
 license:            BSD3
@@ -27,8 +27,8 @@ library
                       Data.ByteString.Lazy
                       -- Data.ByteString.Lazy.Char8
   hs-source-dirs:     src
-  build-depends:      liquid-base          >= 0.8.10.1
-                    , bytestring           >= 0.10
+  build-depends:      liquid-base          < 5
+                    , bytestring           >= 0.10.0.0
                     , liquidhaskell        >= 0.8.10.1
   default-language:   Haskell98
   default-extensions: PackageImports

--- a/liquid-bytestring/liquid-bytestring.cabal
+++ b/liquid-bytestring/liquid-bytestring.cabal
@@ -28,7 +28,7 @@ library
                       -- Data.ByteString.Lazy.Char8
   hs-source-dirs:     src
   build-depends:      liquid-base          < 5
-                    , bytestring           >= 0.10.0.0
+                    , bytestring           >= 0.10.10.0 && < 0.11
                     , liquidhaskell        >= 0.8.10.1
   default-language:   Haskell98
   default-extensions: PackageImports

--- a/liquid-containers/liquid-containers.cabal
+++ b/liquid-containers/liquid-containers.cabal
@@ -19,7 +19,7 @@ library
                       Data.Map
   hs-source-dirs:     src
   build-depends:      liquid-base          < 5
-                    , containers           >= 0.6.0.0
+                    , containers           >= 0.6.2.1 && < 0.7
                     , liquidhaskell        >= 0.8.10.1
   default-language:   Haskell98
   default-extensions: PackageImports

--- a/liquid-containers/liquid-containers.cabal
+++ b/liquid-containers/liquid-containers.cabal
@@ -1,5 +1,5 @@
 name:               liquid-containers
-version:            0.8.10.1
+version:            0.6.2.1
 synopsis:           LiquidHaskell specs for the containers package
 description:        LiquidHaskell specs for the containers package.
 license:            BSD3
@@ -18,8 +18,8 @@ library
   exposed-modules:    Data.Set
                       Data.Map
   hs-source-dirs:     src
-  build-depends:      liquid-base          >= 0.8.10.1
-                    , containers           >= 0.5.9.2
+  build-depends:      liquid-base          < 5
+                    , containers           >= 0.6.0.0
                     , liquidhaskell        >= 0.8.10.1
   default-language:   Haskell98
   default-extensions: PackageImports

--- a/liquid-containers/liquid-containers.cabal
+++ b/liquid-containers/liquid-containers.cabal
@@ -21,7 +21,7 @@ library
   build-depends:      liquid-base          < 5
                     , containers           >= 0.6.2.1 && < 0.7
                     , liquidhaskell        >= 0.8.10.1
-  default-language:   Haskell98
+  default-language:   Haskell2010
   default-extensions: PackageImports
   if impl(ghc >= 8.10)
     ghc-options: -fplugin=LiquidHaskell

--- a/liquid-ghc-prim/liquid-ghc-prim.cabal
+++ b/liquid-ghc-prim/liquid-ghc-prim.cabal
@@ -27,7 +27,7 @@ library
                     GHC.Tuple
 
   hs-source-dirs:     src
-  build-depends:      ghc-prim             >= 0.6.1 && < 0.7
+  build-depends:      ghc-prim             == 0.6.1
                     , liquidhaskell        >= 0.8.10.1
   default-language:   Haskell98
   default-extensions: PackageImports

--- a/liquid-ghc-prim/liquid-ghc-prim.cabal
+++ b/liquid-ghc-prim/liquid-ghc-prim.cabal
@@ -29,7 +29,7 @@ library
   hs-source-dirs:     src
   build-depends:      ghc-prim             == 0.6.1
                     , liquidhaskell        >= 0.8.10.1
-  default-language:   Haskell98
+  default-language:   Haskell2010
   default-extensions: PackageImports
                       NoImplicitPrelude
                       MagicHash

--- a/liquid-ghc-prim/liquid-ghc-prim.cabal
+++ b/liquid-ghc-prim/liquid-ghc-prim.cabal
@@ -1,5 +1,5 @@
 name:               liquid-ghc-prim
-version:            0.8.10.1
+version:            0.6.1
 synopsis:           Drop-in ghc-prim replacement for LiquidHaskell
 description:        Drop-in ghc-prim replacement for LiquidHaskell.
 license:            BSD3
@@ -27,7 +27,7 @@ library
                     GHC.Tuple
 
   hs-source-dirs:     src
-  build-depends:      ghc-prim
+  build-depends:      ghc-prim             >= 0.6.1 && < 0.7
                     , liquidhaskell        >= 0.8.10.1
   default-language:   Haskell98
   default-extensions: PackageImports

--- a/liquid-parallel/liquid-parallel.cabal
+++ b/liquid-parallel/liquid-parallel.cabal
@@ -17,8 +17,8 @@ data-files:           src/Control/Parallel/Strategies.spec
 library
   exposed-modules:    Control.Parallel.Strategies
   hs-source-dirs:     src
-  build-depends:      liquid-base          < 5
-                    , parallel             >= 3.2.0.0
+  build-depends:      liquid-base          < 4.15
+                    , parallel             >= 3.2.0.0 && < 3.3
                     , liquidhaskell        >= 0.8.10.1
   default-language:   Haskell98
   default-extensions: PackageImports

--- a/liquid-parallel/liquid-parallel.cabal
+++ b/liquid-parallel/liquid-parallel.cabal
@@ -1,5 +1,5 @@
 name:               liquid-parallel
-version:            0.8.10.1
+version:            3.2.2.0
 synopsis:           LiquidHaskell specs for the parallel package
 description:        LiquidHaskell specs for the parallel package.
 license:            BSD3
@@ -17,8 +17,8 @@ data-files:           src/Control/Parallel/Strategies.spec
 library
   exposed-modules:    Control.Parallel.Strategies
   hs-source-dirs:     src
-  build-depends:      liquid-base          >= 0.8.10.1
-                    , parallel             >= 3.0.0.0
+  build-depends:      liquid-base          < 5
+                    , parallel             >= 3.2.0.0
                     , liquidhaskell        >= 0.8.10.1
   default-language:   Haskell98
   default-extensions: PackageImports

--- a/liquid-parallel/liquid-parallel.cabal
+++ b/liquid-parallel/liquid-parallel.cabal
@@ -20,7 +20,7 @@ library
   build-depends:      liquid-base          < 4.15
                     , parallel             >= 3.2.0.0 && < 3.3
                     , liquidhaskell        >= 0.8.10.1
-  default-language:   Haskell98
+  default-language:   Haskell2010
   default-extensions: PackageImports
   if impl(ghc >= 8.10)
     ghc-options: -fplugin=LiquidHaskell

--- a/liquid-platform/liquid-platform.cabal
+++ b/liquid-platform/liquid-platform.cabal
@@ -26,13 +26,13 @@ executable liquidhaskell
   else
     buildable: True
     build-depends:      liquid-base       >= 4.14.0.0 && < 5
-                      , liquid-containers >= 0.6.0.0  && < 7
+                      , liquid-containers >= 0.6.2.1  && < 0.7
                       , liquid-prelude    >= 0.8.10.1
                       , liquid-vector     >= 0.12.1.2 && < 0.13
-                      , liquid-bytestring >= 0.10.0.0 && < 0.10.11.0
+                      , liquid-bytestring >= 0.10.0.0 && < 0.11
                       , liquidhaskell     >= 0.8.10.1
-                      , process           >= 1.6.0.0 && < 1.7.0.0
-                      , cmdargs           >= 0.10    && < 0.12
+                      , process           >= 1.6.0.0 && < 1.7
+                      , cmdargs           >= 0.10    && < 0.11
 
   if flag(devel)
     ghc-options: -Werror

--- a/liquid-platform/liquid-platform.cabal
+++ b/liquid-platform/liquid-platform.cabal
@@ -20,19 +20,19 @@ flag devel
 executable liquidhaskell
   main-is:            src/Liquid.hs
   default-language:   Haskell98
-  ghc-options:        -W -O2 -threaded -fdefer-typed-holes
+  ghc-options:        -W -O2 -threaded
   if impl(ghc < 8.10.1)
     buildable: False
   else
     buildable: True
-    build-depends:      liquid-base       >= 0.8.10.1
-                      , liquid-containers >= 0.8.10.1
+    build-depends:      liquid-base       >= 4.14.0.0 && < 5
+                      , liquid-containers >= 0.6.0.0  && < 7
                       , liquid-prelude    >= 0.8.10.1
-                      , liquid-vector     >= 0.8.10.1
-                      , liquid-bytestring >= 0.8.10.1
+                      , liquid-vector     >= 0.12.1.2 && < 0.13
+                      , liquid-bytestring >= 0.10.0.0 && < 0.10.11.0
                       , liquidhaskell     >= 0.8.10.1
-                      , process           >= 1.6.0.0
-                      , cmdargs           >= 0.10
+                      , process           >= 1.6.0.0 && < 1.7.0.0
+                      , cmdargs           >= 0.10    && < 0.12
 
   if flag(devel)
     ghc-options: -Werror

--- a/liquid-platform/liquid-platform.cabal
+++ b/liquid-platform/liquid-platform.cabal
@@ -19,7 +19,7 @@ flag devel
 
 executable liquidhaskell
   main-is:            src/Liquid.hs
-  default-language:   Haskell98
+  default-language:   Haskell2010
   ghc-options:        -W -O2 -threaded
   if impl(ghc < 8.10.1)
     buildable: False

--- a/liquid-prelude/liquid-prelude.cabal
+++ b/liquid-prelude/liquid-prelude.cabal
@@ -26,9 +26,9 @@ library
                     KMeansHelper
   hs-source-dirs:     src
   build-depends:      liquid-base          < 5
-                    , bytestring           >= 0.10.0.0
-                    , containers           >= 0.5.0.0
+                    , bytestring           >= 0.10.0.0 && < 0.11
+                    , containers           >= 0.6.0.0  && < 0.7
                     , liquidhaskell        >= 0.8.10.1
-  default-language:   Haskell98
+  default-language:   Haskell2010
   if impl(ghc >= 8.10)
     ghc-options: -fplugin=LiquidHaskell

--- a/liquid-prelude/liquid-prelude.cabal
+++ b/liquid-prelude/liquid-prelude.cabal
@@ -25,9 +25,9 @@ library
                     Language.Haskell.Liquid.Synthesize.Error
                     KMeansHelper
   hs-source-dirs:     src
-  build-depends:      liquid-base          >= 0.8.10.1
-                    , bytestring           >= 0.10
-                    , containers           >= 0.5
+  build-depends:      liquid-base          < 5
+                    , bytestring           >= 0.10.0.0
+                    , containers           >= 0.5.0.0
                     , liquidhaskell        >= 0.8.10.1
   default-language:   Haskell98
   if impl(ghc >= 8.10)

--- a/liquid-vector/liquid-vector.cabal
+++ b/liquid-vector/liquid-vector.cabal
@@ -22,10 +22,10 @@ library
                       Data.Vector.Internal.Check
                       Data.Vector.Unboxed.Mutable
   hs-source-dirs:     src
-  build-depends:      liquid-base          < 5
-                    , vector               >= 0.12.1.2 && < 0.13.0.0
+  build-depends:      liquid-base          < 4.15
+                    , vector               >= 0.12.1.2 && < 0.13
                     , liquidhaskell        >= 0.8.10.1
-  default-language:   Haskell98
+  default-language:   Haskell2010
   default-extensions: PackageImports
   if impl(ghc >= 8.10)
     ghc-options: -fplugin=LiquidHaskell

--- a/liquid-vector/liquid-vector.cabal
+++ b/liquid-vector/liquid-vector.cabal
@@ -1,5 +1,5 @@
 name:               liquid-vector
-version:            0.8.10.1
+version:            0.12.1.2
 synopsis:           LiquidHaskell specs for the vector package
 description:        LiquidHaskell specs for the vector package.
 license:            BSD3
@@ -22,8 +22,8 @@ library
                       Data.Vector.Internal.Check
                       Data.Vector.Unboxed.Mutable
   hs-source-dirs:     src
-  build-depends:      liquid-base          >= 0.8.10.1
-                    , vector               >= 0.10
+  build-depends:      liquid-base          < 5
+                    , vector               >= 0.12.1.2 && < 0.13.0.0
                     , liquidhaskell        >= 0.8.10.1
   default-language:   Haskell98
   default-extensions: PackageImports


### PR DESCRIPTION
This PR adds "proper" versions to the `liquid-*` packages, using the tentative versioning scheme me and @kosmikus proposed a while back. Trying to put the correct constraints on libraries always felt a balance between science and art to me, so I have done my best here to not restrict things too much, while at the same time not making things too loose.

In particular, compiler-dependent packages like `liquid-base` and `liquid-ghc-prim` have been versioned with bounds "in lockstep" to their underlying libraries. For things like `containers`, `bytestring` etc fortunately I could use the latest versions as they are "old enough" to be used in not-so-new Stackage LTSs, which means `liquid-platform` should ideally build for a variety of Stack configurations.

Things like `liquid-prelude` and `liquid-platform` have the same version used for `liquidhaskell`, as they are not really "mirror" packages. 