### PR TITLE
Lazy PLE

### DIFF
--- a/benchmarks/sf/Lists.hs
+++ b/benchmarks/sf/Lists.hs
@@ -1,5 +1,6 @@
-{-@ LIQUID "--reflection" @-} 
-{-@ LIQUID "--ple"        @-} 
+{-@ LIQUID "--reflection"  @-}
+{-@ LIQUID "--ple"         @-}
+{-@ LIQUID "--no-lazy-ple" @-}
 
 module Lists where
 

--- a/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
+++ b/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
@@ -58,6 +58,7 @@ fixConfig tgt cfg = def
   , FC.oldPLE                   = oldPLE cfg
   , FC.maxRWOrderingConstraints = maxRWOrderingConstraints cfg
   , FC.rwTerminationCheck       = rwTerminationCheck cfg
+  , FC.noLazyPLE                = noLazyPLE cfg
   }
 
 

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -416,6 +416,11 @@ config = cmdArgsMode $ Config {
     = def
         &= name "skip-module"
         &= help "Completely skip this module, don't even compile any specifications in it."
+  ,
+    noLazyPLE
+    = def
+        &= name "no-lazy-ple"
+        &= help "Don't use Lazy PLE"
  
   } &= program "liquid"
     &= help    "Refinement Types for Haskell"
@@ -660,7 +665,8 @@ defConfig = Config
   , maxArgsDepth             = 1
   , maxRWOrderingConstraints = Nothing
   , rwTerminationCheck       = False
-  , skipModule            = False
+  , skipModule               = False
+  , noLazyPLE                = False
   }
 
 

--- a/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/src/Language/Haskell/Liquid/UX/Config.hs
@@ -97,7 +97,8 @@ data Config = Config
   , maxArgsDepth             :: Int
   , maxRWOrderingConstraints :: Maybe Int
   , rwTerminationCheck       :: Bool
-  , skipModule             :: Bool       -- ^ Skip this module entirely (don't even compile any specs in it)
+  , skipModule               :: Bool       -- ^ Skip this module entirely (don't even compile any specs in it)
+  , noLazyPLE                :: Bool
   } deriving (Generic, Data, Typeable, Show, Eq)
 
 allowPLE :: Config -> Bool


### PR DESCRIPTION
"Lazy PLE" changes LH to use the following behavior:

1. First check all constraints without PLE
2. Run PLE on any unsafe constraints, then recheck them

See: https://github.com/ucsd-progsys/liquid-fixpoint/pull/462

This can result in a speedup if constraints are already safe without PLE. For example, I noticed a 25% speedup on the tests in `tests/ple/pos`

However, this can also lead to a significant slowdown in some cases (see: https://github.com/ucsd-progsys/liquidhaskell/blob/develop/benchmarks/sf/Lists.hs), when attempting verification without PLE would take a lot of time. Therefore the "--no-lazy-ple" flag can be added to restore the old behavior.