### PR TITLE
Some improvements to chart generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,24 @@ You can directly extend and run the tests by modifying
 
     tests/test.hs
 
+## How to create performance comparison charts
+
+Everytime `liquidhaskell` tests are run, a report of the time taken by
+each test is written to a file `tests/logs/<host>-<time>/summary.csv`.
+
+There is a script `scripts/plot-performance/chart_perf.sh` that can be
+used to generate comparison charts in `svg` and `png` formats. It
+requires [gnuplot](http://www.gnuplot.info/) to run. The following
+command will produce two files `perf.svg` and `perf.png` in the
+current directory.
+
+    $ scripts/plot-performance/chart_perf.sh path_to_before_summary.csv path_to_after_summary.csv
+
+The current formatting is optmized for comparing the outputs of running
+the benchmarks alone.
+
+    $ scripts/test/test_810.sh Benchmarks
+
 ## How to Profile
 
 1. Build with profiling on

--- a/scripts/plot-performance/chart_perf.sh
+++ b/scripts/plot-performance/chart_perf.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+HERE=$(cd "$(dirname $0)" && pwd)
 
 # Simple script to plot the performance regression between different testruns in Liquidhaskell.
 # It requires:
@@ -13,5 +14,5 @@ cat $2 | tail -n +5 > after.csv
 
 paste before.csv after.csv > combined.csv
 
-gnuplot -p -e "csv_1='before.csv';csv_2='after.csv';csv_3='combined.csv'" perf.gnuplot
+gnuplot -p -e "csv_1='before.csv';csv_2='after.csv';csv_3='combined.csv'" "$HERE/perf.gnuplot"
 convert -trim -density 300 perf.svg perf.png

--- a/scripts/plot-performance/chart_perf.sh
+++ b/scripts/plot-performance/chart_perf.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -x
 HERE=$(cd "$(dirname $0)" && pwd)
 
 # Simple script to plot the performance regression between different testruns in Liquidhaskell.

--- a/scripts/plot-performance/chart_perf.sh
+++ b/scripts/plot-performance/chart_perf.sh
@@ -3,9 +3,7 @@ set -x
 HERE=$(cd "$(dirname $0)" && pwd)
 
 # Simple script to plot the performance regression between different testruns in Liquidhaskell.
-# It requires:
-# - gnuplot
-# - Imagemagick
+# It requires gnuplot.
 
 # $1 = before.csv
 # $2 = after.csv
@@ -16,4 +14,3 @@ cat $2 | tail -n +5 > after.csv
 paste before.csv after.csv > combined.csv
 
 gnuplot -p -e "csv_1='before.csv';csv_2='after.csv';csv_3='combined.csv'" "$HERE/perf.gnuplot"
-convert -trim -density 300 perf.svg perf.png

--- a/scripts/plot-performance/perf.gnuplot
+++ b/scripts/plot-performance/perf.gnuplot
@@ -6,7 +6,8 @@ set bmargin 22    # For some reason using xticlabels adds tons of whitespaces at
 set tics font ",4"
 
 # Y (time) axis config
-set ylabel "Time"
+set ylabel "Time (seconds)"
+set ytics font ",8"
 set logscale y 10
 
 # Chart shape
@@ -20,9 +21,9 @@ set style line 100 lt 1 lc rgb "grey" lw 0.5 # linestyle for the grid
 set grid ls 100 # enable grid with specific linestyle
 
 # X axis config
-set xtics 1 rotate
+set xtics scale 0 rotate
 
-set terminal svg enhanced size 2048,1024
+set terminal svg enhanced size 8192,1024
 set output 'perf.svg'
 plot csv_2 using 2:xticlabels(1) with boxes lc rgb'red90' axis x1y1 title "after", \
      csv_3 using 2:xticlabels(1) with boxes lc rgb'blue90' axis x1y1 title "before", \

--- a/scripts/plot-performance/perf.gnuplot
+++ b/scripts/plot-performance/perf.gnuplot
@@ -3,7 +3,7 @@ set datafile separator ','
 # General config.
 set autoscale
 set bmargin 22    # For some reason using xticlabels adds tons of whitespaces at the end
-set tics font ",4"
+set tics font ",8"
 
 # Y (time) axis config
 set ylabel "Time (seconds)"
@@ -23,8 +23,15 @@ set grid ls 100 # enable grid with specific linestyle
 # X axis config
 set xtics scale 0 rotate
 
-set terminal svg enhanced size 8192,1024
+#set terminal svg enhanced size 8192,1024
+set terminal svg enhanced size 1024,1024
 set output 'perf.svg'
 plot csv_2 using 2:xticlabels(1) with boxes lc rgb'red90' axis x1y1 title "after", \
      csv_3 using 2:xticlabels(1) with boxes lc rgb'blue90' axis x1y1 title "before", \
-     '' u 0:($2+.1):(sprintf("%3.2f",$4-$2)) with labels rotate left font ",4" notitle
+     '' u 0:($2+.1):(sprintf("%3.2f",$4-$2)) with labels rotate left font ",8" notitle
+
+set terminal png truecolor enhanced size 2048,2048
+set output 'perf.png'
+plot csv_2 using 2:xticlabels(1) with boxes lc rgb'red90' axis x1y1 title "after", \
+     csv_3 using 2:xticlabels(1) with boxes lc rgb'blue90' axis x1y1 title "before", \
+     '' u 0:($2+.1):(sprintf("%3.2f",$4-$2)) with labels rotate left font ",8" notitle


### PR DESCRIPTION
With this patch we don't need imagemagick anymore. Also, chart_perf.sh can generate charts when invoked from any directory. Also, the rendering of the labels is correct. ImageMagick would be confused by some characters when converting from svg to png.

Here's an [example](https://github.com/ucsd-progsys/liquid-fixpoint/pull/493#issuecomment-924046602).