### PR TITLE
Add "missing field in record construction" error

### DIFF
--- a/include/PatErr.spec
+++ b/include/PatErr.spec
@@ -11,3 +11,5 @@ assume Control.Exception.Base.recSelError :: {v:GHC.Prim.Addr# | totalityError "
 assume Control.Exception.Base.nonExhaustiveGuardsError :: {v:GHC.Prim.Addr# | totalityError "Pattern match(es) are non-exhaustive"} -> a
 
 assume Control.Exception.Base.noMethodBindingError :: {v:GHC.Prim.Addr# | totalityError "Pattern match(es) are non-exhaustive"} -> a
+
+assume Control.Exception.Base.recConError :: {v:GHC.Prim.Addr# | totalityError "Missing field in record construction"} -> a

--- a/liquid-base/src/Liquid/Prelude/Totality.spec
+++ b/liquid-base/src/Liquid/Prelude/Totality.spec
@@ -11,3 +11,5 @@ assume Control.Exception.Base.recSelError :: {v:GHC.Prim.Addr# | totalityError "
 assume Control.Exception.Base.nonExhaustiveGuardsError :: {v:GHC.Prim.Addr# | totalityError "Pattern match(es) are non-exhaustive"} -> a
 
 assume Control.Exception.Base.noMethodBindingError :: {v:GHC.Prim.Addr# | totalityError "Pattern match(es) are non-exhaustive"} -> a
+
+assume Control.Exception.Base.recConError :: {v:GHC.Prim.Addr# | totalityError "Missing field in record construction"} -> a

--- a/tests/terminate/neg/total02.hs
+++ b/tests/terminate/neg/total02.hs
@@ -1,0 +1,7 @@
+-- test recConError
+module Total2 where
+
+data Foo = Foo {a :: Int, b :: Int}
+
+foo :: Foo
+foo = Foo {a = 1}


### PR DESCRIPTION
This commit add `recConError` in the list of totality errors. With this change, records with missing fields will not be checked by LH. For example:

    data Foo = Foo {a :: Int, b :: Int}

    foo :: Foo
    foo = Foo {a = 1}

This code will give the error "_Missing field in record construction_"