### PR TITLE
Update fixpoint with new PLE unfold logic

### DIFF
--- a/benchmarks/cse230/LICENSE
+++ b/benchmarks/cse230/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Dr. Kat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/benchmarks/cse230/README.md
+++ b/benchmarks/cse230/README.md
@@ -1,0 +1,1 @@
+Retrieved from: https://github.com/ucsd-progsys/230-wi19-web/

--- a/benchmarks/cse230/src/Week10/Axiomatic.hs
+++ b/benchmarks/cse230/src/Week10/Axiomatic.hs
@@ -1,0 +1,364 @@
+{-@ LIQUID "--reflection"  @-}
+{-@ LIQUID "--ple"         @-}
+{-@ LIQUID "--diff"        @-}
+{- LIQUID "--short-names" @-}
+{-@ infixr ++              @-}  -- TODO: Silly to have to rewrite this annotation!
+{-@ infixr <~              @-}  -- TODO: Silly to have to rewrite this annotation!
+
+--------------------------------------------------------------------------------
+-- | Inspired by 
+--     http://flint.cs.yale.edu/cs428/coq/sf/Hoare.html
+--     http://flint.cs.yale.edu/cs428/coq/sf/Hoare2.html
+--------------------------------------------------------------------------------
+
+{-# LANGUAGE GADTs #-}
+
+module Axiomatic where
+
+import           Prelude hiding ((++)) 
+import           ProofCombinators
+import qualified State as S
+import           Expressions  
+import           Imp 
+import           BigStep hiding (And)
+
+--------------------------------------------------------------------------------
+{- | A Floyd-Hoare triple is of the form 
+
+        { P }  c { Q }
+
+     where 
+      
+     - `P` and `Q` are assertions (think `BExp`) and 
+     - `c` is a command (think `Com`) 
+    
+     A Floyd-Hoare triple states that 
+
+     IF 
+
+     * The program `c` is starts at a state where the *precondition* `P` is True, and 
+     * The program finishes execution
+
+     THEN 
+
+     * At the final state, the *postcondition* `Q` will also evaluate to True.
+
+     -}
+
+{- | Lets paraphrase the following Hoare triples in English.
+
+   1) {True}   c {X = 5}
+
+   2) {X = m}  c {X = m + 5}
+
+   3) {X <= Y} c {Y <= X}
+
+   4) {True}   c {False}
+
+-}
+
+
+--------------------------------------------------------------------------------
+-- | The type `Assertion` formalizes the type for the 
+--   assertions (i.e. pre- and post-conditions) `P`, `Q`
+--   appearing in the triples {P} c {Q}
+
+type Assertion = BExp 
+
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+{- | Legitimate Triples 
+--------------------------------------------------------------------------------
+
+Which of the following triples are "legit" i.e.,  the claimed relation between 
+`pre`condition` `P`, `com`mand `C`, and `post`condition `Q` is true?
+
+   1) {True}  
+        X <~ 5 
+      {X = 5}
+
+   2) {X = 2} 
+        X <~ X + 1 
+      {X = 3}
+
+   3) {True}  
+        X <~ 5; 
+        Y <~ 0 
+      {X = 5}
+
+   4) {True}  
+        X <~ 5; 
+        Y <~ X 
+      {Y = 5}
+
+   5) {X = 2 && X = 3} 
+        X <~ 5 
+      {X = 0}
+
+   6) {True} 
+        SKIP 
+      {False}
+
+   7) {False} 
+        SKIP 
+      {True}
+
+   8) {True} 
+        WHILE True DO 
+          SKIP 
+      {False}
+
+   9) {X = 0}
+        WHILE X <= 0 DO 
+          X <~ X + 1 
+      {X = 1}
+
+   10) {X = 1}
+         WHILE not (X <= 0) DO 
+           X <~ X + 1 
+       {X = 100}
+ -}
+
+--------------------------------------------------------------------------------
+-- | `Legit` formalizes the notion of when a Floyd-Hoare triple is legitimate 
+--------------------------------------------------------------------------------
+{-@ type Legit P C Q =  s:{State | bval P s} 
+                     -> s':_ -> Prop (BStep C s s') 
+                     -> {bval Q s'} 
+  @-}
+type Legit = State -> State -> BStep -> Proof 
+
+-- | {True}  X <~ 5  {X = 5} ---------------------------------------------------
+
+{-@ leg1 :: Legit tt (Assign {"x"} (N 5)) (Equal (V {"x"}) (N 5)) @-}
+leg1 :: Legit  
+leg1 s s' (BAssign {}) 
+  = S.lemma_get_set "x" 5 s 
+
+
+-- | {True}  X <~ 5; y <- X  {X = 5} -------------------------------------------
+
+{-@ leg3 :: Legit tt (Seq (Assign {"x"} (N 5)) (Assign {"y"} (V {"x"}))) (Equal (V {"y"}) (N 5)) @-}
+leg3 :: Legit  
+leg3 s s' (BSeq _ _ _ smid _ (BAssign {}) (BAssign {})) 
+  = S.lemma_get_set "x" 5 s &&& S.lemma_get_set "y" 5 smid 
+
+
+-- | {False}  X <~ 5  {X = 0} --------------------------------------------------
+
+{-@ leg5 :: Legit ff (Assign {"x"} (N 5)) (Equal (V {"x"}) (N 22)) @-}
+leg5 :: Legit  
+leg5 s s' _ = () 
+
+
+--------------------------------------------------------------------------------
+-- | Two simple facts about Floyd-Hoare Triples --------------------------------
+--------------------------------------------------------------------------------
+
+{-@ lem_post_true :: p:_ -> c:_ -> Legit p c tt @-}
+lem_post_true :: Assertion -> Com -> Legit
+lem_post_true p c = \s s' c_s_s' -> () 
+
+{-@ lem_pre_false :: c:_ -> q:_ -> Legit ff c q @-}
+lem_pre_false :: Com -> Assertion -> Legit 
+lem_pre_false c q = \s s' c_s_s' -> () 
+
+
+-- | Assignment 
+
+--  { Y = 1     }  X <~ Y      { X = 1 }
+
+--  { X + Y = 1 }  X <~ X + Y  { X = 1 }
+
+--  { a = 1     }  X <~ a      { X = 1 }
+
+
+{- | Lets fill in the blanks
+
+     { ??? } 
+        x <~ 3 
+     { x == 3 }
+
+     { ??? } 
+        x <~ x + 1 
+     { x <= 5 }
+
+     { ??? }
+        x <~ y + 1 
+     { 0 <= x && x <= 5 }
+
+ -} 
+
+
+{- | To conclude that an arbitrary postcondition `Q` holds after 
+     `x <~ a`, we need to assume that Q holds before `x <~ a` 
+     but with all occurrences of `x` replaced by `a` in `Q` 
+
+     Lets revisit the example above:
+
+     { ??? } 
+        x <~ 3 
+     { x == 3 }
+
+     { ??? } 
+        x <~ x + 1 
+     { x <= 5 }
+
+     { ??? }
+        x <~ y + 1 
+     { 0 <= x && x <= 5 }
+
+  -} 
+
+--------------------------------------------------------------------------------
+-- | `Valid`ity of an assertion
+--------------------------------------------------------------------------------
+
+
+-- forall s. bval P s == True 
+{-@ type Valid P = s:State -> { v: Proof | bval P s } @-}
+type Valid = State -> Proof 
+
+-- x >= 0 || x < 0
+
+{-@ checkValid :: p:_ -> Valid p -> () @-}
+checkValid :: Assertion -> Valid -> ()
+checkValid p v = () 
+
+-- x <= 0 
+ex0 = checkValid (e0 `bImp` e1) (\_ -> ())
+  where 
+    e0 = (V "x") `Leq` (N 0)
+    e1 = ((V "x") `Minus` (N 1)) `Leq` (N 0)
+
+-- x <= 0 => x - 1 <= 0
+-- e1 = e0 `bImp` ((V "x" `Minus` N 1) `Leq` (N 0))
+
+--------------------------------------------------------------------------------
+-- | When does an assertion `Imply` another
+--------------------------------------------------------------------------------
+
+{-@ type Imply P Q = Valid (bImp P Q) @-}
+
+-- 10 <= x => 5 <= x
+{-@ v1 :: _ -> Imply (Leq (N 10) (V {"x"})) (Leq (N 5) (V {"x"})) @-} 
+v1 :: a -> Valid 
+v1 _ = \_ -> ()
+
+-- (0 < x && 0 < y) ===> (0 < x + y)
+{-@ v2 :: _ -> Imply (bAnd (Leq (N 0) (V {"x"})) (Leq (N 0) (V {"y"}))) 
+                     (Leq (N 0) (Plus (V {"x"}) (V {"y"})))
+  @-}             
+v2 :: a -> Valid 
+v2 _ = \_ -> ()
+
+--------------------------------------------------------------------------------
+-- | The Floyd-Hoare proof system
+--------------------------------------------------------------------------------
+
+data FHP where 
+  FH :: Assertion -> Com -> Assertion -> FHP
+
+data FH where 
+  FHSkip    :: Assertion -> FH 
+  FHAssign  :: Assertion -> Vname -> AExp -> FH 
+  FHSeq     :: Assertion -> Com -> Assertion -> Com -> Assertion -> FH -> FH -> FH 
+  FHIf      :: Assertion -> Assertion -> BExp -> Com -> Com -> FH -> FH -> FH
+  FHWhile   :: Assertion -> BExp -> Com -> FH -> FH 
+  FHConPre  :: Assertion -> Assertion -> Assertion -> Com -> Valid -> FH -> FH 
+  FHConPost :: Assertion -> Assertion -> Assertion -> Com -> FH -> Valid -> FH 
+
+{-@ data FH where 
+      FHSkip   :: p:_
+               -> Prop (FH p Skip p) 
+    | FHAssign :: q:_ -> x:_ -> a:_
+               -> Prop (FH (bsubst x a q) (Assign x a) q) 
+    | FHSeq    :: p:_ -> c1:_ -> q:_ -> c2:_ -> r:_ 
+               -> Prop (FH p c1 q) 
+               -> Prop (FH q c2 r) 
+               -> Prop (FH p (Seq c1 c2) r) 
+    | FHIf     :: p:_ -> q:_ -> b:_ -> c1:_ -> c2:_
+               -> Prop (FH (bAnd p b)       c1 q) 
+               -> Prop (FH (bAnd p (Not b)) c2 q)
+               -> Prop (FH p (If b c1 c2) q)
+    | FHWhile  :: inv:_ -> b:_ -> c:_
+               -> Prop (FH (bAnd inv b) c inv) 
+               -> Prop (FH inv (While b c) (bAnd inv (Not b)))
+    | FHConPre :: p':_ -> p:_ -> q:_ -> c:_  
+               -> Imply p' p
+               -> Prop (FH p c q) 
+               -> Prop (FH p' c q)
+    | FHConPost :: p:_ -> q:_ -> q':_ -> c:_  
+                -> Prop (FH p c q) 
+                -> Imply q q'
+                -> Prop (FH p c q')
+  @-}
+
+--------------------------------------------------------------------------------
+-- | THEOREM: Soundness of Floyd-Hoare Logic 
+--------------------------------------------------------------------------------
+-- thm_fh_legit :: p:_ -> c:_ -> q:_ -> Prop (FH p c q) -> Legit p c q
+
+-- thm_legit_fh :: p:_ -> c:_ -> q:_ -> Legit p c q -> Prop (FH p c q) 
+
+
+--------------------------------------------------------------------------------
+-- | Making FH Algorithmic: Verification Conditions 
+--------------------------------------------------------------------------------
+data ICom 
+  = ISkip                          -- skip 
+  | IAssign Vname     AExp         -- x := a
+  | ISeq    ICom      ICom         -- c1; c2
+  | IIf     BExp      ICom  ICom   -- if b then c1 else c2
+  | IWhile  Assertion BExp  ICom   -- while {I} b c 
+  deriving (Show)
+
+{-@ reflect pre @-}
+pre :: ICom -> Assertion -> Assertion 
+pre ISkip          q = q
+pre (IAssign x a)  q = bsubst x a q 
+pre (ISeq c1 c2)   q = pre c1 (pre c2 q)
+pre (IIf b c1 c2)  q = bIte b (pre c1 q) (pre c2 q) 
+pre (IWhile i _ _) _ = i 
+
+
+
+
+{-@ reflect vc @-}
+vc :: ICom -> Assertion -> Assertion
+vc ISkip          _ = tt 
+vc (IAssign {})   _ = tt 
+vc (ISeq c1 c2)   q = (vc c1 (pre c2 q)) `bAnd` (vc c2 q)
+vc (IIf _ c1 c2)  q = (vc c1 q) `bAnd` (vc c2 q)
+vc (IWhile i b c) q = ((bAnd i b)       `bImp` (pre c i)) `bAnd`   -- { i && b} c { i }
+                      ((bAnd i (Not b)) `bImp` q        ) `bAnd`   -- { i & ~b} => Q 
+                      vc c i
+
+{-@ reflect erase @-}
+erase :: ICom -> Com 
+erase ISkip          = Skip 
+erase (IAssign x a)  = Assign x a 
+erase (ISeq c1 c2)   = Seq (erase c1) (erase c2)
+erase (IIf b c1 c2)  = If b (erase c1) (erase c2)
+erase (IWhile _ b c) = While b (erase c)
+
+-----------------------------------------------------------------------------------
+-- | THEOREM: Soundness of VC
+-----------------------------------------------------------------------------------
+-- thm_vc :: c:_ -> q:_ -> Valid (vc c q) -> Legit (pre c q) (erase c) q
+
+-----------------------------------------------------------------------------------
+-- | Extending the above to triples [HW] 
+-----------------------------------------------------------------------------------
+
+{-@ reflect vc' @-}
+vc' :: Assertion -> ICom -> Assertion -> Assertion 
+vc' p c q = bAnd (bImp p (pre c q)) (vc c q) 
+
+-----------------------------------------------------------------------------------
+-- | THEOREM: Soundness of VC'
+-----------------------------------------------------------------------------------
+-- thm_vc' :: p:_ -> c:_ -> q:_ -> Valid (vc' p c q) -> Legit p (erase c) q
+
+

--- a/benchmarks/cse230/src/Week10/BigStep.hs
+++ b/benchmarks/cse230/src/Week10/BigStep.hs
@@ -1,0 +1,160 @@
+{-@ LIQUID "--reflection"  @-}
+{-@ LIQUID "--diff"        @-}
+{-@ LIQUID "--ple"         @-}
+{-@ LIQUID "--short-names" @-}
+
+{-@ infixr ++  @-}  -- TODO: Silly to have to rewrite this annotation!
+
+{-# LANGUAGE GADTs #-}
+
+module BigStep where
+
+import           Prelude hiding ((++)) 
+import           ProofCombinators
+import qualified State as S
+import           Expressions hiding (And)
+import           Imp 
+
+{- 
+  BStep c s1 s2 
+
+  ------------------[BSkip]
+    BStep Skip s s
+
+
+    s' = set x (aval a s) s
+  ----------------------------------[BAssign]
+    BStep (x := a) s s'
+
+
+    BStep c1 s smid    BStep c2 smid s'
+  ----------------------------------------[BSeq]
+    BStep (c1; c2) s s' 
+
+
+    bval b s1 = TRUE      BStep c1 s s'
+  ----------------------------------------
+    BStep (If b c1 c2) s s' 
+
+    bval b s = FALSE     BStep c2 s s'
+  -------------------------------
+    BStep (If b c1 c2) s s' 
+
+    WHILE 
+ -}
+
+--------------------------------------------------------------------------------
+-- | Big-step Semantics 
+--------------------------------------------------------------------------------
+
+data BStepP where
+  BStep :: Com -> State -> State -> BStepP 
+
+data BStep where 
+  BSkip   :: State -> BStep 
+  BAssign :: Vname -> AExp -> State -> BStep 
+  BSeq    :: Com   -> Com  -> State  -> State -> State -> BStep -> BStep -> BStep 
+  BIfT    :: BExp  -> Com  -> Com   -> State -> State -> BStep -> BStep  
+  BIfF    :: BExp  -> Com  -> Com   -> State -> State -> BStep -> BStep
+  BWhileF :: BExp  -> Com  -> State -> BStep 
+  BWhileT :: BExp  -> Com  -> State -> State -> State -> BStep -> BStep -> BStep 
+
+{-@ data BStep  where 
+      BSkip   :: s:State 
+              -> Prop (BStep Skip s s)
+    | BAssign :: x:Vname -> a:AExp -> s:State 
+              -> Prop (BStep (Assign x a) s (asgn x a s)) 
+    | BSeq    :: c1:Com -> c2:Com -> s1:State -> s2:State -> s3:State 
+              -> Prop (BStep c1 s1 s2) -> Prop (BStep c2 s2 s3) 
+              -> Prop (BStep (Seq c1 c2) s1 s3)
+    | BIfT    :: b:BExp -> c1:Com -> c2:Com -> s:{State | bval b s} -> s1:State
+              -> Prop (BStep c1 s s1) -> Prop (BStep (If b c1 c2) s s1)
+    | BIfF    :: b:BExp -> c1:Com -> c2:Com -> s:{State | not (bval b s)} -> s2:State
+              -> Prop (BStep c2 s s2) -> Prop (BStep (If b c1 c2) s s2)
+    | BWhileF :: b:BExp -> c:Com -> s:{State | not (bval b s)} 
+              -> Prop (BStep (While b c) s s)
+    | BWhileT :: b:BExp -> c:Com -> s1:{State | bval b s1} -> s1':State -> s2:State
+              -> Prop (BStep c s1 s1') -> Prop (BStep (While b c) s1' s2)
+              -> Prop (BStep (While b c) s1 s2)
+  @-}  
+
+
+{-@ reflect cmd_1 @-}
+cmd_1 = "x" <~ N 5
+
+{-@ reflect cmd_2 @-}
+cmd_2 = "y" <~ (V "x")
+
+{-@ reflect cmd_1_2 @-}
+cmd_1_2 = cmd_1 @@ cmd_2
+
+{-@ reflect prop_set @-}
+prop_set cmd x v s = BStep cmd s (S.set s x v)
+
+{-@ step_1 :: s:State -> Prop (prop_set cmd_1 {"x"} 5 s)  @-}
+step_1 s =  BAssign "x" (N 5) s
+
+{-@ step_2 :: s:{State | S.get s "x" == 5} -> Prop (prop_set cmd_2 {"y"} 5 s) @-}
+step_2 s = BAssign "y" (V "x") s
+
+{-@ step_1_2 :: s:State -> Prop (BStep cmd_1_2 s (S.set (S.set s {"x"} 5) {"y"} 5)) @-}
+step_1_2 s = BSeq cmd_1 cmd_2 s s1 s2 (step_1 s) (step_2 s1)
+  where
+    s1     = S.set s  "x" 5
+    s2     = S.set s1 "y" 5
+
+
+
+-------------------------------------------------------------------------------
+-- | We say `Sim c1 c2` or `c1` is simulated by `c2` if 
+--   the transitions of `c1` are contained within those of `c2`
+-------------------------------------------------------------------------------
+
+{-@ type Sim C1 C2 = s:State -> t:State -> Prop (BStep C1 s t) -> Prop (BStep C2 s t) @-}
+type SimT = State -> State -> BStep -> BStep 
+
+
+---------------------------------------------------------------------------------
+-- | IMP is Deterministic
+---------------------------------------------------------------------------------
+
+{- 
+{-@ thm_bigstep_det 
+      :: s:_ -> t1:_ -> t2:_ -> c:_
+      -> Prop (BStep c s t1) 
+      -> Prop (BStep c s t2) 
+      -> { t1 == t2 }
+  @-}
+thm_bigstep_det :: State -> State -> State -> Com -> BStep -> BStep -> Proof
+
+
+
+
+{- -}
+thm_bigstep_det s t t' Skip         (BSkip {})   (BSkip {})
+    = ()
+  
+thm_bigstep_det s t t' (Assign x a) (BAssign {}) (BAssign {})
+    = ()
+  
+thm_bigstep_det s t t' (Seq c1 c2)  (BSeq _ _ _ s1 s2 s_s1 s1_s2) (BSeq _ _ _ s1' s2' s_s1' s1_s2')
+    = thm_bigstep_det s1_eq_s1' s2 s2' c2 s1_s2 s1_s2'        
+    where s1_eq_s1' = s1 ? thm_bigstep_det s  s1 s1' c1 s_s1  s_s1'
+  
+thm_bigstep_det s t t' (If b c1 c2) (BIfT _ _ _ _ _t c1_s_t) (BIfT _ _ _ _ _t' c1_s_t')
+    = thm_bigstep_det s t t' c1 c1_s_t c1_s_t'
+  
+thm_bigstep_det s t t' (If b c1 c2) (BIfF _ _ _ _ _t c2_s_t) (BIfF _ _ _ _ _t' c2_s_t')
+    = thm_bigstep_det s t t' c2 c2_s_t c2_s_t'
+  
+thm_bigstep_det s t t' (While b c)  (BWhileF {}) (BWhileF {})
+    = ()
+  
+thm_bigstep_det s t t' (While b c)  (BWhileT _ _ _ s1 _ s_s1 s1_t) (BWhileT _ _ _ s1' _ s_s1' s1_t')
+    = thm_bigstep_det s1_eq_s1' t t' (While b c) s1_t s1_t'   
+    where s1_eq_s1' = s1 ? thm_bigstep_det s s1 s1' c s_s1 s_s1'
+
+thm_bigstep_det _ _ _ _  _ _ 
+    = impossible "no really" 
+  
+-}

--- a/benchmarks/cse230/src/Week10/Expressions.hs
+++ b/benchmarks/cse230/src/Week10/Expressions.hs
@@ -1,0 +1,144 @@
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
+{-@ LIQUID "--diff"       @-}
+
+{-# LANGUAGE PartialTypeSignatures #-}
+
+module Expressions where
+
+import qualified State as S 
+import ProofCombinators 
+
+--------------------------------------------------------------------------------
+-- | Arithmetic Expressions 
+--------------------------------------------------------------------------------
+type Vname = String
+
+data AExp  
+  = N Val 
+  | V Vname 
+  | Plus  AExp AExp 
+  | Minus AExp AExp 
+  | Times AExp AExp 
+  deriving (Show)
+
+type Val   = Int 
+type State = S.GState Vname Val 
+
+{-@ reflect aval @-}
+aval                :: AExp -> State -> Val 
+aval (N n) _         = n 
+aval (V x) s         = S.get s x 
+aval (Plus  e1 e2) s = aval e1 s + aval e2 s
+aval (Minus e1 e2) s = aval e1 s - aval e2 s
+aval (Times e1 e2) s = aval e1 s * aval e2 s
+
+{-@ reflect asgn @-}
+asgn :: Vname -> AExp -> State -> State
+asgn x a s = S.set s x (aval a s)
+
+{-@ reflect subst @-}
+subst :: Vname -> AExp -> AExp -> AExp
+subst x e (Plus  a1 a2)  = Plus  (subst x e a1) (subst x e a2)
+subst x e (Minus a1 a2)  = Minus (subst x e a1) (subst x e a2)
+subst x e (Times a1 a2)  = Times (subst x e a1) (subst x e a2)
+subst x e (V y) | x == y = e
+subst _ _ a              = a
+
+{-@ lem_subst :: x:_ -> a:_ -> e:_ -> s:_ -> 
+      { aval (subst x a e) s = aval e (asgn x a s) } 
+  @-}
+lem_subst :: Vname -> AExp -> AExp -> State -> Proof
+lem_subst x a (V y) s
+  | x == y                    = ()
+  | otherwise                 = S.lemma_get_not_set y x (aval a s) s
+lem_subst x a (N i) s         = ()
+lem_subst x a (Plus  e1 e2) s = lem_subst x a e1 s &&& lem_subst x a e2 s
+lem_subst x a (Minus e1 e2) s = lem_subst x a e1 s &&& lem_subst x a e2 s
+lem_subst x a (Times e1 e2) s = lem_subst x a e1 s &&& lem_subst x a e2 s
+
+
+
+--------------------------------------------------------------------------------
+-- | Boolean Expressions 
+--------------------------------------------------------------------------------
+
+data BExp 
+  = Bc    Bool       -- true, false 
+  | Not   BExp       -- not b 
+  | And   BExp BExp  -- b1 && b2
+  | Leq   AExp AExp  -- a1 <= a2 
+  | Equal AExp AExp  -- a1 == a2 
+  deriving (Show)
+
+{-@ reflect .&&. @-}
+(.&&.) :: BExp -> BExp -> BExp 
+b1 .&&. b2 = And b1 b2 
+
+{-@ reflect .=>. @-}
+(.=>.) :: BExp -> BExp -> BExp 
+b1 .=>. b2 = bImp b1 b2 
+
+{-@ reflect bAnd @-}
+bAnd :: BExp -> BExp -> BExp 
+bAnd b1 b2 = And b1 b2 
+
+{-@ reflect bIte @-}
+bIte :: BExp -> BExp -> BExp -> BExp 
+bIte p b1 b2 = And (bImp p b1) (bImp (Not p) b2)
+
+{-@ reflect .==. @-}
+(.==.) :: AExp -> AExp -> BExp 
+b1 .==. b2 = Equal b1 b2 
+
+{-@ reflect .<=. @-}
+(.<=.) :: AExp -> AExp -> BExp 
+b1 .<=. b2 = Leq b1 b2 
+
+{-@ reflect bOr @-}
+bOr :: BExp -> BExp -> BExp 
+bOr b1 b2 = Not ((Not b1) `And` (Not b2))
+       
+{-@ reflect bImp @-}
+bImp :: BExp -> BExp -> BExp 
+bImp b1 b2 = bOr (Not b1) b2
+
+{-@ reflect bLess @-}
+bLess :: AExp -> AExp -> BExp 
+bLess a1 a2 = And (Leq a1 a2) (Not (Equal a1 a2))
+
+{-@ reflect tt @-}
+tt :: BExp 
+tt = Bc True 
+
+{-@ reflect ff @-}
+ff :: BExp 
+ff = Bc False 
+
+{-@ reflect bval @-}
+bval :: BExp -> State -> Bool
+bval (Bc   b)      _ = b 
+bval (Not  b)      s = not (bval b s) 
+bval (And  b1 b2)  s = bval b1 s && bval b2 s 
+bval (Leq  a1 a2)  s = aval a1 s <= aval a2 s 
+bval (Equal a1 a2) s = aval a1 s == aval a2 s 
+
+
+{-@ reflect bsubst @-}
+bsubst :: Vname -> AExp -> BExp -> BExp
+bsubst x a (Bc    b)     = Bc    b
+bsubst x a (Not   b)     = Not   (bsubst x a b)
+bsubst x a (And   b1 b2) = And   (bsubst x a b1) (bsubst x a b2)
+bsubst x a (Leq   a1 a2) = Leq   (subst  x a a1) (subst  x a a2)
+bsubst x a (Equal a1 a2) = Equal (subst  x a a1) (subst  x a a2)
+
+{-@ lem_bsubst :: x:_ -> a:_ -> b:_ -> s:_ -> 
+      { bval (bsubst x a b) s = bval b (asgn x a s) } 
+  @-}
+lem_bsubst :: Vname -> AExp -> BExp -> State -> Proof 
+lem_bsubst x a (Bc _) _        = () 
+lem_bsubst x a (Not b)       s = lem_bsubst x a b  s 
+lem_bsubst x a (And b1 b2)   s = lem_bsubst x a b1 s &&& lem_bsubst x a b2 s 
+lem_bsubst x a (Leq a1 a2)   s = lem_subst  x a a1 s &&& lem_subst  x a a2 s 
+lem_bsubst x a (Equal a1 a2) s = lem_subst  x a a1 s &&& lem_subst  x a a2 s 
+

--- a/benchmarks/cse230/src/Week10/Imp.hs
+++ b/benchmarks/cse230/src/Week10/Imp.hs
@@ -1,0 +1,36 @@
+{-@ LIQUID "--reflection"  @-}
+{-@ LIQUID "--diff"        @-}
+{-@ LIQUID "--ple"         @-}
+{-@ LIQUID "--short-names" @-}
+
+{-@ infixr ++  @-}  -- TODO: Silly to have to rewrite this annotation!
+{-@ infixr <~  @-}  -- TODO: Silly to have to rewrite this annotation!
+
+{-# LANGUAGE GADTs #-}
+
+module Imp where
+
+import           Prelude hiding ((++)) 
+import           ProofCombinators
+import qualified State as S
+import           Expressions -- hiding (And)
+
+--------------------------------------------------------------------------------
+-- | IMP Commands
+--------------------------------------------------------------------------------
+data Com 
+  = Skip                      -- skip 
+  | Assign Vname AExp         -- x := a
+  | Seq    Com   Com          -- c1; c2
+  | If     BExp  Com   Com    -- if b then c1 else c2
+  | While  BExp  Com          -- while b c 
+  deriving (Show)
+
+{-@ reflect <~ @-}
+(<~) :: Vname -> AExp -> Com 
+x <~ a = Assign x a 
+
+{-@ reflect @@ @-}
+(@@) :: Com -> Com -> Com 
+s1 @@ s2 = Seq s1 s2
+

--- a/benchmarks/cse230/src/Week10/Lec_3_11.hs
+++ b/benchmarks/cse230/src/Week10/Lec_3_11.hs
@@ -1,0 +1,427 @@
+{-@ LIQUID "--reflection"  @-}
+{-@ LIQUID "--ple"         @-}
+{-@ LIQUID "--diff"        @-}
+{- LIQUID "--short-names" @-}
+{-@ infixr ++              @-}  -- TODO: Silly to have to rewrite this annotation!
+{-@ infixr <~              @-}  -- TODO: Silly to have to rewrite this annotation!
+
+--------------------------------------------------------------------------------
+-- | Inspired by 
+--     http://flint.cs.yale.edu/cs428/coq/sf/Hoare.html
+--     http://flint.cs.yale.edu/cs428/coq/sf/Hoare2.html
+--------------------------------------------------------------------------------
+
+{-# LANGUAGE GADTs #-}
+
+module Axiomatic where
+
+import           Prelude hiding ((++)) 
+import           ProofCombinators
+import qualified State as S
+import           Expressions  
+import           Imp 
+import           BigStep hiding (And)
+
+--------------------------------------------------------------------------------
+{- | A Floyd-Hoare triple is of the form 
+
+        { P }  c { Q }
+
+     where 
+      
+     - `P` and `Q` are assertions (think `BExp`) and 
+     - `c` is a command (think `Com`) 
+    
+     A Floyd-Hoare triple states that 
+
+     IF 
+
+     * The program `c` is starts at a state where the *precondition* `P` is True, and 
+     * The program finishes execution
+
+     THEN 
+
+     * At the final state, the *postcondition* `Q` will also evaluate to True.
+
+     -}
+
+{- | Lets paraphrase the following Hoare triples in English.
+
+   1) {True}   c {X = 5}
+
+   2) {X = m}  c {X = m + 5}
+
+   3) {X <= Y} c {Y <= X}
+
+   4) {True}   c {False}
+
+-}
+
+
+--------------------------------------------------------------------------------
+-- | The type `Assertion` formalizes the type for the 
+--   assertions (i.e. pre- and post-conditions) `P`, `Q`
+--   appearing in the triples {P} c {Q}
+
+type Assertion = BExp 
+
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+{- | Legitimate Triples 
+--------------------------------------------------------------------------------
+
+Which of the following triples are "legit" i.e.,  the claimed relation between 
+`pre`condition` `P`, `com`mand `C`, and `post`condition `Q` is true?
+
+   1) {True}  
+        X <~ 5 
+      {X = 5}
+
+   2) {X = 2} 
+        X <~ X + 1 
+      {X = 3}
+
+   3) {True}  
+        X <~ 5; 
+        Y <~ 0 
+      {X = 5}
+
+   4) {True}  
+        X <~ 5; 
+        Y <~ X 
+      {Y = 5}
+
+   5) {X = 2 && X = 3} 
+        X <~ 5 
+      {X = 0}
+
+   6) {True} 
+        SKIP 
+      {False}
+
+   7) {False} 
+        SKIP 
+      {True}
+
+   8) {True} 
+        WHILE True DO 
+          SKIP 
+      {False}
+
+   9) {X = 0}
+        WHILE X <= 0 DO 
+          X <~ X + 1 
+      {X = 1}
+
+   10) {X = 1}
+         WHILE not (X <= 0) DO 
+           X <~ X + 1 
+       {X = 100}
+ -}
+
+--------------------------------------------------------------------------------
+-- | `Legit` formalizes the notion of when a Floyd-Hoare triple is legitimate 
+--------------------------------------------------------------------------------
+{-@ type Legit P C Q =  s:{State | bval P s} 
+                     -> s':_ -> Prop (BStep C s s') 
+                     -> {bval Q s'} 
+  @-}
+type Legit = State -> State -> BStep -> Proof 
+
+-- | {True}  X <~ 5  {X = 5} ---------------------------------------------------
+
+{-@ leg1 :: Legit tt (Assign {"x"} (N 5)) (Equal (V {"x"}) (N 5)) @-}
+leg1 :: Legit  
+leg1 s s' (BAssign {}) 
+  = S.lemma_get_set "x" 5 s 
+
+
+-- | {True}  X <~ 5; y <- X  {X = 5} -------------------------------------------
+
+{-@ leg3 :: Legit tt (Seq (Assign {"x"} (N 5)) (Assign {"y"} (V {"x"}))) (Equal (V {"y"}) (N 5)) @-}
+leg3 :: Legit  
+leg3 s s' (BSeq _ _ _ smid _ (BAssign {}) (BAssign {})) 
+  = S.lemma_get_set "x" 5 s &&& S.lemma_get_set "y" 5 smid 
+
+
+-- | {False}  X <~ 5  {X = 0} --------------------------------------------------
+
+{-@ leg5 :: Legit ff (Assign {"x"} (N 5)) (Equal (V {"x"}) (N 22)) @-}
+leg5 :: Legit  
+leg5 s s' _ = () 
+
+
+--------------------------------------------------------------------------------
+-- | 1. Simple facts about Floyd-Hoare Triples --------------------------------
+--------------------------------------------------------------------------------
+
+{-@ lem_post_true :: p:_ -> c:_ -> Legit p c tt @-}
+lem_post_true :: Assertion -> Com -> Legit
+lem_post_true p c = \s s' c_s_s' -> () 
+
+{-@ lem_pre_false :: c:_ -> q:_ -> Legit ff c q @-}
+lem_pre_false :: Com -> Assertion -> Legit 
+lem_pre_false c q = \s s' c_s_s' -> () 
+
+--------------------------------------------------------------------------------
+-- | 2. Validity and Implication
+--------------------------------------------------------------------------------
+
+{-@ type Valid P = s:State -> { v: Proof | bval P s } @-}
+type Valid = State -> Proof 
+
+{-@ type Imply P Q = Valid (bImp P Q) @-}
+
+-- 10 <= x  => 5 <= x 
+{-@ v1 :: _ -> Imply (Leq (N 10) (V {"x"})) (Leq (N 5) (V {"x"})) @-} 
+v1 :: a -> Valid 
+v1 _ = \_ -> ()
+
+-- (0 < x && 0 < y) ===> (0 < x + y)
+
+{-@ v2 :: _ -> Imply (bAnd (Leq (N 0) (V {"x"})) (Leq (N 0) (V {"y"}))) 
+                     (Leq (N 0) (Plus (V {"x"}) (V {"y"})))
+  @-}             
+v2 :: a -> Valid 
+v2 _ = \_ -> ()
+
+--------------------------------------------------------------------------------
+-- | 3. Consequence
+--------------------------------------------------------------------------------
+{-@ lem_conseq_pre :: p':_ -> p:_ -> q:_ -> c:_ 
+                   -> Imply p' p -> Legit p c q 
+                   -> Legit p' c q
+  @-}
+lem_conseq_pre :: Assertion -> Assertion -> Assertion -> Com -> Valid -> Legit -> Legit 
+lem_conseq_pre p' p q c impl pcq = \s s' c_s_s' -> pcq (s ? (impl s)) s' c_s_s'
+
+{-@ lem_conseq_post :: p:_ -> q:_ -> q':_ -> c:_ 
+                    -> Legit p c q -> Imply q q' 
+                    -> Legit p c q'
+  @-}
+lem_conseq_post :: Assertion -> Assertion -> Assertion -> Com -> Legit -> Valid -> Legit 
+lem_conseq_post p q q' c pcq impl = \s s' c_s_s' -> pcq s s' c_s_s' ? (impl s') 
+
+--------------------------------------------------------------------------------
+-- | 4. Skip 
+--------------------------------------------------------------------------------
+-- {P} Skip {P}
+
+{-@ lem_skip :: p:_ -> (Legit p Skip p) @-}
+lem_skip :: Assertion -> Legit 
+lem_skip p = \s s' (BSkip {}) -> () 
+
+
+{- | Exercise suppose you have 
+
+      {P} Skip {Q} 
+
+   Prove that 
+
+      P => Q 
+
+ -}
+
+--------------------------------------------------------------------------------
+-- | 5. Assignment 
+--------------------------------------------------------------------------------
+
+--  { Y = 1     }  X <~ Y      { X = 1 }
+
+--  { X + Y = 1 }  X <~ X + Y  { X = 1 }
+
+--  { a = 1     }  X <~ a      { X = 1 }
+
+
+{- | Lets fill in the blanks
+
+     { ??? } 
+        x <~ 3 
+     { x == 3 }
+
+     { ??? } 
+        x <~ x + 1 
+     { x <= 5 }
+
+     { ??? }
+        x <~ y + 1 
+     { 0 <= x && x <= 5 }
+
+ -} 
+
+
+{- | To conclude that an arbitrary postcondition `Q` holds after 
+     `x <~ a`, we need to assume that Q holds before `x <~ a` 
+     but with all occurrences of `x` replaced by `a` in `Q` 
+
+     Lets revisit the example above:
+
+     { ??? } 
+        x <~ 3 
+     { x == 3 }
+
+     { ??? } 
+        x <~ x + 1 
+     { x <= 5 }
+
+     { ??? }
+        x <~ y + 1 
+     { 0 <= x && x <= 5 }
+
+  -} 
+
+{-@ lem_asgn :: x:_ -> a:_ -> q:_ -> 
+      Legit (bsubst x a q) (Assign x a) q 
+  @-}
+lem_asgn :: Vname -> AExp -> Assertion -> Legit 
+lem_asgn x a q = \s s' (BAssign {}) -> lem_bsubst x a q s
+
+
+--------------------------------------------------------------------------------
+-- | 6. Sequencing 
+--------------------------------------------------------------------------------
+{-@ lem_seq :: c1:_ -> c2:_ -> p:_ -> q:_ -> r:_ 
+            -> Legit p c1 q -> Legit q c2 r 
+            -> Legit p (Seq c1 c2) r 
+  @-}
+lem_seq :: Com -> Com -> Assertion -> Assertion -> Assertion -> Legit -> Legit -> Legit 
+lem_seq c1 c2 p q r l1 l2 = \s s' (BSeq _ _ _ smid _ t1 t2) -> 
+  l1 s smid t1 &&& l2 smid s' t2 
+
+
+--------------------------------------------------------------------------------
+-- | 7. Branches 
+--------------------------------------------------------------------------------
+{-@ lem_if :: b:_ -> c1:_ -> c2:_ -> p:_ -> q:_ 
+           -> Legit (bAnd p b)       c1 q 
+           -> Legit (bAnd p (Not b)) c2 q 
+           -> Legit p (If b c1 c2)  q
+  @-}
+lem_if :: BExp -> Com -> Com -> Assertion -> Assertion -> Legit -> Legit -> Legit
+lem_if b c1 c2 p q l1 l2 = \s s' bs -> case bs of 
+  BIfF _ _ _ _ _ c2_s_s' -> l2 s s' c2_s_s'
+  BIfT _ _ _ _ _ c1_s_s' -> l1 s s' c1_s_s'
+
+--------------------------------------------------------------------------------
+-- | 8. Loops 
+--------------------------------------------------------------------------------
+{-@ lem_while :: b:_ -> c:_ -> p:_ 
+              -> Legit (bAnd p b) c p 
+              -> Legit p (While b c) (bAnd p (Not b)) 
+  @-}
+lem_while :: BExp -> Com -> Assertion -> Legit -> Legit 
+lem_while b c p lbody s s' (BWhileF {}) 
+  = ()
+lem_while b c p lbody s s' (BWhileT _ _ _ smid _ c_s_smid w_smid_s') 
+  = lem_while b c p lbody (smid ? lbody s smid c_s_smid) s' w_smid_s' 
+
+--------------------------------------------------------------------------------
+-- | The Floyd-Hoare proof system
+--------------------------------------------------------------------------------
+
+data FHP where 
+  FH :: Assertion -> Com -> Assertion -> FHP
+
+data FH where 
+  FHSkip    :: Assertion -> FH 
+  FHAssign  :: Assertion -> Vname -> AExp -> FH 
+  FHSeq     :: Assertion -> Com -> Assertion -> Com -> Assertion -> FH -> FH -> FH 
+  FHIf      :: Assertion -> Assertion -> BExp -> Com -> Com -> FH -> FH -> FH
+  FHWhile   :: Assertion -> BExp -> Com -> FH -> FH 
+  FHConPre  :: Assertion -> Assertion -> Assertion -> Com -> Valid -> FH -> FH 
+  FHConPost :: Assertion -> Assertion -> Assertion -> Com -> FH -> Valid -> FH 
+
+{-@ data FH where 
+      FHSkip   :: p:_
+               -> Prop (FH p Skip p) 
+    | FHAssign :: q:_ -> x:_ -> a:_
+               -> Prop (FH (bsubst x a q) (Assign x a) q) 
+    | FHSeq    :: p:_ -> c1:_ -> q:_ -> c2:_ -> r:_ 
+               -> Prop (FH p c1 q) 
+               -> Prop (FH q c2 r) 
+               -> Prop (FH p (Seq c1 c2) r) 
+    | FHIf     :: p:_ -> q:_ -> b:_ -> c1:_ -> c2:_
+               -> Prop (FH (bAnd p b)       c1 q) 
+               -> Prop (FH (bAnd p (Not b)) c2 q)
+               -> Prop (FH p (If b c1 c2) q)
+    | FHWhile  :: p:_ -> b:_ -> c:_
+               -> Prop (FH (bAnd p b) c p) 
+               -> Prop (FH p (While b c) (bAnd p (Not b)))
+    | FHConPre :: p':_ -> p:_ -> q:_ -> c:_  
+               -> Imply p' p
+               -> Prop (FH p c q) 
+               -> Prop (FH p' c q)
+    | FHConPost :: p:_ -> q:_ -> q':_ -> c:_  
+                -> Prop (FH p c q) 
+                -> Imply q q'
+                -> Prop (FH p c q')
+  @-}
+
+--------------------------------------------------------------------------------
+-- | THEOREM: Soundness of Floyd-Hoare Logic 
+--------------------------------------------------------------------------------
+-- thm_fh_legit :: p:_ -> c:_ -> q:_ -> Prop (FH p c q) -> Legit p c q
+
+
+
+
+
+
+
+
+
+--------------------------------------------------------------------------------
+-- | Making FH Algorithmic: Verification Conditions 
+--------------------------------------------------------------------------------
+data ICom 
+  = ISkip                      -- skip 
+  | IAssign Vname AExp         -- x := a
+  | ISeq    ICom  ICom         -- c1; c2
+  | IIf     BExp  ICom  ICom   -- if b then c1 else c2
+  | IWhile  BExp  BExp  ICom   -- while {I} b c 
+  deriving (Show)
+
+{-@ reflect pre @-}
+pre :: ICom -> Assertion -> Assertion 
+pre ISkip          q = q
+pre (IAssign x a)  q = bsubst x a q 
+pre (ISeq c1 c2)   q = pre c1 (pre c2 q)
+pre (IIf b c1 c2)  q = bIte b (pre c1 q) (pre c2 q) 
+pre (IWhile i _ _) _ = i 
+
+{-@ reflect vc @-}
+vc :: ICom -> Assertion -> Assertion
+vc ISkip          _ = tt 
+vc (IAssign {})   _ = tt 
+vc (ISeq c1 c2)   q = (vc c1 (pre c2 q)) `bAnd` (vc c2 q)
+vc (IIf _ c1 c2)  q = (vc c1 q) `bAnd` (vc c2 q)
+vc (IWhile i b c) q = ((bAnd i b)       `bImp` (pre c i)) `bAnd` 
+                      ((bAnd i (Not b)) `bImp` q        ) `bAnd`
+                      vc c i
+
+{-@ reflect strip @-}
+strip :: ICom -> Com 
+strip ISkip          = Skip 
+strip (IAssign x a)  = Assign x a 
+strip (ISeq c1 c2)   = Seq (strip c1) (strip c2)
+strip (IIf b c1 c2)  = If b (strip c1) (strip c2)
+strip (IWhile _ b c) = While b (strip c)
+
+-----------------------------------------------------------------------------------
+-- | THEOREM: Soundness of VC
+-----------------------------------------------------------------------------------
+-- thm_vc :: c:_ -> q:_ -> Valid (vc c q) -> Legit (pre c q) (strip c) q
+
+-----------------------------------------------------------------------------------
+-- | Extending the above to triples [HW] 
+-----------------------------------------------------------------------------------
+
+{-@ reflect vc' @-}
+vc' :: Assertion -> ICom -> Assertion -> Assertion 
+vc' p c q = bAnd (bImp p (pre c q)) (vc c q) 
+
+-----------------------------------------------------------------------------------
+-- | THEOREM: Soundness of VC'
+-----------------------------------------------------------------------------------
+-- thm_vc' :: p:_ -> c:_ -> q:_ -> Valid (vc' p c q) -> Legit p (strip c) q

--- a/benchmarks/cse230/src/Week10/Lec_3_15.hs
+++ b/benchmarks/cse230/src/Week10/Lec_3_15.hs
@@ -1,0 +1,170 @@
+{-@ LIQUID "--reflection"  @-}
+{-@ LIQUID "--ple"         @-}
+{-@ LIQUID "--diff"        @-}
+
+module Lec_3_15 () where 
+
+import           ProofCombinators
+import qualified State as S
+import           Expressions  
+import           Imp 
+import           BigStep hiding (And)
+import           Axiomatic 
+
+imports = (FH undefined undefined undefined)
+
+----------------------------------------------------------------
+-- TODO: Move into FloydHoare.hs 
+----------------------------------------------------------------
+
+----------------------------------------------------------------
+-- | Lets build a 'verify'-er
+----------------------------------------------------------------
+
+{-@ verify :: p:_ -> c:_ -> q:_ -> Valid (vc' p c q) -> () @-}
+verify :: Assertion -> ICom -> Assertion -> Valid -> () 
+verify _ _ _ _ = () 
+{-
+----------------------------------------------------------------
+ex1   :: () -> ()
+ex1 _ = verify p c q (\_ -> ()) 
+  where 
+    p = tt                                    -- { true } 
+    c = IAssign "x" (N 5)                    --    x := 50
+    q = Equal (V "x") (N 5)                   -- { x == 5 }
+
+    --        p    => pre c q /\ vc c q
+    -- VC  = (True => 5 = 5) /\ True 
+    -- pre = 50 == 5 
+----------------------------------------------------------------
+-}
+
+ex2   :: () -> () 
+ex2 _ = verify p c q (\_ -> ()) 
+  where 
+    p = Equal (V "x") (N 2)                   -- { x = 2 } 
+    c = IAssign "x" (Plus (V "x") (N 1))      --    x := x + 1
+    q = Equal (V "x") (N 3)                   -- { x = 3 }
+
+    --        p    => pre c q /\ vc c q
+    -- VC  = (x=2 => x+1=3) /\ True 
+    -- pre = x+1 = 3 
+----------------------------------------------------------------
+
+{-
+ex2a   :: () -> () 
+ex2a _ = verify p c q (\_ -> ()) 
+  where 
+    p  = Equal (V "x") (N 2)                   -- { x = 2 } 
+    c  = c1 `ISeq` c1                          --    x := x + 1 
+    c1 = IAssign "x" (Plus (V "x") (N 1))      --    x := x + 1
+    q  = Equal (V "x") (N 4)                   -- { x = 4 }
+
+----------------------------------------------------------------
+
+ex4  :: () -> () 
+ex4 _  = verify p (c1 `ISeq` c2) q (\_ -> ()) 
+  where 
+    p  = tt                                    -- { True } 
+    c1 = IAssign "x" (N 5)                     --    x := 5 
+    c2 = IAssign "y" (V "x")                   --    y := x 
+    q  = Equal (V "y") (N 5)                   -- { y = 5 }
+
+----------------------------------------------------------------
+ex5  :: () -> () 
+ex5 _ = verify p c q (\_ -> ()) 
+  where 
+    p = ((V "x") `Equal` (N 2)) `bAnd` 
+        ((V "x") `Equal` (N 3))                -- { x = 2 && x = 3} 
+    c = IAssign "x" (N 5)                      --    x := 5
+    q = V "x" `Equal` N 0                      -- { x = 0}
+
+----------------------------------------------------------------
+-}
+ex8  :: () -> () 
+ex8 _ = verify p c q (\_ -> ()) 
+  where 
+    p = tt                                     -- { true } 
+    c = IWhile i tt ISkip                      --    WHILE_i true SKIP 
+    q = ff                                     -- { false }
+    i = tt
+----------------------------------------------------------------
+
+ex9  :: () -> () 
+ex9 _ = verify p c q (\_ -> ()) 
+  where 
+    p = Equal (V "x") (N 0)                    -- { x = 0 } 
+    c = IWhile i (Leq (V "x") (N 0))           --   WHILE_i (x <= 0) DO
+          (IAssign "x" (Plus (V "x") (N 1)))   --     x := x + 1
+    q = Equal (V "x") (N 1)                    -- { x = 1 } 
+    i = bOr p (Equal (V "x") (N 1))
+
+      -- x=0 => (x=0 || x=1)
+      -- {(x=0 || x=1) /\ x <= 0 } x := x+1 {x=0 || x=1}
+      -- (x=0|| x=1) /\ x > 0 => x = 1
+----------------------------------------------------------------
+ex10  :: () -> () 
+ex10 _ = verify p c q (\_ -> ()) 
+  where 
+    p = Equal (V "x") (N 1)                    -- { x = 1 } 
+    c = IWhile i (Not (Leq (V "x") (N 0)))     --   WHILE (x > 0) DO
+          (IAssign "x" (Plus (V "x") (N 1)))   --     x := x + 1
+    q = Equal (V "x") (N 100)                  -- { x = 100 } 
+    i = undefined -- TODO: In class
+
+    -- P => I 
+    -- {I && b} c { I }
+    -- I && !b => Q 
+        -- x>0 &&& not ( x > 0 ) => Q
+    -- I := x > 0 
+{-
+-------------------------------------------------------------------------------
+-- | Example 1: branching
+-------------------------------------------------------------------------------
+
+bx1 :: () -> () 
+bx1 _ = verify p c q (\_ -> ()) 
+  where 
+    p = tt                                     -- { true } 
+    c = IIf (Equal (V "x") (N 0))              --   IF x == 0 
+            (IAssign "y" (N 2))                --     THEN y := 2
+            (IAssign "y" (Plus (V "x") (N 1))) --     ELSE y := x + 1
+    q = Leq (V "x") (V "y")                    -- { x <= y } 
+
+-------------------------------------------------------------------------------
+-- | Example 2: Swapping Using Addition and Subtraction 
+-------------------------------------------------------------------------------
+-} 
+
+bx2 :: () -> () 
+bx2 _ = verify p c q (\_ -> ()) 
+  where 
+    p =      (V "x" `Equal` V "a") 
+      `bAnd` (V "y" `Equal` V "b")                -- { x = a && y = b } 
+    c =      IAssign "x" (Plus  (V "x") (V "y"))  --     x := x + y
+      `ISeq` IAssign "y" (Minus (V "x") (V "y"))  --     y := x - y
+      `ISeq` IAssign "x" (Minus (V "x") (V "y"))  --     x := x - y
+    q =      (V "x" `Equal` V "b")                -- { x = b && y = a } 
+      `bAnd` (V "y" `Equal` V "a") 
+
+      -- vc' = x=a & y=b => (x+y-(x+y-y) =b && (x+y)-y=a) && true & True & true
+      -- pre = (x+y-(x+y-y) =b && (x+y)-y=a)
+      -- vc  = true & true & true 
+{-
+-------------------------------------------------------------------------------
+-- | Example 4: Reduce to Zero  
+-------------------------------------------------------------------------------
+
+bx4 :: () -> () 
+bx4 _ = verify p c q (\_ -> ()) 
+  where 
+    p = tt                                      -- { true } 
+    c = IWhile i (Not (Equal (V "x") (N 0)))    --   WHILE not (x == 0) DO: 
+          (IAssign "x" (Minus (V "x") (N 1)))   --     x := x - 1
+    q = (V "x" `Equal` N 0)                     -- { x = 0 } 
+    i = tt 
+
+
+
+
+-}

--- a/benchmarks/cse230/src/Week10/ProofCombinators.hs
+++ b/benchmarks/cse230/src/Week10/ProofCombinators.hs
@@ -1,0 +1,183 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE IncoherentInstances   #-}
+
+module ProofCombinators (
+
+  -- ATTENTION! `Admit` and `(==!)` are UNSAFE: they should not belong the final proof term
+
+  -- * Proof is just a () alias
+  Proof
+  , toProof 
+
+  -- * Proof constructors
+  , trivial, unreachable, (***), QED(..)
+
+  -- * "Because" combinator 
+  , (?)
+
+  -- * These two operators check all intermediate equalities
+  , (===) -- proof of equality is implicit eg. x === y
+  , (=<=) -- proof of equality is implicit eg. x <= y
+  , (=>=)  -- proof of equality is implicit eg. x =>= y 
+
+  -- * This operator does not check intermediate equalities
+  , (==.) 
+
+  -- Uncheck operator used only for proof debugging
+  , (==!) -- x ==! y always succeds
+
+  -- * Combining Proofs
+  , (&&&)
+  , withProof 
+  , impossible 
+
+
+) where
+
+-------------------------------------------------------------------------------
+-- | Proof is just a () alias -------------------------------------------------
+-------------------------------------------------------------------------------
+
+type Proof = ()
+
+toProof :: a -> Proof
+toProof _ = ()
+
+-------------------------------------------------------------------------------
+-- | Proof Construction -------------------------------------------------------
+-------------------------------------------------------------------------------
+
+-- | trivial is proof by SMT
+
+trivial :: Proof
+trivial =  ()
+
+-- {-@ unreachable :: {v : Proof | False } @-}
+unreachable :: Proof
+unreachable =  ()
+
+-- All proof terms are deleted at runtime.
+{- RULE "proofs are irrelevant" forall (p :: Proof). p = () #-}
+
+-- | proof casting
+-- | `x *** QED`: x is a proof certificate* strong enough for SMT to prove your theorem
+-- | `x *** Admit`: x is an unfinished proof
+
+infixl 3 ***
+{-@ assume (***) :: a -> p:QED -> { if (isAdmit p) then false else true } @-}
+(***) :: a -> QED -> Proof
+_ *** _ = ()
+
+data QED = Admit | QED
+
+{-@ measure isAdmit :: QED -> Bool @-}
+{-@ Admit :: {v:QED | isAdmit v } @-}
+
+
+-------------------------------------------------------------------------------
+-- | * Checked Proof Certificates ---------------------------------------------
+-------------------------------------------------------------------------------
+
+-- Any (refined) carries proof certificates.
+-- For example 42 :: {v:Int | v == 42} is a certificate that
+-- the value 42 is equal to 42.
+-- But, this certificate will not really be used to proof any fancy theorems.
+
+-- Below we provide a number of equational operations
+-- that constuct proof certificates.
+
+-- | Implicit equality
+
+-- x === y returns the proof certificate that
+-- result value is equal to both x and y
+-- when y == x (as assumed by the operator's precondition)
+
+infixl 3 ===
+{-@ (===) :: x:a -> y:{a | y == x} -> {v:a | v == x && v == y} @-}
+(===) :: a -> a -> a
+_ === y  = y
+
+infixl 3 =<=
+{-@ (=<=) :: x:a -> y:{a | x <= y} -> {v:a | x <= y && v == y} @-}
+(=<=) :: a -> a -> a
+_ =<= y  = y
+
+infixl 3 =>=
+{-@ (=>=) :: x:a -> y:{a | x >= y}  -> {v:a | x >= y && v == y} @-}
+(=>=) :: a -> a -> a
+_ =>= y  = y
+
+-------------------------------------------------------------------------------
+-- | `?` is basically Haskell's $ and is used for the right precedence
+-- | `?` lets you "add" some fact into a proof term
+-------------------------------------------------------------------------------
+
+infixl 3 ?
+
+{-@ (?) :: forall a b <pa :: a -> Bool, pb :: b -> Bool>. a<pa> -> b<pb> -> a<pa> @-}
+(?) :: a -> b -> a 
+x ? _ = x 
+{-# INLINE (?)   #-} 
+
+-------------------------------------------------------------------------------
+-- | Assumed equality
+-- 	`x ==! y `
+--   returns the admitted proof certificate that result value is equals x and y
+-------------------------------------------------------------------------------
+
+infixl 3 ==!
+{-@ assume (==!) :: x:a -> y:a -> {v:a | v == x && v == y} @-}
+(==!) :: a -> a -> a
+(==!) _ y = y
+
+
+-- | To summarize:
+--
+-- 	- (==!) is *only* for proof debugging
+--	- (===) does not require explicit proof term
+-- 	- (?)   lets you insert "lemmas" as other `Proof` values
+
+-------------------------------------------------------------------------------
+-- | * Unchecked Proof Certificates -------------------------------------------
+-------------------------------------------------------------------------------
+
+-- | The above operators check each intermediate proof step.
+--   The operator `==.` below accepts an optional proof term
+--   argument, but does not check intermediate steps.
+--   TODO: What is it USEFUL FOR?
+
+infixl 3 ==.
+
+{-# DEPRECATED (==.) "Use (===) instead" #-}
+
+{-# INLINE (==.) #-} 
+(==.) :: a -> a -> a 
+_ ==. x = x 
+
+-------------------------------------------------------------------------------
+-- | * Combining Proof Certificates -------------------------------------------
+-------------------------------------------------------------------------------
+
+(&&&) :: Proof -> Proof -> Proof
+x &&& _ = x
+
+
+{-@ withProof :: x:a -> b -> {v:a | v = x} @-}
+withProof :: a -> b -> a
+withProof x _ = x
+
+{-@ impossible :: {v:a | false} -> b @-}
+impossible :: a -> b
+impossible _ = undefined
+
+-------------------------------------------------------------------------------
+-- | Convenient Syntax for Inductive Propositions 
+-------------------------------------------------------------------------------
+
+{-@ measure prop :: a -> b           @-}
+{-@ type Prop E = {v:_ | prop v = E} @-}
+
+
+

--- a/benchmarks/cse230/src/Week10/STLC.lhs
+++ b/benchmarks/cse230/src/Week10/STLC.lhs
@@ -1,0 +1,473 @@
+
+The Simply Typed Lambda Calculus 
+================================ 
+  
+A formalization of the Simply Typed Lambda Calculus (STLC) in the style 
+of [Jeremy Siek](http://siek.blogspot.com/2013/05/type-safety-in-three-easy-lemmas.html)
+
+\begin{code}
+{-@ LIQUID "--reflection"     @-}
+{-@ LIQUID "--ple"            @-}
+{-@ LIQUID "--no-termination" @-}
+
+{-# LANGUAGE GADTs #-}
+
+module STLC where 
+
+import ProofCombinators
+\end{code}
+
+
+Variables 
+---------
+
+\begin{code} 
+type Var = String 
+\end{code} 
+
+Types and Environments
+----------------------
+
+\begin{code}
+data Type 
+  = TInt                     -- ^ `TInt`         is `Int`  
+  | TBool                    -- ^ `TBool`        is `Bool`
+  | TFun Type Type           -- ^ `TFun t1 t2`   is `t1 -> t2`
+  deriving (Eq, Show) 
+
+data TEnv                  
+  = TBind Var Type TEnv      -- ^ x:t, G
+  | TEmp                     -- ^ Empty environment
+  deriving (Eq, Show) 
+\end{code}
+
+Terms 
+-----
+
+\begin{code}
+data Op  
+  = Add                      -- ^ `Add` is `+` 
+  | Leq                      -- ^ `Leq` is `<=`
+  | And                      -- ^ `And` is `&&`
+  deriving (Eq, Show) 
+
+data Expr 
+  = EBool Bool               -- ^ 'EBool b'       is 'b'
+  | EInt  Int                -- ^ 'EInt i'        is 'i'
+  | EBin  Op Expr Expr       -- ^ 'EBin op e1 e2' is 'e1 `op` e2'
+  | EVar  Var                -- ^ 'EVar x'        is 'x'
+  | EFun  Var Var Type Expr  -- ^ 'EFun f x t e'  is 'fun f(x:t) e'
+  | EApp  Expr Expr          -- ^ 'EApp e1 e2'    is 'e1 e2' 
+  deriving (Eq, Show) 
+\end{code}
+
+
+Values and Stores 
+-----------------
+
+\begin{code}
+data Val 
+  = VBool Bool 
+  | VInt  Int
+  | VClos Var Var Expr Store
+  deriving (Eq, Show) 
+
+data Store  
+  = VBind Var Val Store 
+  | VEmp 
+  deriving (Eq, Show) 
+\end{code}
+
+
+Evaluation Result 
+-----------------
+
+\begin{code}
+data Result 
+  = Result Val  
+  | Stuck 
+  | Timeout
+  deriving (Eq, Show) 
+\end{code}
+
+
+Dynamic Semantics (Evaluator)
+----------------------------- 
+
+Big-Step? Small-Step?
+
+\begin{code}
+{-@ reflect eval @-}
+eval :: Store -> Expr -> Result 
+eval _   (EBool b)    = Result (VBool b)
+eval _   (EInt  n)    = Result (VInt  n)
+eval s (EBin o e1 e2) = seq2 (evalOp o) (eval s e1) (eval s e2) 
+eval s (EVar x)       = case lookupStore x s of 
+                          Nothing -> Stuck 
+                          Just v  -> Result v 
+eval s (EFun f x t e) = Result (VClos f x e s) 
+eval s (EApp e1 e2)   = seq2 evalApp (eval s e1) (eval s e2)
+
+{-@ reflect evalApp @-}
+evalApp :: Val -> Val -> Result 
+evalApp v1@(VClos f x e s) v2 = eval (VBind x v2 (VBind f v1 s)) e 
+evalApp _                  _  = Stuck 
+
+{-@ reflect evalOp @-}
+evalOp :: Op -> Val -> Val -> Result 
+evalOp Add (VInt n1)  (VInt n2)  = Result (VInt  (n1 +  n2))
+evalOp Leq (VInt n1)  (VInt n2)  = Result (VBool (n1 <= n2))
+evalOp And (VBool b1) (VBool b2) = Result (VBool (b1 && b2)) 
+evalOp _   _          _          = Stuck 
+
+{-@ reflect lookupStore @-}
+lookupStore :: Var -> Store -> Maybe Val 
+lookupStore x VEmp             = Nothing 
+lookupStore x (VBind y v env)  = if x == y then Just v else lookupStore x env
+\end{code}
+
+Helper to *sequence* sub-computations.
+
+\begin{code}
+{-@ reflect seq2 @-}
+seq2 :: (Val -> Val -> Result) -> Result -> Result -> Result
+seq2 f r1 r2 = case r1 of 
+                 Stuck     -> Stuck 
+                 Timeout   -> Timeout 
+                 Result v1 -> case r2 of 
+                                Stuck     -> Stuck 
+                                Timeout   -> Timeout 
+                                Result v2 -> f v1 v2
+\end{code}
+
+Tests before proofs 
+-------------------
+
+\begin{code}
+tests :: [Expr]
+tests  = [ e1              -- 15
+         , EBin Leq e1 e1  -- True
+         , EBin And e1 e1  -- Stuck!
+         ]
+  where 
+    e1 = EBin Add (EInt 5) (EInt 10)
+\end{code}
+
+Static Semantics (aka Static Typing Rules) 
+------------------------------------------
+
+
+**Typing Results** 
+
+[ . |- r : T ]
+
+
+    |- v : T 
+  -------------------- [R_Res]
+    |- Result v : T  
+
+  -------------------- [R_Time]
+    |- Timeout  : T  
+
+\begin{code}
+{-@ data ResTy where
+      R_Res  :: x:Val -> t:Type -> Prop (ValTy x t) -> Prop (ResTy (Result x) t) 
+    | R_Time :: t:Type -> Prop (ResTy Timeout t) 
+  @-}
+
+data ResTyP where 
+  ResTy  :: Result -> Type -> ResTyP 
+
+data ResTy where 
+  R_Res  :: Val -> Type -> ValTy -> ResTy 
+  R_Time :: Type -> ResTy 
+\end{code}
+
+**Typing Values**
+
+[ |- v : T ] 
+
+    ----------------------- [V_Bool]
+      |- VBool b : TBool
+
+    ----------------------- [V_Int]
+      |- VInt i : TInt 
+   
+    G |- s  (x,t1), (f,t1->t2),G |- e : t2 
+    --------------------------------------- [V_Clos]
+      |- VClos f x e s : t1 -> t2 
+
+\begin{code}
+{-@ data ValTy where
+      V_Bool :: b:Bool -> Prop (ValTy (VBool b) TBool) 
+    | V_Int  :: i:Int  -> Prop (ValTy (VInt i)  TInt) 
+    | V_Clos :: g:TEnv -> s:Store -> f:Var -> x:Var -> t1:Type -> t2:Type -> e:Expr 
+             -> Prop (StoTy g s) 
+             -> Prop (ExprTy (TBind x t1 (TBind f (TFun t1 t2) g)) e t2)
+             -> Prop (ValTy (VClos f x e s) (TFun t1 t2)) 
+  @-}
+
+data ValTyP where 
+  ValTy  :: Val -> Type -> ValTyP 
+
+data ValTy where 
+  V_Bool :: Bool -> ValTy 
+  V_Int  :: Int  -> ValTy 
+  V_Clos :: TEnv -> Store -> Var -> Var -> Type -> Type -> Expr -> StoTy -> ExprTy  -> ValTy 
+\end{code}
+
+**Typing Stores**
+
+[ G |- S ] 
+
+   ------------------------[S_Emp]
+   TEmp |- VEmp 
+
+      |- v : t   g |- s 
+   ------------------------[S_Bind]
+   (x, t), g |- (x, v), s 
+
+\begin{code}
+{-@ data StoTy where
+      S_Emp  :: Prop (StoTy TEmp VEmp) 
+    | S_Bind :: x:Var -> t:Type -> val:Val -> g:TEnv -> s:Store
+             -> Prop (ValTy val t) 
+             -> Prop (StoTy g   s) 
+             -> Prop (StoTy (TBind x t g) (VBind x val s)) 
+  @-}
+
+data StoTyP where 
+  StoTy  :: TEnv -> Store -> StoTyP 
+
+data StoTy where 
+  S_Emp  :: StoTy 
+  S_Bind :: Var -> Type -> Val -> TEnv -> Store -> ValTy -> StoTy -> StoTy 
+\end{code}
+
+**Typing Expressions**
+
+  --------------------------------------[E-Bool]
+    G |- EBool b : TBool
+
+  --------------------------------------[E-Int]
+    G |- EInt n  : TInt 
+
+    lookupTEnv x G = Just t
+  --------------------------------------[E-Var]
+    G |- Var x  : t 
+
+    G |- e1 : opIn o  G |- e2 : opIn o 
+  --------------------------------------[E-Bin]
+    G |- EBin o e1 e2 : opOut o
+
+
+    (x,t1), (f, t1->t2), G |- e : t2 
+  --------------------------------------[E-Fun]
+    G |- EFun f x t1 e : t1 -> t2 
+
+    G |- e1 : t1 -> t2   G |- e2 : t1 
+  --------------------------------------[E-App]
+    G |- EApp e1 e2 : t2 
+
+\begin{code}
+{-@ reflect opIn @-}
+opIn :: Op -> Type 
+opIn Add = TInt 
+opIn Leq = TInt 
+opIn And = TBool
+
+{-@ reflect opOut @-}
+opOut :: Op -> Type 
+opOut Add = TInt 
+opOut Leq = TBool 
+opOut And = TBool
+
+{-@ reflect lookupTEnv @-}
+lookupTEnv :: Var -> TEnv -> Maybe Type 
+lookupTEnv x TEmp             = Nothing 
+lookupTEnv x (TBind y v env)  = if x == y then Just v else lookupTEnv x env
+
+
+{-@ data ExprTy where 
+      E_Bool :: g:TEnv -> b:Bool 
+             -> Prop (ExprTy g (EBool b) TBool)
+    | E_Int  :: g:TEnv -> i:Int  
+             -> Prop (ExprTy g (EInt i)  TInt)
+    | E_Bin  :: g:TEnv -> o:Op -> e1:Expr -> e2:Expr 
+             -> Prop (ExprTy g e1 (opIn o)) 
+             -> Prop (ExprTy g e2 (opIn o))
+             -> Prop (ExprTy g (EBin o e1 e2) (opOut o))
+    | E_Var  :: g:TEnv -> x:Var -> t:{Type| lookupTEnv x g == Just t} 
+             -> Prop (ExprTy g (EVar x) t)
+    | E_Fun  :: g:TEnv -> f:Var -> x:Var -> t1:Type -> e:Expr -> t2:Type
+             -> Prop (ExprTy (TBind x t1 (TBind f (TFun t1 t2) g)) e t2)
+             -> Prop (ExprTy g (EFun f x t1 e) (TFun t1 t2))       
+    | E_App  :: g:TEnv -> e1:Expr -> e2:Expr -> t1:Type -> t2:Type 
+             -> Prop (ExprTy g e1 (TFun t1 t2))
+             -> Prop (ExprTy g e2 t1)
+             -> Prop (ExprTy g (EApp e1 e2) t2)
+  @-}
+data ExprTyP where 
+  ExprTy :: TEnv -> Expr -> Type -> ExprTyP  
+
+data ExprTy where 
+  E_Bool :: TEnv -> Bool -> ExprTy 
+  E_Int  :: TEnv -> Int  -> ExprTy 
+  E_Var  :: TEnv -> Var  -> Type -> ExprTy 
+  E_Bin  :: TEnv -> Op   -> Expr -> Expr -> ExprTy -> ExprTy -> ExprTy 
+  E_Fun  :: TEnv -> Var -> Var -> Type -> Expr -> Type -> ExprTy -> ExprTy 
+  E_App  :: TEnv -> Expr -> Expr -> Type -> Type -> ExprTy -> ExprTy -> ExprTy 
+\end{code}
+
+Lemma 1: "evalOp_safe" 
+----------------------
+
+
+\begin{code}
+{-@ reflect isValTy @-}
+isValTy :: Val -> Type -> Bool 
+isValTy (VInt _)  TInt  = True 
+isValTy (VBool _) TBool = True 
+isValTy _         _     = False 
+
+{-@ propValTy :: o:Op -> w:Val -> Prop (ValTy w (opIn o)) -> { w' : Val | w = w' && isValTy w' (opIn o) } @-}
+propValTy :: Op -> Val -> ValTy -> Val 
+propValTy Add w (V_Int _) = w 
+propValTy Leq w (V_Int _)  = w 
+propValTy And w (V_Bool _) = w 
+
+{-@ evalOp_safe 
+      :: o:Op -> v1:{Val | isValTy v1 (opIn o) } -> v2:{Val | isValTy v2 (opIn o) } 
+      -> (v :: Val, ( {y:() | evalOp o v1 v2 == Result v} , {z:ValTy | prop z = ValTy v (opOut o)}))
+  @-}
+evalOp_safe :: Op -> Val -> Val -> (Val, ((), ValTy))
+evalOp_safe Add (VInt n1) (VInt n2)   = (VInt n, ((), V_Int n))   where n = n1 + n2 
+evalOp_safe Leq (VInt n1) (VInt n2)   = (VBool b, ((), V_Bool b)) where b = n1 <= n2 
+evalOp_safe And (VBool b1) (VBool b2) = (VBool b, ((), V_Bool b)) where b = b1 && b2 
+
+{-@ evalOp_res_safe 
+      :: o:Op -> r1:Result -> r2:Result
+      -> Prop (ResTy r1 (opIn o))
+      -> Prop (ResTy r2 (opIn o))
+      -> Prop (ResTy (seq2 (evalOp o) r1 r2) (opOut o)) 
+  @-}
+evalOp_res_safe :: Op -> Result -> Result -> ResTy -> ResTy -> ResTy
+evalOp_res_safe o (Result v1) (Result v2) (R_Res _ t1 vt1) (R_Res _ t2 vt2) 
+  = case evalOp_safe o (propValTy o v1 vt1) (propValTy o v2 vt2) of 
+      (v, (_, vt)) -> R_Res v (opOut o) vt  
+evalOp_res_safe o _ _  (R_Time t1) _ 
+  = R_Time (opOut o)
+evalOp_res_safe o _ _  _ (R_Time t2) 
+  = R_Time (opOut o)
+\end{code}
+
+Lemma 2: "lookup_safe"
+----------------------
+
+\begin{code}
+{-@ lookup_safe :: g:TEnv -> s:Store -> x:Var -> t:{Type | lookupTEnv x g == Just t} 
+                -> Prop (StoTy g s) 
+                -> (w :: Val, ({z:() | lookupStore x s ==  Just w} , {z:ValTy | prop z = ValTy w t} ))
+  @-}
+lookup_safe :: TEnv -> Store -> Var -> Type -> StoTy -> (Val, ((), ValTy)) 
+lookup_safe _ _ _ _ S_Emp 
+  = impossible () 
+lookup_safe g s x t (S_Bind y yt yv g' s' yvt gs')  
+  | x == y 
+  = (yv, ((), yvt)) 
+  | otherwise 
+  = lookup_safe g' s' x t gs' 
+\end{code}
+
+Lemma 3: "app_safe" 
+-------------------
+
+\begin{code}
+{-@ evalApp_safe 
+      :: v1:Val -> v2:Val -> t1:Type -> t2:Type
+      -> Prop (ValTy v1 (TFun t1 t2)) 
+      -> Prop (ValTy v2 t1)
+      -> Prop (ResTy (evalApp v1 v2) t2) 
+  @-}
+evalApp_safe :: Val -> Val -> Type -> Type -> ValTy -> ValTy -> ResTy 
+evalApp_safe v1@(VClos f x e s) v2 t1 t2 v1_t1_t2@(V_Clos g _ _ _ _ _ _ g_s gxf_e_t2) v2_t1 
+  = eval_safe gxf sxf e t2 gxf_e_t2 gxf_sxf  
+  where 
+    gf      = TBind f (TFun t1 t2) g
+    sf      = VBind f v1           s
+    gxf     = TBind x t1 gf 
+    sxf     = VBind x v2 sf  
+    gf_sf   = S_Bind f (TFun t1 t2) v1 g  s  v1_t1_t2 g_s 
+    gxf_sxf = S_Bind x t1           v2 gf sf v2_t1    gf_sf             
+    
+evalApp_safe (VInt {}) _ _ _ (V_Clos {}) _ 
+  = impossible () 
+
+evalApp_safe (VBool {}) _ _ _ (V_Clos {}) _ 
+  = impossible () 
+
+
+
+
+{-@ evalApp_res_safe 
+      :: r1:Result -> r2:Result -> t1:Type -> t2:Type
+      -> Prop (ResTy r1 (TFun t1 t2)) 
+      -> Prop (ResTy r2 t1)
+      -> Prop (ResTy (seq2 evalApp r1 r2) t2)
+  @-}
+evalApp_res_safe :: Result -> Result -> Type -> Type -> ResTy -> ResTy -> ResTy 
+evalApp_res_safe (Result v1) (Result v2) t1 t2 (R_Res _ _ v1_t1_t2) (R_Res _ _ v2_t1)
+  = evalApp_safe v1 v2 t1 t2 v1_t1_t2 v2_t1 
+evalApp_res_safe _ _ _ t2 (R_Time {}) _ 
+  = R_Time t2 
+evalApp_res_safe _ _ _ t2 _ (R_Time {}) 
+  = R_Time t2 
+\end{code}
+
+THEOREM: "eval_safe" 
+--------------------
+
+\begin{code}
+{-@ eval_safe :: g:TEnv -> s:Store -> e:Expr -> t:Type 
+              -> Prop (ExprTy g e t) 
+              -> Prop (StoTy  g s) 
+              -> Prop (ResTy (eval s e) t) 
+  @-}
+eval_safe :: TEnv -> Store -> Expr -> Type -> ExprTy -> StoTy -> ResTy 
+
+eval_safe _ _ (EBool b) _ (E_Bool {}) _          
+  = R_Res (VBool b) TBool (V_Bool b) 
+ 
+eval_safe _ _ (EInt n) _ (E_Int {}) _ 
+  = R_Res (VInt n) TInt (V_Int n) 
+
+eval_safe g s (EBin o e1 e2) t (E_Bin _ _ _ _ et1 et2) gs
+  = evalOp_res_safe o (eval s e1) (eval s e2) rt1 rt2     
+  where 
+    rt1          = eval_safe g s e1 (opIn o) et1 gs
+    rt2          = eval_safe g s e2 (opIn o) et2 gs
+
+eval_safe g s (EVar x) t (E_Var {}) gs     
+  = R_Res w t wt 
+  where 
+    (w, (_, wt)) = lookup_safe g s x t gs 
+
+eval_safe g s (EFun f x t1 e) t (E_Fun _ _ _ _ _ t2 et2) gs 
+  = R_Res (VClos f x e s) t (V_Clos g s f x t1 t2 e gs et2)
+      
+eval_safe g s (EApp e1 e2) t2 (E_App _ _ _ t1 _ e1_t1_t2 e2_t1) gs 
+  = evalApp_res_safe (eval s e1) (eval s e2) t1 t2 r1_t1_t2 r2_t1 
+  where 
+    r1_t1_t2 = eval_safe g s e1 (TFun t1 t2) e1_t1_t2 gs 
+    r2_t1    = eval_safe g s e2 t1           e2_t1    gs
+\end{code} 
+
+Boilerplate 
+-----------
+
+{-@ measure prop :: a -> b           @-}
+{-@ type Prop E = {v:_ | prop v = E} @-}
+
+{-@ impossible :: {v:a | false} -> b @-}
+impossible :: a -> b
+impossible x = impossible x  

--- a/benchmarks/cse230/src/Week10/State.hs
+++ b/benchmarks/cse230/src/Week10/State.hs
@@ -1,0 +1,32 @@
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
+
+module State where
+
+import Prelude hiding ((++), const, max)
+import ProofCombinators
+
+data GState k v = Init v | Bind k v (GState k v)
+
+{-@ reflect init @-}
+init :: v -> GState k v
+init v = Init v
+
+{-@ reflect set @-}
+set :: GState k v -> k -> v -> GState k v
+set s k v = Bind k v s
+
+{-@ reflect get @-}
+get :: (Eq k) => GState k v -> k -> v
+get (Init v)     _   = v
+get (Bind k v s) key = if key == k then v else get s key
+
+{-@ lemma_get_set :: k:_ -> v:_ -> s:_ -> { get (set s k v) k == v }  @-}
+lemma_get_set :: k -> v -> GState k v -> Proof 
+lemma_get_set _ _ _ = () 
+
+{-@ lemma_get_not_set :: k0:_ -> k:{k /= k0} -> val:_ -> s:_ 
+                      -> { get (set s k val) k0 = get s k0 }  @-}
+lemma_get_not_set :: k -> k -> v -> GState k v -> Proof 
+lemma_get_not_set _ _ _ (Bind {}) = ()
+lemma_get_not_set _ _ _ (Init {}) = ()

--- a/benchmarks/cse230/src/Week10/Verifier.hs
+++ b/benchmarks/cse230/src/Week10/Verifier.hs
@@ -1,0 +1,149 @@
+{-@ LIQUID "--reflection"  @-}
+{-@ LIQUID "--ple"         @-}
+{-@ LIQUID "--diff"        @-}
+
+module Verifier () where 
+
+import           ProofCombinators
+import qualified State as S
+import           Expressions  
+import           Imp 
+import           BigStep hiding (And)
+import           Axiomatic 
+
+imports = (FH undefined undefined undefined)
+
+----------------------------------------------------------------
+-- TODO: Move into FloydHoare.hs 
+----------------------------------------------------------------
+
+----------------------------------------------------------------
+-- | Lets build a 'verify'-er
+----------------------------------------------------------------
+
+{-@ verify :: p:_ -> c:_ -> q:_ -> Valid (vc' p c q) -> () @-}
+verify :: Assertion -> ICom -> Assertion -> Valid -> () 
+verify _ _ _ _ = () 
+
+----------------------------------------------------------------
+ex1   :: () -> ()
+ex1 _ = verify p c q (\_ -> ()) 
+  where 
+    p = tt                                    -- { true } 
+    c = IAssign "x" (N 5)                     --    x := 5
+    q = Equal (V "x") (N 5)                   -- { x == 5 }
+
+----------------------------------------------------------------
+
+ex2   :: () -> () 
+ex2 _ = verify p c q (\_ -> ()) 
+  where 
+    p = Equal (V "x") (N 2)                   -- { x = 2 } 
+    c = IAssign "x" (Plus (V "x") (N 1))      --    x := x + 1
+    q = Equal (V "x") (N 3)                   -- { x = 3 }
+
+----------------------------------------------------------------
+
+ex2a   :: () -> () 
+ex2a _ = verify p c q (\_ -> ()) 
+  where 
+    p  = Equal (V "x") (N 2)                   -- { x = 2 } 
+    c  = c1 `ISeq` c1                          --    x := x + 1 
+    c1 = IAssign "x" (Plus (V "x") (N 1))      --    x := x + 1
+    q  = Equal (V "x") (N 4)                   -- { x = 4 }
+
+----------------------------------------------------------------
+
+ex4  :: () -> () 
+ex4 _  = verify p (c1 `ISeq` c2) q (\_ -> ()) 
+  where 
+    p  = tt                                    -- { True } 
+    c1 = IAssign "x" (N 5)                     --    x := 5 
+    c2 = IAssign "y" (V "x")                   --    y := x 
+    q  = Equal (V "y") (N 5)                   -- { y = 5 }
+
+----------------------------------------------------------------
+ex5  :: () -> () 
+ex5 _ = verify p c q (\_ -> ()) 
+  where 
+    p = ((V "x") `Equal` (N 2)) `bAnd` 
+        ((V "x") `Equal` (N 3))                -- { x = 2 && x = 3} 
+    c = IAssign "x" (N 5)                      --    x := 5
+    q = V "x" `Equal` N 0                      -- { x = 0}
+
+----------------------------------------------------------------
+
+ex8  :: () -> () 
+ex8 _ = verify p c q (\_ -> ()) 
+  where 
+    p = tt                                     -- { true } 
+    c = IWhile i tt ISkip                      --    WHILE_i true SKIP 
+    q = ff                                     -- { false }
+    i = tt -- undefined -- TODO: In class
+
+----------------------------------------------------------------
+
+ex9  :: () -> () 
+ex9 _ = verify p c q (\_ -> ()) 
+  where 
+    p = Equal (V "x") (N 0)                    -- { x = 0 } 
+    c = IWhile i (Leq (V "x") (N 0))           --   WHILE_i (x <= 0) DO
+          (IAssign "x" (Plus (V "x") (N 1)))   --     x := x + 1
+    q = Equal (V "x") (N 1)                    -- { x = 1 } 
+    i = undefined -- TODO: In class
+
+----------------------------------------------------------------
+ex10  :: () -> () 
+ex10 _ = verify p c q (\_ -> ()) 
+  where 
+    p = Equal (V "x") (N 1)                    -- { x = 1 } 
+    c = IWhile i (Not (Leq (V "x") (N 0)))     --   WHILE_i not (x <= 0) DO
+          (IAssign "x" (Plus (V "x") (N 1)))   --     x := x + 1
+    q = Equal (V "x") (N 100)                  -- { x = 100 } 
+    i = undefined -- TODO: In class
+
+-------------------------------------------------------------------------------
+-- | Example 1: branching
+-------------------------------------------------------------------------------
+
+bx1 :: () -> () 
+bx1 _ = verify p c q (\_ -> ()) 
+  where 
+    p = tt                                     -- { true } 
+    c = IIf (Equal (V "x") (N 0))              --   IF x == 0 
+            (IAssign "y" (N 2))                --     THEN y := 2
+            (IAssign "y" (Plus (V "x") (N 1))) --     ELSE y := x + 1
+    q = Leq (V "x") (V "y")                    -- { x <= y } 
+
+-------------------------------------------------------------------------------
+-- | Example 2: Swapping Using Addition and Subtraction 
+-------------------------------------------------------------------------------
+
+bx2 :: () -> () 
+bx2 _ = verify p c q (\_ -> ()) 
+  where 
+    p =      (V "x" `Equal` V "a") 
+      `bAnd` (V "y" `Equal` V "b")                -- { x = a && y = b } 
+    c =      IAssign "x" (Plus  (V "x") (V "y"))  --     x := x + y
+      `ISeq` IAssign "y" (Minus (V "x") (V "y"))  --     y := x - y
+      `ISeq` IAssign "x" (Minus (V "x") (V "y"))  --     x := x - y
+    q =      (V "x" `Equal` V "b")                -- { x = a && y = b } 
+      `bAnd` (V "y" `Equal` V "a") 
+
+
+-------------------------------------------------------------------------------
+-- | Example 4: Reduce to Zero  
+-------------------------------------------------------------------------------
+
+bx4 :: () -> () 
+bx4 _ = verify p c q (\_ -> ()) 
+  where 
+    p = tt                                      -- { true } 
+    c = IWhile i (Not (Equal (V "x") (N 0)))    --   WHILE not (x == 0) DO: 
+          (IAssign "x" (Minus (V "x") (N 1)))   --     x := x - 1
+    q = (V "x" `Equal` N 0)                     -- { x = 0 } 
+    i = tt 
+
+
+
+

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -313,7 +313,8 @@ gNegIgnored   = ["Interpretations.hs", "Gradual.hs"]
 
 benchTests :: IO TestTree
 benchTests = group "Benchmarks"
-  [ testGroup "esop"        <$> dirTests  "benchmarks/esop2013-submission"        esopIgnored               ExitSuccess
+  [ testGroup "cse230"      <$> dirTests   "benchmarks/cse230/src/Week10"         []                        ExitSuccess
+  , testGroup "esop"        <$> dirTests   "benchmarks/esop2013-submission"       esopIgnored               ExitSuccess
   , testGroup "vect-algs"   <$> odirTests  "benchmarks/vector-algorithms-0.5.4.2" []            vectOrder   ExitSuccess
   , testGroup "bytestring"  <$> odirTests  "benchmarks/bytestring-0.9.2.1"        bsIgnored     bsOrder     ExitSuccess
   , testGroup "text"        <$> odirTests  "benchmarks/text-0.11.2.3"             textIgnored   textOrder   ExitSuccess


### PR DESCRIPTION
Evaluation of function applications should enter a branch before expanding the body, if possible.
This reduces the number of intermediate SMT equalities generated by PLE.