### PR TITLE
T1697

### DIFF
--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -439,12 +439,14 @@ consCB _ _ γ (NonRec x def)
   , Just d      <- dlookup (denv γ) w
   = do t        <- mapM trueTy τ
        mapM addW (WfC γ <$> t)
-       let xts   = dmap (fmap (foldl1 (flip f) t)) d
+       let xts   = dmap (fmap (f t)) d
        let  γ'   = γ { denv = dinsert (denv γ) x xts }
        t        <- trueTy (varType x)
        extender γ' (x, Assumed t)
    where
-    f t' (RAllT α te _)    = subsTyVar_meet' (ty_var_value α, t') te
+    f [t']    (RAllT α te _) = subsTyVar_meet' (ty_var_value α, t') te
+    f (t':ts) (RAllT α te _) = f ts $ subsTyVar_meet' (ty_var_value α, t') te
+--     f t' (RAllT α te _)    = subsTyVar_meet' (ty_var_value α, t') te
     f _ _ = impossible Nothing "consCB on Dictionary: this should not happen"
 
 consCB _ _ γ (NonRec x e)

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -1448,14 +1448,13 @@ isType a                        = eqType (exprType a) predType
 
 -- | @isGenericVar@ determines whether the @RTyVar@ has no class constraints
 isGenericVar :: RTyVar -> SpecType -> Bool
-isGenericVar α t =  all (\(c, α') -> (α'/=α) || isOrd c || isEq c ) (classConstrs t)
+isGenericVar α t =  all (\(c, α') -> (α'/=α) || isGenericClass c ) (classConstrs t)
   where 
     classConstrs t = [(c, ty_var_value α')
                         | (c, ts) <- tyClasses t
                         , t'      <- ts
                         , α'      <- freeTyVars t']
-    isOrd          = (ordClassName ==) . className
-    isEq           = (eqClassName ==) . className
+    isGenericClass c = className c `elem` [ordClassName, eqClassName, functorClassName, monadClassName]
 
 -- instance MonadFail CG where 
 --  fail msg = panic Nothing msg

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -439,14 +439,12 @@ consCB _ _ γ (NonRec x def)
   , Just d      <- dlookup (denv γ) w
   = do t        <- mapM trueTy τ
        mapM addW (WfC γ <$> t)
-       let xts   = dmap (fmap (\x ->foldl f x t)) d
+       let xts   = dmap (fmap (foldl1 (flip f) t)) d
        let  γ'   = γ { denv = dinsert (denv γ) x xts }
        t        <- trueTy (varType x)
        extender γ' (x, Assumed t)
    where
     f t' (RAllT α te _)    = subsTyVar_meet' (ty_var_value α, t') te
---     f [t'] tt@(RAllT α te _)    = subsTyVar_meet' (ty_var_value α, t') te
---     f (t':ts) tt@(RAllT α te _) = f ts $ subsTyVar_meet' (ty_var_value α, t') te
     f _ _ = impossible Nothing "consCB on Dictionary: this should not happen"
 
 consCB _ _ γ (NonRec x e)

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -446,7 +446,6 @@ consCB _ _ γ (NonRec x def)
    where
     f [t']    (RAllT α te _) = subsTyVar_meet' (ty_var_value α, t') te
     f (t':ts) (RAllT α te _) = f ts $ subsTyVar_meet' (ty_var_value α, t') te
---     f t' (RAllT α te _)    = subsTyVar_meet' (ty_var_value α, t') te
     f _ _ = impossible Nothing "consCB on Dictionary: this should not happen"
 
 consCB _ _ γ (NonRec x e)

--- a/tests/neg/monad4.hs
+++ b/tests/neg/monad4.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--no-pattern-inline" @-}
 module Foo () where
 
 import Language.Haskell.Liquid.Prelude

--- a/tests/neg/monad4.hs
+++ b/tests/neg/monad4.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-pattern-inline" @-}
 module Foo () where
 
 import Language.Haskell.Liquid.Prelude

--- a/tests/pos/T1697.hs
+++ b/tests/pos/T1697.hs
@@ -1,6 +1,7 @@
 -------------------------------------------------------------------------------------------
 -- | Polymorphic user (NOT WORKING)
 -------------------------------------------------------------------------------------------
+{-@ LIQUID "--no-pattern-inline" @-}
 
 module B where
 
@@ -44,7 +45,7 @@ instance Monad m => Monad (TaggedT user m) where
 
   return :: a -> TaggedT<{\_ -> True}, {\_ -> False}> user m a
 @-}
-instance Monad m => Monad (TaggedT user m) where
+instance Monad m =>  Monad (TaggedT user m) where
   x >>= f = TaggedT $ unTag x >>= \y -> unTag (f y)
   
 -------------------------------------------------------------------------------------------

--- a/tests/pos/T1697.hs
+++ b/tests/pos/T1697.hs
@@ -1,0 +1,60 @@
+-------------------------------------------------------------------------------------------
+-- | Polymorphic user (NOT WORKING)
+-------------------------------------------------------------------------------------------
+
+module B where
+
+data User = U
+
+{-@ measure currentUser :: User @-}
+
+{-@ data TaggedT user m a <label :: user -> Bool, clear :: user -> Bool> = TaggedT _ @-}
+data TaggedT user m a = TaggedT { unTag :: m a }
+{-@ data variance TaggedT invariant invariant covariant contravariant covariant @-}
+
+instance Functor m => Functor (TaggedT user m) where
+  fmap f = TaggedT . fmap f . unTag
+
+instance Applicative m => Applicative (TaggedT user m) where
+  pure = TaggedT . pure
+  f <*> x = TaggedT $ unTag f <*> unTag x
+
+{-@
+instance Monad m => Monad (TaggedT user m) where
+  >>= :: forall < p :: user -> Bool
+                , q :: user -> Bool
+                , r :: user -> Bool
+                , s :: user -> Bool
+                , t :: user -> Bool
+                , u :: user -> Bool
+                , rx :: a -> Bool
+                , rf :: a -> b -> Bool
+                , ro :: b -> Bool
+                >.
+    {content :: a<rx> |- b<rf content> <: b<ro>}
+    {content :: a<rx> |- b<ro> <: b<rf content>}
+    {{v : (user<s>) | True} <: {v : (user<p>) | True}}
+    {{v : (user<t>) | True} <: {v : (user<p>) | True}}
+    {{v : (user<t>) | True} <: {v : (user<r>) | True}}
+    {{v : (user<q>) | True} <: {v : (user<u>) | True}}
+    {{v : (user<s>) | True} <: {v : (user<u>) | True}}
+    x:TaggedT<p, q> user m (a<rx>)
+    -> (y:a -> TaggedT<r, s> user m (b<rf y>))
+    -> TaggedT<t, u> user m (b<ro>);
+
+  return :: a -> TaggedT<{\_ -> True}, {\_ -> False}> user m a
+@-}
+instance Monad m => Monad (TaggedT user m) where
+  x >>= f = TaggedT $ unTag x >>= \y -> unTag (f y)
+  
+-------------------------------------------------------------------------------------------
+-- | Test
+-------------------------------------------------------------------------------------------
+
+{-@ assume respondT :: String -> TaggedT<{\_ -> True}, {\v -> v == currentUser}> User m () @-}
+respondT :: String -> TaggedT User m ()
+respondT = undefined
+
+{-@ test :: TaggedT<{\_ -> True}, {\v -> v == currentUser}> User m () @-}
+test :: Monad m => TaggedT User m ()
+test = return "a" >>= respondT

--- a/tests/pos/T1697A.hs
+++ b/tests/pos/T1697A.hs
@@ -1,0 +1,60 @@
+-------------------------------------------------------------------------------------------
+-- | Fixed User (WORKING)
+-------------------------------------------------------------------------------------------
+
+module A where
+
+data User = U
+
+{-@ measure currentUser :: User @-}
+
+{-@ data TaggedT m a <label :: User -> Bool, clear :: User -> Bool> = TaggedT _ @-}
+data TaggedT m a = TaggedT { unTag :: m a }
+{-@ data variance TaggedT invariant covariant contravariant covariant @-}
+
+instance Functor m => Functor (TaggedT m) where
+  fmap f = TaggedT . fmap f . unTag
+
+instance Applicative m => Applicative (TaggedT m) where
+  pure = TaggedT . pure
+  f <*> x = TaggedT $ unTag f <*> unTag x
+
+{-@
+instance Monad m => Monad (TaggedT m) where
+  >>= :: forall < p :: User -> Bool
+                , q :: User -> Bool
+                , r :: User -> Bool
+                , s :: User -> Bool
+                , t :: User -> Bool
+                , u :: User -> Bool
+                , rx :: a -> Bool
+                , rf :: a -> b -> Bool
+                , ro :: b -> Bool
+                >.
+    {content :: a<rx> |- b<rf content> <: b<ro>}
+    {content :: a<rx> |- b<ro> <: b<rf content>}
+    {{v : (User<s>) | True} <: {v : (User<p>) | True}}
+    {{v : (User<t>) | True} <: {v : (User<p>) | True}}
+    {{v : (User<t>) | True} <: {v : (User<r>) | True}}
+    {{v : (User<q>) | True} <: {v : (User<u>) | True}}
+    {{v : (User<s>) | True} <: {v : (User<u>) | True}}
+    x:TaggedT<p, q> m (a<rx>)
+    -> (y:a -> TaggedT<r, s> m (b<rf y>))
+    -> TaggedT<t, u> m (b<ro>);
+
+  return :: a -> TaggedT<{\_ -> True}, {\_ -> False}> m a
+@-}
+instance Monad m => Monad (TaggedT m) where
+  x >>= f = TaggedT $ unTag x >>= \y -> unTag (f y)
+  
+-------------------------------------------------------------------------------------------
+-- | Test
+-------------------------------------------------------------------------------------------
+
+{-@ assume respondT :: String -> TaggedT<{\_ -> True}, {\v -> v == currentUser}> m () @-}
+respondT :: String -> TaggedT m ()
+respondT = undefined
+
+{-@ test :: TaggedT<{\_ -> True}, {\v -> v == currentUser}> m () @-}
+test :: Monad m => TaggedT m ()
+test = return "a" >>= respondT

--- a/tests/pos/T1697C.hs
+++ b/tests/pos/T1697C.hs
@@ -1,6 +1,8 @@
-{-@ LIQUID "--no-pattern-inline" @-}
+-------------------------------------------------------------------------------------------
+-- | Polymorphic user but defining bind and return as normal functions (WORKING)
+-------------------------------------------------------------------------------------------
 
-module B where
+module C where
 
 data User = U
 
@@ -10,25 +12,17 @@ data User = U
 data TaggedT user m a = TaggedT { unTag :: m a }
 {-@ data variance TaggedT invariant invariant covariant contravariant covariant @-}
 
-instance Functor m => Functor (TaggedT user m) where
-  fmap f = TaggedT . fmap f . unTag
-
-instance Applicative m => Applicative (TaggedT user m) where
-  pure = TaggedT . pure
-  f <*> x = TaggedT $ unTag f <*> unTag x
-
 {-@
-instance Monad m => Monad (TaggedT user m) where
-  >>= :: forall < p :: user -> Bool
-                , q :: user -> Bool
-                , r :: user -> Bool
-                , s :: user -> Bool
-                , t :: user -> Bool
-                , u :: user -> Bool
-                , rx :: a -> Bool
-                , rf :: a -> b -> Bool
-                , ro :: b -> Bool
-                >.
+assume bindT :: forall < p :: user -> Bool
+                       , q :: user -> Bool
+                       , r :: user -> Bool
+                       , s :: user -> Bool
+                       , t :: user -> Bool
+                       , u :: user -> Bool
+                       , rx :: a -> Bool
+                       , rf :: a -> b -> Bool
+                       , ro :: b -> Bool
+                       >.
     {content :: a<rx> |- b<rf content> <: b<ro>}
     {content :: a<rx> |- b<ro> <: b<rf content>}
     {{v : (user<s>) | True} <: {v : (user<p>) | True}}
@@ -38,13 +32,15 @@ instance Monad m => Monad (TaggedT user m) where
     {{v : (user<s>) | True} <: {v : (user<u>) | True}}
     x:TaggedT<p, q> user m (a<rx>)
     -> (y:a -> TaggedT<r, s> user m (b<rf y>))
-    -> TaggedT<t, u> user m (b<ro>);
-
-  return :: a -> TaggedT<{\_ -> True}, {\_ -> False}> user m a
+    -> TaggedT<t, u> user m (b<ro>)
 @-}
-instance Monad m =>  Monad (TaggedT user m) where
-  x >>= f = TaggedT $ unTag x >>= \y -> unTag (f y)
-  
+bindT :: Monad m => TaggedT user m a -> (a -> TaggedT user m b) -> TaggedT user m b
+bindT x f = TaggedT $ unTag x >>= \y -> unTag (f y)
+
+{-@ assume returnT :: a -> TaggedT<{\_ -> True}, {\_ -> False}> user m a @-}
+returnT :: Monad m => a -> TaggedT user m a
+returnT x = TaggedT (return x)
+
 -------------------------------------------------------------------------------------------
 -- | Test
 -------------------------------------------------------------------------------------------
@@ -55,4 +51,4 @@ respondT = undefined
 
 {-@ test :: TaggedT<{\_ -> True}, {\v -> v == currentUser}> User m () @-}
 test :: Monad m => TaggedT User m ()
-test = return "a" >>= respondT
+test = returnT "a" `bindT` respondT


### PR DESCRIPTION
Seems that generic monad gets unsafe only when pattern-inline is on.

