### PR TITLE
Add tool to generate mirror packages easily

### DIFF
--- a/MIRRORING_MODULES.md
+++ b/MIRRORING_MODULES.md
@@ -1,0 +1,62 @@
+
+## Mirroring modules for the liquid ecosystem
+
+We provide a fairly simple tool (under the form of an Haskell executable) to make the process of
+generating "mirror modules" easy. This need might arise when developing new packages containing only refinemnents
+for existing packages. These modules are usually meant to be considered \"drop in\", which means they should
+expose the very same modules the original package provided. For big and rich packages, this process can be
+tedious to do by hand, especially if only a handful of modules contains refinemnents. This is where this
+tool comes in hand.
+
+The tool for now can be built only if the `mirror-modules-helper` flag is passed 
+(and it's **not** turned on by default) to avoid pulling unnecessary dependencies when we build
+the `liquidhaskell` library. We can in principle move this into a standalone package, in the future.
+
+### Installation instructions (stack)
+
+```
+stack build --flag liquidhaskell:mirror-modules-helper
+```
+
+### Usage
+
+The tool accepts the following options:
+
+```
+stack exec mirror-modules -- --help
+
+Usage: mirror-modules [--unsafe-override-files] (-l|--modules-list ARG)
+                      (-p|--mirror-package-name ARG) (-i|--target ARG)
+  Create modules to be used in mirror packages.
+
+Available options:
+  --unsafe-override-files  Overrides an Haskell module if already present in the
+                           folder.
+  -l,--modules-list ARG    The path to a file containing a newline-separated
+                           list of modules to mirror.
+  -p,--mirror-package-name ARG
+                           The name of the mirror package we are targeting.
+                           (example: liquid-foo)
+  -i,--target ARG          The path to the root of the module hierarchy for the
+                           target package. (example: liquid-foo/src)
+  -h,--help                Show this help text
+```
+
+
+The tool is faily simple and eschew more sophisticated mechanisms (like automatically pulling the mirrored
+package from Hackage and extract the exposed-modules from the parsed Cabal manifest), so it accepts a file
+with the full list of exposed modules of the mirrored package (which can be copied and pasted from the Cabal
+manifest directly) and it's smart enough to figure out which modules needs mirroring. The user can decide
+to unsafely override existing modules by passing the `--unsafe-override-files` option as input.
+Last but not least, we require the name of the mirror package (e.g. `liquid-foo`) as well as the path
+(relative or absolute) where the source files are (e.g. `liquid-foo/src`).
+
+### Example (liquid-base)
+
+For example, this is how we can mirror all the packages from `base` into `liquid-base`:
+
+```
+stack exec mirror-modules -- -l ../packages.txt -p liquid-base -i liquid-base/src/
+```
+
+Where `packages.txt` contains the newline-separated list of all the `exposed-modules` from `base`.

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -51,6 +51,9 @@ data-files:         include/*.hquals
                     include/Language/Haskell/Liquid/*.hs
                     include/Language/Haskell/Liquid/*.pred
 
+                    -- Needed for the mirror-modules helper
+                    mirror-modules/templates/MirrorModule.mustache
+
 cabal-version:      >= 1.22
 
 source-repository head
@@ -332,6 +335,7 @@ executable mirror-modules
   hs-source-dirs: mirror-modules
 
   other-modules: CLI
+                 Paths_liquidhaskell
 
   if flag(mirror-modules-helper)
     build-depends: base >= 4.9.1.0 && < 5
@@ -339,6 +343,7 @@ executable mirror-modules
                  , text < 1.3
                  , filepath < 1.5
                  , containers < 0.7
+                 , mustache < 2.4
                  , optparse-applicative < 0.16.1.0
     buildable: True
   else

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -71,6 +71,11 @@ flag no-plugin
   manual:      True
   description: Disables the use of the GHC plugin. Use the legacy executable for testing.
 
+flag mirror-modules-helper
+  default:     False
+  manual:      True
+  description: Build the "mirror-modules" helper executable.
+
 library
   exposed-modules:    Gradual.Concretize
                       Gradual.GUI
@@ -319,3 +324,23 @@ test-suite synthesis
                   , extra
   default-language: Haskell2010
   ghc-options:      -W
+
+
+-- This executable can be used to generate modules for mirror-packages.
+executable mirror-modules
+  main-is:        Main.hs
+  hs-source-dirs: mirror-modules
+
+  other-modules: CLI
+
+  if flag(mirror-modules-helper)
+    build-depends: base >= 4.9.1.0 && < 5
+                 , shelly < 1.10.0
+                 , optparse-applicative < 0.16.1.0
+    buildable: True
+  else
+    buildable: False
+
+  default-language:   Haskell2010
+  default-extensions: OverloadedStrings
+  ghc-options:        -W -threaded

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -336,11 +336,17 @@ executable mirror-modules
   if flag(mirror-modules-helper)
     build-depends: base >= 4.9.1.0 && < 5
                  , shelly < 1.10.0
+                 , text
+                 , filepath
                  , optparse-applicative < 0.16.1.0
     buildable: True
   else
     buildable: False
 
   default-language:   Haskell2010
-  default-extensions: OverloadedStrings
+  default-extensions:
+    OverloadedStrings
+    RecordWildCards
+    MultiWayIf
+    LambdaCase
   ghc-options:        -W -threaded

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -335,9 +335,10 @@ executable mirror-modules
 
   if flag(mirror-modules-helper)
     build-depends: base >= 4.9.1.0 && < 5
-                 , shelly < 1.10.0
-                 , text
-                 , filepath
+                 , shelly < 1.10
+                 , text < 1.3
+                 , filepath < 1.5
+                 , containers < 0.7
                  , optparse-applicative < 0.16.1.0
     buildable: True
   else

--- a/mirror-modules/CLI.hs
+++ b/mirror-modules/CLI.hs
@@ -1,0 +1,47 @@
+module CLI (
+    CLI (..)
+  , Flag(..)
+  , parseCLI
+  ) where
+
+
+import Options.Applicative
+
+
+-- Flags
+data OverrideFiles
+
+-- The @Flag@ datatype.
+
+newtype Flag ix = Flag { unFlag :: Bool }
+
+data CLI = CLI {
+    overrideFiles :: Flag OverrideFiles
+  , modulesList   :: FilePath
+  -- ^ A path to a list of modules to create.
+  , targetPackage :: FilePath
+  -- ^ A path to a valid \"liquid-*\" package.
+  }
+
+parseCLI :: Parser CLI
+parseCLI = CLI <$> parseOverrideFiles <*> parseModulesList <*> parseTargetPackage
+
+parseOverrideFiles :: Parser (Flag OverrideFiles)
+parseOverrideFiles =
+  Flag <$> switch (  long "unsafe-override-files"
+                  <> help "Overrides an Haskell module if already present in the folder."
+                  )
+
+parseModulesList :: Parser FilePath
+parseModulesList =
+  strOption (  short 'i'
+            <> long "modules-list"
+            <> help "The path to a file containing a newline-separated list of modules to mirror."
+            )
+
+parseTargetPackage :: Parser FilePath
+parseTargetPackage =
+  strOption (  short 't'
+            <> long "target"
+            <> help "The path to a target package we would like adding modules to."
+            )

--- a/mirror-modules/CLI.hs
+++ b/mirror-modules/CLI.hs
@@ -16,15 +16,15 @@ data OverrideFiles
 newtype Flag ix = Flag { unFlag :: Bool }
 
 data CLI = CLI {
-    overrideFiles :: Flag OverrideFiles
-  , modulesList   :: FilePath
+    overrideFiles       :: Flag OverrideFiles
+  , modulesList         :: FilePath
   -- ^ A path to a list of modules to create.
-  , targetPackage :: FilePath
-  -- ^ A path to a valid \"liquid-*\" package.
+  , moduleHierarchyRoot :: FilePath
+  -- ^ A path to the root of the module hierarchy for the package we would like to target.
   }
 
 parseCLI :: Parser CLI
-parseCLI = CLI <$> parseOverrideFiles <*> parseModulesList <*> parseTargetPackage
+parseCLI = CLI <$> parseOverrideFiles <*> parseModulesList <*> parseModuleRoot
 
 parseOverrideFiles :: Parser (Flag OverrideFiles)
 parseOverrideFiles =
@@ -39,9 +39,9 @@ parseModulesList =
             <> help "The path to a file containing a newline-separated list of modules to mirror."
             )
 
-parseTargetPackage :: Parser FilePath
-parseTargetPackage =
+parseModuleRoot :: Parser FilePath
+parseModuleRoot =
   strOption (  short 't'
             <> long "target"
-            <> help "The path to a target package we would like adding modules to."
+            <> help "The path to the root of the module hierarchy for the target package. (example: liquid-foo/src)"
             )

--- a/mirror-modules/CLI.hs
+++ b/mirror-modules/CLI.hs
@@ -6,6 +6,7 @@ module CLI (
 
 
 import Options.Applicative
+import qualified Data.Text as T
 
 
 -- Flags
@@ -19,12 +20,16 @@ data CLI = CLI {
     overrideFiles       :: Flag OverrideFiles
   , modulesList         :: FilePath
   -- ^ A path to a list of modules to create.
+  , mirrorPackageName   :: T.Text
   , moduleHierarchyRoot :: FilePath
   -- ^ A path to the root of the module hierarchy for the package we would like to target.
   }
 
 parseCLI :: Parser CLI
-parseCLI = CLI <$> parseOverrideFiles <*> parseModulesList <*> parseModuleRoot
+parseCLI = CLI <$> parseOverrideFiles
+               <*> parseModulesList
+               <*> parsePackageName
+               <*> parseModuleRoot
 
 parseOverrideFiles :: Parser (Flag OverrideFiles)
 parseOverrideFiles =
@@ -34,14 +39,21 @@ parseOverrideFiles =
 
 parseModulesList :: Parser FilePath
 parseModulesList =
-  strOption (  short 'i'
+  strOption (  short 'l'
             <> long "modules-list"
             <> help "The path to a file containing a newline-separated list of modules to mirror."
             )
 
+parsePackageName :: Parser T.Text
+parsePackageName = T.pack <$>
+  strOption (  short 'p'
+            <> long "mirror-package-name"
+            <> help "The name of the mirror package we are targeting."
+            )
+
 parseModuleRoot :: Parser FilePath
 parseModuleRoot =
-  strOption (  short 't'
+  strOption (  short 'i'
             <> long "target"
             <> help "The path to the root of the module hierarchy for the target package. (example: liquid-foo/src)"
             )

--- a/mirror-modules/CLI.hs
+++ b/mirror-modules/CLI.hs
@@ -48,7 +48,7 @@ parsePackageName :: Parser T.Text
 parsePackageName = T.pack <$>
   strOption (  short 'p'
             <> long "mirror-package-name"
-            <> help "The name of the mirror package we are targeting."
+            <> help "The name of the mirror package we are targeting. (example: liquid-foo)"
             )
 
 parseModuleRoot :: Parser FilePath

--- a/mirror-modules/Main.hs
+++ b/mirror-modules/Main.hs
@@ -1,0 +1,18 @@
+
+module Main where
+
+import CLI
+import Options.Applicative
+
+
+main :: IO ()
+main = mirrorModules =<< execParser opts
+  where
+    opts = info (parseCLI <**> helper)
+      ( fullDesc
+     <> progDesc "Create modules to be used in mirror packages."
+     <> header "mirror-modules - Generate modules in mirror packages." )
+
+
+mirrorModules :: CLI -> IO ()
+mirrorModules _ = putStrLn "todo"

--- a/mirror-modules/Main.hs
+++ b/mirror-modules/Main.hs
@@ -4,14 +4,20 @@ module Main where
 import           CLI
 import           Options.Applicative
 
+import           Control.Monad
+
 import qualified Data.Text                               as T
-import qualified Data.Text.IO                            as TIO
 import qualified Data.Set                                as S
+import qualified Data.Map.Strict                         as M
 import           Data.Set                                 ( Set )
 import           Data.Function                            ( (&) )
 
 import           System.FilePath
-import           Shelly                                  as Sh
+import           Shelly                                  as Sh hiding ((</>))
+
+import           Text.Mustache                           (substitute, automaticCompile)
+
+import Paths_liquidhaskell
 
 --
 -- Utility functions
@@ -42,11 +48,38 @@ mirroredPackage = T.tail . snd . T.breakOn "-" . mirrorPackageName
 --
 
 mirrorModules :: CLI -> IO ()
-mirrorModules cli@CLI{..} = shelly $ do
-  inputModules    <- S.fromList . map T.strip . T.words <$> liftIO (TIO.readFile modulesList)
+mirrorModules cli@CLI{..} = shelly $ silently $ do
+  dataDir         <- liftIO getDataDir
+  inputModules    <- S.fromList . map T.strip . T.words <$> readfile modulesList
   existingModules <- findExistingModules cli
-  let notMirrored = inputModules `S.difference` existingModules
-  echo $ (T.pack . show $ notMirrored)
+
+  -- If the user decided to completely override existing files, simply return all the input modules.
+  let notMirrored = if | unFlag overrideFiles -> inputModules
+                       | otherwise            -> inputModules `S.difference` existingModules
+
+
+  -- Use a template to automatically generate the module.
+  let searchSpace = [dataDir </> "mirror-modules/templates"]
+      templateName = "MirrorModule.mustache"
+
+  compiled <- liftIO $ automaticCompile searchSpace templateName
+  case compiled of
+    Left err       -> errorExit (T.pack . show $ err)
+    Right template -> do
+      forM_ notMirrored $ \toMirror -> do
+        let ctx = M.fromList [("packageName" :: String, mirroredPackage cli), ("moduleName", toMirror)]
+        let newModule = substitute template ctx
+
+        let pathToModule = moduleHierarchyRoot </> T.unpack (T.replace "." "/" toMirror) <> ".hs"
+        parentFolder <- T.strip <$> run "dirname" [T.pack pathToModule]
+
+        -- Create the parent folder, if necessary.
+        mkdir_p (T.unpack parentFolder)
+
+        -- Write the module.
+        writefile pathToModule newModule
+
+      echo $ "Mirrored " <> T.pack (show . length $ notMirrored) <> " modules."
 
 main :: IO ()
 main = mirrorModules =<< execParser opts

--- a/mirror-modules/Main.hs
+++ b/mirror-modules/Main.hs
@@ -1,14 +1,52 @@
 
 module Main where
 
-import CLI
-import Options.Applicative
-import qualified Data.Text as T
+import           CLI
+import           Options.Applicative
 
-import System.FilePath
+import qualified Data.Text                               as T
+import qualified Data.Text.IO                            as TIO
+import qualified Data.Set                                as S
+import           Data.Set                                 ( Set )
+import           Data.Function                            ( (&) )
 
-import Shelly as Sh
+import           System.FilePath
+import           Shelly                                  as Sh
 
+--
+-- Utility functions
+--
+
+findExistingModules :: CLI -> Sh (Set T.Text)
+findExistingModules cli = do
+  allFiles <- Sh.findWhen (\f -> pure $ takeExtension f == ".hs") (moduleHierarchyRoot cli)
+  pure . S.fromList . map transform $ allFiles
+  where
+    -- Transform an input file by:
+    -- * Stripping the path;
+    -- * Replacing slashes with dots;
+    -- * Remove the final \".hs"\ extension.
+    transform :: FilePath -> T.Text
+    transform f = f & dropExtension
+                    & T.pack
+                    & T.replace (T.pack $ moduleHierarchyRoot cli) mempty
+                    & T.replace "/" "."
+                    & T.replace "/" "."
+
+-- Extracts the name of the mirrored package by dropping the \"liquid-\" prefix.
+mirroredPackage :: CLI -> T.Text
+mirroredPackage = T.tail . snd . T.breakOn "-" . mirrorPackageName
+
+--
+-- The main workhorse
+--
+
+mirrorModules :: CLI -> IO ()
+mirrorModules cli@CLI{..} = shelly $ do
+  inputModules    <- S.fromList . map T.strip . T.words <$> liftIO (TIO.readFile modulesList)
+  existingModules <- findExistingModules cli
+  let notMirrored = inputModules `S.difference` existingModules
+  echo $ (T.pack . show $ notMirrored)
 
 main :: IO ()
 main = mirrorModules =<< execParser opts
@@ -17,13 +55,3 @@ main = mirrorModules =<< execParser opts
       ( fullDesc
      <> progDesc "Create modules to be used in mirror packages."
      <> header "mirror-modules - Generate modules in mirror packages." )
-
-
-mirrorModules :: CLI -> IO ()
-mirrorModules cli = shelly (findExistingModules cli) >>= print
-
-
-findExistingModules :: CLI -> Sh [T.Text]
-findExistingModules cli = do
-  allFiles <- Sh.findWhen (\f -> pure $ takeExtension f == ".hs") (moduleHierarchyRoot cli)
-  pure $ map (T.replace "/" "." . T.replace (T.pack $ moduleHierarchyRoot cli) mempty . T.pack) allFiles

--- a/mirror-modules/Main.hs
+++ b/mirror-modules/Main.hs
@@ -3,6 +3,11 @@ module Main where
 
 import CLI
 import Options.Applicative
+import qualified Data.Text as T
+
+import System.FilePath
+
+import Shelly as Sh
 
 
 main :: IO ()
@@ -15,4 +20,10 @@ main = mirrorModules =<< execParser opts
 
 
 mirrorModules :: CLI -> IO ()
-mirrorModules _ = putStrLn "todo"
+mirrorModules cli = shelly (findExistingModules cli) >>= print
+
+
+findExistingModules :: CLI -> Sh [T.Text]
+findExistingModules cli = do
+  allFiles <- Sh.findWhen (\f -> pure $ takeExtension f == ".hs") (moduleHierarchyRoot cli)
+  pure $ map (T.replace "/" "." . T.replace (T.pack $ moduleHierarchyRoot cli) mempty . T.pack) allFiles

--- a/mirror-modules/templates/MirrorModule.mustache
+++ b/mirror-modules/templates/MirrorModule.mustache
@@ -1,0 +1,3 @@
+module {{ moduleName }} (module Exports) where
+
+import "{{ packageName }}" {{ moduleName }} as Exports


### PR DESCRIPTION
This PR adds a fairly simple tool (under the form of an Haskell executable) to make the process of generating "mirror modules" easy. The tool for now can be built only if the `mirror-modules-helper` flag is passed (and it's not turned on by default) to avoid pulling unnecessary dependencies when we build `liquidhaskell`. We can in principle move this into a standalone package, but I haven't done that here.

_To not inflate the size of this PR, I will open another one which actually adds all the modules to liquid-base._

## Installation instructions (stack)

```
stack build --flag liquidhaskell:mirror-modules-helper
```

## Usage

The tool accepts the following options:

```
stack exec mirror-modules -- --help

Usage: mirror-modules [--unsafe-override-files] (-l|--modules-list ARG)
                      (-p|--mirror-package-name ARG) (-i|--target ARG)
  Create modules to be used in mirror packages.

Available options:
  --unsafe-override-files  Overrides an Haskell module if already present in the
                           folder.
  -l,--modules-list ARG    The path to a file containing a newline-separated
                           list of modules to mirror.
  -p,--mirror-package-name ARG
                           The name of the mirror package we are targeting.
                           (example: liquid-foo)
  -i,--target ARG          The path to the root of the module hierarchy for the
                           target package. (example: liquid-foo/src)
  -h,--help                Show this help text
```

For now I have eschew more sophisticated mechanisms (like automatically pulling the mirrored package from Hackage and extract the `exposed-modules` from the parsed Cabal manifest), so the tool accepts a file with the _full_ list of exposed modules of the mirrored package (which can be copied and pasted from the Cabal manifest directly) and it's smart enough to figure out which modules needs mirroring. The user can decide to unsafely override this safety mechanism by passing the `--unsafe-override-files` option as input. Last but not least, we require the name of the _mirror_ package (e.g. `liquid-foo`) as well as the path (relative or absolute) where the source files are (e.g. `liquid-foo/src`).

## Example (liquid-base)

This is how we can mirror all the packages from `base` into `liquid-base`:

```
stack exec mirror-modules -- -l ../packages.txt -p liquid-base -i liquid-base/src/
```

Where `packages.txt` contains the newline-separated list of all the `exposed-modules` from `base`.





