### PR TITLE
Allow verbosity to be changed via pragma per module

### DIFF
--- a/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -449,56 +449,56 @@ processModule LiquidHaskellContext{..} = do
 
   _                   <- LH.checkFilePragmas $ Ms.pragmas (review bareSpecIso bareSpec)
 
-  moduleCfg           <- liftIO $ withPragmas lhGlobalCfg file (Ms.pragmas $ review bareSpecIso bareSpec)
-  eps                 <- liftIO $ readIORef (hsc_EPS hscEnv)
+  withPragmas lhGlobalCfg file (Ms.pragmas $ review bareSpecIso bareSpec) $ \moduleCfg -> do
+    eps                 <- liftIO $ readIORef (hsc_EPS hscEnv)
 
-  dependencies       <- loadDependencies moduleCfg
-                                         eps
-                                         (hsc_HPT hscEnv)
-                                         thisModule
-                                         (S.toList lhRelevantModules)
+    dependencies       <- loadDependencies moduleCfg
+                                           eps
+                                           (hsc_HPT hscEnv)
+                                           thisModule
+                                           (S.toList lhRelevantModules)
 
-  debugLog $ "Found " <> show (HM.size $ getDependencies dependencies) <> " dependencies:"
-  when debugLogs $
-    forM_ (HM.keys . getDependencies $ dependencies) $ debugLog . moduleStableString . unStableModule
+    debugLog $ "Found " <> show (HM.size $ getDependencies dependencies) <> " dependencies:"
+    when debugLogs $
+      forM_ (HM.keys . getDependencies $ dependencies) $ debugLog . moduleStableString . unStableModule
 
-  debugLog $ "mg_exports => " ++ (O.showSDocUnsafe $ O.ppr $ mg_exports modGuts)
-  debugLog $ "mg_tcs => " ++ (O.showSDocUnsafe $ O.ppr $ mg_tcs modGuts)
+    debugLog $ "mg_exports => " ++ (O.showSDocUnsafe $ O.ppr $ mg_exports modGuts)
+    debugLog $ "mg_tcs => " ++ (O.showSDocUnsafe $ O.ppr $ mg_tcs modGuts)
 
-  targetSrc  <- makeTargetSrc moduleCfg file lhModuleTcData modGuts hscEnv
-  dynFlags <- getDynFlags
+    targetSrc  <- makeTargetSrc moduleCfg file lhModuleTcData modGuts hscEnv
+    dynFlags <- getDynFlags
 
-  -- See https://github.com/ucsd-progsys/liquidhaskell/issues/1711
-  -- Due to the fact the internals can throw exceptions from pure code at any point, we need to
-  -- call 'evaluate' to force any exception and catch it, if we can.
+    -- See https://github.com/ucsd-progsys/liquidhaskell/issues/1711
+    -- Due to the fact the internals can throw exceptions from pure code at any point, we need to
+    -- call 'evaluate' to force any exception and catch it, if we can.
 
-  result <-
-    (liftIO $ evaluate (makeTargetSpec moduleCfg lhModuleLogicMap targetSrc bareSpec dependencies))
-      `gcatch` (\(e :: UserError) -> LH.reportErrors Full [e] >> failM)
-      `gcatch` (\(e :: Error)     -> LH.reportErrors Full [e] >> failM)
+    result <-
+      (liftIO $ evaluate (makeTargetSpec moduleCfg lhModuleLogicMap targetSrc bareSpec dependencies))
+        `gcatch` (\(e :: UserError) -> LH.reportErrors Full [e] >> failM)
+        `gcatch` (\(e :: Error)     -> LH.reportErrors Full [e] >> failM)
 
-  case result of
-    -- Print warnings and errors, aborting the compilation.
-    Left diagnostics -> do
-      liftIO $ mapM_ (printWarning dynFlags)    (allWarnings diagnostics)
-      LH.reportErrors Full (allErrors diagnostics)
-      failM
+    case result of
+      -- Print warnings and errors, aborting the compilation.
+      Left diagnostics -> do
+        liftIO $ mapM_ (printWarning dynFlags)    (allWarnings diagnostics)
+        LH.reportErrors Full (allErrors diagnostics)
+        failM
 
-    Right (warnings, targetSpec, liftedSpec) -> do
-      liftIO $ mapM_ (printWarning dynFlags) warnings
-      let targetInfo = TargetInfo targetSrc targetSpec
+      Right (warnings, targetSpec, liftedSpec) -> do
+        liftIO $ mapM_ (printWarning dynFlags) warnings
+        let targetInfo = TargetInfo targetSrc targetSpec
 
-      debugLog $ "bareSpec ==> "   ++ show bareSpec
-      debugLog $ "liftedSpec ==> " ++ show liftedSpec
+        debugLog $ "bareSpec ==> "   ++ show bareSpec
+        debugLog $ "liftedSpec ==> " ++ show liftedSpec
 
-      let clientLib  = mkLiquidLib liftedSpec & addLibDependencies dependencies
+        let clientLib  = mkLiquidLib liftedSpec & addLibDependencies dependencies
 
-      let result = ProcessModuleResult {
-            pmrClientLib  = clientLib
-          , pmrTargetInfo = targetInfo
-          }
+        let result = ProcessModuleResult {
+              pmrClientLib  = clientLib
+            , pmrTargetInfo = targetInfo
+            }
 
-      pure result
+        pure result
 
   where
     modGuts    = fromUnoptimised lhModuleGuts

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -584,10 +584,16 @@ canonConfig cfg = cfg
   }
 
 --------------------------------------------------------------------------------
-withPragmas :: Config -> FilePath -> [Located String] -> IO Config
+withPragmas :: MonadIO m => Config -> FilePath -> [Located String] -> (Config -> m a) -> m a
 --------------------------------------------------------------------------------
-withPragmas cfg fp ps
-  = foldM withPragma cfg ps >>= canonicalizePaths fp >>= (return . canonConfig)
+withPragmas cfg fp ps action
+  = do cfg' <- liftIO $ foldM withPragma cfg ps >>= canonicalizePaths fp >>= (return . canonConfig)
+       -- As the verbosity is set /globally/ via the cmdargs lib, re-set it.
+       liftIO $ setVerbosity (loggingVerbosity cfg')
+       res <- action cfg'
+       liftIO $ setVerbosity (loggingVerbosity cfg) -- restore the original verbosity.
+       pure res
+
 
 withPragma :: Config -> Located String -> IO Config
 withPragma c s = withArgs [val s] $ cmdArgsRun


### PR DESCRIPTION
This PR fixes a bug where setting the verbosity using the `LIQUID` pragma wasn't doing anything.

I am not sure when we introduced this regression, but the culprit was the fact that when we call `withPragmas` from `Language.Haskell.Liquid.GHC.Plugin.processModule`, due to the fact the verbosity level is _global_ and it's actually set by the `cmdargs` library statefully, we were losing this information.

This PR changes the `withPragmas` function to check if the `cfg` changed and then the verbosity is changed. This has a practical implication: until we don't find another verbosity pragma, the verbosity will remain to the one last set.

Maybe we should really have `withPragmas` to take an `action` so that the action is executed with the given verbosity, but after the exit the logical block, it's set back to its original value. Something like this, basically:

```hs
--------------------------------------------------------------------------------
withPragmas :: Config -> FilePath -> [Located String] -> (Config -> IO a) -> IO a
--------------------------------------------------------------------------------
withPragmas cfg fp ps action
  = do cfg' <- foldM withPragma cfg ps >>= canonicalizePaths fp >>= (return . canonConfig)
       -- As the verbosity is set /globally/ via the cmdargs lib, check if it has
       -- changed, and re-set it.
       when (loggingVerbosity cfg /= loggingVerbosity cfg') $ setVerbosity (loggingVerbosity cfg')
       res <- action cfg'
       setVerbosity (loggingVerbosity cfg)
       pure res
```