### PR TITLE
add stats to unsafe result

### DIFF
--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -301,10 +301,10 @@ makeFailErrors bs cis = [ mkError x | x <- bs, notElem (val x) vs ]
 splitFails :: S.HashSet Var -> F.FixResult (a, Cinfo) -> (F.FixResult (a, Cinfo),  [Cinfo])
 splitFails _ r@(F.Crash _ _) = (r,mempty)
 splitFails _ r@(F.Safe _)    = (r,mempty)
-splitFails fs (F.Unsafe xs)  = (mkRes r, snd <$> rfails)
+splitFails fs (F.Unsafe s xs)  = (mkRes r, snd <$> rfails)
   where 
     (rfails,r) = L.partition (Mb.maybe False (`S.member` fs) . ci_var . snd) xs 
-    mkRes [] = F.Safe mempty
-    mkRes ys = F.Unsafe ys 
+    mkRes [] = F.Safe s
+    mkRes ys = F.Unsafe s ys 
 
   

--- a/src/Language/Haskell/Liquid/UX/Annotate.hs
+++ b/src/Language/Haskell/Liquid/UX/Annotate.hs
@@ -244,16 +244,16 @@ mkAnnMap cfg res ann     = ACSS.Ann
 
 mkStatus :: FixResult t -> ACSS.Status
 mkStatus (Safe _)        = ACSS.Safe
-mkStatus (Unsafe _)      = ACSS.Unsafe
+mkStatus (Unsafe _ _)    = ACSS.Unsafe
 mkStatus (Crash _ _)     = ACSS.Error
 
 
 
 mkAnnMapErr :: PPrint (TError t)
             => FixResult (TError t) -> [(Loc, Loc, String)]
-mkAnnMapErr (Unsafe ls)  = mapMaybe cinfoErr ls
-mkAnnMapErr (Crash ls _) = mapMaybe cinfoErr ls
-mkAnnMapErr _            = []
+mkAnnMapErr (Unsafe _ ls) = mapMaybe cinfoErr ls
+mkAnnMapErr (Crash ls _)  = mapMaybe cinfoErr ls
+mkAnnMapErr _             = []
 
 cinfoErr :: PPrint (TError t) => TError t -> Maybe (Loc, Loc, String)
 cinfoErr e = case pos e of

--- a/src/Language/Haskell/Liquid/UX/DiffCheck.hs
+++ b/src/Language/Haskell/Liquid/UX/DiffCheck.hs
@@ -426,7 +426,7 @@ adjustTypes lm cm (AI m)          = AI $ M.fromList
                                               , Just sp' <- [adjustSrcSpan lm cm sp]]
 
 adjustResult :: LMap -> ChkItv -> ErrorResult -> ErrorResult
-adjustResult lm cm (Unsafe es)    = errorsResult Unsafe      $ adjustErrors lm cm es
+adjustResult lm cm (Unsafe s es)  = errorsResult (Unsafe s)  $ adjustErrors lm cm es
 adjustResult lm cm (Crash es z)   = errorsResult (`Crash` z) $ adjustErrors lm cm es
 adjustResult _  _  r              = r
 

--- a/tests/pos/T1709.hs
+++ b/tests/pos/T1709.hs
@@ -1,0 +1,10 @@
+module T1709 where 
+
+{-@ incr :: x:Int -> {v:Int | x < v } @-}
+incr :: Int -> Int 
+incr x = x + 1
+
+{-@ fail decr @-}
+{-@ decr :: x:Int -> {v:Int | x < v } @-}
+decr :: Int -> Int 
+decr x = x - 1


### PR DESCRIPTION
Add stats in Unsafe Result. 

This is required when the `fail` keyword is used. 
Before, the result was unsafe so "0 contraints checked" was wrongly reported. 

For example, https://github.com/ucsd-progsys/liquidhaskell/blob/20341f29535680e18c081467f93a8e8356afe57d/tests/pos/T1709.hs was reporting 0 constraints checked before 