### PR TITLE
Tentatively adding gsTySigs to ghcSpecEnv

### DIFF
--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -176,12 +176,13 @@ ghcSpecEnv sp = fromListSEnv binds
   where
     emb       = gsTcEmbeds (_gsName sp)
     binds     = concat 
-                 [ [(x,        rSort t) | (x, Loc _ _ t) <- gsMeas     (_gsData sp)]
-                 , [(symbol v, rSort t) | (v, Loc _ _ t) <- gsCtors    (_gsData sp)]
-                 , [(symbol v, vSort v) | v              <- gsReflects (_gsRefl sp)]
-                 , [(x,        vSort v) | (x, v)         <- gsFreeSyms (_gsName sp), Ghc.isConLikeId v ]
-                 , [(x, RR s mempty)    | (x, s)         <- wiredSortedSyms       ]
-                 , [(x, RR s mempty)    | (x, s)         <- _gsImps sp       ]
+                 [ [(x,        rSort t) | (x, Loc _ _ t)  <- gsMeas     (_gsData sp)]
+                 , [(symbol v, rSort t) | (v, Loc _ _ t)  <- gsCtors    (_gsData sp)]
+                 , [(symbol v, vSort v) | v               <- gsReflects (_gsRefl sp)]
+                 , [(x,        vSort v) | (x, v)          <- gsFreeSyms (_gsName sp), Ghc.isConLikeId v ]
+                 , [(x, RR s mempty)    | (x, s)          <- wiredSortedSyms       ]
+                 , [(x, RR s mempty)    | (x, s)          <- _gsImps sp       ]
+                 , [(symbol x, rSort t) | (x, Loc _ _ t)  <- gsTySigs (_gsSig sp)   ]
                  ]
     vSort     = Bare.varSortedReft emb
     rSort     = rTypeSortedReft    emb

--- a/tests/pos/T1761.hs
+++ b/tests/pos/T1761.hs
@@ -1,0 +1,11 @@
+
+module T1761 where
+
+{-@ inline oneFunPred @-}
+oneFunPred :: Int -> Bool
+oneFunPred x = x == 1
+
+{-@ type OneTyAlias a = {v:a | oneFunPred v} @-}
+
+{-@ data One = One { field :: OneTyAlias Int }  @-}
+data One = One Int


### PR DESCRIPTION
Opening this as a draft so we can discuss the changes further.

@ranjitjhala This simple fix adds the `gsTySigs` to the `GhcSpecEnv`, making the code as part of #1761 pass. This works because `T1761.oneFunPred` is a signature of the current file, but when we check the sorts, we were not including this signature in the env. The `inline` was a red herring: adding or removing `inline` as part of that example doesn't seem to change things.

What is interesting, is that these changes causes exactly **one** regression, in the `MissingReflect.hs` test. Now, I find the regression and more so the test fairly strange:

```haskell
{-@ LIQUID "--reflection"                     @-}
{-@ LIQUID "--ple"                                @-}

import Language.Haskell.Liquid.ProofCombinators 

-- | This fails with an error as `foo` is unbound sans the `reflect` annotation. 

{- reflect foo -}

{-@ foo  :: Nat ->  xs: [Nat] -> Nat -> Bool / [len xs ]@-}
foo :: Int ->  [Int] -> Int -> Bool
foo lo [] hi     = (lo<=hi)
foo lo (x:xs) hi = (lo<=hi) && foo lo xs x

{-@ empty_foo :: lo:Nat -> hi:{Nat | lo <= hi } -> {foo lo [] hi} @-}
empty_foo :: Int -> Int -> Proof
empty_foo lo hi = (foo lo [] hi) ==. (lo <= hi) ==.True  *** QED

main :: IO ()
main = pure ()
```

What is the purpose of this test, and why adding `--reflection` silently makes everything work, but this commit breaks things? 


I think that in principle I can circumvent this and add some bandaid to actually make `MissingReflect.hs` pass again, but I couldn't help but wonder if this test is actually encouraging behaviour _we want_: if we are not reflecting `foo`, like in the example, what do we expect to happen?