### PR TITLE
Make production of match clauses resilient to PIff simplification

### DIFF
--- a/shell-stack.nix
+++ b/shell-stack.nix
@@ -6,7 +6,7 @@ with pkgs;
 
 haskell.lib.buildStackProject ({
   name = "liquidhaskell-stack";
-  buildInputs = [ git z3 ];
+  buildInputs = [ git z3 hostname ];
   ghc = ghc;
   LANG = "en_US.utf8";
 })

--- a/src/Language/Haskell/Liquid/Constraint/Env.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Env.hs
@@ -292,8 +292,3 @@ setTRec γ xts  = γ' {trec = Just $ M.fromList xts' `M.union` trec'}
     γ'         = γ `setRecs` (fst <$> xts)
     trec'      = fromMaybe M.empty $ trec γ
     xts'       = first F.symbol <$> xts
-
-------------------------------------------------------------------------
-getLocation :: CGEnv -> SrcSpan
-------------------------------------------------------------------------
-getLocation = Sp.srcSpan . cgLoc

--- a/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
+++ b/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
@@ -222,6 +222,18 @@ makeSimplify (x, t)
       , all isEVar xs
       = [F.SMeasure f dc (fromEVar <$> xs) bd]
 
+    go (F.EApp (F.EVar f) dc)
+      | (F.EVar dc, xs) <- F.splitEApp dc
+      , dc == F.symbol x
+      , all isEVar xs
+      = [F.SMeasure f dc (fromEVar <$> xs) F.PTrue]
+
+    go (F.PNot (F.EApp (F.EVar f) dc))
+      | (F.EVar dc, xs) <- F.splitEApp dc
+      , dc == F.symbol x
+      , all isEVar xs
+      = [F.SMeasure f dc (fromEVar <$> xs) F.PFalse]
+
     go _ = []
 
     isEVar (F.EVar _) = True

--- a/src/Language/Haskell/Liquid/Constraint/Types.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Types.hs
@@ -53,6 +53,8 @@ module Language.Haskell.Liquid.Constraint.Types
   , removeInvariant, restoreInvariant, makeRecInvariants
 
   , getTemplates
+
+  , getLocation
   ) where
 
 import Prelude hiding (error)
@@ -128,6 +130,9 @@ instance PPrint CGEnv where
 instance Show CGEnv where
   show = showpp
 
+getLocation :: CGEnv -> SrcSpan
+getLocation = srcSpan . cgLoc
+
 --------------------------------------------------------------------------------
 -- | Subtyping Constraints -----------------------------------------------------
 --------------------------------------------------------------------------------
@@ -154,14 +159,42 @@ subVar :: FixSubC -> Maybe Var
 subVar = ci_var . F.sinfo
 
 instance PPrint SubC where
-  pprintTidy k c@(SubC {}) = pprintTidy k (senv c)
-                             $+$ ("||-" <+> vcat [ pprintTidy k (lhs c)
-                                                 , "<:"
-                                                 , pprintTidy k (rhs c) ] )
-  pprintTidy k c@(SubR {}) = pprintTidy k (senv c)
-                             $+$ ("||-" <+> vcat [ pprintTidy k (ref c)
-                                                 , parens (pprintTidy k (oblig c))])
+  pprintTidy k c@(SubC {}) =
+    "The environment:"
+    $+$
+    ""
+    $+$
+    pprintTidy k (senv c)
+    $+$
+    ""
+    $+$
+    "Location: " <> pprintTidy k (getLocation (senv c))
+    $+$
+    "The constraint:"
+    $+$
+    ""
+    $+$
+    "||-" <+> vcat [ pprintTidy k (lhs c)
+                   , "<:"
+                   , pprintTidy k (rhs c) ]
 
+  pprintTidy k c@(SubR {}) =
+    "The environment:"
+    $+$
+    ""
+    $+$
+    pprintTidy k (senv c)
+    $+$
+    ""
+    $+$
+    "Location: " <> pprintTidy k (getLocation (senv c))
+    $+$
+    "The constraint:"
+    $+$
+    ""
+    $+$
+    "||-" <+> vcat [ pprintTidy k (ref c)
+                   , parens (pprintTidy k (oblig c))]
 
 instance PPrint WfC where
   pprintTidy k (WfC _ r) = {- pprintTidy k w <> text -} "<...> |-" <+> pprintTidy k r

--- a/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/src/Language/Haskell/Liquid/Types/Types.hs
@@ -1996,9 +1996,20 @@ instance Functor AREnv where
   fmap f (REnv g l) = REnv (fmap f g) (fmap f l)
 
 instance (F.PPrint t) => F.PPrint (AREnv t) where
-  pprintTidy k re = "RENV LOCAL" $+$ F.pprintTidy k (reLocal re) <>
-                    "\nRENV GLOBAL" $+$ F.pprintTidy k (reGlobal re)
-  
+  pprintTidy k re =
+    "RENV LOCAL"
+    $+$
+    ""
+    $+$
+    F.pprintTidy k (reLocal re)
+    $+$
+    ""
+    $+$
+    "RENV GLOBAL"
+    $+$
+    ""
+    $+$
+    F.pprintTidy k (reGlobal re)
 
 instance Semigroup REnv where 
   REnv g1 l1 <> REnv g2 l2 = REnv (g1 <> g2) (l1 <> l2)  


### PR DESCRIPTION
closes #1863

The code that produces the clauses expects a very specific form of the predicates in order to introduce them. This PR enlarges the set of predicates from which `match` clauses can be created.

Now a predicate `f (D x1 x2 x3)` turns into `match f (D x1 x2 x3) = true`, and `not (f (D x1 x2 x3))` turns into `match f (D x1 x2 x3) = false`.