### PR TITLE
Properly mirror all the `liquid-*` modules

### DIFF
--- a/liquid-base/liquid-base.cabal
+++ b/liquid-base/liquid-base.cabal
@@ -235,6 +235,11 @@ library
                     Type.Reflection.Unsafe
                     Unsafe.Coerce
 
+                    -- Liquid special modules
+                    Liquid.Prelude.Real
+                    Liquid.Prelude.NotReal
+                    Liquid.Prelude.Totality
+
   hs-source-dirs:     src
   build-depends:      base                 >= 4.11.1.0 && < 5
                     , liquid-ghc-prim

--- a/liquid-base/liquid-base.cabal
+++ b/liquid-base/liquid-base.cabal
@@ -24,23 +24,55 @@ data-files:         src/Data/*.spec
 
 library
   exposed-modules:  Control.Applicative
+                    Control.Arrow
                     Control.Category
+                    Control.Concurrent
+                    Control.Concurrent.Chan
+                    Control.Concurrent.MVar
+                    Control.Concurrent.QSem
+                    Control.Concurrent.QSemN
                     Control.Exception
                     Control.Exception.Base
                     Control.Monad
+                    Control.Monad.Fail
+                    Control.Monad.Fix
+                    Control.Monad.Instances
+                    Control.Monad.IO.Class
                     Control.Monad.ST
+                    Control.Monad.ST.Lazy
+                    Control.Monad.ST.Lazy.Safe
+                    Control.Monad.ST.Lazy.Unsafe
+                    Control.Monad.ST.Safe
+                    Control.Monad.ST.Strict
                     Control.Monad.ST.Unsafe
+                    Control.Monad.Zip
+                    Data.Bifoldable
                     Data.Bifunctor
+                    Data.Bitraversable
                     Data.Bits
+                    Data.Bool
                     Data.Char
+                    Data.Coerce
+                    Data.Complex
                     Data.Data
+                    Data.Dynamic
                     Data.Either
+                    Data.Eq
+                    Data.Fixed
                     Data.Foldable
                     Data.Function
                     Data.Functor
+                    Data.Functor.Classes
+                    Data.Functor.Contravariant
                     Data.Functor.Compose
+                    Data.Functor.Const
+                    Data.Functor.Identity
+                    Data.Functor.Product
+                    Data.Functor.Sum
                     Data.IORef
                     Data.Int
+                    Data.Ix
+                    Data.Kind
                     Data.List
                     Data.List.NonEmpty
                     Data.Maybe
@@ -48,54 +80,161 @@ library
                     Data.Ord
                     Data.Proxy
                     Data.Ratio
+                    Data.Semigroup
+                    Data.STRef
+                    Data.STRef.Lazy
+                    Data.STRef.Strict
                     Data.String
                     Data.Traversable
                     Data.Tuple
+                    Data.Type.Bool
+                    Data.Type.Coercion
+                    Data.Type.Equality
                     Data.Typeable
+                    Data.Unique
                     Data.Version
                     Data.Void
                     Data.Word
                     Debug.Trace
                     Foreign
+                    Foreign.C
+                    Foreign.C.Error
                     Foreign.C.String
                     Foreign.C.Types
                     Foreign.Concurrent
                     Foreign.ForeignPtr
+                    Foreign.ForeignPtr.Safe
+                    Foreign.ForeignPtr.Unsafe
+                    Foreign.Marshal
                     Foreign.Marshal.Alloc
                     Foreign.Marshal.Array
+                    Foreign.Marshal.Error
+                    Foreign.Marshal.Pool
+                    Foreign.Marshal.Safe
+                    Foreign.Marshal.Unsafe
                     Foreign.Marshal.Utils
                     Foreign.Ptr
+                    Foreign.Safe
+                    Foreign.StablePtr
                     Foreign.Storable
+                    GHC.Arr
                     GHC.Base
+                    GHC.ByteOrder
+                    GHC.Char
+                    GHC.Clock
+                    GHC.Conc
+                    GHC.Conc.IO
+                    GHC.Conc.Signal
+                    GHC.Conc.Sync
+                    GHC.ConsoleHandler
+                    GHC.Constants
+                    GHC.Desugar
+                    GHC.Enum
+                    GHC.Environment
+                    GHC.Err
+                    GHC.Exception
+                    GHC.Exception.Type
+                    GHC.ExecutionStack
+                    GHC.ExecutionStack.Internal
                     GHC.Exts
+                    GHC.Fingerprint
+                    GHC.Fingerprint.Type
+                    GHC.Float
+                    GHC.Float.ConversionUtils
+                    GHC.Float.RealFracMethods
+                    GHC.Foreign
                     GHC.ForeignPtr
+                    GHC.GHCi
+                    GHC.GHCi.Helpers
                     GHC.Generics
                     GHC.IO
                     GHC.IO.Buffer
                     GHC.IO.BufferedIO
+                    GHC.IO.Device
+                    GHC.IO.Encoding
+                    GHC.IO.Encoding.CodePage
+                    GHC.IO.Encoding.Failure
+                    GHC.IO.Encoding.Iconv
+                    GHC.IO.Encoding.Latin1
+                    GHC.IO.Encoding.Types
+                    GHC.IO.Encoding.UTF16
+                    GHC.IO.Encoding.UTF32
+                    GHC.IO.Encoding.UTF8
+                    GHC.IO.Exception
+                    GHC.IO.FD
                     GHC.IO.Handle
+                    GHC.IO.Handle.FD
                     GHC.IO.Handle.Internals
+                    GHC.IO.Handle.Lock
+                    GHC.IO.Handle.Text
                     GHC.IO.Handle.Types
+                    GHC.IO.IOMode
+                    GHC.IO.Unsafe
+                    GHC.IOArray
+                    GHC.IORef
                     GHC.Int
+                    GHC.Ix
                     GHC.List
+                    GHC.Maybe
+                    GHC.MVar
+                    GHC.Natural
                     GHC.Num
+                    GHC.OldList
+                    GHC.OverloadedLabels
+                    GHC.Pack
+                    GHC.Profiling
                     GHC.Ptr
+                    GHC.Read
                     GHC.Real
+                    GHC.Records
+                    GHC.ResponseFile
+                    GHC.RTS.Flags
                     GHC.ST
+                    GHC.StaticPtr
+                    GHC.STRef
+                    GHC.Show
+                    GHC.Stable
+                    GHC.StableName
+                    GHC.Stack
+                    GHC.Stack.CCS
+                    GHC.Stack.Types
+                    GHC.Stats
+                    GHC.Storable
+                    GHC.TopHandler
                     GHC.TypeLits
+                    GHC.TypeNats
+                    GHC.Unicode
+                    GHC.Weak
                     GHC.Word
                     Numeric
+                    Numeric.Natural
+                    Prelude
+                    System.CPUTime
+                    System.Console.GetOpt
                     System.Environment
+                    System.Environment.Blank
                     System.Exit
                     System.IO
                     System.IO.Error
                     System.IO.Unsafe
-                    Text.Read
+                    System.Info
+                    System.Mem
+                    System.Mem.StableName
+                    System.Mem.Weak
+                    System.Posix.Internals
+                    System.Posix.Types
+                    System.Timeout
+                    Text.ParserCombinators.ReadP
+                    Text.ParserCombinators.ReadPrec
                     Text.Printf
-                    Liquid.Prelude.Totality
-                    Liquid.Prelude.Real
-                    Liquid.Prelude.NotReal
-                    Prelude
+                    Text.Read
+                    Text.Read.Lex
+                    Text.Show
+                    Text.Show.Functions
+                    Type.Reflection
+                    Type.Reflection.Unsafe
+                    Unsafe.Coerce
+
   hs-source-dirs:     src
   build-depends:      base                 >= 4.11.1.0 && < 5
                     , liquid-ghc-prim

--- a/liquid-base/src/Control/Arrow.hs
+++ b/liquid-base/src/Control/Arrow.hs
@@ -1,0 +1,3 @@
+module Control.Arrow (module Exports) where
+
+import "base" Control.Arrow as Exports

--- a/liquid-base/src/Control/Concurrent.hs
+++ b/liquid-base/src/Control/Concurrent.hs
@@ -1,0 +1,3 @@
+module Control.Concurrent (module Exports) where
+
+import "base" Control.Concurrent as Exports

--- a/liquid-base/src/Control/Concurrent/Chan.hs
+++ b/liquid-base/src/Control/Concurrent/Chan.hs
@@ -1,0 +1,3 @@
+module Control.Concurrent.Chan (module Exports) where
+
+import "base" Control.Concurrent.Chan as Exports

--- a/liquid-base/src/Control/Concurrent/MVar.hs
+++ b/liquid-base/src/Control/Concurrent/MVar.hs
@@ -1,0 +1,3 @@
+module Control.Concurrent.MVar (module Exports) where
+
+import "base" Control.Concurrent.MVar as Exports

--- a/liquid-base/src/Control/Concurrent/QSem.hs
+++ b/liquid-base/src/Control/Concurrent/QSem.hs
@@ -1,0 +1,3 @@
+module Control.Concurrent.QSem (module Exports) where
+
+import "base" Control.Concurrent.QSem as Exports

--- a/liquid-base/src/Control/Concurrent/QSemN.hs
+++ b/liquid-base/src/Control/Concurrent/QSemN.hs
@@ -1,0 +1,3 @@
+module Control.Concurrent.QSemN (module Exports) where
+
+import "base" Control.Concurrent.QSemN as Exports

--- a/liquid-base/src/Control/Monad/Fail.hs
+++ b/liquid-base/src/Control/Monad/Fail.hs
@@ -1,0 +1,3 @@
+module Control.Monad.Fail (module Exports) where
+
+import "base" Control.Monad.Fail as Exports

--- a/liquid-base/src/Control/Monad/Fix.hs
+++ b/liquid-base/src/Control/Monad/Fix.hs
@@ -1,0 +1,3 @@
+module Control.Monad.Fix (module Exports) where
+
+import "base" Control.Monad.Fix as Exports

--- a/liquid-base/src/Control/Monad/IO/Class.hs
+++ b/liquid-base/src/Control/Monad/IO/Class.hs
@@ -1,0 +1,3 @@
+module Control.Monad.IO.Class (module Exports) where
+
+import "base" Control.Monad.IO.Class as Exports

--- a/liquid-base/src/Control/Monad/Instances.hs
+++ b/liquid-base/src/Control/Monad/Instances.hs
@@ -1,0 +1,3 @@
+module Control.Monad.Instances (module Exports) where
+
+import "base" Control.Monad.Instances as Exports

--- a/liquid-base/src/Control/Monad/ST/Lazy.hs
+++ b/liquid-base/src/Control/Monad/ST/Lazy.hs
@@ -1,0 +1,3 @@
+module Control.Monad.ST.Lazy (module Exports) where
+
+import "base" Control.Monad.ST.Lazy as Exports

--- a/liquid-base/src/Control/Monad/ST/Lazy/Safe.hs
+++ b/liquid-base/src/Control/Monad/ST/Lazy/Safe.hs
@@ -1,0 +1,3 @@
+module Control.Monad.ST.Lazy.Safe (module Exports) where
+
+import "base" Control.Monad.ST.Lazy.Safe as Exports

--- a/liquid-base/src/Control/Monad/ST/Lazy/Unsafe.hs
+++ b/liquid-base/src/Control/Monad/ST/Lazy/Unsafe.hs
@@ -1,0 +1,3 @@
+module Control.Monad.ST.Lazy.Unsafe (module Exports) where
+
+import "base" Control.Monad.ST.Lazy.Unsafe as Exports

--- a/liquid-base/src/Control/Monad/ST/Safe.hs
+++ b/liquid-base/src/Control/Monad/ST/Safe.hs
@@ -1,0 +1,3 @@
+module Control.Monad.ST.Safe (module Exports) where
+
+import "base" Control.Monad.ST.Safe as Exports

--- a/liquid-base/src/Control/Monad/ST/Strict.hs
+++ b/liquid-base/src/Control/Monad/ST/Strict.hs
@@ -1,0 +1,3 @@
+module Control.Monad.ST.Strict (module Exports) where
+
+import "base" Control.Monad.ST.Strict as Exports

--- a/liquid-base/src/Control/Monad/Zip.hs
+++ b/liquid-base/src/Control/Monad/Zip.hs
@@ -1,0 +1,3 @@
+module Control.Monad.Zip (module Exports) where
+
+import "base" Control.Monad.Zip as Exports

--- a/liquid-base/src/Data/Bifoldable.hs
+++ b/liquid-base/src/Data/Bifoldable.hs
@@ -1,0 +1,3 @@
+module Data.Bifoldable (module Exports) where
+
+import "base" Data.Bifoldable as Exports

--- a/liquid-base/src/Data/Bitraversable.hs
+++ b/liquid-base/src/Data/Bitraversable.hs
@@ -1,0 +1,3 @@
+module Data.Bitraversable (module Exports) where
+
+import "base" Data.Bitraversable as Exports

--- a/liquid-base/src/Data/Bool.hs
+++ b/liquid-base/src/Data/Bool.hs
@@ -1,0 +1,3 @@
+module Data.Bool (module Exports) where
+
+import "base" Data.Bool as Exports

--- a/liquid-base/src/Data/Coerce.hs
+++ b/liquid-base/src/Data/Coerce.hs
@@ -1,0 +1,3 @@
+module Data.Coerce (module Exports) where
+
+import "base" Data.Coerce as Exports

--- a/liquid-base/src/Data/Complex.hs
+++ b/liquid-base/src/Data/Complex.hs
@@ -1,0 +1,3 @@
+module Data.Complex (module Exports) where
+
+import "base" Data.Complex as Exports

--- a/liquid-base/src/Data/Dynamic.hs
+++ b/liquid-base/src/Data/Dynamic.hs
@@ -1,0 +1,3 @@
+module Data.Dynamic (module Exports) where
+
+import "base" Data.Dynamic as Exports

--- a/liquid-base/src/Data/Eq.hs
+++ b/liquid-base/src/Data/Eq.hs
@@ -1,0 +1,3 @@
+module Data.Eq (module Exports) where
+
+import "base" Data.Eq as Exports

--- a/liquid-base/src/Data/Fixed.hs
+++ b/liquid-base/src/Data/Fixed.hs
@@ -1,0 +1,3 @@
+module Data.Fixed (module Exports) where
+
+import "base" Data.Fixed as Exports

--- a/liquid-base/src/Data/Functor/Classes.hs
+++ b/liquid-base/src/Data/Functor/Classes.hs
@@ -1,0 +1,3 @@
+module Data.Functor.Classes (module Exports) where
+
+import "base" Data.Functor.Classes as Exports

--- a/liquid-base/src/Data/Functor/Const.hs
+++ b/liquid-base/src/Data/Functor/Const.hs
@@ -1,0 +1,3 @@
+module Data.Functor.Const (module Exports) where
+
+import "base" Data.Functor.Const as Exports

--- a/liquid-base/src/Data/Functor/Contravariant.hs
+++ b/liquid-base/src/Data/Functor/Contravariant.hs
@@ -1,0 +1,3 @@
+module Data.Functor.Contravariant (module Exports) where
+
+import "base" Data.Functor.Contravariant as Exports

--- a/liquid-base/src/Data/Functor/Identity.hs
+++ b/liquid-base/src/Data/Functor/Identity.hs
@@ -1,0 +1,3 @@
+module Data.Functor.Identity (module Exports) where
+
+import "base" Data.Functor.Identity as Exports

--- a/liquid-base/src/Data/Functor/Product.hs
+++ b/liquid-base/src/Data/Functor/Product.hs
@@ -1,0 +1,3 @@
+module Data.Functor.Product (module Exports) where
+
+import "base" Data.Functor.Product as Exports

--- a/liquid-base/src/Data/Functor/Sum.hs
+++ b/liquid-base/src/Data/Functor/Sum.hs
@@ -1,0 +1,3 @@
+module Data.Functor.Sum (module Exports) where
+
+import "base" Data.Functor.Sum as Exports

--- a/liquid-base/src/Data/Ix.hs
+++ b/liquid-base/src/Data/Ix.hs
@@ -1,0 +1,3 @@
+module Data.Ix (module Exports) where
+
+import "base" Data.Ix as Exports

--- a/liquid-base/src/Data/Kind.hs
+++ b/liquid-base/src/Data/Kind.hs
@@ -1,0 +1,3 @@
+module Data.Kind (module Exports) where
+
+import "base" Data.Kind as Exports

--- a/liquid-base/src/Data/STRef.hs
+++ b/liquid-base/src/Data/STRef.hs
@@ -1,0 +1,3 @@
+module Data.STRef (module Exports) where
+
+import "base" Data.STRef as Exports

--- a/liquid-base/src/Data/STRef/Lazy.hs
+++ b/liquid-base/src/Data/STRef/Lazy.hs
@@ -1,0 +1,3 @@
+module Data.STRef.Lazy (module Exports) where
+
+import "base" Data.STRef.Lazy as Exports

--- a/liquid-base/src/Data/STRef/Strict.hs
+++ b/liquid-base/src/Data/STRef/Strict.hs
@@ -1,0 +1,3 @@
+module Data.STRef.Strict (module Exports) where
+
+import "base" Data.STRef.Strict as Exports

--- a/liquid-base/src/Data/Semigroup.hs
+++ b/liquid-base/src/Data/Semigroup.hs
@@ -1,0 +1,3 @@
+module Data.Semigroup (module Exports) where
+
+import "base" Data.Semigroup as Exports

--- a/liquid-base/src/Data/Type/Bool.hs
+++ b/liquid-base/src/Data/Type/Bool.hs
@@ -1,0 +1,3 @@
+module Data.Type.Bool (module Exports) where
+
+import "base" Data.Type.Bool as Exports

--- a/liquid-base/src/Data/Type/Coercion.hs
+++ b/liquid-base/src/Data/Type/Coercion.hs
@@ -1,0 +1,3 @@
+module Data.Type.Coercion (module Exports) where
+
+import "base" Data.Type.Coercion as Exports

--- a/liquid-base/src/Data/Type/Equality.hs
+++ b/liquid-base/src/Data/Type/Equality.hs
@@ -1,0 +1,3 @@
+module Data.Type.Equality (module Exports) where
+
+import "base" Data.Type.Equality as Exports

--- a/liquid-base/src/Data/Unique.hs
+++ b/liquid-base/src/Data/Unique.hs
@@ -1,0 +1,3 @@
+module Data.Unique (module Exports) where
+
+import "base" Data.Unique as Exports

--- a/liquid-base/src/Foreign/C.hs
+++ b/liquid-base/src/Foreign/C.hs
@@ -1,0 +1,3 @@
+module Foreign.C (module Exports) where
+
+import "base" Foreign.C as Exports

--- a/liquid-base/src/Foreign/C/Error.hs
+++ b/liquid-base/src/Foreign/C/Error.hs
@@ -1,0 +1,3 @@
+module Foreign.C.Error (module Exports) where
+
+import "base" Foreign.C.Error as Exports

--- a/liquid-base/src/Foreign/ForeignPtr/Safe.hs
+++ b/liquid-base/src/Foreign/ForeignPtr/Safe.hs
@@ -1,0 +1,3 @@
+module Foreign.ForeignPtr.Safe (module Exports) where
+
+import "base" Foreign.ForeignPtr.Safe as Exports

--- a/liquid-base/src/Foreign/ForeignPtr/Unsafe.hs
+++ b/liquid-base/src/Foreign/ForeignPtr/Unsafe.hs
@@ -1,0 +1,3 @@
+module Foreign.ForeignPtr.Unsafe (module Exports) where
+
+import "base" Foreign.ForeignPtr.Unsafe as Exports

--- a/liquid-base/src/Foreign/Marshal.hs
+++ b/liquid-base/src/Foreign/Marshal.hs
@@ -1,0 +1,3 @@
+module Foreign.Marshal (module Exports) where
+
+import "base" Foreign.Marshal as Exports

--- a/liquid-base/src/Foreign/Marshal/Error.hs
+++ b/liquid-base/src/Foreign/Marshal/Error.hs
@@ -1,0 +1,3 @@
+module Foreign.Marshal.Error (module Exports) where
+
+import "base" Foreign.Marshal.Error as Exports

--- a/liquid-base/src/Foreign/Marshal/Pool.hs
+++ b/liquid-base/src/Foreign/Marshal/Pool.hs
@@ -1,0 +1,3 @@
+module Foreign.Marshal.Pool (module Exports) where
+
+import "base" Foreign.Marshal.Pool as Exports

--- a/liquid-base/src/Foreign/Marshal/Safe.hs
+++ b/liquid-base/src/Foreign/Marshal/Safe.hs
@@ -1,0 +1,3 @@
+module Foreign.Marshal.Safe (module Exports) where
+
+import "base" Foreign.Marshal.Safe as Exports

--- a/liquid-base/src/Foreign/Marshal/Unsafe.hs
+++ b/liquid-base/src/Foreign/Marshal/Unsafe.hs
@@ -1,0 +1,3 @@
+module Foreign.Marshal.Unsafe (module Exports) where
+
+import "base" Foreign.Marshal.Unsafe as Exports

--- a/liquid-base/src/Foreign/Safe.hs
+++ b/liquid-base/src/Foreign/Safe.hs
@@ -1,0 +1,3 @@
+module Foreign.Safe (module Exports) where
+
+import "base" Foreign.Safe as Exports

--- a/liquid-base/src/Foreign/StablePtr.hs
+++ b/liquid-base/src/Foreign/StablePtr.hs
@@ -1,0 +1,3 @@
+module Foreign.StablePtr (module Exports) where
+
+import "base" Foreign.StablePtr as Exports

--- a/liquid-base/src/GHC/Arr.hs
+++ b/liquid-base/src/GHC/Arr.hs
@@ -1,0 +1,3 @@
+module GHC.Arr (module Exports) where
+
+import "base" GHC.Arr as Exports

--- a/liquid-base/src/GHC/ByteOrder.hs
+++ b/liquid-base/src/GHC/ByteOrder.hs
@@ -1,0 +1,3 @@
+module GHC.ByteOrder (module Exports) where
+
+import "base" GHC.ByteOrder as Exports

--- a/liquid-base/src/GHC/Char.hs
+++ b/liquid-base/src/GHC/Char.hs
@@ -1,0 +1,3 @@
+module GHC.Char (module Exports) where
+
+import "base" GHC.Char as Exports

--- a/liquid-base/src/GHC/Clock.hs
+++ b/liquid-base/src/GHC/Clock.hs
@@ -1,0 +1,3 @@
+module GHC.Clock (module Exports) where
+
+import "base" GHC.Clock as Exports

--- a/liquid-base/src/GHC/Conc.hs
+++ b/liquid-base/src/GHC/Conc.hs
@@ -1,0 +1,3 @@
+module GHC.Conc (module Exports) where
+
+import "base" GHC.Conc as Exports

--- a/liquid-base/src/GHC/Conc/IO.hs
+++ b/liquid-base/src/GHC/Conc/IO.hs
@@ -1,0 +1,3 @@
+module GHC.Conc.IO (module Exports) where
+
+import "base" GHC.Conc.IO as Exports

--- a/liquid-base/src/GHC/Conc/Signal.hs
+++ b/liquid-base/src/GHC/Conc/Signal.hs
@@ -1,0 +1,3 @@
+module GHC.Conc.Signal (module Exports) where
+
+import "base" GHC.Conc.Signal as Exports

--- a/liquid-base/src/GHC/Conc/Sync.hs
+++ b/liquid-base/src/GHC/Conc/Sync.hs
@@ -1,0 +1,3 @@
+module GHC.Conc.Sync (module Exports) where
+
+import "base" GHC.Conc.Sync as Exports

--- a/liquid-base/src/GHC/ConsoleHandler.hs
+++ b/liquid-base/src/GHC/ConsoleHandler.hs
@@ -1,0 +1,3 @@
+module GHC.ConsoleHandler (module Exports) where
+
+import "base" GHC.ConsoleHandler as Exports

--- a/liquid-base/src/GHC/Constants.hs
+++ b/liquid-base/src/GHC/Constants.hs
@@ -1,0 +1,3 @@
+module GHC.Constants (module Exports) where
+
+import "base" GHC.Constants as Exports

--- a/liquid-base/src/GHC/Desugar.hs
+++ b/liquid-base/src/GHC/Desugar.hs
@@ -1,0 +1,3 @@
+module GHC.Desugar (module Exports) where
+
+import "base" GHC.Desugar as Exports

--- a/liquid-base/src/GHC/Enum.hs
+++ b/liquid-base/src/GHC/Enum.hs
@@ -1,0 +1,3 @@
+module GHC.Enum (module Exports) where
+
+import "base" GHC.Enum as Exports

--- a/liquid-base/src/GHC/Environment.hs
+++ b/liquid-base/src/GHC/Environment.hs
@@ -1,0 +1,3 @@
+module GHC.Environment (module Exports) where
+
+import "base" GHC.Environment as Exports

--- a/liquid-base/src/GHC/Err.hs
+++ b/liquid-base/src/GHC/Err.hs
@@ -1,0 +1,3 @@
+module GHC.Err (module Exports) where
+
+import "base" GHC.Err as Exports

--- a/liquid-base/src/GHC/Exception.hs
+++ b/liquid-base/src/GHC/Exception.hs
@@ -1,0 +1,3 @@
+module GHC.Exception (module Exports) where
+
+import "base" GHC.Exception as Exports

--- a/liquid-base/src/GHC/Exception/Type.hs
+++ b/liquid-base/src/GHC/Exception/Type.hs
@@ -1,0 +1,3 @@
+module GHC.Exception.Type (module Exports) where
+
+import "base" GHC.Exception.Type as Exports

--- a/liquid-base/src/GHC/ExecutionStack.hs
+++ b/liquid-base/src/GHC/ExecutionStack.hs
@@ -1,0 +1,3 @@
+module GHC.ExecutionStack (module Exports) where
+
+import "base" GHC.ExecutionStack as Exports

--- a/liquid-base/src/GHC/ExecutionStack/Internal.hs
+++ b/liquid-base/src/GHC/ExecutionStack/Internal.hs
@@ -1,0 +1,3 @@
+module GHC.ExecutionStack.Internal (module Exports) where
+
+import "base" GHC.ExecutionStack.Internal as Exports

--- a/liquid-base/src/GHC/Fingerprint.hs
+++ b/liquid-base/src/GHC/Fingerprint.hs
@@ -1,0 +1,3 @@
+module GHC.Fingerprint (module Exports) where
+
+import "base" GHC.Fingerprint as Exports

--- a/liquid-base/src/GHC/Fingerprint/Type.hs
+++ b/liquid-base/src/GHC/Fingerprint/Type.hs
@@ -1,0 +1,3 @@
+module GHC.Fingerprint.Type (module Exports) where
+
+import "base" GHC.Fingerprint.Type as Exports

--- a/liquid-base/src/GHC/Float.hs
+++ b/liquid-base/src/GHC/Float.hs
@@ -1,0 +1,3 @@
+module GHC.Float (module Exports) where
+
+import "base" GHC.Float as Exports

--- a/liquid-base/src/GHC/Float/ConversionUtils.hs
+++ b/liquid-base/src/GHC/Float/ConversionUtils.hs
@@ -1,0 +1,3 @@
+module GHC.Float.ConversionUtils (module Exports) where
+
+import "base" GHC.Float.ConversionUtils as Exports

--- a/liquid-base/src/GHC/Float/RealFracMethods.hs
+++ b/liquid-base/src/GHC/Float/RealFracMethods.hs
@@ -1,0 +1,3 @@
+module GHC.Float.RealFracMethods (module Exports) where
+
+import "base" GHC.Float.RealFracMethods as Exports

--- a/liquid-base/src/GHC/Foreign.hs
+++ b/liquid-base/src/GHC/Foreign.hs
@@ -1,0 +1,3 @@
+module GHC.Foreign (module Exports) where
+
+import "base" GHC.Foreign as Exports

--- a/liquid-base/src/GHC/GHCi.hs
+++ b/liquid-base/src/GHC/GHCi.hs
@@ -1,0 +1,3 @@
+module GHC.GHCi (module Exports) where
+
+import "base" GHC.GHCi as Exports

--- a/liquid-base/src/GHC/GHCi/Helpers.hs
+++ b/liquid-base/src/GHC/GHCi/Helpers.hs
@@ -1,0 +1,3 @@
+module GHC.GHCi.Helpers (module Exports) where
+
+import "base" GHC.GHCi.Helpers as Exports

--- a/liquid-base/src/GHC/IO/Device.hs
+++ b/liquid-base/src/GHC/IO/Device.hs
@@ -1,0 +1,3 @@
+module GHC.IO.Device (module Exports) where
+
+import "base" GHC.IO.Device as Exports

--- a/liquid-base/src/GHC/IO/Encoding.hs
+++ b/liquid-base/src/GHC/IO/Encoding.hs
@@ -1,0 +1,3 @@
+module GHC.IO.Encoding (module Exports) where
+
+import "base" GHC.IO.Encoding as Exports

--- a/liquid-base/src/GHC/IO/Encoding/CodePage.hs
+++ b/liquid-base/src/GHC/IO/Encoding/CodePage.hs
@@ -1,0 +1,3 @@
+module GHC.IO.Encoding.CodePage (module Exports) where
+
+import "base" GHC.IO.Encoding.CodePage as Exports

--- a/liquid-base/src/GHC/IO/Encoding/Failure.hs
+++ b/liquid-base/src/GHC/IO/Encoding/Failure.hs
@@ -1,0 +1,3 @@
+module GHC.IO.Encoding.Failure (module Exports) where
+
+import "base" GHC.IO.Encoding.Failure as Exports

--- a/liquid-base/src/GHC/IO/Encoding/Iconv.hs
+++ b/liquid-base/src/GHC/IO/Encoding/Iconv.hs
@@ -1,0 +1,3 @@
+module GHC.IO.Encoding.Iconv (module Exports) where
+
+import "base" GHC.IO.Encoding.Iconv as Exports

--- a/liquid-base/src/GHC/IO/Encoding/Latin1.hs
+++ b/liquid-base/src/GHC/IO/Encoding/Latin1.hs
@@ -1,0 +1,3 @@
+module GHC.IO.Encoding.Latin1 (module Exports) where
+
+import "base" GHC.IO.Encoding.Latin1 as Exports

--- a/liquid-base/src/GHC/IO/Encoding/Types.hs
+++ b/liquid-base/src/GHC/IO/Encoding/Types.hs
@@ -1,0 +1,3 @@
+module GHC.IO.Encoding.Types (module Exports) where
+
+import "base" GHC.IO.Encoding.Types as Exports

--- a/liquid-base/src/GHC/IO/Encoding/UTF16.hs
+++ b/liquid-base/src/GHC/IO/Encoding/UTF16.hs
@@ -1,0 +1,3 @@
+module GHC.IO.Encoding.UTF16 (module Exports) where
+
+import "base" GHC.IO.Encoding.UTF16 as Exports

--- a/liquid-base/src/GHC/IO/Encoding/UTF32.hs
+++ b/liquid-base/src/GHC/IO/Encoding/UTF32.hs
@@ -1,0 +1,3 @@
+module GHC.IO.Encoding.UTF32 (module Exports) where
+
+import "base" GHC.IO.Encoding.UTF32 as Exports

--- a/liquid-base/src/GHC/IO/Encoding/UTF8.hs
+++ b/liquid-base/src/GHC/IO/Encoding/UTF8.hs
@@ -1,0 +1,3 @@
+module GHC.IO.Encoding.UTF8 (module Exports) where
+
+import "base" GHC.IO.Encoding.UTF8 as Exports

--- a/liquid-base/src/GHC/IO/Exception.hs
+++ b/liquid-base/src/GHC/IO/Exception.hs
@@ -1,0 +1,3 @@
+module GHC.IO.Exception (module Exports) where
+
+import "base" GHC.IO.Exception as Exports

--- a/liquid-base/src/GHC/IO/FD.hs
+++ b/liquid-base/src/GHC/IO/FD.hs
@@ -1,0 +1,3 @@
+module GHC.IO.FD (module Exports) where
+
+import "base" GHC.IO.FD as Exports

--- a/liquid-base/src/GHC/IO/Handle/FD.hs
+++ b/liquid-base/src/GHC/IO/Handle/FD.hs
@@ -1,0 +1,3 @@
+module GHC.IO.Handle.FD (module Exports) where
+
+import "base" GHC.IO.Handle.FD as Exports

--- a/liquid-base/src/GHC/IO/Handle/Lock.hs
+++ b/liquid-base/src/GHC/IO/Handle/Lock.hs
@@ -1,0 +1,3 @@
+module GHC.IO.Handle.Lock (module Exports) where
+
+import "base" GHC.IO.Handle.Lock as Exports

--- a/liquid-base/src/GHC/IO/Handle/Text.hs
+++ b/liquid-base/src/GHC/IO/Handle/Text.hs
@@ -1,0 +1,3 @@
+module GHC.IO.Handle.Text (module Exports) where
+
+import "base" GHC.IO.Handle.Text as Exports

--- a/liquid-base/src/GHC/IO/IOMode.hs
+++ b/liquid-base/src/GHC/IO/IOMode.hs
@@ -1,0 +1,3 @@
+module GHC.IO.IOMode (module Exports) where
+
+import "base" GHC.IO.IOMode as Exports

--- a/liquid-base/src/GHC/IO/Unsafe.hs
+++ b/liquid-base/src/GHC/IO/Unsafe.hs
@@ -1,0 +1,3 @@
+module GHC.IO.Unsafe (module Exports) where
+
+import "base" GHC.IO.Unsafe as Exports

--- a/liquid-base/src/GHC/IOArray.hs
+++ b/liquid-base/src/GHC/IOArray.hs
@@ -1,0 +1,3 @@
+module GHC.IOArray (module Exports) where
+
+import "base" GHC.IOArray as Exports

--- a/liquid-base/src/GHC/IORef.hs
+++ b/liquid-base/src/GHC/IORef.hs
@@ -1,0 +1,3 @@
+module GHC.IORef (module Exports) where
+
+import "base" GHC.IORef as Exports

--- a/liquid-base/src/GHC/Ix.hs
+++ b/liquid-base/src/GHC/Ix.hs
@@ -1,0 +1,3 @@
+module GHC.Ix (module Exports) where
+
+import "base" GHC.Ix as Exports

--- a/liquid-base/src/GHC/MVar.hs
+++ b/liquid-base/src/GHC/MVar.hs
@@ -1,0 +1,3 @@
+module GHC.MVar (module Exports) where
+
+import "base" GHC.MVar as Exports

--- a/liquid-base/src/GHC/Maybe.hs
+++ b/liquid-base/src/GHC/Maybe.hs
@@ -1,0 +1,3 @@
+module GHC.Maybe (module Exports) where
+
+import "base" GHC.Maybe as Exports

--- a/liquid-base/src/GHC/Natural.hs
+++ b/liquid-base/src/GHC/Natural.hs
@@ -1,0 +1,3 @@
+module GHC.Natural (module Exports) where
+
+import "base" GHC.Natural as Exports

--- a/liquid-base/src/GHC/OldList.hs
+++ b/liquid-base/src/GHC/OldList.hs
@@ -1,0 +1,3 @@
+module GHC.OldList (module Exports) where
+
+import "base" GHC.OldList as Exports

--- a/liquid-base/src/GHC/OverloadedLabels.hs
+++ b/liquid-base/src/GHC/OverloadedLabels.hs
@@ -1,0 +1,3 @@
+module GHC.OverloadedLabels (module Exports) where
+
+import "base" GHC.OverloadedLabels as Exports

--- a/liquid-base/src/GHC/Pack.hs
+++ b/liquid-base/src/GHC/Pack.hs
@@ -1,0 +1,3 @@
+module GHC.Pack (module Exports) where
+
+import "base" GHC.Pack as Exports

--- a/liquid-base/src/GHC/Profiling.hs
+++ b/liquid-base/src/GHC/Profiling.hs
@@ -1,0 +1,3 @@
+module GHC.Profiling (module Exports) where
+
+import "base" GHC.Profiling as Exports

--- a/liquid-base/src/GHC/RTS/Flags.hs
+++ b/liquid-base/src/GHC/RTS/Flags.hs
@@ -1,0 +1,3 @@
+module GHC.RTS.Flags (module Exports) where
+
+import "base" GHC.RTS.Flags as Exports

--- a/liquid-base/src/GHC/Read.hs
+++ b/liquid-base/src/GHC/Read.hs
@@ -1,0 +1,3 @@
+module GHC.Read (module Exports) where
+
+import "base" GHC.Read as Exports

--- a/liquid-base/src/GHC/Records.hs
+++ b/liquid-base/src/GHC/Records.hs
@@ -1,0 +1,3 @@
+module GHC.Records (module Exports) where
+
+import "base" GHC.Records as Exports

--- a/liquid-base/src/GHC/ResponseFile.hs
+++ b/liquid-base/src/GHC/ResponseFile.hs
@@ -1,0 +1,3 @@
+module GHC.ResponseFile (module Exports) where
+
+import "base" GHC.ResponseFile as Exports

--- a/liquid-base/src/GHC/STRef.hs
+++ b/liquid-base/src/GHC/STRef.hs
@@ -1,0 +1,3 @@
+module GHC.STRef (module Exports) where
+
+import "base" GHC.STRef as Exports

--- a/liquid-base/src/GHC/Show.hs
+++ b/liquid-base/src/GHC/Show.hs
@@ -1,0 +1,3 @@
+module GHC.Show (module Exports) where
+
+import "base" GHC.Show as Exports

--- a/liquid-base/src/GHC/Stable.hs
+++ b/liquid-base/src/GHC/Stable.hs
@@ -1,0 +1,3 @@
+module GHC.Stable (module Exports) where
+
+import "base" GHC.Stable as Exports

--- a/liquid-base/src/GHC/StableName.hs
+++ b/liquid-base/src/GHC/StableName.hs
@@ -1,0 +1,3 @@
+module GHC.StableName (module Exports) where
+
+import "base" GHC.StableName as Exports

--- a/liquid-base/src/GHC/Stack.hs
+++ b/liquid-base/src/GHC/Stack.hs
@@ -1,0 +1,3 @@
+module GHC.Stack (module Exports) where
+
+import "base" GHC.Stack as Exports

--- a/liquid-base/src/GHC/Stack/CCS.hs
+++ b/liquid-base/src/GHC/Stack/CCS.hs
@@ -1,0 +1,3 @@
+module GHC.Stack.CCS (module Exports) where
+
+import "base" GHC.Stack.CCS as Exports

--- a/liquid-base/src/GHC/Stack/Types.hs
+++ b/liquid-base/src/GHC/Stack/Types.hs
@@ -1,0 +1,3 @@
+module GHC.Stack.Types (module Exports) where
+
+import "base" GHC.Stack.Types as Exports

--- a/liquid-base/src/GHC/StaticPtr.hs
+++ b/liquid-base/src/GHC/StaticPtr.hs
@@ -1,0 +1,3 @@
+module GHC.StaticPtr (module Exports) where
+
+import "base" GHC.StaticPtr as Exports

--- a/liquid-base/src/GHC/Stats.hs
+++ b/liquid-base/src/GHC/Stats.hs
@@ -1,0 +1,3 @@
+module GHC.Stats (module Exports) where
+
+import "base" GHC.Stats as Exports

--- a/liquid-base/src/GHC/Storable.hs
+++ b/liquid-base/src/GHC/Storable.hs
@@ -1,0 +1,3 @@
+module GHC.Storable (module Exports) where
+
+import "base" GHC.Storable as Exports

--- a/liquid-base/src/GHC/TopHandler.hs
+++ b/liquid-base/src/GHC/TopHandler.hs
@@ -1,0 +1,3 @@
+module GHC.TopHandler (module Exports) where
+
+import "base" GHC.TopHandler as Exports

--- a/liquid-base/src/GHC/TypeNats.hs
+++ b/liquid-base/src/GHC/TypeNats.hs
@@ -1,0 +1,3 @@
+module GHC.TypeNats (module Exports) where
+
+import "base" GHC.TypeNats as Exports

--- a/liquid-base/src/GHC/Unicode.hs
+++ b/liquid-base/src/GHC/Unicode.hs
@@ -1,0 +1,3 @@
+module GHC.Unicode (module Exports) where
+
+import "base" GHC.Unicode as Exports

--- a/liquid-base/src/GHC/Weak.hs
+++ b/liquid-base/src/GHC/Weak.hs
@@ -1,0 +1,3 @@
+module GHC.Weak (module Exports) where
+
+import "base" GHC.Weak as Exports

--- a/liquid-base/src/Numeric/Natural.hs
+++ b/liquid-base/src/Numeric/Natural.hs
@@ -1,0 +1,3 @@
+module Numeric.Natural (module Exports) where
+
+import "base" Numeric.Natural as Exports

--- a/liquid-base/src/System/CPUTime.hs
+++ b/liquid-base/src/System/CPUTime.hs
@@ -1,0 +1,3 @@
+module System.CPUTime (module Exports) where
+
+import "base" System.CPUTime as Exports

--- a/liquid-base/src/System/Console/GetOpt.hs
+++ b/liquid-base/src/System/Console/GetOpt.hs
@@ -1,0 +1,3 @@
+module System.Console.GetOpt (module Exports) where
+
+import "base" System.Console.GetOpt as Exports

--- a/liquid-base/src/System/Environment/Blank.hs
+++ b/liquid-base/src/System/Environment/Blank.hs
@@ -1,0 +1,3 @@
+module System.Environment.Blank (module Exports) where
+
+import "base" System.Environment.Blank as Exports

--- a/liquid-base/src/System/Info.hs
+++ b/liquid-base/src/System/Info.hs
@@ -1,0 +1,3 @@
+module System.Info (module Exports) where
+
+import "base" System.Info as Exports

--- a/liquid-base/src/System/Mem.hs
+++ b/liquid-base/src/System/Mem.hs
@@ -1,0 +1,3 @@
+module System.Mem (module Exports) where
+
+import "base" System.Mem as Exports

--- a/liquid-base/src/System/Mem/StableName.hs
+++ b/liquid-base/src/System/Mem/StableName.hs
@@ -1,0 +1,3 @@
+module System.Mem.StableName (module Exports) where
+
+import "base" System.Mem.StableName as Exports

--- a/liquid-base/src/System/Mem/Weak.hs
+++ b/liquid-base/src/System/Mem/Weak.hs
@@ -1,0 +1,3 @@
+module System.Mem.Weak (module Exports) where
+
+import "base" System.Mem.Weak as Exports

--- a/liquid-base/src/System/Posix/Internals.hs
+++ b/liquid-base/src/System/Posix/Internals.hs
@@ -1,0 +1,3 @@
+module System.Posix.Internals (module Exports) where
+
+import "base" System.Posix.Internals as Exports

--- a/liquid-base/src/System/Posix/Types.hs
+++ b/liquid-base/src/System/Posix/Types.hs
@@ -1,0 +1,3 @@
+module System.Posix.Types (module Exports) where
+
+import "base" System.Posix.Types as Exports

--- a/liquid-base/src/System/Timeout.hs
+++ b/liquid-base/src/System/Timeout.hs
@@ -1,0 +1,3 @@
+module System.Timeout (module Exports) where
+
+import "base" System.Timeout as Exports

--- a/liquid-base/src/Text/ParserCombinators/ReadP.hs
+++ b/liquid-base/src/Text/ParserCombinators/ReadP.hs
@@ -1,0 +1,3 @@
+module Text.ParserCombinators.ReadP (module Exports) where
+
+import "base" Text.ParserCombinators.ReadP as Exports

--- a/liquid-base/src/Text/ParserCombinators/ReadPrec.hs
+++ b/liquid-base/src/Text/ParserCombinators/ReadPrec.hs
@@ -1,0 +1,3 @@
+module Text.ParserCombinators.ReadPrec (module Exports) where
+
+import "base" Text.ParserCombinators.ReadPrec as Exports

--- a/liquid-base/src/Text/Read/Lex.hs
+++ b/liquid-base/src/Text/Read/Lex.hs
@@ -1,0 +1,3 @@
+module Text.Read.Lex (module Exports) where
+
+import "base" Text.Read.Lex as Exports

--- a/liquid-base/src/Text/Show.hs
+++ b/liquid-base/src/Text/Show.hs
@@ -1,0 +1,3 @@
+module Text.Show (module Exports) where
+
+import "base" Text.Show as Exports

--- a/liquid-base/src/Text/Show/Functions.hs
+++ b/liquid-base/src/Text/Show/Functions.hs
@@ -1,0 +1,3 @@
+module Text.Show.Functions (module Exports) where
+
+import "base" Text.Show.Functions as Exports

--- a/liquid-base/src/Type/Reflection.hs
+++ b/liquid-base/src/Type/Reflection.hs
@@ -1,0 +1,3 @@
+module Type.Reflection (module Exports) where
+
+import "base" Type.Reflection as Exports

--- a/liquid-base/src/Type/Reflection/Unsafe.hs
+++ b/liquid-base/src/Type/Reflection/Unsafe.hs
@@ -1,0 +1,3 @@
+module Type.Reflection.Unsafe (module Exports) where
+
+import "base" Type.Reflection.Unsafe as Exports

--- a/liquid-base/src/Unsafe/Coerce.hs
+++ b/liquid-base/src/Unsafe/Coerce.hs
@@ -1,0 +1,3 @@
+module Unsafe.Coerce (module Exports) where
+
+import "base" Unsafe.Coerce as Exports

--- a/liquid-bytestring/liquid-bytestring.cabal
+++ b/liquid-bytestring/liquid-bytestring.cabal
@@ -21,11 +21,28 @@ data-files:           src/Data/ByteString.spec
 
 library
   exposed-modules:    Data.ByteString
-                      Data.ByteString.Short
-                      Data.ByteString.Unsafe
                       Data.ByteString.Char8
+                      Data.ByteString.Unsafe
+                      Data.ByteString.Internal
                       Data.ByteString.Lazy
+                      Data.ByteString.Lazy.Internal
+                      Data.ByteString.Short
+                      Data.ByteString.Short.Internal
+
+                      Data.ByteString.Builder
+                      Data.ByteString.Builder.Extra
+                      Data.ByteString.Builder.Prim
+
+                      Data.ByteString.Builder.Internal
+                      Data.ByteString.Builder.Prim.Internal
+                      Data.ByteString.Lazy.Builder
+                      Data.ByteString.Lazy.Builder.Extras
+                      Data.ByteString.Lazy.Builder.ASCII
+
+                      -- FIXME: This is commented out as unfortunately it doesn't refine
+                      -- correctly with modern versions of bytestring.
                       -- Data.ByteString.Lazy.Char8
+
   hs-source-dirs:     src
   build-depends:      liquid-base          >= 0.8.10.1
                     , bytestring           >= 0.10

--- a/liquid-bytestring/src/Data/ByteString/Builder.hs
+++ b/liquid-bytestring/src/Data/ByteString/Builder.hs
@@ -1,0 +1,3 @@
+module Data.ByteString.Builder (module Exports) where
+
+import "bytestring" Data.ByteString.Builder as Exports

--- a/liquid-bytestring/src/Data/ByteString/Builder/Extra.hs
+++ b/liquid-bytestring/src/Data/ByteString/Builder/Extra.hs
@@ -1,0 +1,3 @@
+module Data.ByteString.Builder.Extra (module Exports) where
+
+import "bytestring" Data.ByteString.Builder.Extra as Exports

--- a/liquid-bytestring/src/Data/ByteString/Builder/Internal.hs
+++ b/liquid-bytestring/src/Data/ByteString/Builder/Internal.hs
@@ -1,0 +1,3 @@
+module Data.ByteString.Builder.Internal (module Exports) where
+
+import "bytestring" Data.ByteString.Builder.Internal as Exports

--- a/liquid-bytestring/src/Data/ByteString/Builder/Prim.hs
+++ b/liquid-bytestring/src/Data/ByteString/Builder/Prim.hs
@@ -1,0 +1,3 @@
+module Data.ByteString.Builder.Prim (module Exports) where
+
+import "bytestring" Data.ByteString.Builder.Prim as Exports

--- a/liquid-bytestring/src/Data/ByteString/Builder/Prim/Internal.hs
+++ b/liquid-bytestring/src/Data/ByteString/Builder/Prim/Internal.hs
@@ -1,0 +1,3 @@
+module Data.ByteString.Builder.Prim.Internal (module Exports) where
+
+import "bytestring" Data.ByteString.Builder.Prim.Internal as Exports

--- a/liquid-bytestring/src/Data/ByteString/Internal.hs
+++ b/liquid-bytestring/src/Data/ByteString/Internal.hs
@@ -1,0 +1,3 @@
+module Data.ByteString.Internal (module Exports) where
+
+import "bytestring" Data.ByteString.Internal as Exports

--- a/liquid-bytestring/src/Data/ByteString/Lazy/Builder.hs
+++ b/liquid-bytestring/src/Data/ByteString/Lazy/Builder.hs
@@ -1,0 +1,3 @@
+module Data.ByteString.Lazy.Builder (module Exports) where
+
+import "bytestring" Data.ByteString.Lazy.Builder as Exports

--- a/liquid-bytestring/src/Data/ByteString/Lazy/Builder/ASCII.hs
+++ b/liquid-bytestring/src/Data/ByteString/Lazy/Builder/ASCII.hs
@@ -1,0 +1,3 @@
+module Data.ByteString.Lazy.Builder.ASCII (module Exports) where
+
+import "bytestring" Data.ByteString.Lazy.Builder.ASCII as Exports

--- a/liquid-bytestring/src/Data/ByteString/Lazy/Builder/Extras.hs
+++ b/liquid-bytestring/src/Data/ByteString/Lazy/Builder/Extras.hs
@@ -1,0 +1,3 @@
+module Data.ByteString.Lazy.Builder.Extras (module Exports) where
+
+import "bytestring" Data.ByteString.Lazy.Builder.Extras as Exports

--- a/liquid-bytestring/src/Data/ByteString/Lazy/Internal.hs
+++ b/liquid-bytestring/src/Data/ByteString/Lazy/Internal.hs
@@ -1,0 +1,3 @@
+module Data.ByteString.Lazy.Internal (module Exports) where
+
+import "bytestring" Data.ByteString.Lazy.Internal as Exports

--- a/liquid-bytestring/src/Data/ByteString/Short/Internal.hs
+++ b/liquid-bytestring/src/Data/ByteString/Short/Internal.hs
@@ -1,0 +1,3 @@
+module Data.ByteString.Short.Internal (module Exports) where
+
+import "bytestring" Data.ByteString.Short.Internal as Exports

--- a/liquid-containers/liquid-containers.cabal
+++ b/liquid-containers/liquid-containers.cabal
@@ -15,8 +15,35 @@ cabal-version:      >= 1.22
 data-files:           src/Data/Set.spec
 
 library
-  exposed-modules:    Data.Set
+  exposed-modules:    Data.Containers.ListUtils
+                      Data.IntMap
+                      Data.IntMap.Lazy
+                      Data.IntMap.Strict
+                      Data.IntMap.Strict.Internal
+                      Data.IntMap.Internal
+                      Data.IntMap.Internal.Debug
+                      Data.IntMap.Merge.Lazy
+                      Data.IntMap.Merge.Strict
+                      Data.IntSet.Internal
+                      Data.IntSet
                       Data.Map
+                      Data.Map.Lazy
+                      Data.Map.Merge.Lazy
+                      Data.Map.Strict.Internal
+                      Data.Map.Strict
+                      Data.Map.Merge.Strict
+                      Data.Map.Internal
+                      Data.Map.Internal.Debug
+                      Data.Set.Internal
+                      Data.Set
+                      Data.Graph
+                      Data.Sequence
+                      Data.Sequence.Internal
+                      Data.Sequence.Internal.Sorting
+                      Data.Tree
+                      Utils.Containers.Internal.BitUtil
+                      Utils.Containers.Internal.BitQueue
+                      Utils.Containers.Internal.StrictPair
   hs-source-dirs:     src
   build-depends:      liquid-base          >= 0.8.10.1
                     , containers           >= 0.5.9.2

--- a/liquid-containers/src/Data/Containers/ListUtils.hs
+++ b/liquid-containers/src/Data/Containers/ListUtils.hs
@@ -1,0 +1,3 @@
+module Data.Containers.ListUtils (module Exports) where
+
+import "containers" Data.Containers.ListUtils as Exports

--- a/liquid-containers/src/Data/Graph.hs
+++ b/liquid-containers/src/Data/Graph.hs
@@ -1,0 +1,3 @@
+module Data.Graph (module Exports) where
+
+import "containers" Data.Graph as Exports

--- a/liquid-containers/src/Data/IntMap.hs
+++ b/liquid-containers/src/Data/IntMap.hs
@@ -1,0 +1,3 @@
+module Data.IntMap (module Exports) where
+
+import "containers" Data.IntMap as Exports

--- a/liquid-containers/src/Data/IntMap/Internal.hs
+++ b/liquid-containers/src/Data/IntMap/Internal.hs
@@ -1,0 +1,3 @@
+module Data.IntMap.Internal (module Exports) where
+
+import "containers" Data.IntMap.Internal as Exports

--- a/liquid-containers/src/Data/IntMap/Internal/Debug.hs
+++ b/liquid-containers/src/Data/IntMap/Internal/Debug.hs
@@ -1,0 +1,3 @@
+module Data.IntMap.Internal.Debug (module Exports) where
+
+import "containers" Data.IntMap.Internal.Debug as Exports

--- a/liquid-containers/src/Data/IntMap/Lazy.hs
+++ b/liquid-containers/src/Data/IntMap/Lazy.hs
@@ -1,0 +1,3 @@
+module Data.IntMap.Lazy (module Exports) where
+
+import "containers" Data.IntMap.Lazy as Exports

--- a/liquid-containers/src/Data/IntMap/Merge/Lazy.hs
+++ b/liquid-containers/src/Data/IntMap/Merge/Lazy.hs
@@ -1,0 +1,3 @@
+module Data.IntMap.Merge.Lazy (module Exports) where
+
+import "containers" Data.IntMap.Merge.Lazy as Exports

--- a/liquid-containers/src/Data/IntMap/Merge/Strict.hs
+++ b/liquid-containers/src/Data/IntMap/Merge/Strict.hs
@@ -1,0 +1,3 @@
+module Data.IntMap.Merge.Strict (module Exports) where
+
+import "containers" Data.IntMap.Merge.Strict as Exports

--- a/liquid-containers/src/Data/IntMap/Strict.hs
+++ b/liquid-containers/src/Data/IntMap/Strict.hs
@@ -1,0 +1,3 @@
+module Data.IntMap.Strict (module Exports) where
+
+import "containers" Data.IntMap.Strict as Exports

--- a/liquid-containers/src/Data/IntMap/Strict/Internal.hs
+++ b/liquid-containers/src/Data/IntMap/Strict/Internal.hs
@@ -1,0 +1,3 @@
+module Data.IntMap.Strict.Internal (module Exports) where
+
+import "containers" Data.IntMap.Strict.Internal as Exports

--- a/liquid-containers/src/Data/IntSet.hs
+++ b/liquid-containers/src/Data/IntSet.hs
@@ -1,0 +1,3 @@
+module Data.IntSet (module Exports) where
+
+import "containers" Data.IntSet as Exports

--- a/liquid-containers/src/Data/IntSet/Internal.hs
+++ b/liquid-containers/src/Data/IntSet/Internal.hs
@@ -1,0 +1,3 @@
+module Data.IntSet.Internal (module Exports) where
+
+import "containers" Data.IntSet.Internal as Exports

--- a/liquid-containers/src/Data/Map/Internal.hs
+++ b/liquid-containers/src/Data/Map/Internal.hs
@@ -1,0 +1,3 @@
+module Data.Map.Internal (module Exports) where
+
+import "containers" Data.Map.Internal as Exports

--- a/liquid-containers/src/Data/Map/Internal/Debug.hs
+++ b/liquid-containers/src/Data/Map/Internal/Debug.hs
@@ -1,0 +1,3 @@
+module Data.Map.Internal.Debug (module Exports) where
+
+import "containers" Data.Map.Internal.Debug as Exports

--- a/liquid-containers/src/Data/Map/Lazy.hs
+++ b/liquid-containers/src/Data/Map/Lazy.hs
@@ -1,0 +1,3 @@
+module Data.Map.Lazy (module Exports) where
+
+import "containers" Data.Map.Lazy as Exports

--- a/liquid-containers/src/Data/Map/Merge/Lazy.hs
+++ b/liquid-containers/src/Data/Map/Merge/Lazy.hs
@@ -1,0 +1,3 @@
+module Data.Map.Merge.Lazy (module Exports) where
+
+import "containers" Data.Map.Merge.Lazy as Exports

--- a/liquid-containers/src/Data/Map/Merge/Strict.hs
+++ b/liquid-containers/src/Data/Map/Merge/Strict.hs
@@ -1,0 +1,3 @@
+module Data.Map.Merge.Strict (module Exports) where
+
+import "containers" Data.Map.Merge.Strict as Exports

--- a/liquid-containers/src/Data/Map/Strict.hs
+++ b/liquid-containers/src/Data/Map/Strict.hs
@@ -1,0 +1,3 @@
+module Data.Map.Strict (module Exports) where
+
+import "containers" Data.Map.Strict as Exports

--- a/liquid-containers/src/Data/Map/Strict/Internal.hs
+++ b/liquid-containers/src/Data/Map/Strict/Internal.hs
@@ -1,0 +1,3 @@
+module Data.Map.Strict.Internal (module Exports) where
+
+import "containers" Data.Map.Strict.Internal as Exports

--- a/liquid-containers/src/Data/Sequence.hs
+++ b/liquid-containers/src/Data/Sequence.hs
@@ -1,0 +1,3 @@
+module Data.Sequence (module Exports) where
+
+import "containers" Data.Sequence as Exports

--- a/liquid-containers/src/Data/Sequence/Internal.hs
+++ b/liquid-containers/src/Data/Sequence/Internal.hs
@@ -1,0 +1,3 @@
+module Data.Sequence.Internal (module Exports) where
+
+import "containers" Data.Sequence.Internal as Exports

--- a/liquid-containers/src/Data/Sequence/Internal/Sorting.hs
+++ b/liquid-containers/src/Data/Sequence/Internal/Sorting.hs
@@ -1,0 +1,3 @@
+module Data.Sequence.Internal.Sorting (module Exports) where
+
+import "containers" Data.Sequence.Internal.Sorting as Exports

--- a/liquid-containers/src/Data/Set/Internal.hs
+++ b/liquid-containers/src/Data/Set/Internal.hs
@@ -1,0 +1,3 @@
+module Data.Set.Internal (module Exports) where
+
+import "containers" Data.Set.Internal as Exports

--- a/liquid-containers/src/Data/Tree.hs
+++ b/liquid-containers/src/Data/Tree.hs
@@ -1,0 +1,3 @@
+module Data.Tree (module Exports) where
+
+import "containers" Data.Tree as Exports

--- a/liquid-containers/src/Utils/Containers/Internal/BitQueue.hs
+++ b/liquid-containers/src/Utils/Containers/Internal/BitQueue.hs
@@ -1,0 +1,3 @@
+module Utils.Containers.Internal.BitQueue (module Exports) where
+
+import "containers" Utils.Containers.Internal.BitQueue as Exports

--- a/liquid-containers/src/Utils/Containers/Internal/BitUtil.hs
+++ b/liquid-containers/src/Utils/Containers/Internal/BitUtil.hs
@@ -1,0 +1,3 @@
+module Utils.Containers.Internal.BitUtil (module Exports) where
+
+import "containers" Utils.Containers.Internal.BitUtil as Exports

--- a/liquid-containers/src/Utils/Containers/Internal/StrictPair.hs
+++ b/liquid-containers/src/Utils/Containers/Internal/StrictPair.hs
@@ -1,0 +1,3 @@
+module Utils.Containers.Internal.StrictPair (module Exports) where
+
+import "containers" Utils.Containers.Internal.StrictPair as Exports

--- a/liquid-ghc-prim/liquid-ghc-prim.cabal
+++ b/liquid-ghc-prim/liquid-ghc-prim.cabal
@@ -21,10 +21,15 @@ library
                     -- treated specially by the GHC pipeline. In particular, GHC doesn't
                     -- generate a '.hi' file for it, and this causes Windows' builds to choke.
                     -- GHC.Prim
-                    GHC.Types
                     GHC.CString
                     GHC.Classes
+                    GHC.Debug
+                    GHC.IntWord64
+                    GHC.Magic
+                    GHC.Prim.Ext
+                    GHC.PrimopWrappers
                     GHC.Tuple
+                    GHC.Types
 
   hs-source-dirs:     src
   build-depends:      ghc-prim

--- a/liquid-ghc-prim/src/GHC/Debug.hs
+++ b/liquid-ghc-prim/src/GHC/Debug.hs
@@ -1,0 +1,3 @@
+module GHC.Debug (module Exports) where
+
+import "ghc-prim" GHC.Debug as Exports

--- a/liquid-ghc-prim/src/GHC/IntWord64.hs
+++ b/liquid-ghc-prim/src/GHC/IntWord64.hs
@@ -1,0 +1,3 @@
+module GHC.IntWord64 (module Exports) where
+
+import "ghc-prim" GHC.IntWord64 as Exports

--- a/liquid-ghc-prim/src/GHC/Magic.hs
+++ b/liquid-ghc-prim/src/GHC/Magic.hs
@@ -1,0 +1,3 @@
+module GHC.Magic (module Exports) where
+
+import "ghc-prim" GHC.Magic as Exports

--- a/liquid-ghc-prim/src/GHC/Prim/Ext.hs
+++ b/liquid-ghc-prim/src/GHC/Prim/Ext.hs
@@ -1,0 +1,3 @@
+module GHC.Prim.Ext (module Exports) where
+
+import "ghc-prim" GHC.Prim.Ext as Exports

--- a/liquid-ghc-prim/src/GHC/PrimopWrappers.hs
+++ b/liquid-ghc-prim/src/GHC/PrimopWrappers.hs
@@ -1,0 +1,3 @@
+module GHC.PrimopWrappers (module Exports) where
+
+import "ghc-prim" GHC.PrimopWrappers as Exports

--- a/liquid-parallel/liquid-parallel.cabal
+++ b/liquid-parallel/liquid-parallel.cabal
@@ -15,7 +15,9 @@ cabal-version:      >= 1.22
 data-files:           src/Control/Parallel/Strategies.spec
 
 library
-  exposed-modules:    Control.Parallel.Strategies
+  exposed-modules:    Control.Seq
+                      Control.Parallel
+                      Control.Parallel.Strategies
   hs-source-dirs:     src
   build-depends:      liquid-base          >= 0.8.10.1
                     , parallel             >= 3.0.0.0

--- a/liquid-parallel/src/Control/Parallel.hs
+++ b/liquid-parallel/src/Control/Parallel.hs
@@ -1,0 +1,3 @@
+module Control.Parallel (module Exports) where
+
+import "parallel" Control.Parallel as Exports

--- a/liquid-parallel/src/Control/Seq.hs
+++ b/liquid-parallel/src/Control/Seq.hs
@@ -1,0 +1,3 @@
+module Control.Seq (module Exports) where
+
+import "parallel" Control.Seq as Exports

--- a/liquid-vector/liquid-vector.cabal
+++ b/liquid-vector/liquid-vector.cabal
@@ -15,12 +15,32 @@ cabal-version:      >= 1.22
 data-files:           src/Data/Vector.spec
 
 library
-  exposed-modules:    Data.Vector
-                      Data.Vector.Mutable
+  exposed-modules:    Data.Vector.Internal.Check
+                      Data.Vector.Fusion.Util
+                      Data.Vector.Fusion.Stream.Monadic
+                      Data.Vector.Fusion.Bundle.Size
+                      Data.Vector.Fusion.Bundle.Monadic
+                      Data.Vector.Fusion.Bundle
+
+                      Data.Vector.Generic.Mutable.Base
                       Data.Vector.Generic.Mutable
+                      Data.Vector.Generic.Base
+                      Data.Vector.Generic.New
+                      Data.Vector.Generic
+
                       Data.Vector.Primitive.Mutable
-                      Data.Vector.Internal.Check
+                      Data.Vector.Primitive
+
+                      Data.Vector.Storable.Internal
+                      Data.Vector.Storable.Mutable
+                      Data.Vector.Storable
+
+                      Data.Vector.Unboxed.Base
                       Data.Vector.Unboxed.Mutable
+                      Data.Vector.Unboxed
+
+                      Data.Vector.Mutable
+                      Data.Vector
   hs-source-dirs:     src
   build-depends:      liquid-base          >= 0.8.10.1
                     , vector               >= 0.10

--- a/liquid-vector/src/Data/Vector/Fusion/Bundle.hs
+++ b/liquid-vector/src/Data/Vector/Fusion/Bundle.hs
@@ -1,0 +1,3 @@
+module Data.Vector.Fusion.Bundle (module Exports) where
+
+import "vector" Data.Vector.Fusion.Bundle as Exports

--- a/liquid-vector/src/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/liquid-vector/src/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -1,0 +1,3 @@
+module Data.Vector.Fusion.Bundle.Monadic (module Exports) where
+
+import "vector" Data.Vector.Fusion.Bundle.Monadic as Exports

--- a/liquid-vector/src/Data/Vector/Fusion/Bundle/Size.hs
+++ b/liquid-vector/src/Data/Vector/Fusion/Bundle/Size.hs
@@ -1,0 +1,3 @@
+module Data.Vector.Fusion.Bundle.Size (module Exports) where
+
+import "vector" Data.Vector.Fusion.Bundle.Size as Exports

--- a/liquid-vector/src/Data/Vector/Fusion/Stream/Monadic.hs
+++ b/liquid-vector/src/Data/Vector/Fusion/Stream/Monadic.hs
@@ -1,0 +1,3 @@
+module Data.Vector.Fusion.Stream.Monadic (module Exports) where
+
+import "vector" Data.Vector.Fusion.Stream.Monadic as Exports

--- a/liquid-vector/src/Data/Vector/Fusion/Util.hs
+++ b/liquid-vector/src/Data/Vector/Fusion/Util.hs
@@ -1,0 +1,3 @@
+module Data.Vector.Fusion.Util (module Exports) where
+
+import "vector" Data.Vector.Fusion.Util as Exports

--- a/liquid-vector/src/Data/Vector/Generic.hs
+++ b/liquid-vector/src/Data/Vector/Generic.hs
@@ -1,0 +1,3 @@
+module Data.Vector.Generic (module Exports) where
+
+import "vector" Data.Vector.Generic as Exports

--- a/liquid-vector/src/Data/Vector/Generic/Base.hs
+++ b/liquid-vector/src/Data/Vector/Generic/Base.hs
@@ -1,0 +1,3 @@
+module Data.Vector.Generic.Base (module Exports) where
+
+import "vector" Data.Vector.Generic.Base as Exports

--- a/liquid-vector/src/Data/Vector/Generic/Mutable/Base.hs
+++ b/liquid-vector/src/Data/Vector/Generic/Mutable/Base.hs
@@ -1,0 +1,3 @@
+module Data.Vector.Generic.Mutable.Base (module Exports) where
+
+import "vector" Data.Vector.Generic.Mutable.Base as Exports

--- a/liquid-vector/src/Data/Vector/Generic/New.hs
+++ b/liquid-vector/src/Data/Vector/Generic/New.hs
@@ -1,0 +1,3 @@
+module Data.Vector.Generic.New (module Exports) where
+
+import "vector" Data.Vector.Generic.New as Exports

--- a/liquid-vector/src/Data/Vector/Primitive.hs
+++ b/liquid-vector/src/Data/Vector/Primitive.hs
@@ -1,0 +1,3 @@
+module Data.Vector.Primitive (module Exports) where
+
+import "vector" Data.Vector.Primitive as Exports

--- a/liquid-vector/src/Data/Vector/Storable.hs
+++ b/liquid-vector/src/Data/Vector/Storable.hs
@@ -1,0 +1,3 @@
+module Data.Vector.Storable (module Exports) where
+
+import "vector" Data.Vector.Storable as Exports

--- a/liquid-vector/src/Data/Vector/Storable/Internal.hs
+++ b/liquid-vector/src/Data/Vector/Storable/Internal.hs
@@ -1,0 +1,3 @@
+module Data.Vector.Storable.Internal (module Exports) where
+
+import "vector" Data.Vector.Storable.Internal as Exports

--- a/liquid-vector/src/Data/Vector/Storable/Mutable.hs
+++ b/liquid-vector/src/Data/Vector/Storable/Mutable.hs
@@ -1,0 +1,3 @@
+module Data.Vector.Storable.Mutable (module Exports) where
+
+import "vector" Data.Vector.Storable.Mutable as Exports

--- a/liquid-vector/src/Data/Vector/Unboxed.hs
+++ b/liquid-vector/src/Data/Vector/Unboxed.hs
@@ -1,0 +1,3 @@
+module Data.Vector.Unboxed (module Exports) where
+
+import "vector" Data.Vector.Unboxed as Exports

--- a/liquid-vector/src/Data/Vector/Unboxed/Base.hs
+++ b/liquid-vector/src/Data/Vector/Unboxed/Base.hs
@@ -1,0 +1,3 @@
+module Data.Vector.Unboxed.Base (module Exports) where
+
+import "vector" Data.Vector.Unboxed.Base as Exports

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -51,6 +51,9 @@ data-files:         include/*.hquals
                     include/Language/Haskell/Liquid/*.hs
                     include/Language/Haskell/Liquid/*.pred
 
+                    -- Needed for the mirror-modules helper
+                    mirror-modules/templates/MirrorModule.mustache
+
 cabal-version:      >= 1.22
 
 source-repository head
@@ -332,6 +335,7 @@ executable mirror-modules
   hs-source-dirs: mirror-modules
 
   other-modules: CLI
+                 Paths_liquidhaskell
 
   if flag(mirror-modules-helper)
     build-depends: base >= 4.9.1.0 && < 5
@@ -339,6 +343,7 @@ executable mirror-modules
                  , text < 1.3
                  , filepath < 1.5
                  , containers < 0.7
+                 , mustache < 2.4
                  , optparse-applicative < 0.16.1.0
     buildable: True
   else

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -71,6 +71,11 @@ flag no-plugin
   manual:      True
   description: Disables the use of the GHC plugin. Use the legacy executable for testing.
 
+flag mirror-modules-helper
+  default:     False
+  manual:      True
+  description: Build the "mirror-modules" helper executable.
+
 library
   exposed-modules:    Gradual.Concretize
                       Gradual.GUI
@@ -319,3 +324,23 @@ test-suite synthesis
                   , extra
   default-language: Haskell2010
   ghc-options:      -W
+
+
+-- This executable can be used to generate modules for mirror-packages.
+executable mirror-modules
+  main-is:        Main.hs
+  hs-source-dirs: mirror-modules
+
+  other-modules: CLI
+
+  if flag(mirror-modules-helper)
+    build-depends: base >= 4.9.1.0 && < 5
+                 , shelly < 1.10.0
+                 , optparse-applicative < 0.16.1.0
+    buildable: True
+  else
+    buildable: False
+
+  default-language:   Haskell2010
+  default-extensions: OverloadedStrings
+  ghc-options:        -W -threaded

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -336,11 +336,17 @@ executable mirror-modules
   if flag(mirror-modules-helper)
     build-depends: base >= 4.9.1.0 && < 5
                  , shelly < 1.10.0
+                 , text
+                 , filepath
                  , optparse-applicative < 0.16.1.0
     buildable: True
   else
     buildable: False
 
   default-language:   Haskell2010
-  default-extensions: OverloadedStrings
+  default-extensions:
+    OverloadedStrings
+    RecordWildCards
+    MultiWayIf
+    LambdaCase
   ghc-options:        -W -threaded

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -335,9 +335,10 @@ executable mirror-modules
 
   if flag(mirror-modules-helper)
     build-depends: base >= 4.9.1.0 && < 5
-                 , shelly < 1.10.0
-                 , text
-                 , filepath
+                 , shelly < 1.10
+                 , text < 1.3
+                 , filepath < 1.5
+                 , containers < 0.7
                  , optparse-applicative < 0.16.1.0
     buildable: True
   else

--- a/mirror-modules/CLI.hs
+++ b/mirror-modules/CLI.hs
@@ -1,0 +1,47 @@
+module CLI (
+    CLI (..)
+  , Flag(..)
+  , parseCLI
+  ) where
+
+
+import Options.Applicative
+
+
+-- Flags
+data OverrideFiles
+
+-- The @Flag@ datatype.
+
+newtype Flag ix = Flag { unFlag :: Bool }
+
+data CLI = CLI {
+    overrideFiles :: Flag OverrideFiles
+  , modulesList   :: FilePath
+  -- ^ A path to a list of modules to create.
+  , targetPackage :: FilePath
+  -- ^ A path to a valid \"liquid-*\" package.
+  }
+
+parseCLI :: Parser CLI
+parseCLI = CLI <$> parseOverrideFiles <*> parseModulesList <*> parseTargetPackage
+
+parseOverrideFiles :: Parser (Flag OverrideFiles)
+parseOverrideFiles =
+  Flag <$> switch (  long "unsafe-override-files"
+                  <> help "Overrides an Haskell module if already present in the folder."
+                  )
+
+parseModulesList :: Parser FilePath
+parseModulesList =
+  strOption (  short 'i'
+            <> long "modules-list"
+            <> help "The path to a file containing a newline-separated list of modules to mirror."
+            )
+
+parseTargetPackage :: Parser FilePath
+parseTargetPackage =
+  strOption (  short 't'
+            <> long "target"
+            <> help "The path to a target package we would like adding modules to."
+            )

--- a/mirror-modules/CLI.hs
+++ b/mirror-modules/CLI.hs
@@ -16,15 +16,15 @@ data OverrideFiles
 newtype Flag ix = Flag { unFlag :: Bool }
 
 data CLI = CLI {
-    overrideFiles :: Flag OverrideFiles
-  , modulesList   :: FilePath
+    overrideFiles       :: Flag OverrideFiles
+  , modulesList         :: FilePath
   -- ^ A path to a list of modules to create.
-  , targetPackage :: FilePath
-  -- ^ A path to a valid \"liquid-*\" package.
+  , moduleHierarchyRoot :: FilePath
+  -- ^ A path to the root of the module hierarchy for the package we would like to target.
   }
 
 parseCLI :: Parser CLI
-parseCLI = CLI <$> parseOverrideFiles <*> parseModulesList <*> parseTargetPackage
+parseCLI = CLI <$> parseOverrideFiles <*> parseModulesList <*> parseModuleRoot
 
 parseOverrideFiles :: Parser (Flag OverrideFiles)
 parseOverrideFiles =
@@ -39,9 +39,9 @@ parseModulesList =
             <> help "The path to a file containing a newline-separated list of modules to mirror."
             )
 
-parseTargetPackage :: Parser FilePath
-parseTargetPackage =
+parseModuleRoot :: Parser FilePath
+parseModuleRoot =
   strOption (  short 't'
             <> long "target"
-            <> help "The path to a target package we would like adding modules to."
+            <> help "The path to the root of the module hierarchy for the target package. (example: liquid-foo/src)"
             )

--- a/mirror-modules/CLI.hs
+++ b/mirror-modules/CLI.hs
@@ -6,6 +6,7 @@ module CLI (
 
 
 import Options.Applicative
+import qualified Data.Text as T
 
 
 -- Flags
@@ -19,12 +20,16 @@ data CLI = CLI {
     overrideFiles       :: Flag OverrideFiles
   , modulesList         :: FilePath
   -- ^ A path to a list of modules to create.
+  , mirrorPackageName   :: T.Text
   , moduleHierarchyRoot :: FilePath
   -- ^ A path to the root of the module hierarchy for the package we would like to target.
   }
 
 parseCLI :: Parser CLI
-parseCLI = CLI <$> parseOverrideFiles <*> parseModulesList <*> parseModuleRoot
+parseCLI = CLI <$> parseOverrideFiles
+               <*> parseModulesList
+               <*> parsePackageName
+               <*> parseModuleRoot
 
 parseOverrideFiles :: Parser (Flag OverrideFiles)
 parseOverrideFiles =
@@ -34,14 +39,21 @@ parseOverrideFiles =
 
 parseModulesList :: Parser FilePath
 parseModulesList =
-  strOption (  short 'i'
+  strOption (  short 'l'
             <> long "modules-list"
             <> help "The path to a file containing a newline-separated list of modules to mirror."
             )
 
+parsePackageName :: Parser T.Text
+parsePackageName = T.pack <$>
+  strOption (  short 'p'
+            <> long "mirror-package-name"
+            <> help "The name of the mirror package we are targeting."
+            )
+
 parseModuleRoot :: Parser FilePath
 parseModuleRoot =
-  strOption (  short 't'
+  strOption (  short 'i'
             <> long "target"
             <> help "The path to the root of the module hierarchy for the target package. (example: liquid-foo/src)"
             )

--- a/mirror-modules/CLI.hs
+++ b/mirror-modules/CLI.hs
@@ -48,7 +48,7 @@ parsePackageName :: Parser T.Text
 parsePackageName = T.pack <$>
   strOption (  short 'p'
             <> long "mirror-package-name"
-            <> help "The name of the mirror package we are targeting."
+            <> help "The name of the mirror package we are targeting. (example: liquid-foo)"
             )
 
 parseModuleRoot :: Parser FilePath

--- a/mirror-modules/Main.hs
+++ b/mirror-modules/Main.hs
@@ -1,0 +1,18 @@
+
+module Main where
+
+import CLI
+import Options.Applicative
+
+
+main :: IO ()
+main = mirrorModules =<< execParser opts
+  where
+    opts = info (parseCLI <**> helper)
+      ( fullDesc
+     <> progDesc "Create modules to be used in mirror packages."
+     <> header "mirror-modules - Generate modules in mirror packages." )
+
+
+mirrorModules :: CLI -> IO ()
+mirrorModules _ = putStrLn "todo"

--- a/mirror-modules/Main.hs
+++ b/mirror-modules/Main.hs
@@ -4,14 +4,20 @@ module Main where
 import           CLI
 import           Options.Applicative
 
+import           Control.Monad
+
 import qualified Data.Text                               as T
-import qualified Data.Text.IO                            as TIO
 import qualified Data.Set                                as S
+import qualified Data.Map.Strict                         as M
 import           Data.Set                                 ( Set )
 import           Data.Function                            ( (&) )
 
 import           System.FilePath
-import           Shelly                                  as Sh
+import           Shelly                                  as Sh hiding ((</>))
+
+import           Text.Mustache                           (substitute, automaticCompile)
+
+import Paths_liquidhaskell
 
 --
 -- Utility functions
@@ -42,11 +48,38 @@ mirroredPackage = T.tail . snd . T.breakOn "-" . mirrorPackageName
 --
 
 mirrorModules :: CLI -> IO ()
-mirrorModules cli@CLI{..} = shelly $ do
-  inputModules    <- S.fromList . map T.strip . T.words <$> liftIO (TIO.readFile modulesList)
+mirrorModules cli@CLI{..} = shelly $ silently $ do
+  dataDir         <- liftIO getDataDir
+  inputModules    <- S.fromList . map T.strip . T.words <$> readfile modulesList
   existingModules <- findExistingModules cli
-  let notMirrored = inputModules `S.difference` existingModules
-  echo $ (T.pack . show $ notMirrored)
+
+  -- If the user decided to completely override existing files, simply return all the input modules.
+  let notMirrored = if | unFlag overrideFiles -> inputModules
+                       | otherwise            -> inputModules `S.difference` existingModules
+
+
+  -- Use a template to automatically generate the module.
+  let searchSpace = [dataDir </> "mirror-modules/templates"]
+      templateName = "MirrorModule.mustache"
+
+  compiled <- liftIO $ automaticCompile searchSpace templateName
+  case compiled of
+    Left err       -> errorExit (T.pack . show $ err)
+    Right template -> do
+      forM_ notMirrored $ \toMirror -> do
+        let ctx = M.fromList [("packageName" :: String, mirroredPackage cli), ("moduleName", toMirror)]
+        let newModule = substitute template ctx
+
+        let pathToModule = moduleHierarchyRoot </> T.unpack (T.replace "." "/" toMirror) <> ".hs"
+        parentFolder <- T.strip <$> run "dirname" [T.pack pathToModule]
+
+        -- Create the parent folder, if necessary.
+        mkdir_p (T.unpack parentFolder)
+
+        -- Write the module.
+        writefile pathToModule newModule
+
+      echo $ "Mirrored " <> T.pack (show . length $ notMirrored) <> " modules."
 
 main :: IO ()
 main = mirrorModules =<< execParser opts

--- a/mirror-modules/Main.hs
+++ b/mirror-modules/Main.hs
@@ -1,14 +1,52 @@
 
 module Main where
 
-import CLI
-import Options.Applicative
-import qualified Data.Text as T
+import           CLI
+import           Options.Applicative
 
-import System.FilePath
+import qualified Data.Text                               as T
+import qualified Data.Text.IO                            as TIO
+import qualified Data.Set                                as S
+import           Data.Set                                 ( Set )
+import           Data.Function                            ( (&) )
 
-import Shelly as Sh
+import           System.FilePath
+import           Shelly                                  as Sh
 
+--
+-- Utility functions
+--
+
+findExistingModules :: CLI -> Sh (Set T.Text)
+findExistingModules cli = do
+  allFiles <- Sh.findWhen (\f -> pure $ takeExtension f == ".hs") (moduleHierarchyRoot cli)
+  pure . S.fromList . map transform $ allFiles
+  where
+    -- Transform an input file by:
+    -- * Stripping the path;
+    -- * Replacing slashes with dots;
+    -- * Remove the final \".hs"\ extension.
+    transform :: FilePath -> T.Text
+    transform f = f & dropExtension
+                    & T.pack
+                    & T.replace (T.pack $ moduleHierarchyRoot cli) mempty
+                    & T.replace "/" "."
+                    & T.replace "/" "."
+
+-- Extracts the name of the mirrored package by dropping the \"liquid-\" prefix.
+mirroredPackage :: CLI -> T.Text
+mirroredPackage = T.tail . snd . T.breakOn "-" . mirrorPackageName
+
+--
+-- The main workhorse
+--
+
+mirrorModules :: CLI -> IO ()
+mirrorModules cli@CLI{..} = shelly $ do
+  inputModules    <- S.fromList . map T.strip . T.words <$> liftIO (TIO.readFile modulesList)
+  existingModules <- findExistingModules cli
+  let notMirrored = inputModules `S.difference` existingModules
+  echo $ (T.pack . show $ notMirrored)
 
 main :: IO ()
 main = mirrorModules =<< execParser opts
@@ -17,13 +55,3 @@ main = mirrorModules =<< execParser opts
       ( fullDesc
      <> progDesc "Create modules to be used in mirror packages."
      <> header "mirror-modules - Generate modules in mirror packages." )
-
-
-mirrorModules :: CLI -> IO ()
-mirrorModules cli = shelly (findExistingModules cli) >>= print
-
-
-findExistingModules :: CLI -> Sh [T.Text]
-findExistingModules cli = do
-  allFiles <- Sh.findWhen (\f -> pure $ takeExtension f == ".hs") (moduleHierarchyRoot cli)
-  pure $ map (T.replace "/" "." . T.replace (T.pack $ moduleHierarchyRoot cli) mempty . T.pack) allFiles

--- a/mirror-modules/Main.hs
+++ b/mirror-modules/Main.hs
@@ -3,6 +3,11 @@ module Main where
 
 import CLI
 import Options.Applicative
+import qualified Data.Text as T
+
+import System.FilePath
+
+import Shelly as Sh
 
 
 main :: IO ()
@@ -15,4 +20,10 @@ main = mirrorModules =<< execParser opts
 
 
 mirrorModules :: CLI -> IO ()
-mirrorModules _ = putStrLn "todo"
+mirrorModules cli = shelly (findExistingModules cli) >>= print
+
+
+findExistingModules :: CLI -> Sh [T.Text]
+findExistingModules cli = do
+  allFiles <- Sh.findWhen (\f -> pure $ takeExtension f == ".hs") (moduleHierarchyRoot cli)
+  pure $ map (T.replace "/" "." . T.replace (T.pack $ moduleHierarchyRoot cli) mempty . T.pack) allFiles

--- a/mirror-modules/templates/MirrorModule.mustache
+++ b/mirror-modules/templates/MirrorModule.mustache
@@ -1,0 +1,3 @@
+module {{ moduleName }} (module Exports) where
+
+import "{{ packageName }}" {{ moduleName }} as Exports


### PR DESCRIPTION
In this PR I am eating my own dogfood (and it's based on #1700) to actually adds the remaining modules for the `liquid-*` packages we provide, which are:

* `liquid-ghc-prim`
* `liquid-base`
* `liquid-parallel`
* `liquid-containers`
* `liquid-vector`
* `liquid-bytestring`

**NOTE: After merging this PR is recommended to build only the liquidhaskell library when making changes to the former rather than a generic `stack build` / `cabal v2-build`, as this would rebuild all the components**.