### PR TITLE
Add a "Hacking on the GHC Plugin" section to the documentation and add some FAQs

### DIFF
--- a/docs/mkDocs/docs/develop.md
+++ b/docs/mkDocs/docs/develop.md
@@ -2,6 +2,43 @@
 
 Here are some notes that are generally useful for people *developing* LH itself.
 
+## Hacking on the GHC Plugin
+
+For a more thorough walkthrough of the plugin architecture, [start here](develop/plugin_architecture.md).
+
+## The GHC.API module
+
+In order to allow LH to work with multiple GHC versions, we need a way to abstract over all the breaking
+changes of the `ghc` library, that changes with every GHC release. This is accomplished by the
+[GHC.API][] module. The idea is that **rather than importing multiple `ghc` modules, LH developers must
+import this single module in order to write future-proof code**. This is especially important for versions
+of the compiler greater than 9, where the module hierarchy changed substantially, and using the [GHC.API][]
+makes it easier to support new versions of GHC when they are released.
+
+### Fragile import strategy
+
+```haskell
+import Predicate
+import TyCoRep
+
+...
+
+-- This will break if 'isEqPrimPred' is (re)moved or the import hierarchy changes.
+foo :: Type -> Bool
+foo = isEqPrimPred
+```
+
+### Recommended import strategy
+
+```haskell
+import qualified Language.Haskell.Liquid.GHC.API as GHC
+
+...
+
+foo :: GHC.Type -> Bool
+foo = GHC.isEqPrimPred -- OK.
+```
+
 ## Fast (re)compilation
 
 When working on the `liquidhaskell` library, usually all we want is to make changes and quickly recompile
@@ -173,3 +210,4 @@ Bash script. The script doesn't accept any argument and it tries to determine th
 to upload by scanning the `$PWD` for packages named appropriately. It will ask the user for confirmation
 before proceeding, and `stack upload` will be used under the hood.
 
+[GHC.API]: https://github.com/ucsd-progsys/liquidhaskell/blob/develop/src/Language/Haskell/Liquid/GHC/API.hs

--- a/docs/mkDocs/docs/develop/plugin_architecture.md
+++ b/docs/mkDocs/docs/develop/plugin_architecture.md
@@ -1,0 +1,122 @@
+# Introduction
+
+This code commentary describes the current architecture for the GHC [Plugin][] that enables LiquidHaskell
+to check files as part of the normal compilation process. For the sake of this commentary, we refer to
+the code provided as part of the `release/0.8.10.2` branch, commit `9a2f8284c5fe5b18ed0410e842acd3329a629a6b`.
+
+## GHC.Interface vs GHC.Plugin
+
+The module [GHC.Plugin][] is the main entrypoint for all the plugin functionalities. Whenever possible, this
+module is reusing common functionalities from the [GHC.Interface][], which is the original module used to
+interface LH with the old executable. Generally speaking, the [GHC.Interface][] module is considered "legacy"
+and it's rarely what one wants to modify. It will probably be removed once the old executable stops being
+supported, with the functions now in use by the [GHC.Plugin][] being moved into the latter.
+
+## The GhcMonadLike shim
+
+Part of the tension in designing the plugin was trying to reuse as much code as possible from the original
+[GHC.Interface][] shipped with LiquidHaskell. Unfortunately this was not possible from the get-go due to the
+fact most of the functions provided by that module were requiring a [GhcMonad][] constraint or usually
+living in the [Ghc monad][], which is also the only concrete type which derives an instance for [GhcMonad][].
+While we could have run each and every function with `runGhc`, this was not very satisfactory due to the
+fact running the `Ghc` monad is fairly expensive as it requires a bit of extra state in order to run it.
+
+However, most of the functions used by the [Ghc.Interface][] didn't require anything specific from the
+underlying [Ghc monad][] if not access to the [HscEnv][] and the ability to grab the [DynFlags][], as well
+as doing `IO`. Therefore, the [GhcMonadLike][] shim was born with the intent of replicating some of the
+functions used by the [GHC.Interface][] but crucially making those polymorphic in a generic [GhcMonadLike][]
+for which we can give instances for `CoreM`, `TcM` etc. We can do this because we do not require the extra
+`ExceptionMonad` constraint and we do not require to implement `setHscEnv`.
+
+This allowed us to change ever so slightly the functions provided by the [GHC.Interface][], expose them and
+reuse them in the [Plugin][] module.
+
+## Plugin architecture
+
+Broadly speaking, the Plugin is organised this way: In the [typechecking phase][], we typecheck and desugar
+each module via the GHC API in order to extract the unoptimised [core binds][] that are needed by
+LH to work correctly. This is due to a tension in the design space; from one side LH needs access to the
+"raw" core binds (binds where primitives types are not unboxed in the presence of a PRAGMA annotation,
+for example) but yet the user can specify any arbitrary optimisation settings during compilation and we do
+not want to betray the principle of least expectation by silently compiling the code with `-O0`. Practically
+speaking, this introduces some overhead and is far from ideal, but for now it allows us to iterate quickly.
+This phase is also responsible for:
+
+* Extracting the [BareSpec][]s associated to any of the dependent modules;
+* Producing the [LiftedSpec][] for the currently-compiled module;
+* Storing the [LiftedSpec][] into an interface annotation for later retrieval;
+* Checking and verifying the module using LH's existing API.
+
+The reason why we do everything in the [typechecking phase][] is also to allow integrations with tools like
+[ghcide][]. There are a number of differences between the plugin and the operations performed as part of the
+[GHC.Interface][], which we are going to outline in the next section.
+
+## Differences with the GHC.Interface
+
+- The [GHC.Interface][] pre-processes the input files and calls into [configureGhcTargets][] trying to
+  build a dependency graph by discovering dependencies the target files might require. Then, from this
+  list any file in the include directory is filtered out, as well as any module which has
+  a "fresh" `.bspec` file on disk, to save time during checking. In the [GHC.Plugin][] module though
+  we don't do this and for us, essentially, each input file is considered a target, where we exploit the
+  fact GHC will skip recompilation if unnecessary. This also implies that while the [GHC.Interface][] calls
+  into [processTargetModule][] only for target files, the [GHC.Plugin][] has a single, flat function simply
+  called [processModule][] that essentially does the same as `GHC.Interface.processModule` and
+  `GHC.Interface.processTargetModule` fused together.
+
+- While the [GHC.Interface][] sometimes "assembles" a [BareSpec][] by mappending the `commSpec` (i.e. comment spec)
+  with the [LiftedSpec][] fetched from disk, if any, the Plugin doesn't do this but rather piggybacks on the
+  [SpecFinder][] (described later) to fetch dependencies' specs.
+
+- There is a difference in how we process LIQUID pragmas. In particular, for the executable they seems to
+  be accumulated "in bulk" i.e. if we are refining a *target* module `A` that depends on `B`, `B` seems to
+  inherit whichever flags we were using in the *target* module `A`. Conversely, the source plugin is "stateless"
+  when it comes to LIQUID options, i.e. it doesn't have memory of _past_ options, what it counts when compiling
+  a module `B` is the _global_ options and _any_ option this module defines. The analogy is exactly the
+  same as with GHC language extensions, they have either global scope (i.e. `default-extensions` in the
+  cabal manifest) or local scope (i.e. `{-# LANGUAGE ... #-}`).
+
+## Finding specs for existing modules
+
+This is all done by a specialised module called the [SpecFinder][]. The main exported function is
+[findRelevantSpecs][] which, given a list of `Module`s, tries to retrieve the `LiftedSpec`s associated with
+them. Typically this is done by looking into the interface files of the input modules, trying to deserialise
+any `LiftedSpec` from the interface file's annotations.
+
+# FAQs
+
+## Is it possible that the behaviour of the old executable and the new / the plugin differ?
+
+It might happen, yes, but the surface area is fairly small. Both modules work by producing a [TargetSrc][]
+that is passed to the internal LH API, which is shared by _both_ modules. Therefore, any difference in 
+behaviour has to be researched in the code path that produces such [TargetSrc][]. For the [GHC.Plugin][] this
+happens in the `makeTargetSrc`, whereas for the [GHC.Interface][] this happens inside the [makeGhcSrc][] function.
+
+## Why is the GHC.Interface using slightly different types than the GHC.Plugin module?
+
+Mostly for backward-compatibility and for historical reasons. Types like [BareSpec][] used to be type alias
+rather than `newtype`s, and things were slightly renamed to reflect better purpose when the support for the
+plugin was added. While doing so we also added a compat layer in the form of some `optics` that can be used
+to map back and forth (sometimes in a partial way) between old and new data structures. When in doubt,
+**consider the GHC.Plugin as the single source of truth, and prefer whichever data structure the latter is
+using**.
+
+
+[Plugin]:              https://github.com/ucsd-progsys/liquidhaskell/blob/9a2f8284c5fe5b18ed0410e842acd3329a629a6b/src/Language/Haskell/Liquid/GHC/Plugin.hs
+[GHC.Plugin]:          https://github.com/ucsd-progsys/liquidhaskell/blob/9a2f8284c5fe5b18ed0410e842acd3329a629a6b/src/Language/Haskell/Liquid/GHC/Plugin.hs
+[GHC.Interface]:       https://github.com/ucsd-progsys/liquidhaskell/blob/9a2f8284c5fe5b18ed0410e842acd3329a629a6b/src/Language/Haskell/Liquid/GHC/Interface.hs
+[SpecFinder]:          https://github.com/ucsd-progsys/liquidhaskell/blob/9a2f8284c5fe5b18ed0410e842acd3329a629a6b/src/Language/Haskell/Liquid/GHC/Plugin/SpecFinder.hs
+[BareSpec]:            https://github.com/ucsd-progsys/liquidhaskell/blob/9a2f8284c5fe5b18ed0410e842acd3329a629a6b/src/Language/Haskell/Liquid/Types/Specs.hs#L301
+[LiftedSpec]:          https://github.com/ucsd-progsys/liquidhaskell/blob/9a2f8284c5fe5b18ed0410e842acd3329a629a6b/src/Language/Haskell/Liquid/Types/Specs.hs#L476
+[TargetSrc]:           https://github.com/ucsd-progsys/liquidhaskell/blob/9a2f8284c5fe5b18ed0410e842acd3329a629a6b/src/Language/Haskell/Liquid/Types/Specs.hs#L160
+[Ghc monad]:           https://hackage.haskell.org/package/ghc-8.10.1/docs/GHC.html#t:Ghc
+[HscEnv]:              https://hackage.haskell.org/package/ghc-8.10.1/docs/GHC.html#t:HscEnv
+[DynFlags]:            https://hackage.haskell.org/package/ghc-8.10.1/docs/GHC.html#t:DynFlags
+[GhcMonad]:            https://hackage.haskell.org/package/ghc-8.10.1/docs/GHC.html#t:GhcMonad
+[GhcMonadLike]:        https://github.com/ucsd-progsys/liquidhaskell/blob/9a2f8284c5fe5b18ed0410e842acd3329a629a6b/src/Language/Haskell/Liquid/GHC/GhcMonadLike.hs
+[typechecking phase]:  https://github.com/ucsd-progsys/liquidhaskell/blob/9a2f8284c5fe5b18ed0410e842acd3329a629a6b/src/Language/Haskell/Liquid/GHC/Plugin.hs#L196-L224
+[ghcide]:              https://github.com/haskell/ghcide
+[findRelevantSpecs]:   https://github.com/ucsd-progsys/liquidhaskell/blob/9a2f8284c5fe5b18ed0410e842acd3329a629a6b/src/Language/Haskell/Liquid/GHC/Plugin/SpecFinder.hs#L61
+[core binds]:          https://hackage.haskell.org/package/ghc-8.10.1/docs/CoreSyn.html#t:CoreBind
+[configureGhcTargets]: https://github.com/ucsd-progsys/liquidhaskell/blob/9a2f8284c5fe5b18ed0410e842acd3329a629a6b/src/Language/Haskell/Liquid/GHC/Interface.hs#L268
+[processTargetModule]: https://github.com/ucsd-progsys/liquidhaskell/blob/9a2f8284c5fe5b18ed0410e842acd3329a629a6b/src/Language/Haskell/Liquid/GHC/Interface.hs#L468
+[processModule]:       https://github.com/ucsd-progsys/liquidhaskell/blob/9a2f8284c5fe5b18ed0410e842acd3329a629a6b/src/Language/Haskell/Liquid/GHC/Plugin.hs#L393

--- a/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -137,16 +137,16 @@ customDynFlags opts dflags = do
   cfg <- liftIO $ LH.getOpts opts
   writeIORef cfgRef cfg
   configureDynFlags dflags
-
-configureDynFlags :: DynFlags -> IO DynFlags
-configureDynFlags df =
-  pure $ df `gopt_set` Opt_ImplicitImportQualified
-            `gopt_set` Opt_PIC
-            `gopt_set` Opt_DeferTypedHoles
-            `gopt_set` Opt_KeepRawTokenStream
-            `xopt_set` MagicHash
-            `xopt_set` DeriveGeneric
-            `xopt_set` StandaloneDeriving
+  where
+    configureDynFlags :: DynFlags -> IO DynFlags
+    configureDynFlags df =
+      pure $ df `gopt_set` Opt_ImplicitImportQualified
+                `gopt_set` Opt_PIC
+                `gopt_set` Opt_DeferTypedHoles
+                `gopt_set` Opt_KeepRawTokenStream
+                `xopt_set` MagicHash
+                `xopt_set` DeriveGeneric
+                `xopt_set` StandaloneDeriving
 
 --------------------------------------------------------------------------------
 -- | \"Unoptimising\" things ----------------------------------------------------

--- a/src/Language/Haskell/Liquid/GHC/Plugin/SpecFinder.hs
+++ b/src/Language/Haskell/Liquid/GHC/Plugin/SpecFinder.hs
@@ -58,9 +58,9 @@ data SearchLocation =
   -- ^ The spec was loaded from disk (e.g. 'Prelude.spec' or similar)
   deriving Show
 
--- | Load any relevant spec in the input 'SpecEnv', by updating it. The update will happen only if necessary,
--- i.e. if the spec is not already present.
-findRelevantSpecs :: forall m. GhcMonadLike m 
+-- | Load any relevant spec for the input list of 'Module's, by querying both the 'ExternalPackageState'
+-- and the 'HomePackageTable'.
+findRelevantSpecs :: forall m. GhcMonadLike m
                   => ExternalPackageState
                   -> HomePackageTable
                   -> [Module]


### PR DESCRIPTION
This PR adds a "Hacking on the GHC Plugin" section to the docs which should hopefully help orient LH hackers in case changes to the GHC Plugin are required. I have also done a sanity check on some code comments and I have slightly upgraded them in case they bit-rotted.

Last but not least I have added a bunch of FAQs in the docs in the style of "How do I do X?" which might come in handy in the future. For example I describe the general approach to take in case supporting a new GHC version is required, or how to run the testsuite targeting a different version of GHC.

I hope this is helpful! 😉 