### PR TITLE
Polish documentation

### DIFF
--- a/docs/mkDocs/README.md
+++ b/docs/mkDocs/README.md
@@ -1,4 +1,4 @@
-## Deploying the Documentation
+# Building and deploying the documentation
 
 To build the documentation, first setup `python3` and related packages
 
@@ -9,16 +9,25 @@ $ python3 get-pip.py
 $ pip3 install mkdocs pygments Pygmentize mkdocs-bootswatch
 ```
 
-after that to view the documents locally do
+after that to view the documents locally run:
 
 ```
-$ mkDocs serve
+mkDocs serve
 ```
 
-to push to github you do
+## Strict mode
 
-mkDocs gh-deploy
+It's recommended to run `mkDocs serve` with the _strict_ option (i.e. `-s`) to ensure no broken links are
+present in the generated docs:
 
 ```
-$ mkdocs gh-deploy
+mkDocs serve -s
+```
+
+## Publishing
+
+To push to github you can simply run:
+
+```
+mkdocs gh-deploy
 ```

--- a/docs/mkDocs/docs/community.md
+++ b/docs/mkDocs/docs/community.md
@@ -4,3 +4,7 @@ If you have any questions, you can:
 
 * Join the Liquid Haskell [slack channel](https://join.slack.com/t/liquidhaskell/shared_invite/enQtMjY4MTk3NDkwODE3LTFmZGFkNGEzYWRkNDJmZDQ0ZGU1MzBiZWZiZDhhNmY3YTJiMjUzYTRlNjMyZDk1NDU3ZGIxYzhlOTIzN2UxNWE)
 * Mail the [users mailing list](https://groups.google.com/forum/#!forum/liquidhaskell)
+
+
+Alternatively, feel free to drop [Ranjit Jhala](https://github.com/ranjitjhala) or
+[Niki Vazou](https://github.com/nikivazou) an email.

--- a/docs/mkDocs/docs/community.md
+++ b/docs/mkDocs/docs/community.md
@@ -1,0 +1,6 @@
+# Community
+
+If you have any questions, you can:
+
+* Join the Liquid Haskell [slack channel](https://join.slack.com/t/liquidhaskell/shared_invite/enQtMjY4MTk3NDkwODE3LTFmZGFkNGEzYWRkNDJmZDQ0ZGU1MzBiZWZiZDhhNmY3YTJiMjUzYTRlNjMyZDk1NDU3ZGIxYzhlOTIzN2UxNWE)
+* Mail the [users mailing list](https://groups.google.com/forum/#!forum/liquidhaskell)

--- a/docs/mkDocs/docs/contributing.md
+++ b/docs/mkDocs/docs/contributing.md
@@ -1,18 +1,31 @@
-# Contributions
+# Get involved
 
-We are excited for you to try LH!
+We are excited for you to try LH! 
 
-## Community
+In this section you can find instructions on how to submit your first PR as well as practical instructions
+on how develop LiquidHaskell.
 
-If you have any questions
+## Hacking on LiquidHaskell
 
-* Join the Liquid Haskell [slack channel](https://join.slack.com/t/liquidhaskell/shared_invite/enQtMjY4MTk3NDkwODE3LTFmZGFkNGEzYWRkNDJmZDQ0ZGU1MzBiZWZiZDhhNmY3YTJiMjUzYTRlNjMyZDk1NDU3ZGIxYzhlOTIzN2UxNWE)
-* Mail the [users mailing list](https://groups.google.com/forum/#!forum/liquidhaskell)
-* Create a [github issue](https://github.com/ucsd-progsys/liquidhaskell/issues)
+If you want to extend LH to fix a bug or provide a new feature, you might be interested in reading
+our [Developer's guide](develop.md).
 
-## Pull requests
+## Reporting a bug
 
-We are thrilled to get PRs!
+If something doesn't work as it should, please consider opening a [github issue](https://github.com/ucsd-progsys/liquidhaskell/issues)
+to let us know. If possible, try to:
+
+* Try to use a descriptive title;
+* State as clearly as possible what is the problem you are facing;
+* Provide a small Haskell file producing the issue;
+* Write down the expected behaviour vs the actual behaviour;
+* If possible, let us know if you have used the [plugin](plugin.md) or the [executable](legacy.md) and
+  which _GHC version_ you are using.
+
+## Your first Pull Request
+
+We are thrilled to get PRs! Please follow these guidelines, as doing so will increase the chances of 
+having your PR accepted:
 
 * The main LH repo [lives here](https://github.com/ucsd-progsys/liquidhaskell)
 * Please create pull requests against the `develop` branch.
@@ -20,3 +33,7 @@ We are thrilled to get PRs!
   - e.g. show new features that that are supported or how it fixes some previous issue
 * If the PR adds a `LIQUID` pragma or option, please also add documentation 
   - e.g. in [options.md](options.md) or [specifications.md](specifications.md) 
+
+## Ask for help
+
+If you have further questions or you just need help, you can always reach out to the [community](community.md).

--- a/docs/mkDocs/docs/develop.md
+++ b/docs/mkDocs/docs/develop.md
@@ -116,163 +116,51 @@ You can directly extend and run the tests by modifying
 
 ## Working With Submodules
 
- - To update the `liquid-fixpoint` submodule, run
-
-    ```
-    cd ./liquid-fixpoint
-    git fetch --all
-    git checkout <remote>/<branch>
-    cd ..
-    ```
-
-   This will update `liquid-fixpoint` to the latest version on `<branch>`
-   (usually `master`) from `<remote>` (usually `origin`).
-
- - After updating `liquid-fixpoint`, make sure to include this change in a
-   commit! Running
-
-    ```
-    git add ./liquid-fixpoint
-    ```
-
-   will save the current commit hash of `liquid-fixpoint` in your next commit
-   to the `liquidhaskell` repository.
-
- - For the best experience, **don't** make changes directly to the
-   `./liquid-fixpoint` submodule, or else git may get confused. Do any
-   `liquid-fixpoint` development inside a separate clone/copy elsewhere.
-
- - If something goes wrong, run
-
-    ```
-    rm -r ./liquid-fixpoint
-    git submodule update --init
-    ```
-
-   to blow away your copy of the `liquid-fixpoint` submodule and revert to the
-   last saved commit hash.
-
- - Want to work fully offline? git lets you add a local directory as a remote.
-   Run
-
-    ```
-    cd ./liquid-fixpoint
-    git remote add local /path/to/your/fixpoint/clone
-    cd ..
-    ```
-
-   Then to update the submodule from your local clone, you can run
-
-    ```
-    cd ./liquid-fixpoint
-    git fetch local
-    git checkout local/<branch>
-    cd ..
-    ```
-
-
-## Generating Performance Reports
-
-**DEPRECATED**
-
-We have set up infrastructure to generate performance reports using [Gipeda](https://github.com/nomeata/gipeda).
-
-Gipeda will generate a static webpage that tracks the performance improvements
-and regressions between commits. To generate the site, first ensure you have the
-following dependencies available:
-
-* Git
-* Cabal >= 1.18
-* GHC
-* Make
-* Bash (installed at `/bin/bash`)
-
-After ensuring all dependencies are available, from the Liquid Haskell
-directory, execute:
-
-    cd scripts/performance
-    ./deploy-gipeda.bash
-
-This will download and install all the relevant repositories and files. Next, to
-generate the performance report, use the `generate-site.bash` script. This script
-has a few options:
-
-* `-s [hash]`: Do not attempt to generate performance reports for any commit
-older than the commit specified by the entered git hash
-* `-e [hash]`: Do not attempt to generate performance reports for any commit
-newer than the commit specified by the entered git hash
-* `-f`: The default behavior of `generate-site.bash` is to first check if logs
-have been created for a given hash. If logs already exist, `generate-site.bash`
-will not recreate them. Specify this option to skip this check and regenerate
-all logs.
-
-You should expect this process to take a very long time. `generate-site.bash`
-will compile each commit, then run the entire test suite and benchmark suite
-for each commit. It is suggested to provide a manageable range to `generate-site.bash`:
-
-    ./generate-site.bash -s [starting hash] -e [ending hash]
-
-...will generate reports for all commits between (inclusive) [starting hash]
-and [ending hash].
-
-    ./generate-site.bash -s [starting hash]
-
-... will generate reports for all commits newer than [starting hash]. This command
-can be the basis for some automated report generation process (i.e. a cron job).
-
-Finally, to remove the Gipeda infrastructure from your computer, you may execute:
-
-    ./cleanup-gipeda.bash
-
-...which will remove any files created by `deploy-gipeda.bash` and `generate-site.bash`
-from your computer.
-
-
-## Configuration Management
-
-It is very important that the version of Liquid Haskell be maintained properly.
-
-Suppose that the current version of Liquid Haskell is `A.B.C.D`:
-
-+ After a release to hackage is made, if any of the components `B`, `C`, or `D` are missing, they shall be added and set to `0`. Then the `D` component of Liquid Haskell shall be incremented by `1`. The version of Liquid Haskell is now `A.B.C.(D + 1)`
-
-+ The first time a new function or type is exported from Liquid Haskell, if any of the components `B`, or `C` are missing, they shall be added and set to `0`. Then the `C` component shall be incremented by `1`, and the `D` component shall stripped. The version of Liquid Haskell is now `A.B.(C + 1)`
-
-+ The first time the signature of an exported function or type is changed, or an exported function or type is removed (this includes functions or types that Liquid Haskell re-exports from its own dependencies), if the `B` component is missing, it shall be added and set to `0`. Then the `B` component shall be incremented by `1`, and the `C` and `D` components shall be stripped. The version of Liquid Haskell is now `A.(B + 1)`
-
-+ The `A` component shall be updated at the sole discretion of the project owners.
-
-## Updating GHC Versions
-
-Here's a script to generate the diff for the `desugar` modules.
+To update the `liquid-fixpoint` submodule, run:
 
 ```
-export GHCSRC=$HOME/Documents/ghc
-
-# Checkout GHC-8.2.2
-(cd $GHCSRC && git checkout ghc-8.2.2 && git pull)
-
-# make a patch
-diff -ur $GHCSRC/compiler/deSugar src/Language/Haskell/Liquid/Desugar > liquid.patch
-
-# Checkout GHC-8.4.3
-(cd $GHCSRC && git checkout ghc-8.2.2 && git pull)
-
-# Copy GHC desugarer to temporary directory
-cp -r $GHCSRC/compiler/deSugar .
-
-# Patch
-(cd deSugar && patch -p5 --merge --ignore-whitespace < ../liquid.patch)
-
-# Copy stuff over
-for i in src/Language/Haskell/Liquid/Desugar/*.*; do j=$(basename $i); echo $j; cp deSugar/$j src/Language/Haskell/Liquid/Desugar; done
+cd ./liquid-fixpoint
+git fetch --all
+git checkout <remote>/<branch>
+cd ..
 ```
 
-Here's the magic diff that we did at some point that we keep bumping up to new GHC versions:
+This will update `liquid-fixpoint` to the latest version on `<branch>` (usually `master`) 
+from `<remote>` (usually `origin`). After updating `liquid-fixpoint`, make sure to include this change in a
+commit! Running:
 
-https://github.com/ucsd-progsys/liquidhaskell/commit/d380018850297b8f1878c33d0e4c586a1fddc2b8#diff-3644b76a8e6b3405f5492d8194da3874R224 
+```
+git add ./liquid-fixpoint
+```
 
-[compiler plugin]: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/extending_ghc.html#compiler-plugins
+will save the current commit hash of `liquid-fixpoint` in your next commit to the `liquidhaskell` repository.
+For the best experience, **don't** make changes directly to the `./liquid-fixpoint` submodule, or else git
+may get confused. Do any `liquid-fixpoint` development inside a separate clone/copy elsewhere. If something
+goes wrong, run:
+
+```
+rm -r ./liquid-fixpoint
+git submodule update --init
+```
+
+to blow away your copy of the `liquid-fixpoint` submodule and revert to the last saved commit hash.
+
+Want to work fully offline? `git` lets you add a local directory as a remote. Run:
+
+```
+cd ./liquid-fixpoint
+git remote add local /path/to/your/fixpoint/clone
+cd ..
+```
+
+Then to update the submodule from your local clone, you can run:
+
+```
+cd ./liquid-fixpoint
+git fetch local
+git checkout local/<branch>
+cd ..
+```
 
 ## Releasing on Hackage
 
@@ -282,5 +170,5 @@ in the release process. Most contributors can skip this section.*
 We provide a conveniency script to upload all the `liquid-*` packages (**including** `liquid-fixpoint`) on
 Hackage, in a lockstep fashion. To do so, it's possible to simply run the `scripts/release_to_hackage.sh`
 Bash script. The script doesn't accept any argument and it tries to determine the packages
-to upload by scanning the $PWD for packages named appropriately. It will ask the user for confirmation
+to upload by scanning the `$PWD` for packages named appropriately. It will ask the user for confirmation
 before proceeding, and `stack upload` will be used under the hood.

--- a/docs/mkDocs/docs/external.md
+++ b/docs/mkDocs/docs/external.md
@@ -1,0 +1,12 @@
+## External software requirements
+
+In order to use `liquidhaskell`, you will need a [SMT solver](https://en.wikipedia.org/wiki/Satisfiability_modulo_theories)
+installed on your system. Download and install at least one of:
+
+* [Z3](https://github.com/Z3Prover/z3) or [Microsoft official binary](https://www.microsoft.com/en-us/download/details.aspx?id=52270)
+* [CVC4](https://cvc4.github.io/)
+* [MathSat](https://mathsat.fbk.eu/)
+
+Note: The SMT solver binary should be on your `PATH`; LiquidHaskell will execute it as a child process.
+
+Once installed, you can now use LH as [a plugin](plugin.md) or using the legacy [executable](legacy.md).

--- a/docs/mkDocs/docs/index.md
+++ b/docs/mkDocs/docs/index.md
@@ -11,7 +11,7 @@ for examples.
 
 Read the below for more details on how to:
 
-* **Install** [external software](external.md) dependencies required by LH
+* **Install** [external software](install.md) dependencies required by LH
 * **Install** and use LH as a [GHC Plugin](plugin.md)
 * **Install** and use the (legacy) LH standalone [executable](legacy.md) 
 * Use the command line [options](options.md) supported by LH
@@ -30,9 +30,10 @@ If the above whets your appetite, you may enjoy working through the following lo
 * [120 minute workshop with more examples](http://ucsd-progsys.github.io/lh-workshop/01-index.html)
 * [Long ish Tutorial](http://ucsd-progsys.github.io/liquidhaskell-tutorial/)
 
-## Contribute
+## Get involved
 
 If you are interested to contribute to LH and its ecosystem, you may want to:
 
+* Read the contribution [guidelines](contributing.md)
 * Read our [developers' guide](develop.md) to LH
-* Join the LH [community](contributing.md) to discuss issues related to LH
+* Join the LH [community](community.md) to discuss issues related to LH

--- a/docs/mkDocs/docs/index.md
+++ b/docs/mkDocs/docs/index.md
@@ -13,7 +13,6 @@ Read the below for more details on how to:
 
 * **Install** [external software](install.md) dependencies required by LH
 * **Install** and use LH as a [GHC Plugin](plugin.md)
-* **Install** and use the (legacy) LH standalone [executable](legacy.md) 
 * Use the command line [options](options.md) supported by LH
 * Write refinement type [specifications](specifications.md)
 

--- a/docs/mkDocs/docs/index.md
+++ b/docs/mkDocs/docs/index.md
@@ -2,33 +2,37 @@
 
 # LiquidHaskell 
 
-LiquidHaskell (LH) refines Haskell's types with logical 
+LiquidHaskell (_LH_) refines Haskell's types with logical 
 predicates that let you enforce important properties at 
 compile time. See [the blog](https://ucsd-progsys.github.io/liquidhaskell-blog/) 
 for examples.
 
 ## Quick Start
 
-The following links are a quick way to play with and learn about LH
+Read the below for more details on how to:
+
+* **Install** [external software](external.md) dependencies required by LH
+* **Install** and use LH as a [GHC Plugin](plugin.md)
+* **Install** and use the (legacy) LH standalone [executable](legacy.md) 
+* Use the command line [options](options.md) supported by LH
+* Write refinement type [specifications](specifications.md)
+
+## Learn
+
+The following links are a quick way to play with and learn about LH:
 
 * [Try online in your browser](http://goto.ucsd.edu:8090/index.html)
 * [Splash page with examples and link to blog](https://ucsd-progsys.github.io/liquidhaskell-blog/)
 * [Andres Loeh's Tutorial](https://liquid.kosmikus.org)
 
-## Longer Tutorials
-
-If the above whets your appetite, you may enjoy working through the following
+If the above whets your appetite, you may enjoy working through the following longer tutorials:
 
 * [120 minute workshop with more examples](http://ucsd-progsys.github.io/lh-workshop/01-index.html)
 * [Long ish Tutorial](http://ucsd-progsys.github.io/liquidhaskell-tutorial/)
 
-## Documentation
+## Contribute
 
-Read the below for more details on how to
+If you are interested to contribute to LH and its ecosystem, you may want to:
 
-* Use LH as a [GHC Plugin](plugin.md)
-* Use the (legacy) LH standalone [executable](legacy.md) 
-* Use the command line [options](options.md) supported by LH
-* Write refinement type [specifications](specifications.md)
-* Develop and [contribute](develop.md) to LH
+* Read our [developers' guide](develop.md) to LH
 * Join the LH [community](contributing.md) to discuss issues related to LH

--- a/docs/mkDocs/docs/install.md
+++ b/docs/mkDocs/docs/install.md
@@ -1,3 +1,7 @@
+# How to install
+
+This sections documents how to install LH and its dependencies.
+
 ## External software requirements
 
 In order to use `liquidhaskell`, you will need a [SMT solver](https://en.wikipedia.org/wiki/Satisfiability_modulo_theories)
@@ -9,4 +13,6 @@ installed on your system. Download and install at least one of:
 
 Note: The SMT solver binary should be on your `PATH`; LiquidHaskell will execute it as a child process.
 
-Once installed, you can now use LH as [a plugin](plugin.md) or using the legacy [executable](legacy.md).
+## Next
+
+Once installed, you can now install and use LH as [a plugin](plugin.md) or legacy [executable](legacy.md).

--- a/docs/mkDocs/docs/legacy.md
+++ b/docs/mkDocs/docs/legacy.md
@@ -61,56 +61,5 @@ ghci> :m +Language.Haskell.Liquid.Liquid
 ghci> liquid ["tests/pos/Abs.hs"]
 ```
 
-## Incremental Checking
-
-The LiquidHaskell executable supports *incremental* checking where each run only checks
-the part of the program that has been modified since the previous run.
-
-```
-    $ liquid --diff foo.hs
-```
-
-Each run of `liquid` saves the file to a `.bak` file and the *subsequent* run does a `diff` to see what
-has changed w.r.t. the `.bak` file only generates constraints for the `[CoreBind]` corresponding to the
-changed top-level binders and their transitive dependencies.
-
-The time savings are quite significant. For example:
-
-```
-    $ time liquid --notermination -i . Data/ByteString.hs > log 2>&1
-
-    real	7m3.179s
-    user	4m18.628s
-    sys	    0m21.549s
-```
-
-Now if you go and tweak the definition of `spanEnd` on line 1192 and re-run:
-
-```
-    $ time liquid -d --notermination -i . Data/ByteString.hs > log 2>&1
-
-    real	0m11.584s
-    user	0m6.008s
-    sys	    0m0.696s
-```
-
-The diff is only performed against **code**, i.e. if you only change
-specifications, qualifiers, measures, etc. `liquid -d` will not perform
-any checks. In this case, you may specify individual definitions to verify:
-
-```
-    $ liquid -b bar -b baz foo.hs
-```
-
-This will verify `bar` and `baz`, as well as any functions they use.
-
-If you always want to run a given file with diff-checking, add
-the pragma:
-
-    {-@ LIQUID "--diff" @-}
-
-
-
-
 [stack]: https://github.com/commercialhaskell/stack/blob/master/doc/install_and_upgrade.md
 [cabal]: https://www.haskell.org/cabal/

--- a/docs/mkDocs/docs/legacy.md
+++ b/docs/mkDocs/docs/legacy.md
@@ -1,4 +1,4 @@
-# Installing and Running the Legacy LiquidHaskell Executable
+# Installing the Legacy LiquidHaskell Executable
 
 **We strongly recommend** that you use the [GHC Plugin](plugin.md) 
 available in version 0.8.10 onwards, as the legacy executable is deprecated and has been 
@@ -60,6 +60,57 @@ $ stack ghci liquidhaskell
 ghci> :m +Language.Haskell.Liquid.Liquid
 ghci> liquid ["tests/pos/Abs.hs"]
 ```
+
+## Incremental Checking
+
+The LiquidHaskell executable supports *incremental* checking where each run only checks
+the part of the program that has been modified since the previous run.
+
+```
+    $ liquid --diff foo.hs
+```
+
+Each run of `liquid` saves the file to a `.bak` file and the *subsequent* run does a `diff` to see what
+has changed w.r.t. the `.bak` file only generates constraints for the `[CoreBind]` corresponding to the
+changed top-level binders and their transitive dependencies.
+
+The time savings are quite significant. For example:
+
+```
+    $ time liquid --notermination -i . Data/ByteString.hs > log 2>&1
+
+    real	7m3.179s
+    user	4m18.628s
+    sys	    0m21.549s
+```
+
+Now if you go and tweak the definition of `spanEnd` on line 1192 and re-run:
+
+```
+    $ time liquid -d --notermination -i . Data/ByteString.hs > log 2>&1
+
+    real	0m11.584s
+    user	0m6.008s
+    sys	    0m0.696s
+```
+
+The diff is only performed against **code**, i.e. if you only change
+specifications, qualifiers, measures, etc. `liquid -d` will not perform
+any checks. In this case, you may specify individual definitions to verify:
+
+```
+    $ liquid -b bar -b baz foo.hs
+```
+
+This will verify `bar` and `baz`, as well as any functions they use.
+
+If you always want to run a given file with diff-checking, add
+the pragma:
+
+    {-@ LIQUID "--diff" @-}
+
+
+
 
 [stack]: https://github.com/commercialhaskell/stack/blob/master/doc/install_and_upgrade.md
 [cabal]: https://www.haskell.org/cabal/

--- a/docs/mkDocs/docs/legacy.md
+++ b/docs/mkDocs/docs/legacy.md
@@ -6,7 +6,7 @@ kept around for backwards compatibility. It will eventually be removed from futu
 
 ## External software requirements
 
-Make sure all the required [external software](external.md) software is installed before proceeding.
+Make sure all the required [external software](install.md) software is installed before proceeding.
 
 ## Installation options
 

--- a/docs/mkDocs/docs/legacy.md
+++ b/docs/mkDocs/docs/legacy.md
@@ -1,34 +1,18 @@
 # Installing and Running the Legacy LiquidHaskell Executable
 
 **We strongly recommend** that you use the [GHC Plugin](plugin.md) 
-available in version 0.8.10 onwards. The legacy executable has been 
-kept around for backwards compatibility but will eventually be deprecated.
+available in version 0.8.10 onwards, as the legacy executable is deprecated and has been 
+kept around for backwards compatibility. It will eventually be removed from future LH releases.
 
+## External software requirements
 
-## Install
+Make sure all the required [external software](external.md) software is installed before proceeding.
 
-To run the legacy LiquidHaskell executable you need to install:
-
-1. An SMT solver
-2. LH itself as a standalone binary
+## Installation options
 
 You can install the `liquid` binary via package manager *or* source.
 
-### 1. Install SMT Solver
-
-Download and install *at least one* of
-
-+ [Z3](https://github.com/Z3Prover/z3/releases) or [Microsoft official binary](https://www.microsoft.com/en-us/download/details.aspx?id=52270)
-+ [CVC4](http://cvc4.cs.stanford.edu/web/)
-+ [MathSat](http://mathsat.fbk.eu/download.html)
-
-**Note:** The SMT solver binary should be on your `PATH`; LiquidHaskell will execute it as a child process.
-
-### 2. Install Legacy Binary
-
-You can install the `liquid` binary via package manager *or* source.
-
-#### Via Package Manager
+### Via Package Manager
 
 Simply do:
 
@@ -38,72 +22,34 @@ We are working to put `liquid` on `stackage`.
 
 You can designate a specific version of LiquidHaskell to
 ensure that the correct GHC version is in the environment. 
-As an example,
+For example:
 
-    cabal install liquidhaskell-0.9.0.0
+    cabal install liquidhaskell-0.8.10.1
 
-#### Build from Source
+### Build from Source
 
 If you want the most recent version, you can build from source as follows,
 either using `stack` (recommended) or `cabal`. In either case:
 
-1. *recursively* `clone` the repo 
+1. *recursively* `clone` the repo:
 
-    git clone --recursive https://github.com/ucsd-progsys/liquidhaskell.git
+    ```git clone --recursive https://github.com/ucsd-progsys/liquidhaskell.git```
+
+2. Go inside the `liquidhaskell` directory:
+
+    ```
     cd liquidhaskell
-
-2. `build` the package with [stack][stack] 
-
-    stack install liquidhaskell
-
-3. or with [cabal][cabal] 
-
-    cabal v2-build liquidhaskell
-
-#### A note on the GHC_PACKAGE_PATH
-
-To work correctly `liquid` requires access to auxiliary packages
-installed as part of the executable. Therefore, you might need to 
-extend your `$GHC_PACKAGE_PATH` to have it point to the right location(s). 
-
-Typically the easiest way is to call `stack path`, which will print 
-a lot of diagnostic output. From that it should be suffient to copy 
-the paths printed as part of `ghc-package-path: <some-paths>` and 
-extend the `GHC_PACKAGE_PATH` this way (typically editing your `.bashrc` 
-to make the changes permanent):
-
-```
-export GHC_PACKAGE_PATH=$GHC_PACKAGE_PATH:<some-paths>
-```
-
-After that, running `liquid` anywhere from the filesystem should work.
-
-### Troubleshooting
-
-1. If you're on Windows, please make sure the SMT solver is installed
-    in the **same** directory as LiquidHaskell itself (i.e. wherever
-    `cabal` or `stack` puts your binaries). That is, do:
-
-    ```
-    which liquid
     ```
 
-    and make sure that `z3` or `cvc4` or `mathsat` are in the `PATH`
-    returned by the above.
+3. Build the package:
 
-2. If you installed via `stack` and are experiencing path related woes, try:
+    a. with [stack][stack]:
 
-    ```
-    stack exec -- liquid path/to/file.hs
-    ```
+        stack install liquidhaskell
 
-## Running the Legacy Binary
+    b. or with [cabal][cabal]:
 
-To verify a file called `foo.hs` at type
-
-```bash
-$ liquid foo.hs
-```
+        cabal v2-build liquidhaskell
 
 ## Running in GHCi
 
@@ -114,7 +60,6 @@ $ stack ghci liquidhaskell
 ghci> :m +Language.Haskell.Liquid.Liquid
 ghci> liquid ["tests/pos/Abs.hs"]
 ```
-
 
 [stack]: https://github.com/commercialhaskell/stack/blob/master/doc/install_and_upgrade.md
 [cabal]: https://www.haskell.org/cabal/

--- a/docs/mkDocs/docs/options.md
+++ b/docs/mkDocs/docs/options.md
@@ -71,7 +71,6 @@ To allow reasoning about function extensionality use the `extensionality flag`. 
 {-@ LIQUID "--extensionality" @-}
 ```
 
-
 ## Fast Checking
 
 The option `--fast` or `--nopolyinfer` greatly recudes verification time, can also reduces precision of type checking. 
@@ -79,6 +78,54 @@ It, per module, deactivates inference of refinements during
 instantiation of polymorphic type variables. 
 It is suggested to use on theorem proving style when reflected 
 functions are trivially refined. 
+
+## Incremental Checking
+
+The LiquidHaskell executable supports *incremental* checking where each run only checks
+the part of the program that has been modified since the previous run.
+
+```
+    $ liquid --diff foo.hs
+```
+
+Each run of `liquid` saves the file to a `.bak` file and the *subsequent* run does a `diff` to see what
+has changed w.r.t. the `.bak` file only generates constraints for the `[CoreBind]` corresponding to the
+changed top-level binders and their transitive dependencies.
+
+The time savings are quite significant. For example:
+
+```
+    $ time liquid --notermination -i . Data/ByteString.hs > log 2>&1
+
+    real	7m3.179s
+    user	4m18.628s
+    sys	    0m21.549s
+```
+
+Now if you go and tweak the definition of `spanEnd` on line 1192 and re-run:
+
+```
+    $ time liquid -d --notermination -i . Data/ByteString.hs > log 2>&1
+
+    real	0m11.584s
+    user	0m6.008s
+    sys	    0m0.696s
+```
+
+The diff is only performed against **code**, i.e. if you only change
+specifications, qualifiers, measures, etc. `liquid -d` will not perform
+any checks. In this case, you may specify individual definitions to verify:
+
+```
+    $ liquid -b bar -b baz foo.hs
+```
+
+This will verify `bar` and `baz`, as well as any functions they use.
+
+If you always want to run a given file with diff-checking, add
+the pragma:
+
+    {-@ LIQUID "--diff" @-}
 
 ## Full Checking (DEFAULT)
 

--- a/docs/mkDocs/docs/options.md
+++ b/docs/mkDocs/docs/options.md
@@ -80,57 +80,6 @@ instantiation of polymorphic type variables.
 It is suggested to use on theorem proving style when reflected 
 functions are trivially refined. 
 
-## Incremental Checking
-
-LiquidHaskell supports *incremental* checking where each run only checks
-the part of the program that has been modified since the previous run.
-
-```
-    $ liquid --diff foo.hs
-```
-
-Each run of `liquid` saves the file to a `.bak` file and the *subsequent* run
-
-    + does a `diff` to see what has changed w.r.t. the `.bak` file
-    + only generates constraints for the `[CoreBind]` corresponding to the
-       changed top-level binders and their transitive dependencies.
-
-The time savings are quite significant. For example:
-
-```
-    $ time liquid --notermination -i . Data/ByteString.hs > log 2>&1
-
-    real	7m3.179s
-    user	4m18.628s
-    sys	    0m21.549s
-```
-
-Now if you go and tweak the definition of `spanEnd` on line 1192 and re-run:
-
-```
-    $ time liquid -d --notermination -i . Data/ByteString.hs > log 2>&1
-
-    real	0m11.584s
-    user	0m6.008s
-    sys	    0m0.696s
-```
-
-The diff is only performed against **code**, i.e. if you only change
-specifications, qualifiers, measures, etc. `liquid -d` will not perform
-any checks. In this case, you may specify individual definitions to verify:
-
-```
-    $ liquid -b bar -b baz foo.hs
-```
-
-This will verify `bar` and `baz`, as well as any functions they use.
-
-If you always want to run a given file with diff-checking, add
-the pragma:
-
-    {-@ LIQUID "--diff" @-}
-
-
 ## Full Checking (DEFAULT)
 
 To force LiquidHaskell to check the **whole** file (DEFAULT), use:
@@ -229,7 +178,7 @@ Use the `--no-termination` option to disable the check
 
     {-@ LIQUID "--no-termination" @-}
 
-See the [specifications documentation][specifications] for how to write termination 
+See the [specifications section](specifications.md) for how to write termination 
 specifications.
 
 
@@ -353,7 +302,9 @@ and multiplication as uninterpreted functions use the `linear` flag
 
     liquid --linear test.hs
 
-## Counter examples (Experimental!)
+## Counter examples
+
+**Status:** `experimental`
 
 When given the `--counter-examples` flag, LiquidHaskell will attempt to produce
 counter-examples for the type errors it discovers. For example, see
@@ -407,4 +358,4 @@ verification attempts.
   your system. If not, `hscolour` is used to render the HTML.
 
   It is also possible to generate *slide shows* from the above.
-  See the [slides directory](docs/slides) for an example.
+  See the [slides directory](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/docs/slides) for an example.

--- a/docs/mkDocs/docs/options.md
+++ b/docs/mkDocs/docs/options.md
@@ -5,18 +5,19 @@ checking.
 
 To see all options, run `liquid --help`. 
 
-Each option can be passed in at the command line, or directly
-added to the source file via a **pragma**
+You can pass options in different ways:
 
-```haskell
-    {-@ LIQUID "option-within-quotes" @-}
-```
+1. From the **command line**, if you use the **legacy executable**:
 
-for example, to disable termination checking (see below)
+        liquid --opt1 --opt2 ...
 
-```haskell
-    {-@ LIQUID "--no-termination" @-}
-```
+2. As a **plugin option**:
+
+        ghc-options: -fplugin-opt=LiquidHaskell:--opt1 -fplugin-opt=LiquidHaskell:--opt2
+
+3. As a **pragma**, directly added to the source file:
+
+        {-@ LIQUID "opt1" @-}
 
 You may also put command line options in the environment variable
 `LIQUIDHASKELL_OPTS`. For example, if you add the line:
@@ -32,6 +33,10 @@ to your `.bashrc` then, by default, all files will be
 Below, we list the various options and what they are used for. 
 
 ## Theorem Proving 
+
+**Options:** `reflection`, `ple`, `ple-local`, `extensionality`
+
+**Directives:** `automatic-instances`
 
 To enable theorem proving, e.g. as [described here](https://ucsd-progsys.github.io/liquidhaskell-blog/tags/reflection.html)
 use the option 
@@ -65,13 +70,16 @@ liquid annotation
 {-@ automatic-instances theorem @-}
 ```
 
-To allow reasoning about function extensionality use the `extensionality flag`. [See](https://github.com/ucsd-progsys/liquidhaskell/blob/880c78f94520d76fa13880eac050f21dacb592fd/tests/pos/T1577.hs)
+To allow reasoning about function extensionality use the `--extensionality` flag. 
+[See test T1577](https://github.com/ucsd-progsys/liquidhaskell/blob/880c78f94520d76fa13880eac050f21dacb592fd/tests/pos/T1577.hs).
 
 ```
 {-@ LIQUID "--extensionality" @-}
 ```
 
 ## Fast Checking
+
+**Options:** `fast`, `nopolyinfer`
 
 The option `--fast` or `--nopolyinfer` greatly recudes verification time, can also reduces precision of type checking. 
 It, per module, deactivates inference of refinements during 
@@ -81,16 +89,13 @@ functions are trivially refined.
 
 ## Incremental Checking
 
+**Options:** `diff`
+
 The LiquidHaskell executable supports *incremental* checking where each run only checks
-the part of the program that has been modified since the previous run.
-
-```
-    $ liquid --diff foo.hs
-```
-
-Each run of `liquid` saves the file to a `.bak` file and the *subsequent* run does a `diff` to see what
-has changed w.r.t. the `.bak` file only generates constraints for the `[CoreBind]` corresponding to the
-changed top-level binders and their transitive dependencies.
+the part of the program that has been modified since the previous run. Each run of `liquid` saves the file
+to a `.bak` file and the *subsequent* run does a `diff` to see what has changed w.r.t. the `.bak` file only
+generates constraints for the `[CoreBind]` corresponding to the changed top-level binders and their
+transitive dependencies.
 
 The time savings are quite significant. For example:
 
@@ -105,7 +110,7 @@ The time savings are quite significant. For example:
 Now if you go and tweak the definition of `spanEnd` on line 1192 and re-run:
 
 ```
-    $ time liquid -d --notermination -i . Data/ByteString.hs > log 2>&1
+    $ time liquid --diff --notermination -i . Data/ByteString.hs > log 2>&1
 
     real	0m11.584s
     user	0m6.008s
@@ -129,20 +134,17 @@ the pragma:
 
 ## Full Checking (DEFAULT)
 
-To force LiquidHaskell to check the **whole** file (DEFAULT), use:
+**Options:** `full`
 
-    $ liquid --full foo.hs
-
-to the file. This will override any other `--diff` incantation
-elsewhere (e.g. inside the file.)
-
-
-If you always want to run a given file with full-checking, add
-the pragma:
+You can force LiquidHaskell to check the **whole** file (which is the _DEFAULT_) using the `--full` option.
+This will override any other `--diff` incantation elsewhere (e.g. inside the file). If you always want
+to run a given file with full-checking, add the pragma:
 
     {-@ LIQUID "--full" @-}
 
 ## Specifying Different SMT Solvers
+
+**Options:** `smtsolver`
 
 By default, LiquidHaskell uses the SMTLIB2 interface for Z3.
 
@@ -163,25 +165,26 @@ dependencies). If you do so, you can use that interface with:
 
     $ liquid --smtsolver=z3mem foo.hs
 
-
 ## Short Error Messages
+
+**Options:** `short-errors`
 
 By default, subtyping error messages will contain the inferred type, the
 expected type -- which is **not** a super-type, hence the error -- and a
 context containing relevant variables and their type to help you understand
 the error. If you don't want the above and instead, want only the
-**source position** of the error use:
-
-    --short-errors
+**source position** of the error use `--short-errors`.
 
 ## Short (Unqualified) Module Names
 
-By default, the inferred types will have fully qualified module names.
-To use unqualified names, much easier to read, use:
+**Options:** `short-names`
 
-    --short-names
+By default, the inferred types will have fully qualified module names.
+To use unqualified names, much easier to read, use `--short-names`.
 
 ## Disabling Checks on Functions
+
+**Directives:** `ignore`
 
 You can _disable_ checking of a particular function (e.g. because it is unsafe,
 or somehow not currently outside the scope of LH) by using the `ignore` directive.
@@ -199,43 +202,43 @@ See `tests/pos/Ignores.hs` for an example.
 
 ## Totality Check
 
+**Options:** `no-totality`
+
 LiquidHaskell proves the absence of pattern match failures.
 
 For example, the definition
 
-    fromJust :: Maybe a -> a
-    fromJust (Just a) = a
+```haskell
+fromJust :: Maybe a -> a
+fromJust (Just a) = a
+```
 
 is not total and it will create an error message.
 If we exclude `Nothing` from its domain, for example using the following specification
 
-    {-@ fromJust :: {v:Maybe a | (isJust v)} -> a @-}
+```haskell
+{-@ fromJust :: {v:Maybe a | (isJust v)} -> a @-}
+```
 
 `fromJust` will be safe.
 
 Use the `no-totality` flag to disable totality checking.
 
-    liquid --no-totality test.hs
-
 ## Termination Check
 
-By **default** a termination check is performed on all recursive functions.
+**Options:** `no-termination`
 
-Use the `--no-termination` option to disable the check
+By **default** a termination check is performed on all recursive functions, but you can disable the check
+with the `--no-termination` option.
 
-    {-@ LIQUID "--no-termination" @-}
-
-See the [specifications section](specifications.md) for how to write termination 
-specifications.
-
+See the [specifications section](specifications.md) for how to write termination specifications.
 
 ## Total Haskell
 
+**Options:** `total-Haskell`
+
 LiquidHaskell provides a total Haskell flag that checks both totallity and termination of the program,
 overriding a potential no-termination flag.
-
-    liquid --total-Haskell test.hs
-
 
 ## Lazy Variables
 
@@ -246,45 +249,49 @@ A variable can be specified as `LAZYVAR`
 With this annotation the definition of `z` will be checked at the points where
 it is used. For example, with the above annotation the following code is SAFE:
 
-    foo   = if x > 0 then z else x
-      where
-        z = 42 `safeDiv` x
-        x = choose 0
+```haskell
+foo   = if x > 0 then z else x
+  where
+    z = 42 `safeDiv` x
+    x = choose 0
+```
 
 By default, all the variables starting with `fail` are marked as LAZY, to defer
 failing checks at the point where these variables are used.
 
 ## No measure fields
 
+**Options:** `no-measure-fields`
+
 When a data type is refined, Liquid Haskell automatically turns the data constructor fields into measures.
 For example,
 
-    {-@ data L a = N | C {hd :: a, tl :: L a} @-}
+```haskell
+{-@ data L a = N | C {hd :: a, tl :: L a} @-}
+```
 
-will automatically create two measures `hd` and `td`.
-To deactivate this automatic measure definition, and speed up verification, you can use the `no-measure-fields` flag.
-
-    liquid --no-measure-fields test.hs
-
-
+will automatically create two measures `hd` and `td`. To deactivate this automatic measure definition,
+and speed up verification, you can use the `--no-measure-fields` flag.
 
 ## Prune Unsorted Predicates
+
+**Options:** `prune-unsorted`
 
 The `--prune-unsorted` flag is needed when using *measures over specialized instances* of ADTs. 
 
 For example, consider a measure over lists of integers
 
 ```haskell
-    sum :: [Int] -> Int
-    sum [] = 0
-    sum (x:xs) = 1 + sum xs
+sum :: [Int] -> Int
+sum [] = 0
+sum (x:xs) = 1 + sum xs
 ```
 
 This measure will translate into strengthening the types of list constructors
 
 ```
-    [] :: {v:[Int] | sum v = 0 }
-    (:) :: x:Int -> xs:[Int] -> {v:[Int] | sum v = x + sum xs}
+[] :: {v:[Int] | sum v = 0 }
+(:) :: x:Int -> xs:[Int] -> {v:[Int] | sum v = x + sum xs}
 ```
 
 But what if our list is polymorphic `[a]` and later instantiate to list of ints?
@@ -292,8 +299,8 @@ The workaround we have right now is to strengthen the polymorphic list with the
 `sum` information
 
 ```
-    [] :: {v:[a] | sum v = 0 }
-    (:) :: x:a -> xs:[a] -> {v:[a] | sum v = x + sum xs}
+[] :: {v:[a] | sum v = 0 }
+(:) :: x:a -> xs:[a] -> {v:[a] | sum v = x + sum xs}
 ```
 
 But for non numeric `a`s, refinements like `x + sum xs` are ill-sorted! 
@@ -301,55 +308,51 @@ But for non numeric `a`s, refinements like `x + sum xs` are ill-sorted!
 We use the flag `--prune-unsorted` to prune away unsorted expressions 
 (like `x + sum xs`) inside refinements.
 
-
-```
-    liquid --prune-unsorted test.hs
-```
-
-
 ## Case Expansion
+
+**Options:** `no-case-expand`
 
 By default LiquidHaskell expands all data constructors to the case statements.
 For example, given the definition
 
 ```haskell 
-  data F = A1 | A2 | .. | A10
+data F = A1 | A2 | .. | A10
 ```
 
 LiquidHaskell will expand the code
 
 ```haskell
-  case f of {A1 -> True; _ -> False}
+case f of {A1 -> True; _ -> False}
 ```
 
 to 
 
 ```haskell
-  case f of {A1 -> True; A2 -> False; ...; A10 -> False}
+case f of {A1 -> True; A2 -> False; ...; A10 -> False}
 ```
 
 This expansion can lead to more precise code analysis
 but it can get really expensive due to code explosion.
-The `no-case-expand` flag prevents this expansion and keeps the user
+The `--no-case-expand` flag prevents this expansion and keeps the user
 provided cases for the case expression.
-
-    liquid --no-case-expand test.hs
-
 
 ## Higher order logic
 
-The flag `--higherorder` allows reasoning about higher order functions.
+**Options:** `higherorder`
 
+The flag `--higherorder` allows reasoning about higher order functions.
 
 ## Restriction to Linear Arithmetic
 
+**Options:** `linear`
+
 When using `z3` as the solver, LiquidHaskell allows for non-linear arithmetic:
 division and multiplication on integers are interpreted by `z3`. To treat division
-and multiplication as uninterpreted functions use the `linear` flag
-
-    liquid --linear test.hs
+and multiplication as uninterpreted functions use the `--linear` flag.
 
 ## Counter examples
+
+**Options:** `counter-examples`
 
 **Status:** `experimental`
 

--- a/docs/mkDocs/docs/plugin.md
+++ b/docs/mkDocs/docs/plugin.md
@@ -20,7 +20,7 @@ of your project in the cabal file, after which `stack` or `cabal` automatically:
 
 ## External software requirements
 
-Make sure all the required [external software](external.md) software is installed before proceeding.
+Make sure all the required [external software](install.md) software is installed before proceeding.
 
 ## Getting started
 

--- a/docs/mkDocs/docs/plugin.md
+++ b/docs/mkDocs/docs/plugin.md
@@ -25,7 +25,7 @@ Make sure all the required [external software](install.md) software is installed
 ## Getting started
 
 We offer a detailed "getting started" walkthrough in the form of a documented Haskell module. 
-You can read it [here](src/Language/Haskell/Liquid/GHC/Plugin/Tutorial.hs).
+You can read it [here](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/src/Language/Haskell/Liquid/GHC/Plugin/Tutorial.hs).
 
 ## Examples
 

--- a/docs/mkDocs/docs/plugin.md
+++ b/docs/mkDocs/docs/plugin.md
@@ -3,9 +3,8 @@
 As of LH version 0.8.10, mirroring GHC-8.10, LiquidHaskell 
 is available as a [GHC compiler plugin](https://downloads.haskell.org/~ghc/8.10.1/docs/html/users_guide/extending_ghc.html). 
 
-(We still offer a [legacy executable](legacy.md) which uses 
-the plugin internally, to give users enough time to complete 
-migrations to the new system.)
+(We still offer the old [legacy executable](legacy.md), to give users enough time to complete migrations
+to the new system.)
 
 ## Benefits
 
@@ -19,19 +18,19 @@ of your project in the cabal file, after which `stack` or `cabal` automatically:
 
 **We recommend switching to the new compiler plugin as soon as possible.**
 
-## Installation and Use
+## External software requirements
 
-1. Install an SMT Solver Download and install at least one of
+Make sure all the required [external software](external.md) software is installed before proceeding.
 
-    Z3 or Microsoft official binary
-    CVC4
-    MathSat
+## Getting started
 
-Note: The SMT solver binary should be on your PATH; LiquidHaskell will execute it as a child process.
+We offer a detailed "getting started" walkthrough in the form of a documented Haskell module. 
+You can read it [here](src/Language/Haskell/Liquid/GHC/Plugin/Tutorial.hs).
 
-The following concrete examples show how the source plugin works
+## Examples
 
-- [Tutorial documentation](src/Language/Haskell/Liquid/GHC/Plugin/Tutorial.hs) 
+The following concrete examples show the source plugin in action:
+
 - [Sample package](https://github.com/ucsd-progsys/lh-plugin-demo)
 - [Sample client package](https://github.com/ucsd-progsys/lh-plugin-demo-client)
 
@@ -41,7 +40,5 @@ codebase.
 
 ## Editor Support
 
-**In plugin-mode** you get to automatically reuse **all** `ghc` 
-based support for your editor as is. Again, the sample packages 
-include examples for `vscode`, `vim` and `emacs`.
-
+One of the added benefit of the plugin is that you get to automatically reuse **all** ghc-based support
+for your editor as is. Again, the sample packages include examples for `vscode`, `vim` and `emacs`.

--- a/docs/mkDocs/docs/plugin.md
+++ b/docs/mkDocs/docs/plugin.md
@@ -24,8 +24,8 @@ Make sure all the required [external software](install.md) software is installed
 
 ## Getting started
 
-We offer a detailed "getting started" walkthrough in the form of a documented Haskell module. 
-You can read it [here](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/src/Language/Haskell/Liquid/GHC/Plugin/Tutorial.hs).
+We offer a detailed "getting started" walkthrough in the form of a Haskell module with a lot of comments,
+written in prose. You can read it [here](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/src/Language/Haskell/Liquid/GHC/Plugin/Tutorial.hs).
 
 ## Examples
 

--- a/docs/mkDocs/docs/specifications.md
+++ b/docs/mkDocs/docs/specifications.md
@@ -1,8 +1,6 @@
 # Writing Specifications
 
-
-Modules WITHOUT code
---------------------
+## Modules WITHOUT code
 
 When checking a file `target.hs`, you can specify an _include_ directory by
 
@@ -13,7 +11,7 @@ you **do not have the code**, you can create a `.spec` file at:
 
     /path/to/include/Foo/Bar/Baz.spec
 
-See, for example, the contents of
+See, for example, the contents of:
 
 + [include/Prelude.spec](https://github.com/ucsd-progsys/liquidhaskell/blob/master/include/Prelude.spec)
 + [include/Data/List.spec](https://github.com/ucsd-progsys/liquidhaskell/blob/master/include/Data/List.spec)
@@ -27,71 +25,77 @@ See, for example, the contents of
   see below for standalone specifications for **internal** or **home** modules.
 
 
-Modules WITH code: Data
------------------------
+## Modules WITH code: Data
 
 Write the specification directly into the .hs or .lhs file,
-above the data definition. See, for example, [tests/pos/Map.hs](tests/pos/Map.hs)
+above the data definition. See, for example, [tests/pos/Map.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/Map.hs):
 
-    {-@
-    data Map k a <l :: k -> k -> Prop, r :: k -> k -> Prop>
-      = Tip
-      | Bin (sz    :: Size)
-            (key   :: k)
-            (value :: a)
-            (left  :: Map <l, r> (k <l key>) a)
-            (right :: Map <l, r> (k <r key>) a)
-    @-}
-    data Map k a = Tip
-                 | Bin Size k a (Map k a) (Map k a)
+```haskell
+{-@
+data Map k a <l :: k -> k -> Prop, r :: k -> k -> Prop>
+  = Tip
+  | Bin (sz    :: Size)
+        (key   :: k)
+        (value :: a)
+        (left  :: Map <l, r> (k <l key>) a)
+        (right :: Map <l, r> (k <r key>) a)
+@-}
+data Map k a = Tip
+             | Bin Size k a (Map k a) (Map k a)
+```
 
 You can also write invariants for data type definitions
-together with the types. For example, see [tests/pos/record0.hs](tests/pos/record0.hs)
+together with the types. For example, see [tests/pos/record0.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/record0.hs):
 
-    {-@ data LL a = BXYZ { size  :: {v: Int | v > 0 }
-                         , elems :: {v: [a] | (len v) = size }
-                         }
-    @-}
+```haskell
+{-@ 
+data LL a = BXYZ { size  :: {v: Int | v > 0 }
+                 , elems :: {v: [a] | (len v) = size }
+                 }
+@-}
+```
 
 Finally you can specify the variance of type variables for data types.
-For example, see [tests/pos/Variance.hs](tests/pos/Variance.hs), where data type `Foo` has four
+For example, see [tests/pos/Variance.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/Variance.hs), where data type `Foo` has four
 type variables `a`, `b`, `c`, `d`, specified as invariant, bivariant,
 covariant and contravariant, respectively.
 
-    data Foo a b c d
-    {-@ data variance Foo invariant bivariant covariant contravariant @-}
+```
+{-@ data variance Foo invariant bivariant covariant contravariant @-}
+data Foo a b c d
+```
 
-
-Modules WITH code: Functions
-----------------------------
-
-Write the specification directly into the .hs or .lhs file,
-above the function definition. [For example](tests/pos/spec0.hs)
-
-    {-@ incr :: x:{v: Int | v > 0} -> {v: Int | v > x} @-}
-    incr   :: Int -> Int
-    incr x = x + 1
-
-Modules WITH code: Type Classes
--------------------------------
+## Modules WITH code: Functions
 
 Write the specification directly into the .hs or .lhs file,
-above the type class definition. [For example](tests/pos/Class.hs)
+above the function definition. [For example](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/spec0.hs):
 
-    {-@ class Sized s where
-          size :: forall a. x:s a -> {v:Int | v = (size x)}
-    @-}
-    class Sized s where
-      size :: s a -> Int
+```haskell
+{-@ incr :: x:{v: Int | v > 0} -> {v: Int | v > x} @-}
+incr   :: Int -> Int
+incr x = x + 1
+```
+
+## Modules WITH code: Type Classes
+
+Write the specification directly into the .hs or .lhs file,
+above the type class definition. [For example](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/Class.hs):
+
+```haskell
+{-@ class Sized s where
+      size :: forall a. x:s a -> {v:Int | v = (size x)}
+@-}
+class Sized s where
+  size :: s a -> Int
+```
 
 Any measures used in the refined class definition will need to be
 *generic* (see [Specifying Measures](#specifying-measures)).
 
-
 As an alternative, you can refine class instances.
-[For example](tests/classes/pos/Inst00.hs)
+[For example](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/classes/pos/Inst00.hs):
 
-~~~~
+```haskell
 instance Compare Int where
 
 {-@ instance Compare Int where
@@ -99,16 +103,13 @@ instance Compare Int where
   @-}
 
 cmax y x = if x >= y then x else y
-~~~~
+```
 
-When `cmax` method is used on `Int`, liquidHaskell will give it
-the refined type `Odd -> Odd -> Odd`.
+When `cmax` method is used on `Int`, `liquidHaskell` will give it the refined type `Odd -> Odd -> Odd`.
 
-Note that currently liquidHaskell does not allow refining instances of
-refined classes.
+_Note that currently `liquidHaskell` does not allow refining instances of refined classes_.
 
-Modules WITH code: QuasiQuotation
----------------------------------
+## Modules WITH code: QuasiQuotation
 
 Instead of writing both a Haskell type signature *and* a
 LiquidHaskell specification for a function, the `lq`
@@ -163,8 +164,7 @@ a type inside `lq` which refers to a refined type alias
 for which there is not a plain Haskell type synonym of the
 same name will result in a "not in scope" error from GHC.
 
-Standalone Specifications for Internal Modules
-----------------------------------------------
+## Standalone Specifications for Internal Modules
 
 Recall that the `.spec` mechanism is only for modules whose
 code is absent; if code is present then there can be multiple,
@@ -205,10 +205,9 @@ import LibSpec  -- use this if you DO want the spec, in addition to OR instead o
 bar = foo 1     -- if you `import LibSpec` then this call is rejected by LH
 ```
 
-Inductive Predicates
---------------------
+## Inductive Predicates
 
-**Very Experimental**
+**Status:** `very_experimental`
 
 LH recently added support for *Inductive Predicates*
 in the style of Isabelle, Coq etc. These are encoded
@@ -217,16 +216,15 @@ simply as plain Haskell GADTs but suitably refined.
 Apologies for the minimal documentation; see the
 following examples for details:
 
-* [Even and Odd](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/ple/pos/IndEven.hs)
+* [Palindrome](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/ple/pos/IndPalindrome.hs)
 * [Permutations](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/ple/pos/IndPerm.hs)
 * [Transitive Closure](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/ple/pos/IndStar.hs)
 * [RegExp Derivatives](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/ple/pos/RegexpDerivative.hs)
 * [Type Safety of STLC](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/ple/pos/STLC2.hs)
 
-Implicit Arguments
-------------------
+## Implicit Arguments
 
-**Experimental**
+**Status:** `experimental`
 
 There is experimental support for implicit arguments, solved for with congruence closure. For example, consider [Implicit1.hs](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/Implicit1.hs):
 
@@ -243,45 +241,47 @@ test1 = foo (\_ -> 10)
 Here, the refinement on `(\_ -> 10) :: Int -> { v:Int | v = 10 }` allows us to solve for `n = 10`, the implicit argument to `foo`.
 
 
-Refinement Type Aliases
------------------------
+## Refinement Type Aliases
 
-#### Predicate Aliases
+### Predicate Aliases
 
 Often, the propositions in the refinements can get rather long and
 verbose. You can write predicate aliases like so:
 
-    {-@ predicate Lt X Y = X < Y        @-}
-    {-@ predicate Ge X Y = not (Lt X Y) @-}
+```haskell
+{-@ predicate Lt X Y = X < Y        @-}
+{-@ predicate Ge X Y = not (Lt X Y) @-}
+```
 
-and then use the aliases inside refinements, [for example](tests/pos/pred.hs)
+and then use the aliases inside refinements, [for example](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/pred.hs)
 
-    {-@ incr :: x:{v:Int | (Pos v)} -> { v:Int | ((Pos v) && (Ge v x))} @-}
-    incr :: Int -> Int
-    incr x = x + 1
+```haskell
+{-@ incr :: x:{v:Int | (Pos v)} -> { v:Int | ((Pos v) && (Ge v x))} @-}
+incr :: Int -> Int
+incr x = x + 1
+```
 
-See [Data.Map](benchmarks/esop2013-submission/Base.hs) for a more substantial
+See [Data.Map](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/benchmarks/esop2013-submission/Base.hs) for a more substantial
 and compelling example.
 
 **Syntax:** The key requirements for type aliases are:
 
 - Value parameters are specified in **upper**case: `X`, `Y`, `Z` etc.
 
+### Failing Specifications 
 
-#### Failing Specifications 
+The `fail b` declaration checks that the definition of `b` is unsafe. E.g., the following is SAFE.
 
-The `fail b` declaration checks that the definition of `b` is unsafe. E.g., the followin is SAFE.
-
-    {-@ fail unsafe @-}
-    {-@ unsafe :: () -> { 0 == 1 } @-}
-    unsafe :: () -> () 
-    unsafe _ = ()
+```haskell
+{-@ fail unsafe @-}
+{-@ unsafe :: () -> { 0 == 1 } @-}
+unsafe :: () -> () 
+unsafe _ = ()
+```
 
 An error is created if `fail` definitions are safe or binders defined as `fail` are used by (failing or not) definitions. 
 
-
-#### Type Aliases
-
+### Type Aliases
 
 Similarly, it is often quite tedious to keep writing
 
@@ -316,32 +316,29 @@ and:
 
     {-@ assert insert :: (Ord a) => a -> SortedList a -> SortedList a @-}
 
-see [tests/pos/ListSort.hs](tests/pos/ListSort.hs)
+see [tests/pos/ListSort.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/ListSort.hs)
 
 and:
 
     {-@ assert insert :: (Ord k) => k -> a -> OMap k a -> OMap k a @-}
 
-see [tests/pos/Map.hs](tests/pos/Map.hs)
+see [tests/pos/Map.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/Map.hs)
 
 **Syntax:** The key requirements for type aliases are:
 
 1. Type parameters are specified in **lower**case: `a`, `b`, `c` etc.
 2. Value parameters are specified in **upper**case: `X`, `Y`, `Z` etc.
 
-
-Infix  Operators
----------------------
+## Infix  Operators
 
 You can define infix types and logical operators in logic [Haskell's infix notation](https://www.haskell.org/onlinereport/decls.html#fixity).
 For example, if `(+++)` is defined as a measure or reflected function, you can use it infix by declaring
 
     {-@ infixl 9 +++ @-}
 
-
 Note: infix operators cannot contain the dot character `.`.
 
-If `(==>)` is a Haskell infix type ([see](tests/pos/T1567.hs)) 
+If `(==>)` is a Haskell infix type ([see](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/T1567.hs)) 
 
     infixr 1 ==> 
 
@@ -350,81 +347,82 @@ then to use it as infix in the refinements types you need to add the refinement 
     {-@ infixr 1 ==> @-}
     {-@ test :: g:(f ==> g) -> f x -> f y -> ()  @-} 
 
+## Specifying Measures
 
-Specifying Measures
--------------------
+They can be placed in a `.spec` file or in a .hs/.lhs file wrapped around `{-@ @-}`.
 
-Can be placed in .spec file or in .hs/.lhs file wrapped around `{-@ @-}`
-
-Value measures: [include/GHC/Base.spec](include/GHC/Base.spec)
+Value measures: [GHC/Base.spec](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/liquid-base/src/GHC/Base.spec)
 
     measure len :: forall a. [a] -> GHC.Types.Int
     len ([])     = 0
     len (y:ys)   = 1 + len(ys)
 
-Propositional measures: [tests/pos/LambdaEval.hs](tests/pos/LambdaEval.hs)
+Propositional measures: [tests/pos/LambdaEval.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/LambdaEval.hs)
 
-    {-@
-    measure isValue      :: Expr -> Bool
-    isValue (Const i)    = true
-    isValue (Lam x e)    = true
-    isValue (Var x)      = false
-    isValue (App e1 e2)  = false
-    isValue (Plus e1 e2) = false
-    isValue (Fst e)      = false
-    isValue (Snd e)      = false
-    isValue (Pair e1 e2) = ((? (isValue(e1))) && (? (isValue(e2))))
-    @-}
+```haskell
+{-@
+measure isValue      :: Expr -> Bool
+isValue (Const i)    = true
+isValue (Lam x e)    = true
+isValue (Var x)      = false
+isValue (App e1 e2)  = false
+isValue (Plus e1 e2) = false
+isValue (Fst e)      = false
+isValue (Snd e)      = false
+isValue (Pair e1 e2) = ((? (isValue(e1))) && (? (isValue(e2))))
+@-}
+```
 
-Raw measures: [tests/pos/meas8.hs](tests/pos/meas8.hs)
+Raw measures: [tests/pos/meas8.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/meas8.hs)
 
-    {-@ measure rlen :: [a] -> Int
-    rlen ([])   = {v | v = 0}
-    rlen (y:ys) = {v | v = (1 + rlen(ys))}
-    @-}
+```haskell
+{-@ measure rlen :: [a] -> Int
+rlen ([])   = {v | v = 0}
+rlen (y:ys) = {v | v = (1 + rlen(ys))}
+@-}
+```
 
-Generic measures: [tests/pos/Class.hs](tests/pos/Class.hs)
+Generic measures: [tests/pos/Class.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/Class.hs)
 
-    {-@ class measure size :: a -> Int @-}
-    {-@ instance measure size :: [a] -> Int
-        size ([])   = 0
-        size (x:xs) = 1 + (size xs)
-    @-}
-    {-@ instance measure size :: Tree a -> Int
-        size (Leaf)       = 0
-        size (Node x l r) = 1 + (size l) + (size r)
-    @-}
+```haskell
+{-@ class measure size :: a -> Int @-}
+{-@ instance measure size :: [a] -> Int
+    size ([])   = 0
+    size (x:xs) = 1 + (size xs)
+@-}
+{-@ instance measure size :: Tree a -> Int
+    size (Leaf)       = 0
+    size (Node x l r) = 1 + (size l) + (size r)
+@-}
+```
 
 **Note:** Measure names **do not** have to be the same as
 field name, e.g. we could call the measure `sz` in the above
-as shown in [tests/pos/Class2.hs](tests/pos/Class2.hs).
+as shown in [tests/pos/Class2.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/Class2.hs).
 
-
-Haskell Functions as Measures (beta): [tests/pos/HaskellMeasure.hs](tests/pos/HaskellMeasure.hs)
+Haskell Functions as Measures (beta): [tests/pos/HaskellMeasure.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/HaskellMeasure.hs)
 
 Inductive Haskell Functions from Data Types to some type can be lifted to logic
 
 ```haskell
-    {-@ measure llen @-}
-    llen        :: [a] -> Int
-    llen []     = 0
-    llen (x:xs) = 1 + llen xs
+{-@ measure llen @-}
+llen        :: [a] -> Int
+llen []     = 0
+llen (x:xs) = 1 + llen xs
 ```
 
-The above definition
-  - refines list's data constructors types with the llen information, and
-  - specifies a singleton type for the haskell function
-        `llen :: xs:[a] -> {v:Int | v == llen xs}`
-    If the user specifies another type for llen, say
-        `llen :: xs:[a] -> {v:Int | llen xs >= 0}`
-    then the auto generated singleton type is overwritten.
+The above definition:
 
-Inlines 
--------
+* refines list's data constructors types with the llen information, and
+* specifies a singleton type for the haskell function `llen :: xs:[a] -> {v:Int | v == llen xs}`.
+  If the user specifies another type for `llen`, say `llen :: xs:[a] -> {v:Int | llen xs >= 0}`,
+  then the auto generated singleton type is overwritten.
 
-The `inline`  lets you use a Haskell function in a type specification. 
+## Inlines 
 
-```
+The `inline` lets you use a Haskell function in a type specification. 
+
+```haskell
 {-@ inline max @-}
 {-@ max :: Int -> Int -> Int @-}
 max :: Int -> Int -> Int
@@ -450,10 +448,9 @@ However, as they are *expanded* at compile time, `inline` functions
 **cannot be recursive**. The can call _other_ (non-recursive) inline functions.
 
 If you want to talk about arbitrary (recursive) functions inside your types, 
-then you need to use `reflect` described [in the blog] (https://ucsd-progsys.github.io/liquidhaskell-blog/tags/reflection.html)
+then you need to use `reflect` described [in the blog](https://ucsd-progsys.github.io/liquidhaskell-blog/tags/reflection.html).
 
-Self-Invariants
-===============
+# Self-Invariants
 
 Sometimes, we require specifications that allow *inner* components of a
 type to refer to the *outer* components, typically, to measure-based
@@ -466,7 +463,7 @@ states that the *inner* `a` enjoys the property that the *outer* container
 is definitely a `Just` and furthermore, the inner value is exactly the same
 as the `fromJust` property of the outer container.
 
-As another example, suppose we have a [measure](include/Data/Set.spec):
+As another example, suppose we have a [measure](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/liquid-containers/src/Data/Set.spec):
 
     measure listElts :: [a] -> (Set a)
     listElts([])   = {v | (? Set_emp(v))}
@@ -481,21 +478,19 @@ set of the elements belonging to the entire list.
 
 One often needs these *circular* or *self* invariants to connect different
 levels (or rather, to *reify* the connections between the two levels.) See
-[this test](tests/pos/maybe4.hs) for a simple example and `hedgeUnion` and
-[Data.Map.Base](benchmarks/esop2013-submission/Base.hs) for a complex one.
+[this test](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/maybe4.hs) for a simple example and `hedgeUnion` and
+[Data.Map.Base](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/benchmarks/esop2013-submission/Base.hs) for a complex one.
 
 
-
-Abstract and Bounded Refinements
-================================
+# Abstract and Bounded Refinements
 
 This is probably the best example of the abstract refinement syntax:
 
-+ [Abstract Refinements](tests/pos/Map.hs)
-+ [Bounded Refinements](benchmarks/icfp15/pos/Overview.lhs)
++ [Abstract Refinements](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/Map.hs)
++ [Bounded Refinements](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/benchmarks/icfp15/pos/Overview.lhs)
 
 Unfortunately, the best documentation for these two advanced features
-is the relevant papers at
+is the relevant papers at:
 
 + [ESOP 2013](https://ranjitjhala.github.io/static/abstract_refinement_types.pdf)
 + [ICFP 2015](https://arxiv.org/abs/1507.00385)
@@ -504,8 +499,8 @@ The bounds correspond to Horn implications between abstract refinements,
 which, as in the classical setting, correspond to subtyping constraints
 that must be satisfied by the concrete refinements used at any call-site.
 
-Dependent Pairs
-===============
+# Dependent Pairs
+
 Dependent Pairs are expressed by binding the initial tuples of the pair. For example
 `incrPair` defines an increasing pair.
 
@@ -520,8 +515,8 @@ Invariants
 
 LH lets you locally associate invariants with specific data types.
 
-For example, in [tests/measure/pos/Using00.hs](tests/measure/pos/Using00.hs) every
-list is treated as a Stream. To establish this local invariant one can use the
+For example, in [tests/measure/pos/Using00.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/measure/pos/Using00.hs) every
+list is treated as a `Stream`. To establish this local invariant one can use the
 `using` declaration
 
     {-@ using ([a]) as  {v:[a] | (len v > 0)} @-}
@@ -533,11 +528,10 @@ calls* to List's constructors (ie., `:` and `[]`) satisfy it, and
 will assume that each list element that is created satisfies
 this invariant.
 
-With this, at the [above](tests/measure/neg/Using00.hs) test LiquidHaskell
+With this, at the [above](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/measure/neg/Using00.hs) test LiquidHaskell
 proves that taking the `head` of a list is safe.
-But, at [tests/measure/neg/Using00.hs](tests/measure/neg/Using00.hs) the usage of
+But, at [tests/measure/neg/Using00.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/measure/neg/Using00.hs) the usage of
 `[]` falsifies this local invariant resulting in an "Invariant Check" error.
-
 
 **WARNING:** There is an older _global_ invariant mechanism that
 attaches a refinement to a datatype globally.
@@ -553,11 +547,9 @@ constructors (ie., `:` and `[]`) satisfy it.(TODO!) Then, LiquidHaskell
 assumes that each list element that is created satisfies
 this invariant.
 
+# Rewriting
 
-Rewriting
-=========
-
-*Experimental*
+**Status:** `experimental`
 
 You use the `rewriteWith` annotation to indicate equalities that PLE will apply automatically. For example, suppose that you have proven associativity
 of `++` for lists.
@@ -586,11 +578,10 @@ You can also annotate a function as being a global rewrite rule by using the
           -> { xs ++ (ys ++ zs) == (xs ++ ys) ++ zs } @-}
 ```
 
-
-### Limitations
+## Limitations
 
 Currently, rewriting does not work if the equality that uses the rewrite rule
-includes parameters that contain inner refinements ([test](tests/errors/ReWrite5.hs)).
+includes parameters that contain inner refinements ([test](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/errors/ReWrite5.hs)).
 
 Rewriting works by pattern-matching expressions to determine if there is a
 variable substitution that would allow it to match against either side of a
@@ -599,29 +590,24 @@ corresponding equality is generated. If one side of the equality contains any
 parameters that are not bound on the other side, it will not be possible to
 generate a rewrite in that direction, because those variables cannot be
 instantiated. Likewise, if there are free variables on both sides of an
-equality, no rewrite can be generated at all ([test](tests/errors/ReWrite7.hs)).
+equality, no rewrite can be generated at all ([test](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/errors/ReWrite7.hs)).
 
 It's possible in theory for rewriting rules to diverge. We have a simple check 
 to ensure that rewriting rules that will always diverge do not get instantiated. 
 However, it's possible that applying a combination of rewrite rules could cause
 divergence.
 
-Formal Grammar of Refinement Predicates
-=======================================
+# Formal Grammar of Refinement Predicates
 
-(C)onstants
------------
+## (C)onstants
 
     c := 0, 1, 2, ...
 
-(V)ariables
------------
+## (V)ariables
 
     v := x, y, z, ...
 
-
-(E)xpressions
--------------
+## (E)xpressions
 
     e := v                      -- variable
        | c                      -- constant
@@ -631,8 +617,7 @@ Formal Grammar of Refinement Predicates
        | (v e1 e2 ... en)       -- uninterpreted function application
        | (if p then e else e)   -- if-then-else
 
-(R)elations
------------
+## (R)elations
 
     r := ==               -- equality
        | /=               -- disequality
@@ -641,9 +626,7 @@ Formal Grammar of Refinement Predicates
        | >                -- greater than
        | <                -- less than
 
-
-(P)redicates
-------------
+## (P)redicates
 
     p := (e r e)          -- binary relation
        | (v e1 e2 ... en) -- predicate (or alias) application
@@ -654,16 +637,13 @@ Formal Grammar of Refinement Predicates
        | true
        | false
 
-
-Specifying Qualifiers
-=====================
+# Specifying Qualifiers
 
 There are several ways to specify qualifiers.
 
-By Separate `.hquals` Files
----------------------------
+## By Separate `.hquals` Files
 
-You can write qualifier files e.g. [Prelude.hquals](include/Prelude.hquals)
+You can write qualifier files e.g. [Prelude.hquals](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/include/Prelude.hquals)..
 
 If a module is called or imports
 
@@ -673,21 +653,19 @@ Then the system automatically searches for
 
     include/Foo/Bar/Baz.hquals
 
-By Including `.hquals` Files
-----------------------------
+## By Including `.hquals` Files
 
 Additional qualifiers may be used by adding lines of the form:
 
     {-@ include <path/to/file.hquals> @-}
 
-to the Haskell source. See, [this](tests/pos/meas5.hs) for example.
+to the Haskell source. See, [this](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/meas5.hs) for example.
 
 
-In Haskell Source or Spec Files
--------------------------------
+## In Haskell Source or Spec Files
 
 Finally, you can specifiers directly inside source (.hs or .lhs) or spec (.spec)
-files by writing as shown [here](tests/pos/qualTest.hs)
+files by writing as shown [here](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/qualTest.hs)
 
     {-@ qualif Foo(v:Int, a: Int) : (v = a + 100)   @-}
 
@@ -700,19 +678,18 @@ the specifications you write i.e.
 3. data constructor definitions.
 
 
-
-## Termination Metrics
+# Termination Metrics
 
 In recursive functions the *first* algebraic or integer argument should be decreasing.
 
 The default decreasing measure for lists is length and Integers its value.
 
-### Default Termination Metrics
+## Default Termination Metrics
 
 The user can specify the *size* of a data-type in the data definition
 
 ```haskell
-    {-@ data L [llen] a = Nil | Cons { x::a, xs:: L a} @-}
+{-@ data L [llen] a = Nil | Cons { x::a, xs:: L a} @-}
 ```
 
 In the above, the measure `llen`, which needs to be defined by the user
@@ -721,9 +698,9 @@ will use this default metric to _automatically_ prove that the following
 terminates:
 
 ```haskell
-    append :: L a -> L a -> L a  
-    append N           ys = ys
-    append (Cons x xs) ys = Cons x (append xs ys)
+append :: L a -> L a -> L a  
+append N           ys = ys
+append (Cons x xs) ys = Cons x (append xs ys)
 ```
 
 as, by default the *first* (non-function) argument with an
@@ -733,14 +710,15 @@ and non-negative at each recursive call.
 A default termination metric is a Haskell function that is proved terminating 
 using structural induction. To deactivate structional induction check on the 
 termination metric, use the `--trust-sizes` flag. 
-### Explicit Termination Metrics
 
-However, consider the function `reverse`
+## Explicit Termination Metrics
+
+However, consider the function `reverse`:
 
 ```haskell
-    reverseAcc :: L a -> L a -> L a  
-    reverseAcc acc N           = acc
-    reverseAcc acc (Cons x xs) = reverseAcc (Cons x acc) xs
+reverseAcc :: L a -> L a -> L a  
+reverseAcc acc N           = acc
+reverseAcc acc (Cons x xs) = reverseAcc (Cons x acc) xs
 ```
 
 Here, the first argument does not decrease, instead
@@ -748,7 +726,7 @@ the second does. We can tell LH to use the second
 argument using the *explicit termination metric*
 
 ```haskell
-    reverseAcc :: L a -> xs:L a -> L a / [llen xs]  
+reverseAcc :: L a -> xs:L a -> L a / [llen xs]  
 ```  
 
 which tells LH that the `llen` of the second argument `xs`
@@ -757,30 +735,29 @@ is what decreases at each recursive call.
 Decreasing expressions can be arbitrary refinement expressions, e.g.,
 
 ```haskell
-    {-@ merge :: Ord a => xs:L a -> ys:L a -> L a / [llen xs + llen ys] @-}
+{-@ merge :: Ord a => xs:L a -> ys:L a -> L a / [llen xs + llen ys] @-}
 ```
 
 states that at each recursive call of `merge` the _sum of the lengths_
 of its arguments will decrease.
 
-### Lexicographic Termination Metrics
+## Lexicographic Termination Metrics
 
 Some functions do not decrease on a single argument, but rather a
 combination of arguments, e.g. the Ackermann function.
 
 ```haskell
-    {-@ ack :: m:Int -> n:Int -> Nat / [m, n] @-}
-    ack m n
-      | m == 0          = n + 1
-      | m > 0 && n == 0 = ack (m-1) 1
-      | m > 0 && n >  0 = ack (m-1) (ack m (n-1))
+{-@ ack :: m:Int -> n:Int -> Nat / [m, n] @-}
+ack m n
+  | m == 0          = n + 1
+  | m > 0 && n == 0 = ack (m-1) 1
+  | m > 0 && n >  0 = ack (m-1) (ack m (n-1))
 ```
 
 In all but one recursive call `m` decreases, in the final call `m`
 does not decrease but `n` does. We can capture this notion of `m`
 normally decreases, but if it does not, `n` will decrease with a
 *lexicographic* termination metric `[m, n]`.
-
 
 An alternative way to express this specification is by annotating
 the function's type with the appropriate *numeric* decreasing expressions.
@@ -790,47 +767,48 @@ As an example, you can give `ack` a type
 
 stating that the *numeric* expressions `[m, n]` are lexicographically decreasing.
 
-### Mutually Recursive Functions
+## Mutually Recursive Functions
 
 When dealing with mutually recursive functions you may run into a
 situation where the decreasing parameter must be measured *across* a
 series of invocations, e.g.
 
 ```haskell
-    even :: Int -> Bool
-    even 0 = True
-    even n = odd (n-1)
+even :: Int -> Bool
+even 0 = True
+even n = odd (n-1)
 
-    odd :: Int -> Bool
-    odd  n = not (even n)
+odd :: Int -> Bool
+odd  n = not (even n)
 ```
 
 In this case, you can introduce a ghost parameter that *orders the functions*
 
 ```haskell
-    {-@ isEven :: n:Nat -> Bool / [n, 0] @-}
-    isEven :: Int -> Bool
-    isEven 0 = True
-    isEven n = isOdd (n-1)
+{-@ isEven :: n:Nat -> Bool / [n, 0] @-}
+isEven :: Int -> Bool
+isEven 0 = True
+isEven n = isOdd (n-1)
 
-    {-@ isOdd :: n:Nat -> Bool / [n, 1] @-}
-    isOdd :: Int -> Bool
-    isOdd  n = not $ isEven n
+{-@ isOdd :: n:Nat -> Bool / [n, 1] @-}
+isOdd :: Int -> Bool
+isOdd  n = not $ isEven n
 ```
 
 thus recovering a decreasing measure for the pair of functions, the
 pair of arguments. This can be encoded with the lexicographic
 termination annotation as shown above.
-See [tests/pos/mutrec.hs](tests/pos/mutrec.hs) for the full example.
+See [tests/pos/mutrec.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/mutrec.hs) 
+for the full example.
 
-### Automatic Termination Metrics
+## Automatic Termination Metrics
 
 Apart from specifying a specific decreasing measure for
 an Algebraic Data Type, the user can specify that the ADT
 follows the expected decreasing measure by
 
 ```haskell
-    {-@ autosize L @-}
+{-@ autosize L @-}
 ```
 
 Then, LH will define an instance of the function `autosize`
@@ -842,20 +820,20 @@ of `L a` with the `autosize :: a -> Int` information, such
 that
 
 ```haskell
-    Nil  :: {v:L a | autosize v = 0}
-    Cons :: x:a -> xs:L a -> {v:L a | autosize v = 1 + autosize xs}
+Nil  :: {v:L a | autosize v = 0}
+Cons :: x:a -> xs:L a -> {v:L a | autosize v = 1 + autosize xs}
 ```
 
 Also, an invariant that `autosize` is non negative will be generated
 
 ```haskell
-    invariant  {v:L a| autosize v >= 0 }
+invariant  {v:L a| autosize v >= 0 }
 ```
 
 This information is all LiquidHaskell needs to prove termination
 on functions that recurse on `L a` (on ADTs in general.)
 
-### Disabling Termination Checking
+## Disabling Termination Checking
 
 To *disable* termination checking for `foo` that is,
 to *assume* that it is terminating (possibly for some
@@ -863,10 +841,12 @@ complicated reason currently beyond the scope of LH)
 you can write
 
 ```haskell
-    {-@ lazy foo @-}
+{-@ lazy foo @-}
 ```
 
-## Synthesis
+# Synthesis
+
+**Status:** `experimental`
 
 LH has some very preliminary support for program synthesis.
 
@@ -874,11 +854,11 @@ LH has some very preliminary support for program synthesis.
 
 Activate the flag for typed holes in LiquidHaskell. E.g.
 from command line: 
-    
+
     liquid --typedholes
 
 In a Haskell source file: 
-    
+
     {-@ LIQUID --typed-holes @-}
 
 Using the flag for typed holes, two more flags can be used:
@@ -890,14 +870,16 @@ Using the flag for typed holes, two more flags can be used:
 Having the program specified in a Haskell source file, use 
 GHC' s hole variables, e.g.:
 
-    {-@ myMap :: (a -> b) -> xs:[a] -> {v:[b] | len v == len xs} @-}
-    myMap :: (a -> b) -> [a] -> [b]
-    myMap = _goal
+```haskell
+{-@ myMap :: (a -> b) -> xs:[a] -> {v:[b] | len v == len xs} @-}
+myMap :: (a -> b) -> [a] -> [b]
+myMap = _goal
+```
 
-### Limitations
+## Limitations
 
 This is an experimental feature, so potential users could only 
-expect to synthesize programs, like [these](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/synth).
+expect to synthesize programs, like [these](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/synthesis).
 
 Current limitations include:
 

--- a/docs/mkDocs/docs/specifications.md
+++ b/docs/mkDocs/docs/specifications.md
@@ -1,6 +1,19 @@
 # Writing Specifications
 
+This section documents how you can actually annotate new or existing code with refinement types, leveraging
+the full power of LiquidHaskell.
+
 ## Modules WITHOUT code
+
+The following section is slightly different depending on whether you are using the plugin (which you should!)
+or the legacy executable.
+
+### (Plugin) Adding refinements for external modules
+
+See the [plugin](plugin.md) section, which cointains a link to a walkthrough document that describes how to add
+refinements for external packages (cfr. **"Providing Specifications for Existing Packages"**)
+
+### (Legacy executable) Adding refinements for external modules
 
 When checking a file `target.hs`, you can specify an _include_ directory by
 
@@ -23,7 +36,6 @@ See, for example, the contents of:
   default when running `liquid`.
 + The `.spec` mechanism is *only for external modules** without code,
   see below for standalone specifications for **internal** or **home** modules.
-
 
 ## Modules WITH code: Data
 

--- a/docs/mkDocs/mkdocs.yml
+++ b/docs/mkDocs/mkdocs.yml
@@ -1,13 +1,19 @@
-site_name: LiquidHaskell 
+site_name: LiquidHaskell
 
 nav:
-    - Online: "https://liquid-demo.programming.systems/index.html"
-    - Blog: "https://ucsd-progsys.github.io/liquidhaskell-blog/"
-    - Plugin: plugin.md 
-    - Legacy: legacy.md
-    - Options: options.md
-    - Specifications: specifications.md
-    - Community: contributing.md    
-    - Development: develop.md         
+    - Install:
+      - 'External Dependencies': install.md
+      - 'Plugin': plugin.md
+      - 'Legacy Executable': legacy.md
+    - Play: "https://liquid-demo.programming.systems/index.html"
+    - Learn:
+      - Blog: "https://ucsd-progsys.github.io/liquidhaskell-blog/"
+      - Options: options.md
+      - Specifications: specifications.md
+    - "Get Involved": contributing.md
 
 theme: litera
+
+markdown_extensions:
+    - toc:
+        permalink: true

--- a/docs/mkDocs/mkdocs.yml
+++ b/docs/mkDocs/mkdocs.yml
@@ -1,16 +1,16 @@
 site_name: LiquidHaskell
 
 nav:
-    - Install:
-      - 'External Dependencies': install.md
-      - 'Plugin': plugin.md
-      - 'Legacy Executable': legacy.md
+    - Home: index.md
+    - Install: plugin.md
     - Play: "https://liquid-demo.programming.systems/index.html"
     - Learn:
       - Blog: "https://ucsd-progsys.github.io/liquidhaskell-blog/"
       - Options: options.md
       - Specifications: specifications.md
     - "Get Involved": contributing.md
+    - "<i class='fa fa-github'></i>&nbsp;Github": "https://github.com/ucsd-progsys/liquidhaskell"
+
 
 theme: litera
 


### PR DESCRIPTION
This (WIP) PR (hopefully) improves and polishes the documentation, by acting on several fronts I am going to discuss below. Feedback and improvements welcome 🙂 

## Navbar & index

I have reworked the navbar and the index page in a "less in more" fashion, to make important content stood out more easily:

<img width="530" alt="Screenshot 2020-07-27 at 12 31 29" src="https://user-images.githubusercontent.com/442035/88532594-2c9b2380-d005-11ea-8039-594523c9050c.png">

And for the index file, this is the first thing the user will see:

<img width="852" alt="Screenshot 2020-07-27 at 12 32 44" src="https://user-images.githubusercontent.com/442035/88532677-4b011f00-d005-11ea-936c-190a42ea593c.png">

As you can see I have given priority to "How to install" rather than the educational aspect, which I have grouped into the umbrella tag "Learn". From the navbar it's also possible to quickly jump into the installation section:

<img width="367" alt="Screenshot 2020-07-27 at 12 31 41" src="https://user-images.githubusercontent.com/442035/88532780-7b48bd80-d005-11ea-81f0-7fafac7c15a1.png">

And the learning material, which also include things like Options & Specifications:

<img width="249" alt="Screenshot 2020-07-27 at 12 31 51" src="https://user-images.githubusercontent.com/442035/88532818-8bf93380-d005-11ea-8aa7-fa7d5b77a9b1.png">

## Sections reshuffling

I have also rebranded the "Community" and "Contributing" aspect under "Get involved", trying to break down a little bit better what the users might be doing in case they want to contribute:
 
<img width="1156" alt="Screenshot 2020-07-27 at 12 35 45" src="https://user-images.githubusercontent.com/442035/88532996-cc58b180-d005-11ea-9162-bfb758bc3949.png">

Generally speaking, every link should be easily accessible either via the navbar or the index page, in a click or two.

## Broken links cleanup

Last but not least I have fixed a lot of broken links (due to the fact `mkDocs` won't accept relative links for anything which is _not_ inside the `docs` directory). This ensures that we can always run `mkDocs serve -s` in _strict mode_ without errors (strict mode bails out in case any warning is reported, which is typically the case for broken links).

## What's left to  do

While this PR should feel like a step forward, there are still some little things to tweak:

- [ ] We currently (almost too casually) mention the `GHC.Plugin.Tutorial` documentation module in the `plugin.md` section,
   which might be easily missed. Furthermore, due to the fact we don't have a Hackage candidate with properly-built Haddock
   documentation, the best we can do for now is to link to the "un-rendered" [file](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/src/Language/Haskell/Liquid/GHC/Plugin/Tutorial.hs) which is not the best experience. 
  Maybe it's time for us to upload the release on Hackage?

- [x] The majority of examples' (see `options.md`) demo the described options using the legacy executable, which might be
   confusing for the user. It's not clear to me what is the best approach. We could either not show any practical example (which
   I don't particularly like) or show _both_ syntax, i.e. the `ghc-options: -fplugin-opt=...` way and the executable way, which
  might get tedious very rapidly. Probably the sweet spot is to showcase _at the beginning of the section_ how you can pass
   options for both the plugin and the executable, once for all, without repeating it for every single option.

- [ ] The `specifications.md` file still doesn't feel right. In particular:
    * There are 1 or 2 links which are now broken because the relevant file they used to point to, doesn't exist anymore in
       the testsuite;
    * It contains sections which are clearly specific for the legacy executable (for example how to add specs to "external"
      modules), which I don't think we should now have, but we should rather advertise the `liquid-*` mirror package approach;
    * It contains a section on `.hquals` files, which I don't think we support anymore. When converting the hardcoded Prelude
      I have simply "unfolded" any of the `.hquals` files into the relevant `.spec` file, so perhaps we shouldn't suggest to write
      a separate `.hquals` file, but rather to add those directly into the `.spec` files.

