### PR TITLE
Improve null type

### DIFF
--- a/include/Data/Foldable.spec
+++ b/include/Data/Foldable.spec
@@ -3,3 +3,4 @@ module spec Data.Foldable where
 import GHC.Base
 
 length :: Data.Foldable.Foldable f => forall a. xs:f a -> {v:Nat | v = len xs}
+null   :: Data.Foldable.Foldable f => v:(f a) -> {b:Bool | (b <=> len v = 0) && (not b <=> len v > 0)}

--- a/include/Data/Foldable.spec
+++ b/include/Data/Foldable.spec
@@ -3,4 +3,4 @@ module spec Data.Foldable where
 import GHC.Base
 
 length :: Data.Foldable.Foldable f => forall a. xs:f a -> {v:Nat | v = len xs}
-null   :: Data.Foldable.Foldable f => v:(f a) -> {b:Bool | (b <=> len v = 0) && (not b <=> len v > 0)}
+null :: v:_ -> {b:Bool | (b <=> len v = 0) && (not b <=> len v > 0)}

--- a/liquid-base/src/Data/Foldable.spec
+++ b/liquid-base/src/Data/Foldable.spec
@@ -3,3 +3,4 @@ module spec Data.Foldable where
 import GHC.Base
 
 length :: Data.Foldable.Foldable f => forall a. xs:f a -> {v:Nat | v = len xs}
+null   :: Data.Foldable.Foldable f => v:(f a) -> {b:Bool | (b <=> len v = 0) && (not b <=> len v > 0)}

--- a/tests/neg/null.hs
+++ b/tests/neg/null.hs
@@ -1,0 +1,4 @@
+module Foo where
+
+foo :: [Int] -> Int
+foo xs = if null xs then head xs else 0

--- a/tests/pos/null.hs
+++ b/tests/pos/null.hs
@@ -1,0 +1,4 @@
+module Foo where
+
+foo :: [a] -> [a]
+foo xs = if null xs then [] else tail xs


### PR DESCRIPTION
Make `null` return information about the list being empty or not. If null returns true, then the list has length zero. And if null returns false, then the list is non-empty. Now the code below can be type-checked

    foo :: [a] -> [a]
    foo xs = if null xs then [] else tail xs