### PR TITLE
Add self-updating syntax cheatsheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 
 * [LH Documentation](http://ucsd-progsys.github.io/liquidhaskell/) 
 * [Edit here](/docs/mkDocs)
+* ([Latest syntax](tests-by-syntax.md))
 
 ## Questions
 

--- a/tests-by-syntax.md
+++ b/tests-by-syntax.md
@@ -10,46 +10,137 @@ It does *not* intend to explain the features that the syntax implements.
 
 ### Refining Type Expressions
 
-TODO
+[Float.hs](tests/basic/pos/Float.hs)
+[inc02.hs](tests/basic/pos/inc02.hs)
+[Compose.hs](tests/spec/pos/Compose.hs)
 
 ### Refining Data Delcarations
 
-TODO
+[Data01.hs](tests/datacon/pos/Data01.hs)
+[NewType.hs](tests/datacon/pos/NewType.hs)
+[Date.hs](tests/datacon/pos/Date.hs)
 
 ### Creating Liquid Type Synonyms
 
-TODO
+[Inc03Lib.hs](tests/basic/pos/Inc03Lib.hs)
+[alias03.hs](tests/basic/pos/alias03.hs)
 
 ## Measures
 
-TODO
+### Built-In Measures
+
+[Len01.hs](tests/measure/pos/Len01.hs)
+
+### Measures Backed by Custom Haskell Functions
+
+[fst00.hs](tests/measure/pos/fst00.hs)
+[GList00Lib.hs](tests/measure/pos/GList00Lib.hs)
+
+### Measures Not Backed By Haskell Functions
+
+[AbsMeasure.hs](tests/measure/pos/AbsMeasure.hs)
 
 ## Checking Termination
 
-TODO
+### Automatic
+
+[Ackermann.hs](tests/terminate/pos/Ackermann.hs)
+[AutoTerm.hs](tests/terminate/pos/AutoTerm.hs)
+[StructSecondArg.hs](tests/terminate/pos/StructSecondArg.hs)
+
+### Manual
+
+[list00-local.hs](tests/terminate/pos/list00-local.hs)
+[list03.hs](tests/terminate/pos/list03.hs)
+[LocalTermExpr.hs](tests/terminate/pos/LocalTermExpr.hs)
+[Papp00.hs](tests/absref/pos/Papp00.hs)
+
+### Annotating Datatypes
+
+[AutoTerm.hs](tests/terminate/pos/AutoTerm.hs)
+[list03.hs](tests/terminate/pos/list03.hs)
 
 ## Abstract Refinements
 
-TODO
+### Binding in Data Declaration
+
+[deptup0.hs](tests/absref/pos/deptup0.hs)
+[deptupW.hs](tests/absref/pos/deptupW.hs)
+[state00.hs](tests/absref/pos/state00.hs)
+
+### Binding via `forall`
+
+[Papp00.hs](tests/absref/pos/Papp00.hs)
+[deptupW.hs](tests/absref/pos/deptupW.hs)
+[state00.hs](tests/absref/pos/state00.hs)
+
+### Binding via lambdas
+
+[ListISort.hs](tests/absref/pos/ListISort.hs)
+[ListQSort.hs](tests/absref/pos/ListQSort.hs)
+[deppair2.hs](tests/absref/pos/deppair2.hs)
+
+### Application
+
+[ListISort.hs](tests/absref/pos/ListISort.hs)
+[ListQSort.hs](tests/absref/pos/ListQSort.hs)
+[deptup0.hs](tests/absref/pos/deptup0.hs)
+[deppair2.hs](tests/absref/pos/deppair2.hs)
+[state00.hs](tests/absref/pos/state00.hs)
+[VectorLoop.hs](tests/absref/pos/VectorLoop.hs)
+
+### Multi-Parameter Abstract Refinements
+
+[VectorLoop.hs](tests/absref/pos/VectorLoop.hs)
+[deppair2.hs](tests/absref/pos/deppair2.hs)
+
 
 ## Proofs
 
-TODO
+### Fully Automated
+
+[ple0.hs](tests/ple/pos/ple0.hs)
+
+### More Manual
+
+[Compiler.hs](tests/ple/pos/Compiler.hs)
+[NegNormalForm.hs](tests/ple/pos/NegNormalForm.hs)
+
+### Use Curly Braces
+
+[ple0.hs](tests/ple/pos/ple0.hs)
+[Compiler.hs](tests/ple/pos/Compiler.hs)
+[NegNormalForm.hs](tests/ple/pos/NegNormalForm.hs)
 
 ## Misc.
 
-### Correct Use of Curly (vs. Round) Braces
-
-TODO
-
 ### Defining Predicates (DEPRECATED in favor of measures)
 
-TODO
+[alias04.hs](tests/basic/pos/alias04.hs)
 
 ### Inlining Functions (DEPRECATED in favor of measures)
 
-TODO
+[alias05.hs](tests/basic/pos/alias05.hs)
+[Date.hs](tests/datacon/pos/Date.hs)
+[DoubleLit.hs](tests/reflect/pos/DoubleLit.hs)
 
 ### Reflecting Functions
 
-TODO
+[Ple1Lib.hs](tests/measure/pos/Ple1Lib.hs)
+[ple00.hs](tests/measure/pos/ple00.hs)
+[ReflString1.hs](tests/reflect/pos/ReflString1.hs)
+
+### `using ... as ...`
+
+[Using00.hs](tests/measure/pos/Using00.hs)
+
+### `autosize` Keyword
+
+[tests/pos/AutoSize.hs](tests/pos/AutoSize.hs)
+
+## `LIQUID` pragmas
+
+TODO (for now, use GitHub search)
+
+
+

--- a/tests-by-syntax.md
+++ b/tests-by-syntax.md
@@ -64,6 +64,7 @@ It does *not* intend to explain the features that the syntax implements.
 
 ### Binding in Data Declaration
 
+[Map.hs](tests/pos/Map.hs)
 [deptup0.hs](tests/absref/pos/deptup0.hs)
 [deptupW.hs](tests/absref/pos/deptupW.hs)
 [state00.hs](tests/absref/pos/state00.hs)
@@ -76,12 +77,14 @@ It does *not* intend to explain the features that the syntax implements.
 
 ### Binding via lambdas
 
+[Map.hs](tests/pos/Map.hs)
 [ListISort.hs](tests/absref/pos/ListISort.hs)
 [ListQSort.hs](tests/absref/pos/ListQSort.hs)
 [deppair2.hs](tests/absref/pos/deppair2.hs)
 
 ### Application
 
+[Map.hs](tests/pos/Map.hs)
 [ListISort.hs](tests/absref/pos/ListISort.hs)
 [ListQSort.hs](tests/absref/pos/ListQSort.hs)
 [deptup0.hs](tests/absref/pos/deptup0.hs)
@@ -91,6 +94,7 @@ It does *not* intend to explain the features that the syntax implements.
 
 ### Multi-Parameter Abstract Refinements
 
+[Map.hs](tests/pos/Map.hs)
 [VectorLoop.hs](tests/absref/pos/VectorLoop.hs)
 [deppair2.hs](tests/absref/pos/deppair2.hs)
 

--- a/tests-by-syntax.md
+++ b/tests-by-syntax.md
@@ -1,0 +1,55 @@
+# Tests By Syntax
+
+This file lists up-to-date examples of Liquid Haskell syntax. It's guaranteed to be up-to-date since the examples are all test cases!
+
+You may find this list useful if the main documentation becomes out of date with the latest version of Liquid Haskell.
+
+It does *not* intend to explain the features that the syntax implements.
+
+## Basics
+
+### Refining Type Expressions
+
+TODO
+
+### Refining Data Delcarations
+
+TODO
+
+### Creating Liquid Type Synonyms
+
+TODO
+
+## Measures
+
+TODO
+
+## Checking Termination
+
+TODO
+
+## Abstract Refinements
+
+TODO
+
+## Proofs
+
+TODO
+
+## Misc.
+
+### Correct Use of Curly (vs. Round) Braces
+
+TODO
+
+### Defining Predicates (DEPRECATED in favor of measures)
+
+TODO
+
+### Inlining Functions (DEPRECATED in favor of measures)
+
+TODO
+
+### Reflecting Functions
+
+TODO


### PR DESCRIPTION
A last resort for when the main documentation (e.g. tutorials, papers) is out of date.

Suggested in #1850 

Some notes on curation:
* The list should keep itself up to date as syntax changes, since it *points to* continuous integration tests (rather than *copying* examples)
* Where possible, the examples containing unrelated mysterious syntax (e.g. the `TT` type) or deprecated/unsound features (e.g. `--no-termination`, `inline`) are avoided.