### PR TITLE
adjust synthesis tests to fix tests under nix-build

### DIFF
--- a/tests/Synthesis.hs
+++ b/tests/Synthesis.hs
@@ -92,11 +92,15 @@ createLogs = do
 
 runLiquid :: FilePath -> IO (ExitCode, T.Text)
 runLiquid tgt = do
-    let bin    = "stack exec -- liquid " 
-        inFile = synthesisTestsDir </> tgt
+    let inFile = synthesisTestsDir </> tgt
         log    = logDir </> (dropExtension tgt <.> ".log")
+    -- use `liquid` if its on the path, otherwise use stack to call it
+    bin <- maybe "stack exec -- liquid"
+        ( <> " --ghc-option=-hide-package=base"
+          <> " --ghc-option=-hide-package=containers"
+        ) <$> findExecutable "liquid"
     withFile log WriteMode $ \h -> do
-        (_, _, _, ph) <- createProcess $ (shell (bin ++ inFile)) { std_out = UseHandle h, std_err = UseHandle h }
+        (_, _, _, ph) <- createProcess $ (shell (bin ++ ' ' : inFile)) { std_out = UseHandle h, std_err = UseHandle h }
         exitCode      <- waitForProcess ph
         (exitCode, ) <$> T.readFile log
 


### PR DESCRIPTION
I have a fix for a testing issue on my [nix branch](https://github.com/plredmond/liquidhaskell/tree/nixify) where the synthesis test incorrectly defaults to using `stack` to locate `liquid`.

This PR upstreams my fix by changing the synthesis test to use `liquid` if it is on path, and otherwise fall back to calling it via `stack`.