### PR TITLE
Improve rewriting functionality

### DIFF
--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -411,6 +411,14 @@ config = cmdArgsMode $ Config {
         &= help (   "Enable the rewrite divergence checker. " 
                  ++ "Can speed up verification if rewriting terminates, but can also cause divergence."
                 )
+  ,
+    onlyRWEqs
+    = def
+        &= name "only-rw-eqs"
+        &= help (   "Only perform rewrites of the form a = b. "
+                 ++ "More general rewrites of the form a -> true are not performed. "
+                 ++ "This can reduce verification time."
+                )
   } &= program "liquid"
     &= help    "Refinement Types for Haskell"
     &= summary copyright
@@ -654,6 +662,7 @@ defConfig = Config
   , maxArgsDepth             = 1
   , maxRWOrderingConstraints = Nothing
   , rwTerminationCheck       = False
+  , onlyRWEqs                = False
   }
 
 

--- a/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/src/Language/Haskell/Liquid/UX/Config.hs
@@ -97,6 +97,7 @@ data Config = Config
   , maxArgsDepth             :: Int
   , maxRWOrderingConstraints :: Maybe Int
   , rwTerminationCheck       :: Bool
+  , onlyRWEqs                :: Bool
   } deriving (Generic, Data, Typeable, Show, Eq)
 
 allowPLE :: Config -> Bool

--- a/tests/errors/ReWrite6.hs
+++ b/tests/errors/ReWrite6.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--only-rw-eqs" @-}
 module ReWrite6 where
 
 -- Reject non equalities

--- a/tests/errors/ReWrite7.hs
+++ b/tests/errors/ReWrite7.hs
@@ -1,4 +1,5 @@
 module ReWrite7 where
+{-@ LIQUID "--only-rw-eqs" @-}
 {-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--ple" @-}
 

--- a/tests/errors/ReWrite8.hs
+++ b/tests/errors/ReWrite8.hs
@@ -1,5 +1,6 @@
 module ReWrite8 where
 
+{-@ LIQUID "--only-rw-eqs" @-}
 {-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--ple" @-}
 {-@ infix ++ @-}

--- a/tests/pos/ReWrite.hs
+++ b/tests/pos/ReWrite.hs
@@ -1,5 +1,6 @@
 module ReWrite where 
 
+{-@ LIQUID "--rw-termination-check" @-}
 {-@ LIQUID "--max-rw-ordering-constraints=1" @-}
 {-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--ple" @-}

--- a/tests/pos/ReWrite10.hs
+++ b/tests/pos/ReWrite10.hs
@@ -3,6 +3,7 @@ module ReWrite10 where
 {-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--ple" @-}
 {-@ LIQUID "--rw-termination-check" @-}
+{-@ LIQUID "--max-rw-ordering-constraints=0" @-}
 {-@ infix ++ @-}
 
 import Prelude hiding (length, (++))

--- a/tests/pos/ReWrite5.hs
+++ b/tests/pos/ReWrite5.hs
@@ -2,6 +2,8 @@
 module ReWrite5 where
 
 {-@ LIQUID "--max-rw-ordering-constraints=0" @-}
+{-@ LIQUID "--rw-termination-check" @-}
+{-@ LIQUID "--only-rw-eqs" @-}
 {-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--ple" @-}
 {-@ infix ++ @-}

--- a/tests/pos/ReWrite6.hs
+++ b/tests/pos/ReWrite6.hs
@@ -2,6 +2,7 @@
 module ReWrite6 where
 
 {-@ LIQUID "--max-rw-ordering-constraints=0" @-}
+{-@ LIQUID "--rw-termination-check" @-}
 {-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--ple" @-}
 {-@ infix ++ @-}

--- a/tests/pos/ReWrite7.hs
+++ b/tests/pos/ReWrite7.hs
@@ -6,6 +6,7 @@
 {-@ LIQUID "--ple" @-}
 {-@ LIQUID "--prune-unsorted" @-}
 {-@ LIQUID "--max-rw-ordering-constraints=0" @-}
+{-@ LIQUID "--rw-termination-check" @-}
 
 
 module ReWrite7 where


### PR DESCRIPTION
Some improvements to rewriting:

- Refinements of the form `t1 <=> t2` can now be turned into rewrite rules (previously only `t1 = t2` was accepted)
- For functions of the form `t1: a -> t2: b -> { r }`, we now generate the rewrite rule `r -> true` (this can be disabled with the flag `--only-rw-eqs`)
- We now support the (slightly strange) rewrite rule `(t1 == t2) -> true`. To accomplish this, `t1 == t2` is now considered a redex in PLE. Will this break anything?