### PR TITLE
Fix diff mode and add ignore-module

### DIFF
--- a/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -62,6 +62,7 @@ module Language.Haskell.Liquid.Types.Specs (
   , bareSpecIso
   , liftedSpecGetter
   , unsafeFromLiftedSpec
+  , emptyLiftedSpec
   ) where
 
 import           Optics
@@ -529,6 +530,37 @@ data LiftedSpec = LiftedSpec
     deriving Hashable via Generically LiftedSpec 
     deriving Binary   via Generically LiftedSpec 
 
+emptyLiftedSpec :: LiftedSpec
+emptyLiftedSpec = LiftedSpec
+  { liftedMeasures = mempty 
+  , liftedImpSigs  = mempty
+  , liftedExpSigs  = mempty
+  , liftedAsmSigs  = mempty
+  , liftedSigs     = mempty
+  , liftedInvariants = mempty
+  , liftedIaliases   = mempty
+  , liftedImports    = mempty
+  , liftedDataDecls  = mempty
+  , liftedNewtyDecls = mempty
+  , liftedAliases    = mempty
+  , liftedEaliases   = mempty
+  , liftedEmbeds     = mempty
+  , liftedQualifiers = mempty
+  , liftedDecr       = mempty
+  , liftedLvars      = mempty
+  , liftedAutois     = mempty
+  , liftedAutosize   = mempty
+  , liftedCmeasures  = mempty
+  , liftedImeasures  = mempty
+  , liftedClasses    = mempty
+  , liftedClaws      = mempty 
+  , liftedRinstance  = mempty
+  , liftedIlaws      = mempty
+  , liftedDvariance  = mempty
+  , liftedBounds     = mempty 
+  , liftedDefs       = mempty
+  , liftedAxeqs      = mempty
+  }
 
 -- $trackingDeps
 

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -411,6 +411,12 @@ config = cmdArgsMode $ Config {
         &= help (   "Enable the rewrite divergence checker. " 
                  ++ "Can speed up verification if rewriting terminates, but can also cause divergence."
                 )
+  , 
+    ignoreModule
+    = def
+        &= name "ignore-module"
+        &= help "Completely skip this module, don't even compile any specifications in it."
+ 
   } &= program "liquid"
     &= help    "Refinement Types for Haskell"
     &= summary copyright
@@ -654,6 +660,7 @@ defConfig = Config
   , maxArgsDepth             = 1
   , maxRWOrderingConstraints = Nothing
   , rwTerminationCheck       = False
+  , ignoreModule            = False
   }
 
 

--- a/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/src/Language/Haskell/Liquid/UX/Config.hs
@@ -97,6 +97,7 @@ data Config = Config
   , maxArgsDepth             :: Int
   , maxRWOrderingConstraints :: Maybe Int
   , rwTerminationCheck       :: Bool
+  , ignoreModule             :: Bool       -- ^ Skip this module entirely (don't even compile any specs in it)
   } deriving (Generic, Data, Typeable, Show, Eq)
 
 allowPLE :: Config -> Bool


### PR DESCRIPTION
This PR does two independent things.

1. Fixes a bug in `diff` mode where in `bytestring` we were getting monstrously large spans that were suppressing errors in parts of the code that were _not_ actually checked in diff mode. This causes LH to magically think a module is safe when it is not! (Now the span for each top-level binder is limited to end before the _next_ top-level binder.)

2. Adds support for a `--ignore-module` flag, where the plugin completely skips a module. Turns out that for some mysterious reason, sometimes `--compile-spec` hangs forever or OOMs even on innocuous modules with no specs 
(e.g. in the `bibifi` example [here](https://github.com/nilehmann/bibifi-code) -- in the `Foundation.App` module, perhaps due to the template-haskell? who knows.  This issue needs further investigation on its own.

