### PR TITLE
Skip failing benchmark in cabal_900

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
     steps:
       - cabal_build_and_test:
           project_file: "cabal.ghc9.project"
-          allow_test_failures: true
+          extra_test_flags: ' --test-options '' -p "\$0 != \"Tests.Benchmarks.text.Data/Text/Foreign.hs\" && \$0 !~ /Tests.Micro.typeclass-pos./ " '' '
           liquid_runner: "--liquid-runner=cabal -v0 v2-exec --project-file cabal.ghc9.project liquidhaskell -- -v0 \
                           -package-env=$(./scripts/generate_testing_ghc_env cabal.ghc9.project) \
                           -package=liquidhaskell -package=Cabal "

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
     steps:
       - cabal_build_and_test:
           project_file: "cabal.ghc9.project"
-          extra_test_flags: ' --test-options '' -p "\$0 != \"Tests.Benchmarks.text.Data/Text/Foreign.hs\" && \$0 !~ /Tests.Micro.typeclass-pos./ " '' '
+          extra_test_flags: ' --test-options '' -p "\$0 != \"Tests.Benchmarks.text.Data/Text/Foreign.hs\" && ! /Tests.Micro.typeclass-pos./ " '' '
           liquid_runner: "--liquid-runner=cabal -v0 v2-exec --project-file cabal.ghc9.project liquidhaskell -- -v0 \
                           -package-env=$(./scripts/generate_testing_ghc_env cabal.ghc9.project) \
                           -package=liquidhaskell -package=Cabal "

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
     steps:
       - cabal_build_and_test:
           project_file: "cabal.ghc9.project"
-          extra_test_flags: ' --test-options '' -p "\$0 != \"Tests.Benchmarks.text.Data/Text/Foreign.hs\" && ! /Tests.Micro.typeclass-pos./ " '' '
+          extra_test_flags: ' --test-options '' -p "$0 != \"Tests.Benchmarks.text.Data/Text/Foreign.hs\" && ! /Tests.Micro.typeclass-pos./"'' '
           liquid_runner: "--liquid-runner=cabal -v0 v2-exec --project-file cabal.ghc9.project liquidhaskell -- -v0 \
                           -package-env=$(./scripts/generate_testing_ghc_env cabal.ghc9.project) \
                           -package=liquidhaskell -package=Cabal "


### PR DESCRIPTION
This PR has CI fail if any test fails in the cabal_900 job. The CI configuration is changed, so the tests that currently fail are skipped.

This should prevent subsequent PRs from breaking more tests than those currently failing.