### PR TITLE
Update liquid-fixpoint

### DIFF
--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -258,7 +258,7 @@ solveCs :: Config -> FilePath -> CGInfo -> TargetInfo -> Maybe [String] -> IO (O
 solveCs cfg tgt cgi info names = do
   finfo            <- cgInfoFInfo info cgi
   let fcfg          = fixConfig tgt cfg
-  F.Result r0 sol _ <- solve fcfg finfo
+  F.Result {resStatus=r0, resSolution=sol} <- solve fcfg finfo
   let failBs        = gsFail $ gsTerm $ giSpec info
   let (r,rf)        = splitFails (S.map val failBs) r0 
   let resErr        = second (applySolution sol . cinfoError) <$> r

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -440,11 +440,11 @@ config = cmdArgsMode $ Config {
         &= name "no-environment-reduction"
         &= help "Don't perform environment reduction"
   , inlineANFBindings
-    = Nothing
+    = False
         &= explicit
         &= name "inline-anf-bindings"
         &= help (unwords
-          [ "Inline ANF bindings with up-to the given amount of conjuncts."
+          [ "Inline ANF bindings."
           , "Sometimes improves performance and sometimes worsens it."
           , "Disabled by --no-environment-reduction"
           ])
@@ -703,7 +703,7 @@ defConfig = Config
   , noLazyPLE                = False
   , fuel                     = Nothing
   , noEnvironmentReduction   = False
-  , inlineANFBindings        = Nothing
+  , inlineANFBindings        = False
   }
 
 

--- a/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/src/Language/Haskell/Liquid/UX/Config.hs
@@ -103,7 +103,7 @@ data Config = Config
   , noLazyPLE                :: Bool
   , fuel                     :: Maybe Int  -- ^ Maximum PLE "fuel" (unfold depth) (default=infinite) 
   , noEnvironmentReduction   :: Bool       -- ^ Don't perform environment reduction
-  , inlineANFBindings :: Maybe Int         -- ^ Inline ANF bindings with up-to the given amount of conjuncts.
+  , inlineANFBindings        :: Bool       -- ^ Inline ANF bindings.
                                            -- Sometimes improves performance and sometimes worsens it.
   } deriving (Generic, Data, Typeable, Show, Eq)
 


### PR DESCRIPTION
This brings fixes to inlining of anf bindings and dumps of formulas.