### PR TITLE
treat measures as reflected too

### DIFF
--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -396,7 +396,7 @@ makeLiftedSpec0 :: Config -> GhcSrc -> F.TCEmb Ghc.TyCon -> LogicMap -> Ms.BareS
                 -> Ms.BareSpec
 makeLiftedSpec0 cfg src embs lmap mySpec = mempty
   { Ms.ealiases  = lmapEAlias . snd <$> Bare.makeHaskellInlines (typeclass cfg) src embs lmap mySpec 
-  , Ms.reflects  = Ms.reflects mySpec
+  , Ms.reflects  = Ms.reflects mySpec <> Ms.hmeas mySpec 
   , Ms.dataDecls = Bare.makeHaskellDataDecls cfg name mySpec tcs  
   , Ms.embeds    = Ms.embeds mySpec
   -- We do want 'embeds' to survive and to be present into the final 'LiftedSpec'. The
@@ -448,7 +448,7 @@ reflectedVars :: Ms.BareSpec -> [Ghc.CoreBind] -> [Ghc.Var]
 reflectedVars spec cbs = fst <$> xDefs
   where
     xDefs              = Mb.mapMaybe (`GM.findVarDef` cbs) reflSyms
-    reflSyms           = fmap val . S.toList . Ms.reflects $ spec
+    reflSyms           = fmap val $ S.toList (Ms.reflects spec <> Ms.hmeas  spec)
 
 ------------------------------------------------------------------------------------------
 makeSpecVars :: Config -> GhcSrc -> Ms.BareSpec -> Bare.Env -> Bare.MeasEnv 

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -1090,7 +1090,7 @@ makeTycEnv0 cfg myName env embs mySpec iSpecs = (diag0 <> diag1, datacons, Bare.
     tds           = [(name, tcpCon tcp, dd) | (name, tcp, Just dd) <- tcDds]
     (diag1, adts) = Bare.makeDataDecls cfg embs myName tds       datacons
     dm            = Bare.dataConMap adts
-    dcSelectors   = concatMap (Bare.makeMeasureSelectors cfg dm) datacons
+    dcSelectors   = concatMap (Bare.makeMeasureSelectors cfg dm) (if reflection cfg then charDataCon:datacons else datacons)
     fiTcs         = _gsFiTcs (Bare.reSrc env)
 
 
@@ -1112,8 +1112,7 @@ makeTycEnv1 cfg myName env (tycEnv, datacons) coreToLg simplifier = do
   where
     (classdcs, dcs) =
       L.partition
-        (Ghc.isClassTyCon . Ghc.dataConTyCon . dcpCon . F.val)
-        (if reflection cfg then charDataCon:datacons else datacons)
+        (Ghc.isClassTyCon . Ghc.dataConTyCon . dcpCon . F.val) datacons
 
     
 knownWiredDataCons :: Bare.Env -> ModName -> [Located DataConP] 

--- a/src/Language/Haskell/Liquid/WiredIn.hs
+++ b/src/Language/Haskell/Liquid/WiredIn.hs
@@ -5,6 +5,8 @@ module Language.Haskell.Liquid.WiredIn
        , wiredDataCons
        , wiredSortedSyms
 
+       , charDataCon
+
        -- * Constants for automatic proofs
        , dictionaryVar
        , dictionaryTyVar
@@ -114,11 +116,10 @@ wiredDataCons = snd wiredTyDataCons
 wiredTyDataCons :: ([TyConP] , [Located DataConP])
 wiredTyDataCons = (concat tcs, dummyLoc <$> concat dcs)
   where
-    (tcs, dcs)  = unzip $ charTyDataCons : listTyDataCons : map tupleTyDataCons [2..maxArity]
+    (tcs, dcs)  = unzip $ listTyDataCons : map tupleTyDataCons [2..maxArity]
 
-charTyDataCons :: ([TyConP] , [DataConP])
-charTyDataCons = ([(TyConP l0 c [] [] [] [] Nothing)]
-                 ,[(DataConP l0 Ghc.charDataCon  [] [] [] [("charX",lt)] lt False wiredInName l0)])
+charDataCon :: Located DataConP
+charDataCon = dummyLoc (DataConP l0 Ghc.charDataCon  [] [] [] [("charX",lt)] lt False wiredInName l0)
   where 
     l0 = F.dummyPos "LH.Bare.charTyDataCons"
     c  = Ghc.charTyCon

--- a/src/Language/Haskell/Liquid/WiredIn.hs
+++ b/src/Language/Haskell/Liquid/WiredIn.hs
@@ -114,8 +114,16 @@ wiredDataCons = snd wiredTyDataCons
 wiredTyDataCons :: ([TyConP] , [Located DataConP])
 wiredTyDataCons = (concat tcs, dummyLoc <$> concat dcs)
   where
-    (tcs, dcs)  = unzip $ listTyDataCons : map tupleTyDataCons [2..maxArity]
+    (tcs, dcs)  = unzip $ charTyDataCons : listTyDataCons : map tupleTyDataCons [2..maxArity]
 
+charTyDataCons :: ([TyConP] , [DataConP])
+charTyDataCons = ([(TyConP l0 c [] [] [] [] Nothing)]
+                 ,[(DataConP l0 Ghc.charDataCon  [] [] [] [("charX",lt)] lt False wiredInName l0)])
+  where 
+    l0 = F.dummyPos "LH.Bare.charTyDataCons"
+    c  = Ghc.charTyCon
+    lt = rApp c [] [] mempty
+    
 listTyDataCons :: ([TyConP] , [DataConP])
 listTyDataCons   = ( [(TyConP l0 c [RTV tyv] [p] [Covariant] [Covariant] (Just fsize))]
                    , [(DataConP l0 Ghc.nilDataCon  [RTV tyv] [p] [] []    lt False wiredInName l0)

--- a/tests/pos/T1874.hs
+++ b/tests/pos/T1874.hs
@@ -1,4 +1,4 @@
-module TypeFail where
+module T1874 where
 
 {-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--reflection"      @-}

--- a/tests/pos/T1874.hs
+++ b/tests/pos/T1874.hs
@@ -1,0 +1,68 @@
+module TypeFail where
+
+{-@ LIQUID "--ple" @-}
+{-@ LIQUID "--exact-data-cons" @-}
+
+import Language.Haskell.Liquid.ProofCombinators
+
+data Ty = TInt | TFun Ty Ty
+
+{-@
+type FunTy = { t : Ty | isFunTy t }
+data Ty = TInt | TFun Ty Ty
+@-}
+
+{-@ measure isFunTy @-}
+isFunTy :: Ty -> Bool
+isFunTy (TFun _ _) = True
+isFunTy _ = False
+
+{- reflect funResTy @-}
+{-@ measure funResTy @-}
+{-@ funResTy :: FunTy -> Ty @-}
+funResTy :: Ty -> Ty
+funResTy (TFun _ b) = b
+
+{-@ measure funArgTy @-}
+{-@ funArgTy :: FunTy -> Ty @-}
+funArgTy :: Ty -> Ty
+funArgTy (TFun a _) = a
+
+{-@
+type FunExp = { e : Exp | isFunTy (exprType e) }
+type ExpT T = { e : Exp | T = exprType e }
+data Exp
+  = Var Ty Int
+  | Lam Ty Exp
+  | App (e1 :: FunExp) (ExpT (funArgTy (exprType e1)))
+@-}
+
+data Exp
+  = Var Ty Int
+  | Lam Ty Exp
+  | App Exp Exp
+
+{-@ measure exprType @-}
+exprType :: Exp -> Ty
+exprType (Var ty _) = ty
+exprType (Lam ty e) = TFun ty (exprType e)
+exprType (App e1 _) = funResTy (exprType e1)
+
+
+{-@ typeAppLam_prop :: ty:Ty -> e0:Exp -> e1:Exp -> { exprType (App (Lam ty e0) e1) = exprType e0 } @-}
+typeAppLam_prop :: Ty -> Exp -> Exp -> Proof
+typeAppLam_prop _ _ _ = trivial *** QED
+
+{-@ step :: e:Exp -> Maybe (ExpT (exprType e)) @-}
+step :: Exp -> Maybe Exp
+step e0 = case e0 of
+    Var{} -> Nothing
+    Lam{} -> Nothing
+    App e1 e2 -> case step e1 of
+      Just e1' -> Just (App e1' e2)
+      Nothing -> case step e2 of
+        Just e2' -> Just (App e1 e2')
+        Nothing -> case e1 of
+          Lam ty e11 ->
+              Just e11 -- ? typeAppLam_prop ty e11 e2
+          _ -> Nothing

--- a/tests/pos/T1874.hs
+++ b/tests/pos/T1874.hs
@@ -1,7 +1,8 @@
 module TypeFail where
 
-{-@ LIQUID "--ple" @-}
 {-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--reflection"      @-}
+{-@ LIQUID "--ple"             @-}
 
 import Language.Haskell.Liquid.ProofCombinators
 


### PR DESCRIPTION
Measures are also PLE-unfolded (when `--reflection` flag is on). As a side effect of this PR, reflection of functions that case split on characters is also supported. 