### PR TITLE
Hacking notes and minimal nix configuration

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,6 +8,8 @@ To run `liquid` you need to install:
 
 ## Step 1: Install SMT Solver
 
+You can skip this if you will be building LiquidHaskell with [Nix][nix].
+
 Download and install *at least one* of
 
 + [Z3](https://github.com/Z3Prover/z3/releases) or [Microsoft official binary](https://www.microsoft.com/en-us/download/details.aspx?id=52270)
@@ -36,6 +38,15 @@ GHC version is in the environment. As an example,
 If you want the most recent version, you can build from source as follows,
 either using `stack` (recommended) or `cabal`. In either case: *recursively*
 clone the repo and then build:
+
+### Build with `stack` and `Nix`
+
+This doesn't require to install `stack` or `z3` in advance. Though it will require
+installing [Nix][nix].
+
+    git clone --recursive git@github.com:ucsd-progsys/liquidhaskell.git
+    cd liquidhaskell
+    nix-shell --pure --run "stack install liquid-platform"
 
 ### Build with `stack` (recommended)
 
@@ -87,4 +98,5 @@ After that, running `liquid` anywhere from the filesystem should work.
     stack exec -- liquid path/to/file.hs
     ```
 
+[nix]: https://nixos.org/download.html
 [stack]: https://github.com/commercialhaskell/stack/blob/master/doc/install_and_upgrade.md

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 ## Quick Links
 
+* See [INSTALL.md](INSTALL.md) for building instructions.
 * [Try LiquidHaskell in your browser](http://goto.ucsd.edu:8090/index.html)
 * [Splash page with examples and link to blog](https://ucsd-progsys.github.io/liquidhaskell-blog/)
 * [120 minute workshop with more examples](http://ucsd-progsys.github.io/lh-workshop/01-index.html)

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,1 @@
+import (fetchTarball "https://github.com/tweag/nixpkgs/archive/76318102e1177a235ff38872cf4dfb2fc9590a42.tar.gz")

--- a/shell-stack.nix
+++ b/shell-stack.nix
@@ -1,0 +1,12 @@
+{ pkgs ?  import ./nixpkgs.nix {}
+, ghc ? pkgs.haskell.compiler.ghc8102
+}:
+
+with pkgs;
+
+haskell.lib.buildStackProject ({
+  name = "liquidhaskell-stack";
+  buildInputs = [ git z3 ];
+  ghc = ghc;
+  LANG = "en_US.utf8";
+})

--- a/shell.nix
+++ b/shell.nix
@@ -8,6 +8,7 @@ mkShell {
   buildInputs = [
     less
     git
+    hostname
     nix
     stack
     z3

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,19 @@
+{pkgs ? import ./nixpkgs.nix {}}:
+
+with pkgs;
+
+mkShell {
+  LANG="C.UTF-8";
+
+  buildInputs = [
+    less
+    git
+    nix
+    stack
+    z3
+    which
+    glibcLocales
+    cacert
+  ];
+
+}

--- a/stack.yaml
+++ b/stack.yaml
@@ -31,3 +31,6 @@ extra-deps:
 resolver: lts-16.8
 compiler: ghc-8.10.2
 
+nix:
+  shell-file: shell-stack.nix
+  path: ["nixpkgs=./nixpkgs.nix"]


### PR DESCRIPTION
This PR explains how to use a minimal `nix` configuration with `stack`. The advantage of this configuration with respect to the previous nix setup is that we reuse all of the `stack` configuration for Haskell dependencies. `nix` is only used to provision `stack` itself and the smt solver.

Also added some notes explaining how to tests changes to LH without rebuilding all of the liquid-* packages. This is a common use case when inserting print statements during debugging or when profiling.