### PR TITLE
Liquid-Dev-Mode prototype

### DIFF
--- a/liquid-base/Setup.hs
+++ b/liquid-base/Setup.hs
@@ -1,16 +1,6 @@
 module Main where
 
-import Distribution.Simple
-import System.Environment
+import Language.Haskell.Liquid.Cabal (liquidHaskellMain)
 
 main :: IO ()
-main = do
-  libHooks <- customHooks
-  defaultMainWithHooks libHooks
-
-customHooks :: IO UserHooks
-customHooks = do
-  mbDevMode <- lookupEnv "LIQUID_DEV_MODE"
-  case mbDevMode of
-    Nothing -> pure simpleUserHooks
-    Just x  -> pure simpleUserHooks { buildHook = \_ _ _ _ -> return () }
+main = liquidHaskellMain

--- a/liquid-base/Setup.hs
+++ b/liquid-base/Setup.hs
@@ -1,0 +1,16 @@
+module Main where
+
+import Distribution.Simple
+import System.Environment
+
+main :: IO ()
+main = do
+  libHooks <- customHooks
+  defaultMainWithHooks libHooks
+
+customHooks :: IO UserHooks
+customHooks = do
+  mbDevMode <- lookupEnv "LIQUID_DEV_MODE"
+  case mbDevMode of
+    Nothing -> pure simpleUserHooks
+    Just x  -> pure simpleUserHooks { buildHook = \_ _ _ _ -> return () }

--- a/liquid-base/liquid-base.cabal
+++ b/liquid-base/liquid-base.cabal
@@ -23,7 +23,7 @@ data-files:         src/Data/*.spec
                     src/Control/*.spec
 
 custom-setup
-  setup-depends: Cabal, base
+  setup-depends: Cabal, base, liquidhaskell
 
 library
   exposed-modules:  Control.Applicative

--- a/liquid-base/liquid-base.cabal
+++ b/liquid-base/liquid-base.cabal
@@ -9,7 +9,7 @@ author:             Ranjit Jhala, Niki Vazou, Eric Seidel
 maintainer:         Ranjit Jhala <jhala@cs.ucsd.edu>
 category:           Language
 homepage:           https://github.com/ucsd-progsys/liquidhaskell
-build-type:         Simple
+build-type:         Custom
 cabal-version:      >= 1.22
 
 data-files:         src/Data/*.spec
@@ -21,6 +21,9 @@ data-files:         src/Data/*.spec
                     src/Foreign/C/*.spec
                     src/Foreign/*.spec
                     src/Control/*.spec
+
+custom-setup
+  setup-depends: Cabal, base
 
 library
   exposed-modules:  Control.Applicative

--- a/liquid-bytestring/Setup.hs
+++ b/liquid-bytestring/Setup.hs
@@ -1,16 +1,6 @@
 module Main where
 
-import Distribution.Simple
-import System.Environment
+import Language.Haskell.Liquid.Cabal (liquidHaskellMain)
 
 main :: IO ()
-main = do
-  libHooks <- customHooks
-  defaultMainWithHooks libHooks
-
-customHooks :: IO UserHooks
-customHooks = do
-  mbDevMode <- lookupEnv "LIQUID_DEV_MODE"
-  case mbDevMode of
-    Nothing -> pure simpleUserHooks
-    Just x  -> pure simpleUserHooks { buildHook = \_ _ _ _ -> return () }
+main = liquidHaskellMain

--- a/liquid-bytestring/Setup.hs
+++ b/liquid-bytestring/Setup.hs
@@ -1,0 +1,16 @@
+module Main where
+
+import Distribution.Simple
+import System.Environment
+
+main :: IO ()
+main = do
+  libHooks <- customHooks
+  defaultMainWithHooks libHooks
+
+customHooks :: IO UserHooks
+customHooks = do
+  mbDevMode <- lookupEnv "LIQUID_DEV_MODE"
+  case mbDevMode of
+    Nothing -> pure simpleUserHooks
+    Just x  -> pure simpleUserHooks { buildHook = \_ _ _ _ -> return () }

--- a/liquid-bytestring/liquid-bytestring.cabal
+++ b/liquid-bytestring/liquid-bytestring.cabal
@@ -20,7 +20,7 @@ data-files:           src/Data/ByteString.spec
                       src/Data/ByteString/Lazy/Char8.spec
 
 custom-setup
-  setup-depends: Cabal, base
+  setup-depends: Cabal, base, liquidhaskell
 
 library
   exposed-modules:    Data.ByteString

--- a/liquid-bytestring/liquid-bytestring.cabal
+++ b/liquid-bytestring/liquid-bytestring.cabal
@@ -9,7 +9,7 @@ author:             Ranjit Jhala, Niki Vazou, Eric Seidel
 maintainer:         Ranjit Jhala <jhala@cs.ucsd.edu>
 category:           Language
 homepage:           https://github.com/ucsd-progsys/liquidhaskell
-build-type:         Simple
+build-type:         Custom
 cabal-version:      >= 1.22
 
 data-files:           src/Data/ByteString.spec
@@ -18,6 +18,9 @@ data-files:           src/Data/ByteString.spec
                       src/Data/ByteString/Unsafe.spec
                       src/Data/ByteString/Char8.spec
                       src/Data/ByteString/Lazy/Char8.spec
+
+custom-setup
+  setup-depends: Cabal, base
 
 library
   exposed-modules:    Data.ByteString

--- a/liquid-containers/Setup.hs
+++ b/liquid-containers/Setup.hs
@@ -1,16 +1,6 @@
 module Main where
 
-import Distribution.Simple
-import System.Environment
+import Language.Haskell.Liquid.Cabal (liquidHaskellMain)
 
 main :: IO ()
-main = do
-  libHooks <- customHooks
-  defaultMainWithHooks libHooks
-
-customHooks :: IO UserHooks
-customHooks = do
-  mbDevMode <- lookupEnv "LIQUID_DEV_MODE"
-  case mbDevMode of
-    Nothing -> pure simpleUserHooks
-    Just x  -> pure simpleUserHooks { buildHook = \_ _ _ _ -> return () }
+main = liquidHaskellMain

--- a/liquid-containers/Setup.hs
+++ b/liquid-containers/Setup.hs
@@ -1,0 +1,16 @@
+module Main where
+
+import Distribution.Simple
+import System.Environment
+
+main :: IO ()
+main = do
+  libHooks <- customHooks
+  defaultMainWithHooks libHooks
+
+customHooks :: IO UserHooks
+customHooks = do
+  mbDevMode <- lookupEnv "LIQUID_DEV_MODE"
+  case mbDevMode of
+    Nothing -> pure simpleUserHooks
+    Just x  -> pure simpleUserHooks { buildHook = \_ _ _ _ -> return () }

--- a/liquid-containers/liquid-containers.cabal
+++ b/liquid-containers/liquid-containers.cabal
@@ -9,10 +9,13 @@ author:             Ranjit Jhala, Niki Vazou, Eric Seidel
 maintainer:         Ranjit Jhala <jhala@cs.ucsd.edu>
 category:           Language
 homepage:           https://github.com/ucsd-progsys/liquidhaskell
-build-type:         Simple
+build-type:         Custom
 cabal-version:      >= 1.22
 
 data-files:           src/Data/Set.spec
+
+custom-setup
+  setup-depends: Cabal, base
 
 library
   exposed-modules:    Data.Set

--- a/liquid-containers/liquid-containers.cabal
+++ b/liquid-containers/liquid-containers.cabal
@@ -15,7 +15,7 @@ cabal-version:      >= 1.22
 data-files:           src/Data/Set.spec
 
 custom-setup
-  setup-depends: Cabal, base
+  setup-depends: Cabal, base, liquidhaskell
 
 library
   exposed-modules:    Data.Set

--- a/liquid-ghc-prim/Setup.hs
+++ b/liquid-ghc-prim/Setup.hs
@@ -1,16 +1,6 @@
 module Main where
 
-import Distribution.Simple
-import System.Environment
+import Language.Haskell.Liquid.Cabal (liquidHaskellMain)
 
 main :: IO ()
-main = do
-  libHooks <- customHooks
-  defaultMainWithHooks libHooks
-
-customHooks :: IO UserHooks
-customHooks = do
-  mbDevMode <- lookupEnv "LIQUID_DEV_MODE"
-  case mbDevMode of
-    Nothing -> pure simpleUserHooks
-    Just x  -> pure simpleUserHooks { buildHook = \_ _ _ _ -> return () }
+main = liquidHaskellMain

--- a/liquid-ghc-prim/Setup.hs
+++ b/liquid-ghc-prim/Setup.hs
@@ -1,0 +1,16 @@
+module Main where
+
+import Distribution.Simple
+import System.Environment
+
+main :: IO ()
+main = do
+  libHooks <- customHooks
+  defaultMainWithHooks libHooks
+
+customHooks :: IO UserHooks
+customHooks = do
+  mbDevMode <- lookupEnv "LIQUID_DEV_MODE"
+  case mbDevMode of
+    Nothing -> pure simpleUserHooks
+    Just x  -> pure simpleUserHooks { buildHook = \_ _ _ _ -> return () }

--- a/liquid-ghc-prim/liquid-ghc-prim.cabal
+++ b/liquid-ghc-prim/liquid-ghc-prim.cabal
@@ -16,7 +16,7 @@ data-files:         src/GHC/*.spec
 
 
 custom-setup
-  setup-depends: Cabal, base
+  setup-depends: Cabal, base, liquidhaskell
 
 library
   exposed-modules:

--- a/liquid-ghc-prim/liquid-ghc-prim.cabal
+++ b/liquid-ghc-prim/liquid-ghc-prim.cabal
@@ -9,10 +9,14 @@ author:             Ranjit Jhala, Niki Vazou, Eric Seidel
 maintainer:         Ranjit Jhala <jhala@cs.ucsd.edu>
 category:           Language
 homepage:           https://github.com/ucsd-progsys/liquidhaskell
-build-type:         Simple
+build-type:         Custom
 cabal-version:      >= 1.22
 
 data-files:         src/GHC/*.spec
+
+
+custom-setup
+  setup-depends: Cabal, base
 
 library
   exposed-modules:

--- a/liquid-parallel/Setup.hs
+++ b/liquid-parallel/Setup.hs
@@ -1,16 +1,6 @@
 module Main where
 
-import Distribution.Simple
-import System.Environment
+import Language.Haskell.Liquid.Cabal (liquidHaskellMain)
 
 main :: IO ()
-main = do
-  libHooks <- customHooks
-  defaultMainWithHooks libHooks
-
-customHooks :: IO UserHooks
-customHooks = do
-  mbDevMode <- lookupEnv "LIQUID_DEV_MODE"
-  case mbDevMode of
-    Nothing -> pure simpleUserHooks
-    Just x  -> pure simpleUserHooks { buildHook = \_ _ _ _ -> return () }
+main = liquidHaskellMain

--- a/liquid-parallel/Setup.hs
+++ b/liquid-parallel/Setup.hs
@@ -1,0 +1,16 @@
+module Main where
+
+import Distribution.Simple
+import System.Environment
+
+main :: IO ()
+main = do
+  libHooks <- customHooks
+  defaultMainWithHooks libHooks
+
+customHooks :: IO UserHooks
+customHooks = do
+  mbDevMode <- lookupEnv "LIQUID_DEV_MODE"
+  case mbDevMode of
+    Nothing -> pure simpleUserHooks
+    Just x  -> pure simpleUserHooks { buildHook = \_ _ _ _ -> return () }

--- a/liquid-parallel/liquid-parallel.cabal
+++ b/liquid-parallel/liquid-parallel.cabal
@@ -15,7 +15,7 @@ cabal-version:      >= 1.22
 data-files:           src/Control/Parallel/Strategies.spec
 
 custom-setup
-  setup-depends: Cabal, base
+  setup-depends: Cabal, base, liquidhaskell
 
 library
   exposed-modules:    Control.Parallel.Strategies

--- a/liquid-parallel/liquid-parallel.cabal
+++ b/liquid-parallel/liquid-parallel.cabal
@@ -9,10 +9,13 @@ author:             Ranjit Jhala, Niki Vazou, Eric Seidel
 maintainer:         Ranjit Jhala <jhala@cs.ucsd.edu>
 category:           Language
 homepage:           https://github.com/ucsd-progsys/liquidhaskell
-build-type:         Simple
+build-type:         Custom
 cabal-version:      >= 1.22
 
 data-files:           src/Control/Parallel/Strategies.spec
+
+custom-setup
+  setup-depends: Cabal, base
 
 library
   exposed-modules:    Control.Parallel.Strategies

--- a/liquid-prelude/Setup.hs
+++ b/liquid-prelude/Setup.hs
@@ -1,17 +1,6 @@
-
 module Main where
 
-import Distribution.Simple
-import System.Environment
+import Language.Haskell.Liquid.Cabal (liquidHaskellMain)
 
 main :: IO ()
-main = do
-  libHooks <- customHooks
-  defaultMainWithHooks libHooks
-
-customHooks :: IO UserHooks
-customHooks = do
-  mbDevMode <- lookupEnv "LIQUID_DEV_MODE"
-  case mbDevMode of
-    Nothing -> pure simpleUserHooks
-    Just x  -> pure simpleUserHooks { buildHook = \_ _ _ _ -> return () }
+main = liquidHaskellMain

--- a/liquid-prelude/Setup.hs
+++ b/liquid-prelude/Setup.hs
@@ -1,0 +1,17 @@
+
+module Main where
+
+import Distribution.Simple
+import System.Environment
+
+main :: IO ()
+main = do
+  libHooks <- customHooks
+  defaultMainWithHooks libHooks
+
+customHooks :: IO UserHooks
+customHooks = do
+  mbDevMode <- lookupEnv "LIQUID_DEV_MODE"
+  case mbDevMode of
+    Nothing -> pure simpleUserHooks
+    Just x  -> pure simpleUserHooks { buildHook = \_ _ _ _ -> return () }

--- a/liquid-prelude/liquid-prelude.cabal
+++ b/liquid-prelude/liquid-prelude.cabal
@@ -9,8 +9,11 @@ author:             Ranjit Jhala, Niki Vazou, Eric Seidel
 maintainer:         Ranjit Jhala <jhala@cs.ucsd.edu>
 category:           Language
 homepage:           https://github.com/ucsd-progsys/liquidhaskell
-build-type:         Simple
+build-type:         Custom
 cabal-version:      >= 1.22
+
+custom-setup
+  setup-depends: Cabal, base
 
 library
   exposed-modules:  Language.Haskell.Liquid.RTick

--- a/liquid-prelude/liquid-prelude.cabal
+++ b/liquid-prelude/liquid-prelude.cabal
@@ -13,7 +13,7 @@ build-type:         Custom
 cabal-version:      >= 1.22
 
 custom-setup
-  setup-depends: Cabal, base
+  setup-depends: Cabal, base, liquidhaskell
 
 library
   exposed-modules:  Language.Haskell.Liquid.RTick

--- a/liquid-vector/Setup.hs
+++ b/liquid-vector/Setup.hs
@@ -1,16 +1,6 @@
 module Main where
 
-import Distribution.Simple
-import System.Environment
+import Language.Haskell.Liquid.Cabal (liquidHaskellMain)
 
 main :: IO ()
-main = do
-  libHooks <- customHooks
-  defaultMainWithHooks libHooks
-
-customHooks :: IO UserHooks
-customHooks = do
-  mbDevMode <- lookupEnv "LIQUID_DEV_MODE"
-  case mbDevMode of
-    Nothing -> pure simpleUserHooks
-    Just x  -> pure simpleUserHooks { buildHook = \_ _ _ _ -> return () }
+main = liquidHaskellMain

--- a/liquid-vector/Setup.hs
+++ b/liquid-vector/Setup.hs
@@ -1,0 +1,16 @@
+module Main where
+
+import Distribution.Simple
+import System.Environment
+
+main :: IO ()
+main = do
+  libHooks <- customHooks
+  defaultMainWithHooks libHooks
+
+customHooks :: IO UserHooks
+customHooks = do
+  mbDevMode <- lookupEnv "LIQUID_DEV_MODE"
+  case mbDevMode of
+    Nothing -> pure simpleUserHooks
+    Just x  -> pure simpleUserHooks { buildHook = \_ _ _ _ -> return () }

--- a/liquid-vector/liquid-vector.cabal
+++ b/liquid-vector/liquid-vector.cabal
@@ -15,7 +15,7 @@ cabal-version:      >= 1.22
 data-files:           src/Data/Vector.spec
 
 custom-setup
-  setup-depends: Cabal, base
+  setup-depends: Cabal, base, liquidhaskell
 
 library
   exposed-modules:    Data.Vector

--- a/liquid-vector/liquid-vector.cabal
+++ b/liquid-vector/liquid-vector.cabal
@@ -9,10 +9,13 @@ author:             Ranjit Jhala, Niki Vazou, Eric Seidel
 maintainer:         Ranjit Jhala <jhala@cs.ucsd.edu>
 category:           Language
 homepage:           https://github.com/ucsd-progsys/liquidhaskell
-build-type:         Simple
+build-type:         Custom
 cabal-version:      >= 1.22
 
 data-files:           src/Data/Vector.spec
+
+custom-setup
+  setup-depends: Cabal, base
 
 library
   exposed-modules:    Data.Vector

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -83,6 +83,7 @@ library
                       Gradual.Trivial
                       Gradual.Types
                       Gradual.Uniquify
+                      Language.Haskell.Liquid.Cabal
                       Language.Haskell.Liquid.Bare
                       Language.Haskell.Liquid.Bare.Axiom
                       Language.Haskell.Liquid.Bare.Check
@@ -199,6 +200,7 @@ library
                     , aeson
                     , binary
                     , bytestring           >= 0.10
+                    , Cabal                < 3.3
                     , cereal
                     , cmdargs              >= 0.10
                     , containers           >= 0.5

--- a/src/Language/Haskell/Liquid/Cabal.hs
+++ b/src/Language/Haskell/Liquid/Cabal.hs
@@ -1,0 +1,21 @@
+{- | This module provides a drop-in replacement for Cabal's 'defaultMain', to be used inside 'Setup.hs'
+     modules of packages that wants to use the \"dev mode\". For more information, visit the documentation,
+     especially the \"Developers' guide\".
+-}
+
+{-# LANGUAGE LambdaCase #-}
+module Language.Haskell.Liquid.Cabal (liquidHaskellMain) where
+
+import Distribution.Simple
+import System.Environment
+
+liquidHaskellMain :: IO ()
+liquidHaskellMain = do
+  mbDevMode <- lookupEnv "LIQUID_DEV_MODE"
+  defaultMainWithHooks (devModeHooks mbDevMode)
+
+devModeHooks :: Maybe String -> UserHooks
+devModeHooks = \case
+  Nothing               -> simpleUserHooks
+  Just x | x == "false" -> simpleUserHooks
+  Just _                -> simpleUserHooks { buildHook = \_ _ _ _ -> return () }


### PR DESCRIPTION

_This PR has to be intended as a prototype and can be easily improved. To name something suboptimal, the current `Setup.hs` is the same for each package and is duplicated everywhere. Also, the actual _value_ of the `LIQUID_DEV_MODE` env var is not taken into account, but maybe it's nice if users could toggle dev mode by passing `LIQUID_DEV_MODE=true` and `LIQUID_DEV_MODE=false`._

This PR is a first attempt in speeding up the LiquidHaskell development experience when using the new GHC plugin. The main idea takes inspiration from the stages of a compiler (think GHC) where usually we build a "stage0" compiler to be used to compile the stage1. Similarly we introduce, for each of the `liquid-*` packages, a custom `Setup.hs` module that disables building the target modules if the `LIQUID_DEV_MODE` env var is set.

### Usage and recommended workflow

This is how one would use this:

* To begin with, perform a **full** build of **all** the libraries, by doing either `cabal v2-build` or `stack build`, **without** specifying any extra environment variables from the command line. This is morally equivalent to our "stage 0".

* At this point, the content of the `liquid-*` packages is considered "trusted" and "frozen", until we don't force another full, _non dev_ build;

* In order to quickly test changes to the `liquidhaskell` library without recompiling the `liquid-*` packages, we user need to build by passing the `LIQUID_DEV_MODE` env var as part of the build command. Examples:

#### Stack

```
LIQUID_DEV_MODE=true stack build
```

#### Cabal

```
LIQUID_DEV_MODE=true cabal v2-build
```

It's also possible (but not recommended) to add `LIQUID_DEV_MODE` to `.bashrc` or similar,but this would permanently disable building the `liquid-*` packages, and this might silently mask breaking changes to the liquidhaskell library that would manifest only when compiling these other packages.

* If the user wishes to _force_ building all the libraries again, it's sufficient to issue the same builds commands _without_ the `LIQUID_DEV_MODE`.