### PR TITLE
remove th-compat to fix nix-build

### DIFF
--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -244,7 +244,6 @@ library
                     , split
                     , syb                  >= 0.4.4
                     , template-haskell     >= 2.9
-                    , th-compat            < 0.2
                     , temporary            >= 1.2
                     , text                 >= 1.2
                     , time                 >= 1.4

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -81,7 +81,6 @@ import Language.Haskell.Liquid.Types       hiding (typ)
 import qualified Language.Haskell.Liquid.UX.ACSS as ACSS
 
 import qualified Language.Haskell.Liquid.GHC.API as GHC
-import           Language.Haskell.TH.Syntax.Compat (fromCode, toCode)
 
 import Text.PrettyPrint.HughesPJ           hiding (Mode, (<>))
 
@@ -532,7 +531,7 @@ gitInfo :: String
 gitInfo  = msg
   where
     giTry :: Either String GitInfo
-    giTry  = $$(fromCode (toCode tGitInfoCwdTry))
+    giTry  = $$(tGitInfoCwdTry)
     msg    = case giTry of
                Left _   -> " no git information"
                Right gi -> gitMsg gi


### PR DESCRIPTION
I've had a build issue on my [nix branch](https://github.com/plredmond/liquidhaskell/tree/nixify) since the [introduction of th-compat](https://github.com/ucsd-progsys/liquidhaskell/commit/8e4bef3e971a71c1045cf70041e8b963601ce232#diff-2d24dcea9ba348ca7a027d0594d13301dae2e361852b74bd0e184e6dd72f812fR84). There's a little more [context in slack](https://liquidhaskell.slack.com/archives/C54QAL9RR/p1612161509020200?thread_ts=1608238627.066000&cid=C54QAL9RR).

<details><summary>git bisect log</summary>

```
# bad: [31b27e6f6e4e6c5f071c241c85a6cda2ab46a8f4] Merge pull request #1815 from ucsd-progsys/T1814
# good: [2a68368ac86743ec5d7dda57416a78076e88223b] Merge pull request #1776 from ucsd-progsys/T1775
git bisect start 'HEAD' '2a68368ac'
# bad: [832f7f1256c84a14d4e7ba6ae21bcd7c402921b1] restore old indenting...
git bisect bad 832f7f1256c84a14d4e7ba6ae21bcd7c402921b1
# bad: [237b2be13cfa0c19e6508fea1deb08b5e92127a2] Import unsafeCoerce# from GHC.Exts
git bisect bad 237b2be13cfa0c19e6508fea1deb08b5e92127a2
# bad: [49b4a9024a49bfa6927e829d39cb63074a5e8bfc] Move unboxed types refinements into GHC.Types.spec
git bisect bad 49b4a9024a49bfa6927e829d39cb63074a5e8bfc
# good: [0406e8d84c7578f10623e074feff148dde07ee30] Port GHC.Misc
git bisect good 0406e8d84c7578f10623e074feff148dde07ee30
# skip: [d4744993ff8214e24a22a1f99e48660f1abe221c] Ported up to GHC.Interface
git bisect skip d4744993ff8214e24a22a1f99e48660f1abe221c
# bad: [8e4bef3e971a71c1045cf70041e8b963601ce232] It compiles everywhere
git bisect bad 8e4bef3e971a71c1045cf70041e8b963601ce232
# skip: [5c0dfbaee621653d42e8f644b982cc6ac97a1f91] Backport some API on Scaled types
git bisect skip 5c0dfbaee621653d42e8f644b982cc6ac97a1f91
# skip: [8bb38aa8e9624d64290cf638be9fa3873cc7c6d8] Port more modules
git bisect skip 8bb38aa8e9624d64290cf638be9fa3873cc7c6d8
# skip: [a978bc12e111fbee2d0b2f3267db7bcf6a7bc579] It almost build on GHC > 9
git bisect skip a978bc12e111fbee2d0b2f3267db7bcf6a7bc579
# good: [f128bcb24f91277784146826cf29483a7c5b1693] Port UX.ACSS
git bisect good f128bcb24f91277784146826cf29483a7c5b1693
# only skipped commits left to test
# possible first bad commit: [8e4bef3e971a71c1045cf70041e8b963601ce232] It compiles everywhere
# possible first bad commit: [a978bc12e111fbee2d0b2f3267db7bcf6a7bc579] It almost build on GHC > 9
# possible first bad commit: [d4744993ff8214e24a22a1f99e48660f1abe221c] Ported up to GHC.Interface
# possible first bad commit: [5c0dfbaee621653d42e8f644b982cc6ac97a1f91] Backport some API on Scaled types
# possible first bad commit: [8bb38aa8e9624d64290cf638be9fa3873cc7c6d8] Port more modules
```

</details>

This PR upstreams my fix by removing the `th-compat` dependency. Perhaps @adinapoli can review?