### PR TITLE
Always build the legacy executable

### DIFF
--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -261,10 +261,6 @@ executable liquid
   default-extensions: PatternGuards
   ghc-options:        -W -threaded -fdefer-typed-holes
 
-  if impl(ghc < 8.10) || flag(no-plugin)
-    buildable: True
-  else
-    buildable: False
 
 test-suite test
   type:             exitcode-stdio-1.0


### PR DESCRIPTION
Fixes #1712. See the linked issue for the rationale.