### PR TITLE
Limit the data types natively encoded in SMT

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,14 @@ icfp_pos
       FoldAbs.hs:            OK (26.68s)
       
 
+## no-adt
+
+Don't encode non-encodable ADTs (by default)
+
+- [ ] ExactGADT6.hs
+- [ ] T1100.hs
+- [ ] T1120A.hs
+
 ## Fix: SpecDependencyGraph
 
 1. Implement `Bare.SpecDep` 

--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,15 @@ icfp_pos
 
 ## no-adt
 
+#1838
+#1747
+#1687
+#1682
+#1673 
+
+#1150 -- FUNCTION
+
+
 Don't encode non-encodable ADTs (by default)
 
 - [ ] ExactGADT6.hs

--- a/TODO.md
+++ b/TODO.md
@@ -1,40 +1,19 @@
 # TODO
 
-## Issue 1773 
 
-### Reproduce 
+## ISSUE: why does bounds stuff take so long?
 
-```sh
-$ cd ../storm-demo
-$ git checkout T1773
-$ LIQUID_DEV_MODE=true cabal v2-build
-```
+https://ucsd-progsys.slack.com/archives/DU17X62Q5/p1621006535008300
 
-which after some grinding will produce
+DISCO full full GHC+LH build = 120s
+      vs Z3 ... 7s (!)
 
-```
-Branch to fix LH #1773
+icfp_pos
 
-ghc: panic! (the 'impossible' happened)
-  (GHC version 8.10.2:
-        error-strictResolveSymUnknown type constructor `EntityFieldWrapper`
-    ofBDataDecl-2
-CallStack (from HasCallStack):
-  error, called at src/Language/Fixpoint/Misc.hs:152:14 in liquid-fixpoint-0.8.10.2.1-inplace:Language.Fixpoint.Misc
-```
-
-### Problem
-
-1. import chain: `Config` -> `Storm.SMTP` -> `Storm.Core`
-2. `Storm.Core` *defines* `EntityFieldWrapper` but
-3. `Storm.Core` *not imported* into the GHC env so name resolution fails
-
-The bug disappears if you extend `src/Config.hs` with
-
-```
-import Storm.Core
-```
-
+      Overview.lhs:          OK (24.82s)
+      IfM.hs:                OK (17.21s)
+      FoldAbs.hs:            OK (26.68s)
+      
 
 ## Fix: SpecDependencyGraph
 

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -1066,7 +1066,7 @@ makeSpecName env tycEnv measEnv name = SpNames
 makeTycEnv0 :: Config -> ModName -> Bare.Env -> TCEmb Ghc.TyCon -> Ms.BareSpec -> Bare.ModSpecs 
            -> (Diagnostics,  [Located DataConP], Bare.TycEnv)
 -------------------------------------------------------------------------------------------
-makeTycEnv0 cfg myName env embs mySpec iSpecs = (diag, datacons, Bare.TycEnv 
+makeTycEnv0 cfg myName env embs mySpec iSpecs = (diag0 <> diag1, datacons, Bare.TycEnv 
   { tcTyCons      = tycons                  
   , tcDataCons    = mempty -- val <$> datacons 
   , tcSelMeasures = dcSelectors             
@@ -1079,7 +1079,7 @@ makeTycEnv0 cfg myName env embs mySpec iSpecs = (diag, datacons, Bare.TycEnv
   })
   where
     (tcDds, dcs)   = conTys
-    (diag, conTys) = withDiagnostics $ Bare.makeConTypes myName env specs 
+    (diag0, conTys) = withDiagnostics $ Bare.makeConTypes myName env specs 
     specs         = (myName, mySpec) : M.toList iSpecs
     tcs           = Misc.snd3 <$> tcDds 
     tyi           = Bare.qualifyTopDummy env myName (makeTyConInfo embs fiTcs tycons)
@@ -1088,7 +1088,7 @@ makeTycEnv0 cfg myName env embs mySpec iSpecs = (diag, datacons, Bare.TycEnv
     tycons        = tcs ++ knownWiredTyCons env myName 
     datacons      = Bare.makePluggedDataCon (typeclass cfg) embs tyi <$> (concat dcs ++ knownWiredDataCons env myName)
     tds           = [(name, tcpCon tcp, dd) | (name, tcp, Just dd) <- tcDds]
-    adts          = Bare.makeDataDecls cfg embs myName tds       datacons
+    (diag1, adts) = Bare.makeDataDecls cfg embs myName tds       datacons
     dm            = Bare.dataConMap adts
     dcSelectors   = concatMap (Bare.makeMeasureSelectors cfg dm) datacons
     fiTcs         = _gsFiTcs (Bare.reSrc env)

--- a/src/Language/Haskell/Liquid/Bare/DataType.hs
+++ b/src/Language/Haskell/Liquid/Bare/DataType.hs
@@ -228,17 +228,11 @@ checkRegularData :: [F.DataDecl] -> ([F.DataDecl], [F.DataDecl])
 checkRegularData ds = (oks, badDs)
   where
     badDs           = F.checkRegular ds
-    badSyms         = F.tracepp "BAD-Data" . S.fromList . fmap F.symbol $ badDs
+    badSyms         = {- F.notracepp "BAD-Data" . -} S.fromList . fmap F.symbol $ badDs
     oks             = [ d |  d <- ds, not (S.member (F.symbol d) badSyms) ] 
 
 mkWarnDecl :: (F.Loc a, F.Symbolic a) => a -> Warning
 mkWarnDecl d = mkWarning (GM.fSrcSpan d) ("Non-regular data declaration" <+> pprint (F.symbol d))
-
--- mkWarnDataProp :: DataDecl -> Warning
--- mkWarnDataProp d = mkWarning (GM.fSrcSpan d) ("Non-regular datatype" <+> pprint (F.symbol d)) 
-
-
-
 
 
 -- [NOTE:Orphan-TyCons]
@@ -660,18 +654,15 @@ dataConResultTy :: Ghc.DataCon
                 -> SpecType         -- ^ vanilla result type
                 -> Maybe SpecType   -- ^ user-provided result type
                 -> SpecType
-dataConResultTy c _ _ (Just t) = F.tracepp ("dataConResultTy-3 : vanilla = " ++ show (Ghc.isVanillaDataCon c) ++ " : ") t
+dataConResultTy c _ _ (Just t) = F.notracepp ("dataConResultTy-3 : vanilla = " ++ show (Ghc.isVanillaDataCon c) ++ " : ") t
 dataConResultTy c _ t _
-  | Ghc.isVanillaDataCon c     = F.tracepp ("dataConResultTy-1 : " ++ F.showpp c) $ t
-  | otherwise                  = F.tracepp ("dataConResultTy-2 : " ++ F.showpp c) $ RT.ofType ct
+  | Ghc.isVanillaDataCon c     = F.notracepp ("dataConResultTy-1 : " ++ F.showpp c) $ t
+  | otherwise                  = F.notracepp ("dataConResultTy-2 : " ++ F.showpp c) $ RT.ofType ct
   where
     (_,_,_,_,_,ct)             = Ghc.dataConFullSig c
-    -- _tr0                    = Ghc.dataConRepType c
-    -- _tr1                    = Ghc.varType (Ghc.dataConWorkId c)
-    -- _tr2                    = Ghc.varType (Ghc.dataConWrapId c)
 
 eqSubst :: SpecType -> Maybe (RTyVar, SpecType)
-eqSubst (RApp c [_, _, (RVar a _), t] _ _)
+eqSubst (RApp c [_, _, RVar a _, t] _ _)
   | rtc_tc c == Ghc.eqPrimTyCon = Just (a, t)
 eqSubst _                       = Nothing
 

--- a/src/Language/Haskell/Liquid/Bare/DataType.hs
+++ b/src/Language/Haskell/Liquid/Bare/DataType.hs
@@ -209,23 +209,37 @@ makeDataDecls :: Config -> F.TCEmb Ghc.TyCon -> ModName
               -> [Located DataConP]
               -> (Diagnostics, [F.DataDecl])
 makeDataDecls cfg tce name tds ds
-  | makeDecls = checkRegularData 
-                  [ makeFDataDecls tce tc dd ctors
-                  | (tc, (dd, ctors)) <- groupDataCons tds' (F.tracepp "makeDataDecls" ds)
-                  , tc /= Ghc.listTyCon
-                  ]
-  | otherwise = (mempty, [])
+  | makeDecls        = (mkDiagnostics warns [], okDecs)  
+  | otherwise        = (mempty, [])
   where
-    makeDecls = exactDCFlag cfg && not (noADT cfg)
-    tds'      = resolveTyCons name tds
+    makeDecls        = exactDCFlag cfg && not (noADT cfg)
+    warns            = (mkWarnDecl . fst . fst . snd <$> badTcs) ++ (mkWarnDecl <$> badDecs)
+    tds'             = resolveTyCons name tds
+    tcDds            = filter ((/= Ghc.listTyCon) . fst) 
+                     $ groupDataCons tds' ds
+    (okTcs, badTcs)  = L.partition isVanillaTc tcDds
+    decs             = [ makeFDataDecls tce tc dd ctors | (tc, (dd, ctors)) <- okTcs] 
+    (okDecs,badDecs) = checkRegularData decs
 
-checkRegularData :: [F.DataDecl] -> (Diagnostics, [F.DataDecl])
-checkRegularData ds = (mkDiagnostics (mkWarn <$> badDs) [], oks)
+isVanillaTc :: (a, (b, [(Ghc.DataCon, c)])) -> Bool
+isVanillaTc (_, (_, ctors)) = all (Ghc.isVanillaDataCon . fst) ctors 
+
+checkRegularData :: [F.DataDecl] -> ([F.DataDecl], [F.DataDecl])
+checkRegularData ds = (oks, badDs)
   where
     badDs           = F.checkRegular ds
-    badSyms         = S.fromList . fmap F.symbol $ badDs
+    badSyms         = F.tracepp "BAD-Data" . S.fromList . fmap F.symbol $ badDs
     oks             = [ d |  d <- ds, not (S.member (F.symbol d) badSyms) ] 
-    mkWarn d        = mkWarning (GM.fSrcSpan d) ("Non-regular datatype" <+> pprint d)
+
+mkWarnDecl :: (F.Loc a, F.Symbolic a) => a -> Warning
+mkWarnDecl d = mkWarning (GM.fSrcSpan d) ("Non-regular data declaration" <+> pprint (F.symbol d))
+
+-- mkWarnDataProp :: DataDecl -> Warning
+-- mkWarnDataProp d = mkWarning (GM.fSrcSpan d) ("Non-regular datatype" <+> pprint (F.symbol d)) 
+
+
+
+
 
 -- [NOTE:Orphan-TyCons]
 
@@ -376,12 +390,9 @@ makeConTypes' :: ModName -> Bare.Env -> (ModName, Ms.BareSpec)
 makeConTypes' _myName env (name, spec) = do
   dcs'   <- canonizeDecls env name dcs
   let gvs = groupVariances dcs' vdcs
-  -- return  $ unzip . rights 
   zong <- catLookups . map (uncurry (ofBDataDecl env name)) $ gvs
   return (unzip zong)
-  -- unzip <$> mapM (uncurry (ofBDataDecl env name)) gvs
   where
-    -- msg  = printf "makeConTypes (%s): %s" (show myName) (show name)
     dcs  = Ms.dataDecls spec 
     vdcs = Ms.dvariance spec 
 
@@ -526,7 +537,7 @@ ofBDataDecl env name (Just dd@(DataDecl tc as ps cts pos sfun pt _)) maybe_invar
   tc'             <- getDnTyCon env name tc
   cts'            <- mapM (ofBDataCtor env name lc lc' tc' αs ps πs) (Mb.fromMaybe [] cts)
   unless (checkDataDecl tc' dd) (Left [err])  
-  let pd           = Bare.ofBareType env name lc (Just []) <$> pt
+  let pd           = Bare.ofBareType env name lc (Just []) <$> (F.tracepp "ofBDataDecl-prop" pt)
   let tys          = [t | dcp <- cts', (_, t) <- dcpTyArgs dcp]
   let varInfo      = L.nub $  concatMap (getPsSig initmap True) tys
   let defPs        = varSignToVariance varInfo <$> [0 .. (length πs - 1)]
@@ -568,7 +579,7 @@ ofBDataCtor env name l l' tc αs ps πs dc = do
 ofBDataCtorTc :: Bare.Env -> ModName -> F.SourcePos -> F.SourcePos -> 
                  Ghc.TyCon -> [RTyVar] -> [PVar BSort] -> [PVar RSort] -> DataCtor -> Ghc.DataCon -> 
                  DataConP
-ofBDataCtorTc env name l l' tc αs ps πs _ctor@(DataCtor c as _ xts res) c' = 
+ofBDataCtorTc env name l l' tc αs ps πs _ctor@(DataCtor _c as _ xts res) c' = 
   DataConP 
     { dcpLoc        = l                
     , dcpCon        = c'                
@@ -649,10 +660,10 @@ dataConResultTy :: Ghc.DataCon
                 -> SpecType         -- ^ vanilla result type
                 -> Maybe SpecType   -- ^ user-provided result type
                 -> SpecType
-dataConResultTy _ _ _ (Just t) = t
+dataConResultTy c _ _ (Just t) = F.tracepp ("dataConResultTy-3 : vanilla = " ++ show (Ghc.isVanillaDataCon c) ++ " : ") t
 dataConResultTy c _ t _
-  | Ghc.isVanillaDataCon c     = F.notracepp ("dataConResultTy-1 : " ++ F.showpp c) $ t
-  | otherwise                  = F.notracepp ("dataConResultTy-2 : " ++ F.showpp c) $ RT.ofType ct
+  | Ghc.isVanillaDataCon c     = F.tracepp ("dataConResultTy-1 : " ++ F.showpp c) $ t
+  | otherwise                  = F.tracepp ("dataConResultTy-2 : " ++ F.showpp c) $ RT.ofType ct
   where
     (_,_,_,_,_,ct)             = Ghc.dataConFullSig c
     -- _tr0                    = Ghc.dataConRepType c

--- a/src/Language/Haskell/Liquid/Bare/DataType.hs
+++ b/src/Language/Haskell/Liquid/Bare/DataType.hs
@@ -220,10 +220,12 @@ makeDataDecls cfg tce name tds ds
     tds'      = resolveTyCons name tds
 
 checkRegularData :: [F.DataDecl] -> (Diagnostics, [F.DataDecl])
-checkRegularData ds = (mkDiagnostics warns [], oks)
+checkRegularData ds = (mkDiagnostics (mkWarn <$> badDs) [], oks)
   where
-    warns       = [ mkWarning (GM.fSrcSpan d) ("Non-regular datatype" <+> pprint (F.symbol d)) | d <- bads]
-    (oks, bads) = L.partition F.isRegularDataDecl ds
+    badDs           = F.checkRegular ds
+    badSyms         = S.fromList . fmap F.symbol $ badDs
+    oks             = [ d |  d <- ds, not (S.member (F.symbol d) badSyms) ] 
+    mkWarn d        = mkWarning (GM.fSrcSpan d) ("Non-regular datatype" <+> pprint d)
 
 -- [NOTE:Orphan-TyCons]
 

--- a/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/src/Language/Haskell/Liquid/Types/Types.hs
@@ -463,7 +463,6 @@ data DataConP = DataConP
   , dcpTyConstrs  :: ![SpecType]             -- ^ ? Class constraints (via `dataConStupidTheta`)
   , dcpTyArgs     :: ![(Symbol, SpecType)]   -- ^ Value parameters
   , dcpTyRes      :: !SpecType               -- ^ Result type
-  -- , tyData     :: !SpecType               -- ^ The 'generic' ADT, see [NOTE:DataCon-Data]
   , dcpIsGadt     :: !Bool                   -- ^ Was this specified in GADT style (if so, DONT use function names as fields)
   , dcpModule     :: !F.Symbol               -- ^ Which module was this defined in
   , dcpLocE       :: !F.SourcePos

--- a/tests/errors/IrregularData.hs
+++ b/tests/errors/IrregularData.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--reflection" @-}
-{- LIQUID "--no-adt"      @-}
 
 module IrregularData where
 

--- a/tests/errors/IrregularData.hs
+++ b/tests/errors/IrregularData.hs
@@ -1,0 +1,77 @@
+{-@ LIQUID "--reflection" @-}
+{- LIQUID "--no-adt"      @-}
+
+module IrregularData where
+
+import Language.Haskell.Liquid.ProofCombinators (Proof, (***), QED(..), (===))
+
+-- import Demo.Lib 
+
+---------------------------------
+-- Copy pasted from containers --
+---------------------------------
+
+data FingerTree a
+    = EmptyT
+    | Single a
+    | Deep !(Digit a) (FingerTree (Node a)) !(Digit a)
+
+data Node a
+    = Node2 a a
+    | Node3 a a a
+
+data Digit a
+    = One a
+    | Two a a
+    | Three a a a
+    | Four a a a a
+
+{-@ reflect consTree @-}
+consTree        :: a -> FingerTree a -> FingerTree a
+consTree a EmptyT       = Single a
+consTree a (Single b)   = Deep (One a) EmptyT (One b)
+consTree a (Deep (Four b c d e) m sf) = Deep (Two a b) (Node3 c d e `consTree` m) sf
+consTree a (Deep (Three b c d) m sf) = Deep (Four a b c d) m sf
+consTree a (Deep (Two b c) m sf) = Deep (Three a b c) m sf
+consTree a (Deep (One b) m sf) = Deep (Two a b) m sf
+
+-------------------------
+-- Complexity analysis --
+-------------------------
+
+{-@ phi :: FingerTree a -> Nat @-}
+{-@ reflect phi @-}
+phi :: FingerTree a -> Int
+phi EmptyT = 0
+phi (Single _) = 0
+phi (Deep u q v) = dang u + phi q + dang v
+
+{-@ dang :: Digit a -> { n:Int | n == 0 || n == 1 } @-}
+{-@ reflect dang @-}
+dang :: Digit a -> Int
+dang One {} = 1
+dang Two {} = 0
+dang Three {} = 0
+dang Four {} = 1
+
+{-@ consT :: a -> FingerTree a -> Nat @-}
+{-@ reflect consT @-}
+consT :: a -> FingerTree a -> Int
+consT _ EmptyT = 1
+consT _ (Single _) = 1
+consT _ (Deep One {} _ _) = 1
+consT _ (Deep Two {} _ _) = 1
+consT _ (Deep Three {} _ _) = 1
+consT _ (Deep (Four _ a b c) q _) = 1 + consT (Node3 a b c) q
+
+{-@ amortizedConsP :: x:a -> q:FingerTree a -> { consT x q + phi (consTree x q) - phi q <= 3 } @-}
+amortizedConsP :: a -> FingerTree a -> Proof
+amortizedConsP x EmptyT = consT x EmptyT + phi (consTree x EmptyT) - phi EmptyT *** QED
+amortizedConsP x (Single a) =
+  consT x (Single a) + phi (consTree x (Single a)) - phi (Single a)
+    === 1 + phi (Deep (One x) EmptyT (One a))
+    === 1 + dang (One x) + phi EmptyT + dang (One a)    -- This is the line that causes the hang/crash
+    === undefined
+    *** QED
+amortizedConsP _ _ = undefined
+

--- a/tests/ple/pos/pleORM.hs
+++ b/tests/ple/pos/pleORM.hs
@@ -1,6 +1,5 @@
 module ORM where
 
-{- LIQUID "--no-adt" 	      @-}
 {-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
 {-@ LIQUID "--ple"            @-}

--- a/tests/pos/ExactADT6.hs
+++ b/tests/pos/ExactADT6.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--no-adt"         @-}
 {-@ LIQUID "--exact-data-con" @-}
 
 {-# LANGUAGE ExistentialQuantification, KindSignatures, TypeFamilies, GADTs #-}

--- a/tests/pos/ExactGADT0.hs
+++ b/tests/pos/ExactGADT0.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE GADTs #-}
 
-{-@ LIQUID "--no-adt"         @-}
 {-@ LIQUID "--exact-data-con" @-}
 
 

--- a/tests/pos/ExactGADT6.hs
+++ b/tests/pos/ExactGADT6.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--no-adt"         @-}
 {-@ LIQUID "--exact-data-con" @-}
 
 {-# LANGUAGE ExistentialQuantification, KindSignatures, TypeFamilies, GADTs #-}

--- a/tests/pos/FingerTree.hs
+++ b/tests/pos/FingerTree.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--reflection"     @-}
-{-@ LIQUID "--no-adt"         @-}
 {-@ LIQUID "--ple"            @-}
 
 module FingerTree where 

--- a/tests/pos/T1013A.hs
+++ b/tests/pos/T1013A.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--reflection"  @-}
-{-@ LIQUID "--no-adt"      @-} -- TODO: embed HKTs in SMTLIB2 ADTs (e.g. `Rec`)
 
 {-# LANGUAGE RankNTypes #-}
 

--- a/tests/pos/T1100.hs
+++ b/tests/pos/T1100.hs
@@ -6,7 +6,6 @@ module T1100 where
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--no-termination"                      @-}
 
-{- LIQUID "--no-adt"                              @-}
 
 class PersistEntity record where
     data EntityField record :: * -> *

--- a/tests/pos/T1100.hs
+++ b/tests/pos/T1100.hs
@@ -3,10 +3,10 @@
 module T1100 where
 
 {-@ LIQUID "--exact-data-con"                      @-}
-{-@ LIQUID "--no-adt"                              @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--no-termination"                      @-}
 
+{- LIQUID "--no-adt"                              @-}
 
 class PersistEntity record where
     data EntityField record :: * -> *

--- a/tests/pos/T1120A.hs
+++ b/tests/pos/T1120A.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--reflection" @-}
-{-@ LIQUID "--no-adt"     @-}
 
 module Bug where
 

--- a/tests/pos/T1302.hs
+++ b/tests/pos/T1302.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE EmptyDataDecls, GADTs, ExistentialQuantification #-}
 
-{-@ LIQUID "--no-adt" 	      @-}
 {-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
+{- LIQUID "--no-adt" 	      @-}
 
 module Field where
 

--- a/tests/pos/T1302.hs
+++ b/tests/pos/T1302.hs
@@ -2,7 +2,6 @@
 
 {-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
-{- LIQUID "--no-adt" 	      @-}
 
 module Field where
 

--- a/tests/pos/T1647.hs
+++ b/tests/pos/T1647.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE GADTs        #-}
 {-@ LIQUID "--reflection" @-} 
-{-@ LIQUID "--no-adt"     @-} 
 
 module Properties where 
 

--- a/tests/pos/T1649MeasuresDef.hs
+++ b/tests/pos/T1649MeasuresDef.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE RankNTypes      #-}
 {-# LANGUAGE GADTs           #-}
 {-# LANGUAGE KindSignatures  #-}
+
 {-@ LIQUID "--reflection" @-} 
+
 -- Z3 encoding cannot be used until this is fixed: 
 -- https://github.com/Z3Prover/z3/issues/3930
-{-@ LIQUID "--no-adt"         @-} 
+{- LIQUID "--no-adt"         @-} 
 {-@ LIQUID "--ple-local"      @-} 
 {-@ LIQUID "--prune-unsorted" @-} 
 

--- a/tests/pos/T1660.hs
+++ b/tests/pos/T1660.hs
@@ -5,7 +5,7 @@
 {-@ LIQUID "--reflection"  @-} 
 {-@ LIQUID "--ple"         @-}
 {-@ LIQUID "--fast"        @-}
-{-@ LIQUID "--no-adt"      @-} 
+{- LIQUID "--no-adt"      @-} 
 
 module Readers where
 

--- a/tests/pos/T1660.hs
+++ b/tests/pos/T1660.hs
@@ -5,7 +5,6 @@
 {-@ LIQUID "--reflection"  @-} 
 {-@ LIQUID "--ple"         @-}
 {-@ LIQUID "--fast"        @-}
-{- LIQUID "--no-adt"      @-} 
 
 module Readers where
 

--- a/tests/pos/ple1.hs
+++ b/tests/pos/ple1.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--reflection" @-} 
-{- LIQUID "--no-adt"      @-}
 
 module PLE where
 


### PR DESCRIPTION
In short we shouldn’t have to write “—no-adt” matching https://github.com/ucsd-progsys/liquid-fixpoint/pull/476