### PR TITLE
Plugin reexport

### DIFF
--- a/src/Language/Haskell/Liquid/GHC/Interface.hs
+++ b/src/Language/Haskell/Liquid/GHC/Interface.hs
@@ -1006,6 +1006,9 @@ listLMap  = toLogicMap [ (dummyLoc nilName , []     , hNil)
 -- | Pretty Printing -----------------------------------------------------------
 --------------------------------------------------------------------------------
 
+instance PPrint LiftedSpec where
+    pprintTidy _ = text . show
+
 instance PPrint TargetSpec where
   pprintTidy k spec = vcat
     [ "******* Target Variables ********************"
@@ -1018,6 +1021,7 @@ instance PPrint TargetSpec where
     , pprintLongList k (gsCtors (gsData spec))
     , "******* Measure Specifications **************"
     , pprintLongList k (gsMeas (gsData spec))       ]
+
 
 instance PPrint TargetInfo where
   pprintTidy k info = vcat

--- a/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -87,7 +87,7 @@ cfgRef = unsafePerformIO $ newIORef defConfig
 
 -- | Set to 'True' to enable debug logging.
 debugLogs :: Bool
-debugLogs = True
+debugLogs = False
 
 ---------------------------------------------------------------------------------
 -- | Useful functions -----------------------------------------------------------

--- a/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -87,7 +87,7 @@ cfgRef = unsafePerformIO $ newIORef defConfig
 
 -- | Set to 'True' to enable debug logging.
 debugLogs :: Bool
-debugLogs = False
+debugLogs = True
 
 ---------------------------------------------------------------------------------
 -- | Useful functions -----------------------------------------------------------

--- a/src/Language/Haskell/Liquid/Types/PredType.hs
+++ b/src/Language/Haskell/Liquid/Types/PredType.hs
@@ -545,3 +545,12 @@ pappSort n = F.mkFFunc (2 * n) $ [ptycon] ++ args ++ [F.boolSort]
 
 predFTyCon :: F.FTycon
 predFTyCon = F.symbolFTycon $ dummyLoc predName
+
+
+-- | For debugging.
+instance Show DataDecl where
+  show dd = "DataDecl: data = " ++ (show $ tycName   dd) ++ ", tyvars = " ++ (show $ tycTyVars dd) ++ ", sizeFun = " ++ (show $ tycSFun   dd) ++ ", kind = " ++ (show $ tycKind   dd) ++ ", signs = " ++ (show $ tycDCons  dd) -- [at: %s]"
+              
+    
+instance Show DataCtor where
+  show dd = "DataDecl: dcName =" ++ (show $ dcName   dd) ++ ", dcFields = " ++ (showpp $ dcFields  dd) ++ ", dcResult =" ++ (showpp $  dcResult  dd) ++ ", dcTheta =" ++ (showpp $  dcTheta  dd) -- [at: %s]"

--- a/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -79,6 +79,7 @@ import           Data.HashMap.Strict     (HashMap)
 import           Language.Haskell.Liquid.Types.Types 
 import           Language.Haskell.Liquid.Types.Generics
 import           Language.Haskell.Liquid.Types.Variance
+import           Language.Haskell.Liquid.Types.PredType
 import           Language.Haskell.Liquid.Types.Bounds 
 import           Language.Haskell.Liquid.GHC.API hiding (text, (<+>))
 import           Language.Haskell.Liquid.GHC.Types
@@ -198,7 +199,10 @@ data TargetSpec = TargetSpec
   , gsLaws   :: !GhcSpecLaws
   , gsImps   :: ![(F.Symbol, F.Sort)]  -- ^ Imported Environment
   , gsConfig :: !Config
-  }
+  } 
+  
+instance Show TargetSpec where 
+  show t = show (gsSig t) ++ show (gsData t)
 
 instance HasConfig TargetSpec where
   getConfig = gsConfig
@@ -236,7 +240,7 @@ data GhcSpecSig = SpSig
   , gsDicts    :: !(DEnv Var LocSpecType)            -- ^ Refined Classes from Instances 
   , gsMethods  :: ![(Var, MethodType LocSpecType)]   -- ^ Refined Classes from Classes 
   , gsTexprs   :: ![(Var, LocSpecType, [F.Located F.Expr])]  -- ^ Lexicographically ordered expressions for termination
-  }
+  } deriving Show 
 
 instance Semigroup GhcSpecSig where
   x <> y = SpSig 
@@ -267,7 +271,8 @@ data GhcSpecData = SpData
   , gsIaliases   :: ![(LocSpecType, LocSpecType)] -- ^ Data type invariant aliases 
   , gsMeasures   :: ![Measure SpecType DataCon]   -- ^ Measure definitions
   , gsUnsorted   :: ![UnSortedExpr]
-  }
+  } deriving Show 
+
 data GhcSpecNames = SpNames 
   { gsFreeSyms   :: ![(F.Symbol, Var)]            -- ^ List of `Symbol` free in spec and corresponding GHC var, eg. (Cons, Cons#7uz) from tests/pos/ex1.hs
   , gsDconsP     :: ![F.Located DataCon]          -- ^ Predicated Data-Constructors, e.g. see tests/pos/Map.hs

--- a/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/src/Language/Haskell/Liquid/Types/Types.hs
@@ -46,7 +46,7 @@ module Language.Haskell.Liquid.Types.Types (
   , mkBTyCon
   -- , mkClassBTyCon, mkPromotedBTyCon
   , isClassBTyCon
-  , BTyVar(..)
+  , BTyVar(..), tyVaRSymbol
 
   -- * Refined Type Constructors
   , RTyCon (RTyCon, rtc_tc, rtc_info)
@@ -612,6 +612,9 @@ instance NFData   RTyVar
 instance F.Symbolic BTyVar where
   symbol (BTV tv) = tv
 
+
+
+
 instance F.Symbolic RTyVar where
   symbol (RTV tv) = F.symbol tv -- tyVarUniqueSymbol tv
 
@@ -654,6 +657,10 @@ rtyVarType (RTV v) = TyVarTy v
 
 tyVarVar :: RTVar RTyVar c -> Var
 tyVarVar (RTVar (RTV v) _) = v
+
+tyVaRSymbol :: F.Symbolic a => RTVar a s -> F.Symbol
+tyVaRSymbol (RTVar x _) = F.symbol x 
+
 
 
 
@@ -1297,14 +1304,8 @@ instance F.Loc DataName where
   srcSpan (DnCon  z) = F.srcSpan z
 
 
--- | For debugging.
-instance Show DataDecl where
-  show dd = printf "DataDecl: data = %s, tyvars = %s, sizeFun = %s, kind = %s" -- [at: %s]"
-              (show $ tycName   dd)
-              (show $ tycTyVars dd)
-              (show $ tycSFun   dd)
-              (show $ tycKind   dd)
 
+  
 
 instance Show DataName where
   show (DnName n) =               show (F.val n)

--- a/tests/import/client/ReExportClient.hs
+++ b/tests/import/client/ReExportClient.hs
@@ -1,0 +1,7 @@
+module ReExportClient where 
+
+import ReExport 
+
+{-@ bar :: Foo -> {v:Int | 0 < v} @-} 
+bar :: Foo -> Int 
+bar (Foo x) = x 

--- a/tests/import/lib/ReExport.hs
+++ b/tests/import/lib/ReExport.hs
@@ -1,6 +1,5 @@
-module ReExport where 
-( module ReExport
-, module X
-) where
+module ReExport ( module ReExport
+  , module X
+  ) where
 
 import Spec as X

--- a/tests/import/lib/ReExport.hs
+++ b/tests/import/lib/ReExport.hs
@@ -1,0 +1,6 @@
+module ReExport where 
+( module ReExport
+, module X
+) where
+
+import Spec as X

--- a/tests/import/lib/Spec.hs
+++ b/tests/import/lib/Spec.hs
@@ -1,4 +1,4 @@
 module Spec where 
 
 data Foo = Foo Int 
-{-@ data Foo = Foo {unfoo :: {v:Int | 0 < v } @-} 
+{-@ data Foo = Foo (unfoo :: {v:Int | 0 < v }) @-} 

--- a/tests/import/lib/Spec.hs
+++ b/tests/import/lib/Spec.hs
@@ -1,0 +1,4 @@
+module Spec where 
+
+data Foo = Foo Int 
+{-@ data Foo = Foo {unfoo :: {v:Int | 0 < v } @-} 


### PR DESCRIPTION
Addresses re-export of refined data types bug observed by @plredmond. 
This was failing before with the plugin: https://github.com/ucsd-progsys/liquidhaskell/commit/26ce9c9bbaed8c4730fd798425354da5bd753aee

