### PR TITLE
Use a qualified RTEnv during expansion

### DIFF
--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -176,12 +176,12 @@ ghcSpecEnv sp = fromListSEnv binds
   where
     emb       = gsTcEmbeds (_gsName sp)
     binds     = concat 
-                 [ [(x,        rSort t) | (x, Loc _ _ t) <- gsMeas     (_gsData sp)]
-                 , [(symbol v, rSort t) | (v, Loc _ _ t) <- gsCtors    (_gsData sp)]
-                 , [(symbol v, vSort v) | v              <- gsReflects (_gsRefl sp)]
-                 , [(x,        vSort v) | (x, v)         <- gsFreeSyms (_gsName sp), Ghc.isConLikeId v ]
-                 , [(x, RR s mempty)    | (x, s)         <- wiredSortedSyms       ]
-                 , [(x, RR s mempty)    | (x, s)         <- _gsImps sp       ]
+                 [ [(x,        rSort t) | (x, Loc _ _ t)  <- gsMeas     (_gsData sp)]
+                 , [(symbol v, rSort t) | (v, Loc _ _ t)  <- gsCtors    (_gsData sp)]
+                 , [(symbol v, vSort v) | v               <- gsReflects (_gsRefl sp)]
+                 , [(x,        vSort v) | (x, v)          <- gsFreeSyms (_gsName sp), Ghc.isConLikeId v ]
+                 , [(x, RR s mempty)    | (x, s)          <- wiredSortedSyms       ]
+                 , [(x, RR s mempty)    | (x, s)          <- _gsImps sp       ]
                  ]
     vSort     = Bare.varSortedReft emb
     rSort     = rTypeSortedReft    emb

--- a/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -398,6 +398,14 @@ qualifyBareSpec env name l bs sp = sp
   } 
   where f      = qualify env name l bs 
 
+instance Qualify a => Qualify (RTAlias F.Symbol a) where
+  qualify env name l bs rtAlias
+   = rtAlias { rtName  = qualify env name l bs (rtName rtAlias)
+             , rtTArgs = qualify env name l bs (rtTArgs rtAlias)
+             , rtVArgs = qualify env name l bs (rtVArgs rtAlias)
+             , rtBody  = qualify env name l bs (rtBody rtAlias)
+             }
+
 instance Qualify F.Expr where 
   qualify = substEnv 
 

--- a/tests/pos/T1761.hs
+++ b/tests/pos/T1761.hs
@@ -1,0 +1,11 @@
+
+module T1761 where
+
+{-@ inline oneFunPred @-}
+oneFunPred :: Int -> Bool
+oneFunPred x = x == 1
+
+{-@ type OneTyAlias a = {v:a | oneFunPred v} @-}
+
+{-@ data One = One { field :: OneTyAlias Int }  @-}
+data One = One Int


### PR DESCRIPTION
_Actually_ fixes #1761.

The problem was subtle. Let's consider again the test case for #1761:

```haskell
module T1761 where

{-@ inline oneFunPred @-}
oneFunPred :: Int -> Bool
oneFunPred x = x == 1

{-@ type OneTyAlias a = {v:a | oneFunPred v} @-}

{-@ data One = One { field :: OneTyAlias Int }  @-}
data One = One Int
```

What we want here is for LH to first _qualify_ everything and turn `type OneTyAlias a = {v:a | oneFunPred v} ` into `type OneTyAlias a = {v:a | T1761.oneFunPred v}` and then _expand_ everything in a way that `OneTyAlias` is expanded into `{v:a | T1761.oneFunPred v}` and then `T1761.oneFunPred` expanded into `v == 1`, yielding `{v:a | v == 1}`.

However, this wasn't working. Let's remember that a `BareRTEnv` is defined as:

```haskell
type BareRTEnv   = RTEnv Symbol BareType 
data RTEnv tv t = RTE
  { typeAliases :: M.HashMap Symbol (F.Located (RTAlias tv t))
  , exprAliases :: M.HashMap Symbol (F.Located (RTAlias Symbol Expr))
  }
```

The culprit was that the `Symbol` used as keys in the `HashMap` are always qualified, but the inner values were not. This means that when LH tried to expand `OneTyAlias`, it would look into `typeAliases`, find a match and replace this with
`{v:a | oneFunPred v}`. But this is wrong, because now when we try to expand `oneFunPred` by looking into the `exprAliases` `HashMap`, the lookup for `oneFunPred` will fail, because everything is keyed over a qualified `Symbol` (so we would have an entry in the map for `T1761.oneFunPred` but no entry for `oneFunPred`)!

The fix was to call `qualify` over the `(F.Located (RTAlias tv t))` of the `typeAliases` map, producing a new `RTEnv` to be passed to the call to `expand`.