### PR TITLE
Little script to upload to Hackage

### DIFF
--- a/docs/mkDocs/docs/develop.md
+++ b/docs/mkDocs/docs/develop.md
@@ -273,3 +273,14 @@ Here's the magic diff that we did at some point that we keep bumping up to new G
 https://github.com/ucsd-progsys/liquidhaskell/commit/d380018850297b8f1878c33d0e4c586a1fddc2b8#diff-3644b76a8e6b3405f5492d8194da3874R224 
 
 [compiler plugin]: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/extending_ghc.html#compiler-plugins
+
+## Releasing on Hackage
+
+*NOTE: The following section is relevant only for few developers, i.e. the ones which are directly involved
+in the release process. Most contributors can skip this section.*
+
+We provide a conveniency script to upload all the `liquid-*` packages (**including** `liquid-fixpoint`) on
+Hackage, in a lockstep fashion. To do so, it's possible to simply run the `scripts/release_to_hackage.sh`
+Bash script. The script doesn't accept any argument and it tries to determine the packages
+to upload by scanning the $PWD for packages named appropriately. It will ask the user for confirmation
+before proceeding, and `stack upload` will be used under the hood.

--- a/scripts/release_to_hackage.sh
+++ b/scripts/release_to_hackage.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+TO_UPLOAD=($(ls | grep "^liquid\-.*" | xargs echo))
+GREEN='\033[0;32m'
+NC='\033[0m' # no colour
+UPLOAD_CMD=(stack upload)
+
+# Run the upload command to actually upload the packages.
+function doUpload {
+    for pkg in "${TO_UPLOAD[@]}"
+    do
+        ${UPLOAD_CMD[@]} $pkg
+    done
+}
+
+# Shows a recap of the packages that will be uploaded, as well as the commands that
+# will be run.
+function showRecap {
+
+    echo -e "\nThe following packages will be uploaded:\n"
+
+    for pkg in "${TO_UPLOAD[@]}"
+    do
+        pkg_version=$(cat $pkg/$pkg.cabal | grep "^version" | awk '{print $2}')
+        echo -e $pkg-${GREEN}$pkg_version${NC}
+    done
+
+    echo -e "\nHere is what I will run:\n"
+
+    for pkg in "${TO_UPLOAD[@]}"
+    do
+        echo "${UPLOAD_CMD[@]} ${pkg}"
+    done
+
+    echo ""
+
+}
+
+# Shows the recap and ask the user for a choice.
+function main {
+
+    showRecap
+
+    read -p "Continue [Y/n]? " choice
+    case "$choice" in
+      y|Y ) doUpload;;
+      n|N ) echo "Operation aborted.";;
+      * ) echo "Invalid choice.";;
+    esac
+
+}
+
+# Main starts here.
+main


### PR DESCRIPTION
This PR adds a little script to upload all the `liquid-*` packages (including `liquid-fixpoint`). It lives at `scripts/release_to_hackage.sh` and, when run, will scan the `$PWD` for a list of suitable packages (at the moment `liquidhaskell` is left out, due to the current megarepo nature). It will use `stack upload` under the hood and ask the user for confirmation before proceeding:

<img width="572" alt="Screenshot 2020-07-22 at 13 48 59" src="https://user-images.githubusercontent.com/442035/88172989-23374300-cc22-11ea-9170-4164a478364e.png">

I have also added a small section to the new docs.

For _liquidhaskell_ itself, we will do this in two steps: due to the megarepo nature of the project, we first generate the tarball, copy it into a temporary directory and finally call `upload` giving the tarball as input, which explains those two extra commands in the log.