### PR TITLE
Add deprecation warning for getIncludeDir

### DIFF
--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -23,6 +23,12 @@ extra-source-files: CHANGES.md
                     tests/pos/*.hquals
                     tests/ffi-include/foo.c
                     tests/ffi-include/foo.h
+
+-- The legacy executable requires a set of hardcoded specifications
+-- provided by the files in the 'include' directory. This
+-- directory is now deprecated and you should never edit it, unless you
+-- are specifically fixing a bug in the legacy executable.
+-- Remove these lines below once we stop supporting the legacy plugin.
 data-files:         include/*.hquals
                     include/*.hs
                     include/*.spec
@@ -46,11 +52,11 @@ data-files:         include/*.hquals
                     include/Language/Haskell/Liquid/*.pred
                     include/System/*.spec
                     include/710/Data/*.spec
-                    syntax/liquid.css
-                    -- Remove the lines above once we switch to the source plugin.
                     include/*.hs
                     include/Language/Haskell/Liquid/*.hs
                     include/Language/Haskell/Liquid/*.pred
+
+                    syntax/liquid.css
 
                     -- Needed for the mirror-modules helper
                     mirror-modules/templates/MirrorModule.mustache

--- a/src/Language/Haskell/Liquid/Misc.hs
+++ b/src/Language/Haskell/Liquid/Misc.hs
@@ -138,7 +138,8 @@ isIncludeFile incDir src = -- do
   (incDir `L.isPrefixOf` src)
 
 getIncludeDir :: IO FilePath
-getIncludeDir      = dropFileName <$> getDataFileName ("include" </> "Prelude.spec")
+getIncludeDir = dropFileName <$> getDataFileName ("include" </> "Prelude.spec")
+{-# DEPRECATED getIncludeDir "getIncludeDir is deprecated. The hardcoded include folder will be removed in the future." #-}
 
 getCssPath :: IO FilePath
 getCssPath         = getDataFileName $ "syntax" </> "liquid.css"


### PR DESCRIPTION
Fixes #1785 .


~~This slightly controversial PR renames the `include` directory into `legacy-include` to reflect the fact this is something that is going to be removed in the future. Similarly, the `getIncludeDir` has been renamed into `getLegacyIncludeDir` and a `DEPRECATION` pragma has been added.~~

After today's conversation with @ranjitjhala and @nikivazou I have de-scoped this PR to just add the `DEPRECATED` pragma to `getIncludeDir`, without the invasive renaming.