### PR TITLE
Bump liquid-platform and liquid-prelude as well

### DIFF
--- a/liquid-platform/liquid-platform.cabal
+++ b/liquid-platform/liquid-platform.cabal
@@ -1,6 +1,6 @@
 cabal-version:      1.22
 name:               liquid-platform
-version:            0.8.10.1
+version:            0.8.10.2
 synopsis:           A battery-included platform for LiquidHaskell
 description:        A battery-included platform for LiquidHaskell.
 license:            BSD3
@@ -25,12 +25,12 @@ executable liquidhaskell
     buildable: False
   else
     buildable: True
-    build-depends:      liquid-base       >= 4.14.0.0 && < 5
+    build-depends:      liquid-base       >= 4.14.1.0 && < 5
                       , liquid-containers >= 0.6.2.1  && < 0.7
-                      , liquid-prelude    >= 0.8.10.1
+                      , liquid-prelude    >= 0.8.10.2
                       , liquid-vector     >= 0.12.1.2 && < 0.13
                       , liquid-bytestring >= 0.10.0.0 && < 0.11
-                      , liquidhaskell     >= 0.8.10.1
+                      , liquidhaskell     >= 0.8.10.2
                       , process           >= 1.6.0.0 && < 1.7
                       , cmdargs           >= 0.10    && < 0.11
 
@@ -53,7 +53,7 @@ executable gradual
 
 executable target
   main-is:          src/Target.hs
-  build-depends:    base >= 4.8.1.0 && < 5, hint, liquidhaskell >= 0.8.10.1
+  build-depends:    base >= 4.8.1.0 && < 5, hint, liquidhaskell >= 0.8.10.2
   default-language: Haskell2010
   buildable:        False
 

--- a/liquid-prelude/liquid-prelude.cabal
+++ b/liquid-prelude/liquid-prelude.cabal
@@ -1,6 +1,6 @@
 cabal-version:      1.24
 name:               liquid-prelude
-version:            0.8.10.1
+version:            0.8.10.2
 synopsis:           General utility modules for LiquidHaskell
 description:        General utility modules for LiquidHaskell.
 license:            BSD3
@@ -31,7 +31,7 @@ library
   build-depends:      liquid-base          < 5
                     , bytestring           >= 0.10.0.0 && < 0.11
                     , containers           >= 0.6.0.0  && < 0.7
-                    , liquidhaskell        >= 0.8.10.1
+                    , liquidhaskell        >= 0.8.10.2
   default-language:   Haskell2010
   if impl(ghc >= 8.10)
     ghc-options: -fplugin=LiquidHaskell


### PR DESCRIPTION
While uploading the new version of `liquidhaskell`, it occurred to me we didn't bump `liquid-prelude` and `liquid-platform`.

While technically we _don't need_ to do so, having them on version `0.8.10.1` while using under the hood `liquidhaskell-0.8.10.1` feels a bit strange to me, so I have opted for consistency and bumped them as well, with proper bounds.