### PR TITLE
Add trustworthiness pragma

### DIFF
--- a/liquid-base/src/Data/Bits.hs
+++ b/liquid-base/src/Data/Bits.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Trustworthy #-}
 module Data.Bits ( module Exports ) where
 
 import "base" Data.Bits as Exports

--- a/liquid-base/src/Data/Typeable.hs
+++ b/liquid-base/src/Data/Typeable.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Trustworthy #-}
 module Data.Typeable (module Exports) where
 
 import "base" Data.Typeable as Exports

--- a/liquid-base/src/Data/Word.hs
+++ b/liquid-base/src/Data/Word.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Trustworthy #-}
 module Data.Word ( module Exports) where
 
 import "base" Data.Word as Exports

--- a/liquid-base/src/Prelude.hs
+++ b/liquid-base/src/Prelude.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Trustworthy #-}
 module Prelude (module Exports) where
 
 import Data.Foldable

--- a/liquid-bytestring/src/Data/ByteString.hs
+++ b/liquid-bytestring/src/Data/ByteString.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Trustworthy #-}
 module Data.ByteString ( module Exports ) where
 
 import Data.String

--- a/liquid-bytestring/src/Data/ByteString/Char8.hs
+++ b/liquid-bytestring/src/Data/ByteString/Char8.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE Trustworthy #-}
 module Data.ByteString.Char8 ( module Exports ) where
 
 import Data.Int


### PR DESCRIPTION
Mark Prelude, Data.Bits, Data.Word, Data.Typable, Data.ByteString, and Data.ByteString.Char8 as Trustworthy to match modules from base and bytestring packages. Without the pragma it's impossible to `safe import Prelude` and other modules, see https://github.com/ucsd-progsys/liquidhaskell/issues/1827