### PR TITLE
Improve totality error message

### DIFF
--- a/include/PatErr.spec
+++ b/include/PatErr.spec
@@ -1,7 +1,13 @@
 module spec Prelude where
 
-assume Control.Exception.Base.patError :: {v:GHC.Prim.Addr# | 5 <4 } -> a
-assume Control.Exception.Base.irrefutPatError :: {v:GHC.Prim.Addr# | 5 < 4 } -> a
-assume Control.Exception.Base.recSelError :: {v:GHC.Prim.Addr# | 5 < 4 } -> a
-assume Control.Exception.Base.nonExhaustiveGuardsError :: {v:GHC.Prim.Addr# | 5 < 4 } -> a
-assume Control.Exception.Base.noMethodBindingError :: {v:GHC.Prim.Addr# | 5 < 4 } -> a
+
+measure totalityError :: a -> Bool
+
+
+assume Control.Exception.Base.patError :: {v:GHC.Prim.Addr# | totalityError "Pattern match(es) are non-exhaustive"} -> a
+
+assume Control.Exception.Base.recSelError :: {v:GHC.Prim.Addr# | totalityError "Pattern match(es) are non-exhaustive"} -> a
+
+assume Control.Exception.Base.nonExhaustiveGuardsError :: {v:GHC.Prim.Addr# | totalityError "Pattern match(es) are non-exhaustive"} -> a
+
+assume Control.Exception.Base.noMethodBindingError :: {v:GHC.Prim.Addr# | totalityError "Pattern match(es) are non-exhaustive"} -> a

--- a/liquid-base/src/Liquid/Prelude/Totality.hs
+++ b/liquid-base/src/Liquid/Prelude/Totality.hs
@@ -1,3 +1,8 @@
-module Liquid.Prelude.Totality where
+module Liquid.Prelude.Totality (module Exports) where
 
-import "base" Control.Exception.Base
+import GHC.Types
+import "base" Control.Exception.Base as Exports
+
+
+totalityError :: a -> Bool
+totalityError _ = False

--- a/liquid-base/src/Liquid/Prelude/Totality.spec
+++ b/liquid-base/src/Liquid/Prelude/Totality.spec
@@ -1,6 +1,13 @@
 module spec Liquid.Prelude.Totality where
 
-assume Control.Exception.Base.patError :: {v:GHC.Prim.Addr# | 5 <4 } -> a
-assume Control.Exception.Base.recSelError :: {v:GHC.Prim.Addr# | 5 < 4 } -> a
-assume Control.Exception.Base.nonExhaustiveGuardsError :: {v:GHC.Prim.Addr# | 5 < 4 } -> a
-assume Control.Exception.Base.noMethodBindingError :: {v:GHC.Prim.Addr# | 5 < 4 } -> a
+
+measure totalityError :: a -> Bool
+
+
+assume Control.Exception.Base.patError :: {v:GHC.Prim.Addr# | totalityError "Pattern match(es) are non-exhaustive"} -> a
+
+assume Control.Exception.Base.recSelError :: {v:GHC.Prim.Addr# | totalityError "Pattern match(es) are non-exhaustive"} -> a
+
+assume Control.Exception.Base.nonExhaustiveGuardsError :: {v:GHC.Prim.Addr# | totalityError "Pattern match(es) are non-exhaustive"} -> a
+
+assume Control.Exception.Base.noMethodBindingError :: {v:GHC.Prim.Addr# | totalityError "Pattern match(es) are non-exhaustive"} -> a


### PR DESCRIPTION
Change the false proposition `5 < 4` on totality errors to a more descriptive false proposition.

To do that, we create a measure `totalityError` that always returns `false` and passes a descriptive error message to it. The current message is _"Pattern match(es) are non-exhaustive"_, which is the warning that GHC gives in case `-Wincomplete-patterns` is passed.

I've tried to create the measure directly in the spec with

    measure totalityError :: a -> Bool
        totalityError _ = false

But it doesn't work. I'm not sure why, but to create this measure, I've created the `totalityError` function on ` liquid-base/src/Liquid/Prelude/Totality.hs`. I'm not sure if this is the best approach. In `include/PatErr.spec` it was not necessary to create the function and I don't know why.

Another important point is that four functions are used to handle pattern-match erros: `Control.Exception.Base.patError`, `Control.Exception.Base.recSelError`, `Control.Exception.Base.nonExhaustiveGuardsError`, and `Control.Exception.Base.noMethodBindingError`. I'm not sure when this functions are used. In all my tests (that can be found [here](https://pastebin.com/cJmecjnz)) only `patError` was called. Since I don't know how this functions are used, maybe the current error message shouldn't be used in all of them.

I've tested some cases with both, plugin and executable, and it seems to work as expected.