### PR TITLE
Fix for 9.0.1

### DIFF
--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               liquidhaskell
-version:            0.8.10.7.1
+version:            0.8.10.7.1.1
 synopsis:           Liquid Types for Haskell
 description:        Liquid Types for Haskell.
 license:            BSD-3-Clause

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               liquidhaskell
-version:            0.8.10.7.1.1
+version:            0.8.10.7.1
 synopsis:           Liquid Types for Haskell
 description:        Liquid Types for Haskell.
 license:            BSD-3-Clause

--- a/src/Language/Haskell/Liquid/GHC/Interface.hs
+++ b/src/Language/Haskell/Liquid/GHC/Interface.hs
@@ -1056,4 +1056,3 @@ instance PPrint TargetVars where
 
 instance Result SourceError where
   result = (`Crash` "Invalid Source") . sourceErrors ""
-

--- a/src/Language/Haskell/Liquid/GHC/Interface.hs
+++ b/src/Language/Haskell/Liquid/GHC/Interface.hs
@@ -847,7 +847,7 @@ extractSpecQuotes' thisModule getAnns a = mapMaybe extractSpecQuote anns
 
 extractSpecQuote :: AnnPayload -> Maybe BPspec
 extractSpecQuote payload = 
-  case fromSerialized deserializeWithData payload of
+  case Ghc.fromSerialized Ghc.deserializeWithData payload of
     Nothing -> Nothing
     Just qt -> Just $ refreshSymbols $ liquidQuoteSpec qt
 
@@ -1056,3 +1056,4 @@ instance PPrint TargetVars where
 
 instance Result SourceError where
   result = (`Crash` "Invalid Source") . sourceErrors ""
+


### PR DESCRIPTION
This is a small enough change that it could be done without going through a PR. Still, perhaps it could be useful. 

The original error: 

```bash
liquidhaskell  > /private/var/folders/54/4cm564ls04q8_206m8zgx7c40000gn/T/stack-615b78f4f6745fa6/liquidhaskell-0.8.10.7/src/Language/Haskell/Liquid/GHC/Interface.hs:850:8: error:
liquidhaskell  >     Ambiguous occurrence ‘fromSerialized’
liquidhaskell  >     It could refer to
liquidhaskell  >        either ‘GHC.Serialized.fromSerialized’,
liquidhaskell  >               imported from ‘GHC.Serialized’ at src/Language/Haskell/Liquid/GHC/Interface.hs:61:1-21
liquidhaskell  >            or ‘Ghc.fromSerialized’,
liquidhaskell  >               imported from ‘Language.Haskell.Liquid.GHC.API’ at src/Language/Haskell/Liquid/GHC/Interface.hs:(64,1)-(72,64)
liquidhaskell  >               (and originally defined in ‘ghc-boot-9.0.1:GHC.Serialized’)
liquidhaskell  >     |
liquidhaskell  > 850 |   case fromSerialized deserializeWithData payload of
liquidhaskell  >     |        ^^^^^^^^^^^^^^
liquidhaskell  > 
liquidhaskell  > /private/var/folders/54/4cm564ls04q8_206m8zgx7c40000gn/T/stack-615b78f4f6745fa6/liquidhaskell-0.8.10.7/src/Language/Haskell/Liquid/GHC/Interface.hs:850:23: error:
liquidhaskell  >     Ambiguous occurrence ‘deserializeWithData’
liquidhaskell  >     It could refer to
liquidhaskell  >        either ‘GHC.Serialized.deserializeWithData’,
liquidhaskell  >               imported from ‘GHC.Serialized’ at src/Language/Haskell/Liquid/GHC/Interface.hs:61:1-21
liquidhaskell  >            or ‘Ghc.deserializeWithData’,
liquidhaskell  >               imported from ‘Language.Haskell.Liquid.GHC.API’ at src/Language/Haskell/Liquid/GHC/Interface.hs:(64,1)-(72,64)
liquidhaskell  >               (and originally defined in ‘ghc-boot-9.0.1:GHC.Serialized’)
liquidhaskell  >     |
liquidhaskell  > 850 |   case fromSerialized deserializeWithData payload of
```