### PR TITLE
Release 0.8.10.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "liquid-fixpoint"]
 	path = liquid-fixpoint
-	url = https://github.com/ucsd-progsys/liquid-fixpoint.git
+	url = git@github.com:ucsd-progsys/liquid-fixpoint.git
 [submodule "ghc-options"]
 	path = ghc-options
 	url = https://github.com/ranjitjhala/ghc-options.git

--- a/docs/mkDocs/mkdocs.yml
+++ b/docs/mkDocs/mkdocs.yml
@@ -10,4 +10,4 @@ nav:
     - Community: contributing.md    
     - Development: develop.md         
 
-theme: litera
+theme: spacelab

--- a/liquid-base/liquid-base.cabal
+++ b/liquid-base/liquid-base.cabal
@@ -1,3 +1,4 @@
+cabal-version:      1.24
 name:               liquid-base
 version:            4.14.0.0
 synopsis:           Drop-in base replacement for LiquidHaskell
@@ -10,7 +11,6 @@ maintainer:         Ranjit Jhala <jhala@cs.ucsd.edu>
 category:           Language
 homepage:           https://github.com/ucsd-progsys/liquidhaskell
 build-type:         Custom
-cabal-version:      >= 1.22
 
 data-files:         src/Data/*.spec
                     src/System/*.spec

--- a/liquid-bytestring/liquid-bytestring.cabal
+++ b/liquid-bytestring/liquid-bytestring.cabal
@@ -1,3 +1,4 @@
+cabal-version:      1.24
 name:               liquid-bytestring
 version:            0.10.10.0
 synopsis:           LiquidHaskell specs for the bytestring package
@@ -10,7 +11,6 @@ maintainer:         Ranjit Jhala <jhala@cs.ucsd.edu>
 category:           Language
 homepage:           https://github.com/ucsd-progsys/liquidhaskell
 build-type:         Custom
-cabal-version:      >= 1.22
 
 data-files:           src/Data/ByteString.spec
                       src/Data/ByteString/Short.spec

--- a/liquid-containers/liquid-containers.cabal
+++ b/liquid-containers/liquid-containers.cabal
@@ -1,3 +1,4 @@
+cabal-version:      1.24
 name:               liquid-containers
 version:            0.6.2.1
 synopsis:           LiquidHaskell specs for the containers package
@@ -10,7 +11,6 @@ maintainer:         Ranjit Jhala <jhala@cs.ucsd.edu>
 category:           Language
 homepage:           https://github.com/ucsd-progsys/liquidhaskell
 build-type:         Custom
-cabal-version:      >= 1.22
 
 data-files:           src/Data/Set.spec
 

--- a/liquid-ghc-prim/liquid-ghc-prim.cabal
+++ b/liquid-ghc-prim/liquid-ghc-prim.cabal
@@ -1,3 +1,4 @@
+cabal-version:      1.24
 name:               liquid-ghc-prim
 version:            0.6.1
 synopsis:           Drop-in ghc-prim replacement for LiquidHaskell
@@ -10,7 +11,6 @@ maintainer:         Ranjit Jhala <jhala@cs.ucsd.edu>
 category:           Language
 homepage:           https://github.com/ucsd-progsys/liquidhaskell
 build-type:         Custom
-cabal-version:      >= 1.22
 
 data-files:         src/GHC/*.spec
 

--- a/liquid-parallel/liquid-parallel.cabal
+++ b/liquid-parallel/liquid-parallel.cabal
@@ -1,3 +1,4 @@
+cabal-version:      1.24
 name:               liquid-parallel
 version:            3.2.2.0
 synopsis:           LiquidHaskell specs for the parallel package
@@ -10,7 +11,6 @@ maintainer:         Ranjit Jhala <jhala@cs.ucsd.edu>
 category:           Language
 homepage:           https://github.com/ucsd-progsys/liquidhaskell
 build-type:         Custom
-cabal-version:      >= 1.22
 
 data-files:           src/Control/Parallel/Strategies.spec
 

--- a/liquid-platform/liquid-platform.cabal
+++ b/liquid-platform/liquid-platform.cabal
@@ -1,3 +1,4 @@
+cabal-version:      1.22
 name:               liquid-platform
 version:            0.8.10.1
 synopsis:           A battery-included platform for LiquidHaskell
@@ -10,7 +11,6 @@ maintainer:         Ranjit Jhala <jhala@cs.ucsd.edu>
 category:           Language
 homepage:           https://github.com/ucsd-progsys/liquidhaskell
 build-type:         Simple
-cabal-version:      >= 1.22
 
 flag devel
   default:     False
@@ -20,7 +20,7 @@ flag devel
 executable liquidhaskell
   main-is:            src/Liquid.hs
   default-language:   Haskell2010
-  ghc-options:        -W -O2 -threaded
+  ghc-options:        -W -threaded
   if impl(ghc < 8.10.1)
     buildable: False
   else

--- a/liquid-prelude/liquid-prelude.cabal
+++ b/liquid-prelude/liquid-prelude.cabal
@@ -1,3 +1,4 @@
+cabal-version:      1.24
 name:               liquid-prelude
 version:            0.8.10.1
 synopsis:           General utility modules for LiquidHaskell
@@ -10,7 +11,6 @@ maintainer:         Ranjit Jhala <jhala@cs.ucsd.edu>
 category:           Language
 homepage:           https://github.com/ucsd-progsys/liquidhaskell
 build-type:         Custom
-cabal-version:      >= 1.22
 
 custom-setup
   setup-depends: Cabal, base, liquidhaskell

--- a/liquid-vector/liquid-vector.cabal
+++ b/liquid-vector/liquid-vector.cabal
@@ -1,3 +1,4 @@
+cabal-version:      1.24
 name:               liquid-vector
 version:            0.12.1.2
 synopsis:           LiquidHaskell specs for the vector package
@@ -10,7 +11,6 @@ maintainer:         Ranjit Jhala <jhala@cs.ucsd.edu>
 category:           Language
 homepage:           https://github.com/ucsd-progsys/liquidhaskell
 build-type:         Custom
-cabal-version:      >= 1.22
 
 data-files:           src/Data/Vector.spec
 

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -224,7 +224,7 @@ library
                     , gitrev
                     , hashable             >= 1.3
                     , hscolour             >= 1.22
-                    , liquid-fixpoint      >= 0.8.0.0
+                    , liquid-fixpoint      >= 0.8.10.1
                     , mtl                  >= 2.1
                     , optics               >= 0.2
                     , optparse-simple
@@ -297,7 +297,7 @@ test-suite liquidhaskell-parser
   other-modules:    Paths_liquidhaskell
   hs-source-dirs:   tests
   build-depends:    base            >= 4.8.1.0 && < 5
-                  , liquid-fixpoint >= 0.8.0.0
+                  , liquid-fixpoint >= 0.8.10.1
                   , liquidhaskell
                   , parsec
                   , syb
@@ -313,7 +313,7 @@ test-suite synthesis
   other-modules:    Paths_liquidhaskell
   hs-source-dirs:   tests
   build-depends:    base            >= 4.8.1.0 && < 5
-                  , liquid-fixpoint >= 0.8.0.0
+                  , liquid-fixpoint >= 0.8.10.1
                   , liquidhaskell
                   , tasty           >= 0.7
                   , tasty-hunit

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -1,8 +1,9 @@
+cabal-version:      2.4
 name:               liquidhaskell
 version:            0.8.10.1
 synopsis:           Liquid Types for Haskell
 description:        Liquid Types for Haskell.
-license:            BSD3
+license:            BSD-3-Clause
 license-file:       LICENSE
 copyright:          2010-19 Ranjit Jhala & Niki Vazou & Eric L. Seidel, University of California, San Diego.
 author:             Ranjit Jhala, Niki Vazou, Eric Seidel
@@ -54,8 +55,6 @@ data-files:         include/*.hquals
                     -- Needed for the mirror-modules helper
                     mirror-modules/templates/MirrorModule.mustache
 
-cabal-version:      >= 1.22
-
 source-repository head
   type:     git
   location: https://github.com/ucsd-progsys/liquidhaskell/
@@ -80,6 +79,7 @@ flag mirror-modules-helper
   description: Build the "mirror-modules" helper executable.
 
 library
+  autogen-modules:    Paths_liquidhaskell
   exposed-modules:    Gradual.Concretize
                       Gradual.GUI
                       Gradual.GUI.Annotate


### PR DESCRIPTION
This PR cleans up the cabal manifest so that `cabal check` would pass without warnings and it bumps the lower bound on `liquid-fixpoint` to match the revised metadata of the tarball already uploaded to Hackage.

Depends on: https://github.com/ucsd-progsys/liquid-fixpoint/pull/438