### PR TITLE
Use cabal to do the final Hackage upload

### DIFF
--- a/docs/mkDocs/docs/develop.md
+++ b/docs/mkDocs/docs/develop.md
@@ -281,6 +281,11 @@ in the release process. Most contributors can skip this section.*
 
 We provide a conveniency script to upload all the `liquid-*` packages (**including** `liquid-fixpoint`) on
 Hackage, in a lockstep fashion. To do so, it's possible to simply run the `scripts/release_to_hackage.sh`
-Bash script. The script doesn't accept any argument and it tries to determine the packages
-to upload by scanning the $PWD for packages named appropriately. It will ask the user for confirmation
-before proceeding, and `stack upload` will be used under the hood.
+Bash script. The script tries to determine the packages to upload by scanning the $PWD for packages named
+appropriately. It will ask the user for confirmation before proceeding, and `cabal upload` will be used
+under the hood. Any options passed to the script will be routed to `cabal`. For example, to upload a package
+using a particular combination of user and password:
+
+```
+./scripts/release_to_hackage.sh -u foo -p bar
+```


### PR DESCRIPTION
This PR extends the `scripts/release_to_hackage.sh` script to use `cabal upload` rather than `stack upload` to perform the final upload to Hackage. The rationale behind this is that as @kosmikus pointed out, we cannot really upload package candidates using `stack upload` (at least to the best of my knowledge) or it might be risky to go directly for a "full" release. On the other hand, we still want this script to be easily usable also by folks which uses `stack` as their daily driver.

This PR should hopefully give us the best of both worlds: we use `stack sdist` to generate the tarball, and we use `cabal upload` to upload it. The script now accept any number of extra arguments, which will be passed to `cabal upload`. For example, to upload a package using a particular username and password:

```
./scripts/release_to_hackage.sh -u foo -p bar
```

I have amended the docs to reflect that.