### PR TITLE
Try resolving AConLike for Symbols

### DIFF
--- a/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -11,7 +11,6 @@
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE TupleSections         #-}
-{-# LANGUAGE TypeApplications      #-}
 
 module Language.Haskell.Liquid.Bare.Resolve 
   ( -- * Creating the Environment

--- a/tests/import/client/T1688.hs
+++ b/tests/import/client/T1688.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE GADTs #-}
+
+{-@ LIQUID "--reflection"  @-}
+
+module T1688 where
+
+import T1688Lib
+
+data HasFType where
+    FTBC   :: Bool -> HasFType
+
+{-@ ftypSize :: HasFType -> { n:Int | n >= 0 } @-}
+ftypSize :: HasFType -> Int
+ftypSize (FTBC {}) = 1

--- a/tests/import/lib/T1688Lib.hs
+++ b/tests/import/lib/T1688Lib.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE GADTs #-}
+
+{-@ LIQUID "--reflection"  @-}
+
+module T1688Lib where
+
+type Vname = Int
+
+{-@ measure propOf :: a -> b @-}
+{-@ type ProofOf E = { proofObj:_ | propOf proofObj = E } @-}
+
+data Expr = Bc Bool                   -- True, False
+          | Ic Int                    -- 0, 1, 2, ...
+          | Lambda Int Expr         -- \x.e          abstractions
+          | App Expr Expr             -- e e'          applications
+
+data Basic = TBool         -- Bool
+           | TInt          -- Int
+
+data StepProp where
+    Step :: Expr -> Expr -> StepProp
+
+data StepProof where
+    EFake :: Vname -> Expr -> Expr -> StepProof
+
+{-@ data StepProof where
+    EFake :: x:Vname -> e:Expr -> v:_ -> ProofOf( Step (App (Lambda x e) v) e)
+  @-}


### PR DESCRIPTION
Fixes #1688. 

In case we need to qualify a Symbol, we would call the `ResolveSym` instance defined for a GHC.Var, which would look only at Identifiers (i.e. only `Id`s in a TyThing).

This PR adds an extra fallback case to look also for identifiers associated to `AConLike`.

In a nutshell, this allows certain type synonyms to be correctly expanded _in the lib module_ rather than in the client module when it's too late.

As discussed with @ranjitjhala (and as the branch name suggests) this is a bit of a "quick hack" to get this working, and while it should be harmless for existing code, it's not the "morally correct" fix. On the other hand, such "morally correct" fix would entail a substantial rewrite of the name resolution engine, which would be more effort than the few lines this PR costed me.

