### PR TITLE
Show constraint ids in error messages for easier correlation with fq dumps

### DIFF
--- a/src/Language/Haskell/Liquid/Constraint/Split.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Split.hs
@@ -365,7 +365,7 @@ bsplitC' γ t1 t2 tem isHO
     r2' = rTypeSortedReft' γ tem t2
     ci  = \sr -> Ci src (err sr) (cgVar γ)
     tag = getTag γ
-    err = \sr -> Just $ fromMaybe (ErrSubType src (text "subtype") g t1 (replaceTop t2 sr)) (cerr γ)
+    err = \sr -> Just $ fromMaybe (ErrSubType src (text "subtype") Nothing g t1 (replaceTop t2 sr)) (cerr γ)
     src = getLocation γ
     g   = reLocal $ renv γ
 

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -811,7 +811,7 @@ cErrToSpanned k CtxError{ctErr} = (pos ctErr, pprintTidy k ctErr)
 errToFCrash :: CtxError a -> CtxError a
 errToFCrash ce = ce { ctErr    = tx $ ctErr ce}
   where
-    tx (ErrSubType l m g t t') = ErrFCrash l m g t t'
+    tx (ErrSubType l m _ g t t') = ErrFCrash l m g t t'
     tx e                       = e
 
 {-


### PR DESCRIPTION
This PR adds constraint ids to error messages about unsafe subtyping constraints. Now errors read

```
**** LIQUID: UNSAFE ************************************************************

Type.hs:19:1: error:
    Liquid Type Mismatch
    .
    The inferred type
      VV : {v : () | (isAdmit Language.Haskell.Liquid.ProofCombinators.QED => false)
                     && (not (isAdmit Language.Haskell.Liquid.ProofCombinators.QED) => true)}
    .
    is not a subtype of the required type
      VV : {VV : () | ?a == Type.TFun (Type.funArgTy ?a) (Type.funResTy ?a)}
    .
    in the context
      ?a : Type.Ty
    Constraint id 5
```

Where the last line indicates the id of the constraint in `Type.hs.fq` and `Type.hs.fq.prettified`.

Constraint ids are more convenient than source code locations to identify failing constraints. Several constraints might be associated to a source code line and telling them apart is not always immediate. Also, I've seen sometimes errors reported at slightly different lines than their respective constraints, which also makes more challenging relying on source locations alone.