### PR TITLE
Allow inlines expansion in reflected functions

### DIFF
--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -229,6 +229,7 @@ library
                     , optics               >= 0.2
                     , optparse-applicative < 0.16.0.0
                     , optparse-simple
+                    , optparse-applicative < 0.16.0.0
                     , githash
                     , parsec               >= 3.1
                     , pretty               >= 1.1

--- a/src/Language/Haskell/Liquid/Bare/Expand.hs
+++ b/src/Language/Haskell/Liquid/Bare/Expand.hs
@@ -345,7 +345,7 @@ instance Expand Ms.BareSpec where
 instance Expand a => Expand (F.Located a) where 
   expand rtEnv _ = expandLoc rtEnv 
 
-instance (Expand a, PPrint a) => Expand (F.LocSymbol, a) where 
+instance Expand a => Expand (F.LocSymbol, a) where 
   expand rtEnv l (x, y) = (x, expand rtEnv l y)
 
 instance Expand a => Expand (Maybe a) where 

--- a/src/Language/Haskell/Liquid/Bare/Expand.hs
+++ b/src/Language/Haskell/Liquid/Bare/Expand.hs
@@ -266,7 +266,7 @@ qualifyExpand :: (Expand a, Bare.Qualify a)
               => Bare.Env -> ModName -> BareRTEnv -> F.SourcePos -> [F.Symbol] -> a -> a 
 ----------------------------------------------------------------------------------
 qualifyExpand env name rtEnv l bs
-  = expand rtEnv l  
+  = expand rtEnv l
   . Bare.qualify env name l bs
 
 ----------------------------------------------------------------------------------
@@ -345,7 +345,7 @@ instance Expand Ms.BareSpec where
 instance Expand a => Expand (F.Located a) where 
   expand rtEnv _ = expandLoc rtEnv 
 
-instance Expand a => Expand (F.LocSymbol, a) where 
+instance (Expand a, PPrint a) => Expand (F.LocSymbol, a) where 
   expand rtEnv l (x, y) = (x, expand rtEnv l y)
 
 instance Expand a => Expand (Maybe a) where 

--- a/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -100,7 +100,7 @@ cfgRef = unsafePerformIO $ newIORef defConfig
 
 -- | Set to 'True' to enable debug logging.
 debugLogs :: Bool
-debugLogs = True
+debugLogs = False
 
 ---------------------------------------------------------------------------------
 -- | Useful functions -----------------------------------------------------------

--- a/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -100,7 +100,7 @@ cfgRef = unsafePerformIO $ newIORef defConfig
 
 -- | Set to 'True' to enable debug logging.
 debugLogs :: Bool
-debugLogs = False
+debugLogs = True
 
 ---------------------------------------------------------------------------------
 -- | Useful functions -----------------------------------------------------------

--- a/tests/import/client/T1738.hs
+++ b/tests/import/client/T1738.hs
@@ -1,0 +1,9 @@
+{-@ LIQUID "--reflection" @-}
+
+module T1738 where
+
+import T1738Lib
+
+{-@ reflect bar @-}
+bar :: Int -> Int
+bar n = incr n

--- a/tests/import/lib/T1738Lib.hs
+++ b/tests/import/lib/T1738Lib.hs
@@ -1,0 +1,5 @@
+module T1738Lib where
+
+{-@ inline incr @-}
+incr :: Int -> Int
+incr x = x + 1


### PR DESCRIPTION
Hopefully fixes #1738 .

@ranjitjhala's intuition was correct, although the cause from the breakage was subtle, and it is the following:

When we call `qualifyExpand`, we do this on the input spec, but in case of reflected functions this is _not enough_, or rather is _not the right time_. If we take a look at the `Expand` instance which gets invoked for a `BareSpec`, is the following:

```haskell
expandBareSpec :: BareRTEnv -> F.SourcePos -> Ms.BareSpec -> Ms.BareSpec
expandBareSpec rtEnv l sp = sp 
  { measures   = expand rtEnv l (measures   sp) 
  , asmSigs    = expand rtEnv l (asmSigs    sp)
  , sigs       = expand rtEnv l (sigs       sp)
  , localSigs  = expand rtEnv l (localSigs  sp)
  , reflSigs   = expand rtEnv l (reflSigs   sp)
  , ialiases   = [ (f x, f y) | (x, y) <- ialiases sp ]
  , dataDecls  = expand rtEnv l (dataDecls  sp)
  , newtyDecls = expand rtEnv l (newtyDecls sp)
  } 
  where f      = expand rtEnv l 
```

It might seem that reflected-functions expansion happens as part of `reflSigs`, but that's not correct, because in the common case, the input `BareSpec` will record any binder to reflect as part of `reflects`, which is a `[Var]`. This means that during the first expansion we cannot do _anything_, because we have a list of opaque `Var`s at hand.

This also means that we produce a `gsRefSigs` which are not correctly expanded, as you can see from the trace for the offending test:

```
Trace: [gsRefSigs] : [T1738.bar : lq1:GHC.Types.Int -> {VV : GHC.Types.Int | VV == T1738.bar lq1 && VV == T1738Lib.incr lq1}]
```

Once I realised this, it was a matter of adding _another_ call to `qualifyExpand` when we produce the reflected signature. That's the right time to do so, methinks, because this time we have a `[(Var, LocSpecType)]`, and we know how to expand a `LocSpecType`.

This causes test `T1738` to pass, but CI will tell us if I have introduced any regression.

