### PR TITLE
Disable environment reduction by default

### DIFF
--- a/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
+++ b/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
@@ -60,7 +60,7 @@ fixConfig tgt cfg = def
   , FC.rwTerminationCheck       = rwTerminationCheck cfg
   , FC.noLazyPLE                = noLazyPLE cfg
   , FC.fuel                     = fuel      cfg
-  , FC.noEnvironmentReduction   = noEnvironmentReduction cfg
+  , FC.noEnvironmentReduction   = not (environmentReduction cfg)
   , FC.inlineANFBindings        = inlineANFBindings cfg
   }
 

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -434,6 +434,11 @@ config = cmdArgsMode $ Config {
     = Nothing 
         &= help "Maximum fuel (per-function unfoldings) for PLE"
 
+  , environmentReduction
+    = def
+        &= explicit
+        &= name "environment-reduction"
+        &= help "perform environment reduction (disabled by default)"
   , noEnvironmentReduction
     = def
         &= explicit
@@ -702,6 +707,7 @@ defConfig = Config
   , skipModule               = False
   , noLazyPLE                = False
   , fuel                     = Nothing
+  , environmentReduction     = False
   , noEnvironmentReduction   = False
   , inlineANFBindings        = False
   }

--- a/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/src/Language/Haskell/Liquid/UX/Config.hs
@@ -102,6 +102,7 @@ data Config = Config
   , skipModule               :: Bool       -- ^ Skip this module entirely (don't even compile any specs in it)
   , noLazyPLE                :: Bool
   , fuel                     :: Maybe Int  -- ^ Maximum PLE "fuel" (unfold depth) (default=infinite) 
+  , environmentReduction     :: Bool       -- ^ Perform environment reduction
   , noEnvironmentReduction   :: Bool       -- ^ Don't perform environment reduction
   , inlineANFBindings        :: Bool       -- ^ Inline ANF bindings.
                                            -- Sometimes improves performance and sometimes worsens it.


### PR DESCRIPTION
Environment reduction can break the tree-like invariant necessary by PLE, which can cause LH to decide incorrectly on the validity of constraints.

Therefore, this PR makes not running environment reduction the default.

We can revert this after https://github.com/ucsd-progsys/liquid-fixpoint/issues/496 is fixed.