### PR TITLE
Support ghcide (with a caveat)

### DIFF
--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -69,7 +69,7 @@ flag deterministic-profiling
 flag no-plugin
   default:     False
   manual:      True
-  description: Disables the use of the GHC plugin. Use the legacy executable for testing.
+  description: Use the legacy executable for testing.
 
 library
   exposed-modules:    Gradual.Concretize

--- a/src/Language/Haskell/Liquid/GHC/API.hs
+++ b/src/Language/Haskell/Liquid/GHC/API.hs
@@ -56,6 +56,8 @@ import TysPrim        as Ghc
 import HscTypes       as Ghc
 import HscMain        as Ghc
 import Id             as Ghc hiding (lazySetIdInfo, setIdExported, setIdNotExported)
+import ErrUtils       as Ghc
+import DynFlags       as Ghc
 
 --
 -- Compatibility layer for different GHC versions.

--- a/src/Language/Haskell/Liquid/GHC/GhcMonadLike.hs
+++ b/src/Language/Haskell/Liquid/GHC/GhcMonadLike.hs
@@ -53,7 +53,6 @@ import           Language.Haskell.Liquid.GHC.API   hiding ( ModuleInfo
                                                           )
 import qualified CoreMonad
 import qualified EnumSet
-import DynFlags
 import TcRnMonad
 import Outputable
 import UniqFM

--- a/src/Language/Haskell/Liquid/GHC/Logging.hs
+++ b/src/Language/Haskell/Liquid/GHC/Logging.hs
@@ -9,8 +9,6 @@
      to pay the price of a pretty-printing \"roundtrip\".
 -}
 
-{-# LANGUAGE CPP #-}
-
 module Language.Haskell.Liquid.GHC.Logging (
     fromPJDoc
   , putLogMsg
@@ -28,14 +26,8 @@ import qualified Language.Haskell.Liquid.GHC.API as GHC
 import qualified Text.PrettyPrint.HughesPJ as PJ
 import qualified Outputable as O
 
--- Unfortunately we need the two imports (one of which via CPP) below to bring in scope 'PPrint' instances.
+-- Unfortunately we need the import below to bring in scope 'PPrint' instances.
 import Language.Haskell.Liquid.Types.Errors ()
-
-#ifdef LIQUID_NO_PLUGIN
-
-import qualified Language.Fixpoint.Types.PrettyPrint as LH
-
-#endif
 
 fromPJDoc :: PJ.Doc -> O.SDoc
 fromPJDoc = O.text . PJ.render
@@ -56,21 +48,11 @@ putLogMsg dynFlags reason sev srcSpan mbStyle =
     style' = fromMaybe (O.defaultErrStyle dynFlags) mbStyle
 
 putWarnMsg :: GHC.DynFlags -> GHC.SrcSpan -> PJ.Doc -> IO ()
-putWarnMsg _dynFlags srcSpan doc =
-#ifdef LIQUID_NO_PLUGIN
-  putStrLn (PJ.render $ LH.pprint srcSpan PJ.<> PJ.text ": warning: " PJ.<+> doc)
-#else
-  putLogMsg _dynFlags GHC.NoReason GHC.SevWarning srcSpan (Just $ O.defaultErrStyle _dynFlags) doc
-#endif
+putWarnMsg dynFlags srcSpan doc =
+  putLogMsg dynFlags GHC.NoReason GHC.SevWarning srcSpan (Just $ O.defaultErrStyle dynFlags) doc
 
 putErrMsg :: GHC.DynFlags -> GHC.SrcSpan -> PJ.Doc -> IO ()
-putErrMsg _dynFlags srcSpan doc =
-  -- Necessary evil to support the \"legacy\" executable.
-#ifdef LIQUID_NO_PLUGIN
-  putStrLn (PJ.render $ LH.pprint srcSpan PJ.<> PJ.text ": error: " PJ.<+> doc)
-#else
-  putLogMsg _dynFlags GHC.NoReason GHC.SevError srcSpan Nothing doc
-#endif
+putErrMsg dynFlags srcSpan doc = putLogMsg dynFlags GHC.NoReason GHC.SevError srcSpan Nothing doc
 
 -- | Like 'putErrMsg', but it uses GHC's internal 'Doc'. This can be very convenient when logging things
 -- which comes directly from GHC rather than LiquidHaskell.

--- a/src/Language/Haskell/Liquid/GHC/Logging.hs
+++ b/src/Language/Haskell/Liquid/GHC/Logging.hs
@@ -16,12 +16,14 @@ module Language.Haskell.Liquid.GHC.Logging (
   , putWarnMsg
   , putErrMsg
   , putErrMsg'
+  , mkLongErrAt
   ) where
 
 import Data.Maybe
 
-import qualified GHC
-import qualified DynFlags as GHC
+import qualified TcRnMonad as GHC
+
+import qualified Language.Haskell.Liquid.GHC.API as GHC
 import qualified Text.PrettyPrint.HughesPJ as PJ
 import qualified Outputable as O
 
@@ -33,6 +35,9 @@ import Language.Haskell.Liquid.Types.Errors ()
 import qualified Language.Fixpoint.Types.PrettyPrint as LH
 
 #endif
+
+fromPJDoc :: PJ.Doc -> O.SDoc
+fromPJDoc = O.text . PJ.render
 
 -- | Like the original 'putLogMsg', but internally converts the input 'Doc' (from the \"pretty\" library)
 -- into GHC's internal 'SDoc'.
@@ -71,3 +76,7 @@ putErrMsg _dynFlags srcSpan doc =
 putErrMsg' :: GHC.DynFlags -> GHC.SrcSpan -> O.SDoc -> IO ()
 putErrMsg' dynFlags srcSpan =
   GHC.putLogMsg dynFlags GHC.NoReason GHC.SevError srcSpan (O.defaultErrStyle dynFlags)
+
+-- | Like GHC's 'mkLongErrAt', but it builds the final 'ErrMsg' out of two \"HughesPJ\"'s 'Doc's.
+mkLongErrAt :: GHC.SrcSpan -> PJ.Doc -> PJ.Doc -> GHC.TcRn GHC.ErrMsg
+mkLongErrAt srcSpan msg extra = GHC.mkLongErrAt srcSpan (fromPJDoc msg) (fromPJDoc extra)

--- a/src/Language/Haskell/Liquid/GHC/Logging.hs
+++ b/src/Language/Haskell/Liquid/GHC/Logging.hs
@@ -12,7 +12,8 @@
 {-# LANGUAGE CPP #-}
 
 module Language.Haskell.Liquid.GHC.Logging (
-    putLogMsg
+    fromPJDoc
+  , putLogMsg
   , putWarnMsg
   , putErrMsg
   , putErrMsg'

--- a/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -29,7 +29,6 @@ import qualified CoreSyn                                    as Core
 import           CostCentre
 import           Language.Haskell.Liquid.GHC.API            as Ghc hiding (L, sourceName)
 import           Bag
-import           ErrUtils
 import           CoreLint
 import           CoreMonad
 
@@ -55,7 +54,6 @@ import           Control.Arrow                              (second)
 import           Control.Monad                              ((>=>))
 import           Outputable                                 (Outputable (..), text, ppr)
 import qualified Outputable                                 as Out
-import           DynFlags
 import qualified Text.PrettyPrint.HughesPJ                  as PJ
 import           Language.Fixpoint.Types                    hiding (L, panic, Loc (..), SrcSpan, Constant, SESearch (..))
 import qualified Language.Fixpoint.Types                    as F

--- a/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -34,6 +34,7 @@ import qualified Language.Haskell.Liquid.GHC.Misc        as LH
 import qualified Language.Haskell.Liquid.UX.CmdLine      as LH
 import qualified Language.Haskell.Liquid.GHC.Interface   as LH
 import qualified Language.Haskell.Liquid.Liquid          as LH
+import qualified Language.Haskell.Liquid.Types.PrettyPrint as LH (reportErrors)
 
 import           Language.Haskell.Liquid.GHC.Plugin.Types
 import           Language.Haskell.Liquid.GHC.Plugin.Util as Util
@@ -69,7 +70,6 @@ import           Data.Set                                 ( Set )
 import qualified Data.HashSet                            as HS
 import qualified Data.HashMap.Strict                     as HM
 
-import           System.Exit
 import           System.IO.Unsafe                         ( unsafePerformIO )
 import           Language.Fixpoint.Types           hiding ( panic
                                                           , Error
@@ -208,7 +208,7 @@ typecheckHook _ (unoptimise -> modSummary) tcGblEnv = do
   let tcData = mkTcData (tcg_rn_imports tcGblEnv) resolvedNames availTyCons availVars
   let pipelineData = PipelineData (toUnoptimised unoptimisedGuts) tcData (map SpecComment comments)
 
-  liquidHaskellCheck pipelineData tcGblEnv
+  liquidHaskellCheck pipelineData modSummary tcGblEnv
 
   where
     thisModule :: Module
@@ -222,8 +222,8 @@ typecheckHook _ (unoptimise -> modSummary) tcGblEnv = do
                    }
 
 -- | Partially calls into LiquidHaskell's GHC API.
-liquidHaskellCheck :: PipelineData -> TcGblEnv -> TcM TcGblEnv
-liquidHaskellCheck pipelineData tcGblEnv = do
+liquidHaskellCheck :: PipelineData -> ModSummary -> TcGblEnv -> TcM TcGblEnv
+liquidHaskellCheck pipelineData modSummary tcGblEnv = do
   cfg <- liftIO getConfig
 
   -- The 'specQuotes' contain stuff we need from imported modules, extracted
@@ -238,7 +238,6 @@ liquidHaskellCheck pipelineData tcGblEnv = do
 
   debugLog $ " Input spec: \n" ++ show inputSpec
 
-  modSummary <- GhcMonadLike.getModSummary (moduleName thisModule)
   dynFlags <- getDynFlags
 
   debugLog $ "Relevant ===> \n" ++ (unlines $ map renderModule $ (S.toList $ relevantModules modGuts))
@@ -265,7 +264,7 @@ liquidHaskellCheck pipelineData tcGblEnv = do
   void . liftIO $ LH.exitWithResult dynFlags cfg [giTarget (giSrc pmrTargetInfo)] out
   case o_result out of
     Safe _stats -> pure ()
-    _           -> liftIO exitFailure
+    _           -> failM
 
   let serialisedSpec = Util.serialiseLiquidLib pmrClientLib thisModule
   debugLog $ "Serialised annotation ==> " ++ (O.showSDocUnsafe . O.ppr $ serialisedSpec)
@@ -369,17 +368,15 @@ data ProcessModuleResult = ProcessModuleResult {
 -- spec quotes from the imported module. Also looks for
 -- "companion specs" for the current module and merges them in
 -- if it finds one.
-getLiquidSpec :: GhcMonadLike m => Module -> [SpecComment] -> [BPspec] -> m BareSpec
+getLiquidSpec :: Module -> [SpecComment] -> [BPspec] -> TcM BareSpec
 getLiquidSpec thisModule specComments specQuotes = do
 
   let commSpecE :: Either [Error] (ModName, Spec LocBareType LocSymbol)
       commSpecE = hsSpecificationP (moduleName thisModule) (coerce specComments) specQuotes
   case commSpecE of
     Left errors -> do
-      dynFlags <- getDynFlags
-      liftIO $ do
-        mapM_ (printError Full dynFlags) errors
-        exitFailure
+      LH.reportErrors Full errors
+      failM
     Right (view bareSpecIso . snd -> commSpec) -> do
       res <- SpecFinder.findCompanionSpec thisModule
       case res of
@@ -388,7 +385,7 @@ getLiquidSpec thisModule specComments specQuotes = do
           pure $ commSpec <> companionSpec
         _ -> pure commSpec
 
-processModule :: GhcMonadLike m => LiquidHaskellContext -> m ProcessModuleResult
+processModule :: LiquidHaskellContext -> TcM ProcessModuleResult
 processModule LiquidHaskellContext{..} = do
   debugLog ("Module ==> " ++ renderModule thisModule)
   hscEnv              <- askHscEnv
@@ -424,10 +421,9 @@ processModule LiquidHaskellContext{..} = do
 
     -- Print warnings and errors, aborting the compilation.
     Left diagnostics -> do
-      liftIO $ do
-        mapM_ (printWarning dynFlags)    (allWarnings diagnostics)
-        mapM_ (printError Full dynFlags) (allErrors diagnostics)
-        exitFailure
+      liftIO $ mapM_ (printWarning dynFlags)    (allWarnings diagnostics)
+      LH.reportErrors Full (allErrors diagnostics)
+      failM
 
     Right (warnings, targetSpec, liftedSpec) -> do
       liftIO $ mapM_ (printWarning dynFlags) warnings

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE TupleSections             #-}
 {-# LANGUAGE TypeSynonymInstances      #-}
 {-# LANGUAGE NamedFieldPuns            #-}
+{-# LANGUAGE MultiWayIf                #-}
+{-# LANGUAGE ViewPatterns              #-}
 {-# OPTIONS_GHC -fno-cse #-}
 
 -- | This module contains all the code needed to output the result which
@@ -27,15 +29,15 @@ module Language.Haskell.Liquid.UX.CmdLine (
    , exitWithResult
    , addErrors
 
+   -- * Reporting the output of the checking
+   , OutputResult(..)
+   , reportResult
+
    -- * Diff check mode
    , diffcheck
 
    -- * Show info about this version of LiquidHaskell
    , printLiquidHaskellBanner
-
-   -- * Internals
-   , resDocs
-   , resultWithContext
 
 ) where
 
@@ -43,6 +45,7 @@ import Prelude hiding (error)
 
 
 import Control.Monad
+import Control.Monad.IO.Class
 import Data.Maybe
 import Data.Aeson (encode)
 import qualified Data.ByteString.Lazy.Char8 as B
@@ -78,7 +81,6 @@ import Language.Haskell.Liquid.Types       hiding (typ)
 import qualified Language.Haskell.Liquid.UX.ACSS as ACSS
 
 import qualified Language.Haskell.Liquid.GHC.API as GHC
-import qualified Language.Haskell.Liquid.GHC.Logging as GHC
 
 
 import Text.Parsec.Pos                     (newPos)
@@ -638,34 +640,44 @@ defConfig = Config
   , maxArgsDepth      = 1
   }
 
-------------------------------------------------------------------------
--- | Exit Function -----------------------------------------------------
-------------------------------------------------------------------------
+
+-- | Writes the annotations (i.e. the files in the \".liquid\" hidden folder) and report the result
+-- of the checking using a supplied function.
+reportResult :: MonadIO m
+             => (OutputResult -> m ())
+             -> Config
+             -> [FilePath]
+             -> Output Doc
+             -> m ()
+reportResult logResultFull cfg targets out = do
+  annm <- {-# SCC "annotate" #-} liftIO $ annotate cfg targets out
+  liftIO $ whenNormal $ donePhase Loud "annotate"
+  if | json cfg  -> liftIO $ reportResultJson annm
+     | otherwise -> do
+         let r = o_result out
+         liftIO $ writeCheckVars $ o_vars out
+         cr <- liftIO $ resultWithContext r
+         let outputResult = resDocs tidy cr
+         -- For now, always print the \"header\" with colours, irrespective to the logger
+         -- passed as input.
+         liftIO $ printHeader (colorResult r) (orHeader outputResult)
+         logResultFull outputResult
+  pure ()
+  where
+    tidy :: F.Tidy
+    tidy = if shortErrors cfg then F.Lossy else F.Full
+
+    printHeader :: Moods -> Doc -> IO ()
+    printHeader mood d = colorPhaseLn mood "" (render d)
+
 
 ------------------------------------------------------------------------
-exitWithResult :: GHC.DynFlags -> Config -> [FilePath] -> Output Doc -> IO (Output Doc)
+exitWithResult :: Config -> [FilePath] -> Output Doc -> IO ()
 ------------------------------------------------------------------------
-exitWithResult dynFlags cfg targets out = do
-  annm <- {-# SCC "annotate" #-} annotate cfg targets out
-  whenNormal $ donePhase Loud "annotate"
-  -- let r = o_result out -- `addErrors` o_errors out
-  consoleResult dynFlags cfg out annm
-  return out -- { o_result = r }
+exitWithResult cfg = reportResult writeResultStdout cfg
 
-consoleResult :: GHC.DynFlags -> Config -> Output a -> ACSS.AnnMap -> IO ()
-consoleResult dynFlags cfg
-  | json cfg  = consoleResultJson cfg
-  | otherwise = consoleResultFull dynFlags cfg
-
-consoleResultFull :: GHC.DynFlags -> Config -> Output a -> t -> IO ()
-consoleResultFull dynFlags cfg out _ = do
-   let r = o_result out
-   writeCheckVars $ o_vars out
-   cr <- resultWithContext r
-   writeResult dynFlags cfg (colorResult r) cr
-
-consoleResultJson :: t -> t1 -> ACSS.AnnMap -> IO ()
-consoleResultJson _ _ annm = do
+reportResultJson :: ACSS.AnnMap -> IO ()
+reportResultJson annm = do
   putStrLn "LIQUID"
   B.putStrLn . encode . annErrors $ annm
 
@@ -685,26 +697,37 @@ writeCheckVars (Just ns)   = colorPhaseLn Loud "Checked Binders:" ""
 
 type CError = CtxError Doc
 
--- | Writes the result of this LiquidHaskell run to /stdout/.
-writeResult :: GHC.DynFlags -> Config -> Moods -> F.FixResult CError -> IO ()
-writeResult dynFlags cfg c fixResult = do
-  let (header, docErrors) = resDocs tidy fixResult
-  writeHeader header
-  forM_ docErrors $ uncurry (GHC.putErrMsg dynFlags)
-  where
-    tidy :: F.Tidy
-    tidy = if shortErrors cfg then F.Lossy else F.Full
+data OutputResult = OutputResult {
+    orHeader :: Doc
+    -- ^ The \"header\" like \"LIQUID: SAFE\", or \"LIQUID: UNSAFE\".
+  , orMessages :: [(GHC.SrcSpan, Doc)]
+    -- ^ The list of pretty-printable messages (typically errors) together with their
+    -- source locations.
+  }
 
-    writeHeader :: Doc -> IO ()
-    writeHeader d = colorPhaseLn c "" (render d)
+-- | Writes the result of this LiquidHaskell run to /stdout/.
+writeResultStdout :: OutputResult -> IO ()
+writeResultStdout (orMessages -> messages) = do
+  forM_ messages $ \(sSpan, doc) -> putStrLn (render $ pprint sSpan <> (text ": error: " <+> doc))
 
 -- | Given a 'FixResult' parameterised over a 'CError', this function returns the \"header\" to show to
 -- the user (i.e. \"SAFE\" or \"UNSAFE\") plus a list of 'Doc's together with the 'SrcSpan' they refer to.
-resDocs :: F.Tidy -> F.FixResult CError -> (Doc, [(GHC.SrcSpan, Doc)])
+resDocs :: F.Tidy -> F.FixResult CError -> OutputResult
 resDocs _ (F.Safe  stats) =
-  (text $ "LIQUID: SAFE (" <> show (Solver.numChck stats) <> " constraints checked)", mempty)
-resDocs k (F.Crash xs s)  = (text "LIQUID: ERROR" <+> text s, map (cErrToSpanned k . errToFCrash) xs)
-resDocs k (F.Unsafe xs)   = (text "LIQUID: UNSAFE", map (cErrToSpanned k) (nub xs))
+  OutputResult {
+    orHeader   = text $ "LIQUID: SAFE (" <> show (Solver.numChck stats) <> " constraints checked)"
+  , orMessages = mempty
+  }
+resDocs k (F.Crash xs s)  =
+  OutputResult {
+    orHeader = text "LIQUID: ERROR" <+> text s
+  , orMessages = map (cErrToSpanned k . errToFCrash) xs
+  }
+resDocs k (F.Unsafe xs)   =
+  OutputResult {
+    orHeader   = text "LIQUID: UNSAFE"
+  , orMessages = map (cErrToSpanned k) (nub xs)
+  }
 
 -- | Renders a 'CError' into a 'Doc' and its associated 'SrcSpan'.
 cErrToSpanned :: F.Tidy -> CError -> (GHC.SrcSpan, Doc)
@@ -727,4 +750,4 @@ addErrors (Unsafe xs) errs = Unsafe (xs ++ errs)
 addErrors r  _             = r
 
 instance Fixpoint (F.FixResult CError) where
-  toFix = vcat . map snd . snd . resDocs F.Full
+  toFix = vcat . map snd . orMessages . resDocs F.Full

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -33,6 +33,10 @@ module Language.Haskell.Liquid.UX.CmdLine (
    -- * Show info about this version of LiquidHaskell
    , printLiquidHaskellBanner
 
+   -- * Internals
+   , resDocs
+   , resultWithContext
+
 ) where
 
 import Prelude hiding (error)


### PR DESCRIPTION
This PR adds support for integrating LH into `ghcide`. More testing is needed (I think @kosmikus is also trying this out) but this should now support emitting errors and warnings as part of a normal `ghcide` session.

There is a _catch_, however: in order for this to work, we would need a [special version of GHC 8.10.1](https://gitlab.haskell.org/ghc/ghc/-/issues/18070#note_286552), which is not something we can easily provide (however, we might be able to push for a `8.10.2` release if we find enough evidence that this special GHC version indeed fixes some plugin-related woes).

Armed with the code in this branch and this special GHC version, I was finally able to convince `ghcide` to refine my code:

 
<img width="763" alt="Screenshot 2020-07-06 at 12 06 07" src="https://user-images.githubusercontent.com/442035/86605334-deb37280-bfa6-11ea-94ab-b73d9df55303.png">
