### PR TITLE
Release 0.8.10.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
 
   cabal_810:
     docker:
-      - image: phadej/ghc:8.10.1-bionic-slim
+      - image: adinapoli/ghc:8.10.2-bionic-slim
     steps:
       - cabal_build_and_test:
           liquid_runner: "--liquid-runner=cabal -v0 v2-exec liquidhaskell -- -v0 \

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "liquid-fixpoint"]
 	path = liquid-fixpoint
-	url = git@github.com:ucsd-progsys/liquid-fixpoint.git
+	url = https://github.com/ucsd-progsys/liquid-fixpoint.git
 [submodule "ghc-options"]
 	path = ghc-options
 	url = https://github.com/ranjitjhala/ghc-options.git

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,8 +34,8 @@ build_script:
 # Build LiquidHaskell (the legacy executable)
 # until https://gitlab.haskell.org/ghc/ghc/issues/17236 is fixed.
 - echo "" | rm -rf .stack-work
-- echo "" | stack --no-terminal build --ghc-options="-fexternal-interpreter" liquidhaskell:lib --flag liquidhaskell:no-plugin --copy-bins --local-bin-path .
-- echo "" | stack --no-terminal build liquid-fixpoint:exe:fixpoint liquidhaskell:exe:liquid --flag liquidhaskell:no-plugin --copy-bins --local-bin-path .
+- echo "" | stack --no-terminal build --compiler=ghc-8.10.1 --ghc-options="-fexternal-interpreter" liquidhaskell:lib --flag liquidhaskell:no-plugin --copy-bins --local-bin-path .
+- echo "" | stack --no-terminal build --compiler=ghc-8.10.1 liquid-fixpoint:exe:fixpoint liquidhaskell:exe:liquid --flag liquidhaskell:no-plugin --copy-bins --local-bin-path .
 
 # Copy runtime DLLs
 - call appveyor-copy.bat
@@ -49,8 +49,8 @@ build_script:
 
 # Run the tests (using the legacy executable)
 test_script:
-- echo "" | stack --no-terminal test liquidhaskell:liquidhaskell-parser --fast --flag liquidhaskell:no-plugin
-- echo "" | stack --no-terminal test liquidhaskell:test --fast --flag liquidhaskell:no-plugin --ta="--liquid-runner \"stack --silent exec -- liquid\""  --test-arguments "-p Micro"
+- echo "" | stack --compiler=ghc-8.10.1 --no-terminal test liquidhaskell:liquidhaskell-parser --fast --flag liquidhaskell:no-plugin
+- echo "" | stack --compiler=ghc-8.10.1 --no-terminal test liquidhaskell:test --fast --flag liquidhaskell:no-plugin --ta="--liquid-runner \"stack --compiler=ghc-8.10.1 --silent exec -- liquid\""  --test-arguments "-p Micro"
 
 artifacts:
 - path: liquidhaskell.zip

--- a/liquid-base/liquid-base.cabal
+++ b/liquid-base/liquid-base.cabal
@@ -1,6 +1,6 @@
 cabal-version:      1.24
 name:               liquid-base
-version:            4.14.0.0
+version:            4.14.1.0
 synopsis:           Drop-in base replacement for LiquidHaskell
 description:        Drop-in base replacement for LiquidHaskell.
 license:            BSD3
@@ -244,7 +244,7 @@ library
                     Liquid.Prelude.Totality
 
   hs-source-dirs:     src
-  build-depends:      base                 == 4.14.0.0
+  build-depends:      base                 == 4.14.1.0
                     , liquid-ghc-prim
                     , liquidhaskell        >= 0.8.10.1
   default-language:   Haskell2010

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               liquidhaskell
-version:            0.8.10.1
+version:            0.8.10.2
 synopsis:           Liquid Types for Haskell
 description:        Liquid Types for Haskell.
 license:            BSD-3-Clause

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -227,6 +227,7 @@ library
                     , liquid-fixpoint      >= 0.8.10.1
                     , mtl                  >= 2.1
                     , optics               >= 0.2
+                    , optparse-applicative < 0.16.0.0
                     , optparse-simple
                     , githash
                     , parsec               >= 3.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -29,4 +29,4 @@ extra-deps:
 - Diff-0.3.4
 - aeson-1.4.7.1
 resolver: lts-15.4
-compiler: ghc-8.10.1
+compiler: ghc-8.10.2

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -68,12 +68,12 @@ packages:
   original:
     hackage: optics-extra-0.3
 - completed:
-    hackage: Diff-0.4.0@sha256:b5cfbeed498f555a18774ffd549bbeff7a24bdfe5984154dcfc9f4328a3c2847,1275
+    hackage: Diff-0.3.4@sha256:5ab20a407f9e65d13b642c3cd414906a40280343a31b388f6ed69b9228fe42c1,1127
     pantry-tree:
-      size: 415
-      sha256: 01b215c454152a0fe10a5378a4013d92e89da2f0695ffffc466ead5f3343cf3a
+      size: 416
+      sha256: 48d1b942ff99293d69a8ca4ea60f372093e5aeea73f63d11829ceca01d63c7fd
   original:
-    hackage: Diff-0.4.0
+    hackage: Diff-0.3.4
 - completed:
     hackage: aeson-1.4.7.1@sha256:6d8d2fd959b7122a1df9389cf4eca30420a053d67289f92cdc0dbc0dab3530ba,7098
     pantry-tree:
@@ -83,7 +83,7 @@ packages:
     hackage: aeson-1.4.7.1
 snapshots:
 - completed:
-    size: 532379
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/8.yaml
-    sha256: 2ad3210d2ad35f3176005d68369a18e4d984517bfaa2caade76f28ed0b2e0521
-  original: lts-16.8
+    size: 491163
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/4.yaml
+    sha256: bc60043a06b58902b533baa80fb566c0ec495c41e428bc0f8c1e8c15b2a4c468
+  original: lts-15.4


### PR DESCRIPTION
Fixes #1739.

This PR is based on #1740 (to keep CI happy) but it also bump the various versions to `0.8.10.2`, and `liquid-base`, accordingly.

**See also:** https://github.com/ucsd-progsys/liquid-fixpoint/pull/441

Hackage releases to follow. (More specifically, we will need to release only `liquid-haskell`, `liquid-fixpoint` and `liquid-base`).