### PR TITLE
Add "devel" flag to fail the build if there are warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ commands:
             echo 'export PATH=~/.ghcup/bin:$PATH' >> $BASH_ENV
             << parameters.cabal_update_command >>
             cabal v2-clean
-            cabal v2-build --project-file << parameters.project_file >> --flag strict --flag include --flag devel -j2 --enable-tests all
+            cabal v2-build --project-file << parameters.project_file >> --flag include --flag devel -j2 --enable-tests all
       - save_cache:
           key: cabal-cache-v3-{{ checksum "liquidhaskell.cabal" }}-{{ checksum "<< parameters.project_file >>" }}-{{ checksum "liquid-fixpoint-commit" }}
           paths:
@@ -84,8 +84,8 @@ commands:
       - run:
           name: Test
           command: |
-            (liquidhaskell_datadir=$PWD cabal v2-test -j1 --project-file << parameters.project_file >> liquidhaskell:test << parameters.extra_test_flags >> --flag strict --flag include --flag devel --test-show-details=streaming --test-option="<< parameters.liquid_runner >>" --test-options="-t 1200s --xml=/tmp/junit/cabal/main-test-results.xml") || (<<parameters.allow_test_failures>>)
-            (liquidhaskell_datadir=$PWD cabal v2-test -j1 --project-file << parameters.project_file >> liquidhaskell:liquidhaskell-parser --flag strict --flag include --flag devel --test-show-details=streaming --test-options="--xml=/tmp/junit/cabal/parser-test-results.xml") || (<<parameters.allow_test_failures>>)
+            (liquidhaskell_datadir=$PWD cabal v2-test -j1 --project-file << parameters.project_file >> liquidhaskell:test << parameters.extra_test_flags >> --flag include --flag devel --test-show-details=streaming --test-option="<< parameters.liquid_runner >>" --test-options="-t 1200s --xml=/tmp/junit/cabal/main-test-results.xml") || (<<parameters.allow_test_failures>>)
+            (liquidhaskell_datadir=$PWD cabal v2-test -j1 --project-file << parameters.project_file >> liquidhaskell:liquidhaskell-parser --flag include --flag devel --test-show-details=streaming --test-options="--xml=/tmp/junit/cabal/parser-test-results.xml") || (<<parameters.allow_test_failures>>)
           no_output_timeout: 30m
       - store_test_results:
           path: /tmp/junit/cabal
@@ -166,7 +166,7 @@ jobs:
         - stack_build_and_test:
             stack_yaml_file: "stack.yaml"
             liquid_runner: "stack --silent exec -- liquid"
-            extra_build_flags: "--flag liquidhaskell:strict --flag liquidhaskell:include --flag liquid-platform:devel --flag liquidhaskell:no-plugin"
+            extra_build_flags: "--flag liquidhaskell:devel --flag liquidhaskell:include --flag liquid-platform:devel --flag liquidhaskell:no-plugin"
 
   stack_810:
     machine:
@@ -174,7 +174,7 @@ jobs:
     steps:
         - stack_build_and_test:
             stack_yaml_file: "stack.yaml"
-            extra_build_flags: "--flag liquidhaskell:strict"
+            extra_build_flags: "--flag liquidhaskell:devel"
             extra_test_flags: " liquid-platform:liquidhaskell "
 
   cabal_810:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ commands:
             echo 'export PATH=~/.ghcup/bin:$PATH' >> $BASH_ENV
             << parameters.cabal_update_command >>
             cabal v2-clean
-            cabal v2-build --project-file << parameters.project_file >> --flag include --flag devel -j2 --enable-tests all
+            cabal v2-build --project-file << parameters.project_file >> --flag strict --flag include --flag devel -j2 --enable-tests all
       - save_cache:
           key: cabal-cache-v3-{{ checksum "liquidhaskell.cabal" }}-{{ checksum "<< parameters.project_file >>" }}-{{ checksum "liquid-fixpoint-commit" }}
           paths:
@@ -84,8 +84,8 @@ commands:
       - run:
           name: Test
           command: |
-            (liquidhaskell_datadir=$PWD cabal v2-test -j1 --project-file << parameters.project_file >> liquidhaskell:test << parameters.extra_test_flags >> --flag include --flag devel --test-show-details=streaming --test-option="<< parameters.liquid_runner >>" --test-options="-t 1200s --xml=/tmp/junit/cabal/main-test-results.xml") || (<<parameters.allow_test_failures>>)
-            (liquidhaskell_datadir=$PWD cabal v2-test -j1 --project-file << parameters.project_file >> liquidhaskell:liquidhaskell-parser --flag include --flag devel --test-show-details=streaming --test-options="--xml=/tmp/junit/cabal/parser-test-results.xml") || (<<parameters.allow_test_failures>>)
+            (liquidhaskell_datadir=$PWD cabal v2-test -j1 --project-file << parameters.project_file >> liquidhaskell:test << parameters.extra_test_flags >> --flag strict --flag include --flag devel --test-show-details=streaming --test-option="<< parameters.liquid_runner >>" --test-options="-t 1200s --xml=/tmp/junit/cabal/main-test-results.xml") || (<<parameters.allow_test_failures>>)
+            (liquidhaskell_datadir=$PWD cabal v2-test -j1 --project-file << parameters.project_file >> liquidhaskell:liquidhaskell-parser --flag strict --flag include --flag devel --test-show-details=streaming --test-options="--xml=/tmp/junit/cabal/parser-test-results.xml") || (<<parameters.allow_test_failures>>)
           no_output_timeout: 30m
       - store_test_results:
           path: /tmp/junit/cabal
@@ -166,7 +166,7 @@ jobs:
         - stack_build_and_test:
             stack_yaml_file: "stack.yaml"
             liquid_runner: "stack --silent exec -- liquid"
-            extra_build_flags: "--flag liquidhaskell:include --flag liquid-platform:devel --flag liquidhaskell:no-plugin"
+            extra_build_flags: "--flag liquidhaskell:strict --flag liquidhaskell:include --flag liquid-platform:devel --flag liquidhaskell:no-plugin"
 
   stack_810:
     machine:
@@ -174,6 +174,7 @@ jobs:
     steps:
         - stack_build_and_test:
             stack_yaml_file: "stack.yaml"
+            extra_build_flags: "--flag liquidhaskell:strict"
             extra_test_flags: " liquid-platform:liquidhaskell "
 
   cabal_810:

--- a/liquid-base/src/Foreign/ForeignPtr.spec
+++ b/liquid-base/src/Foreign/ForeignPtr.spec
@@ -3,9 +3,10 @@ module spec Foreign.ForeignPtr where
 import GHC.ForeignPtr
 import Foreign.Ptr
 
-Foreign.ForeignPtr.withForeignPtr :: forall a b. fp:(GHC.ForeignPtr.ForeignPtr a) 
-  -> ((PtrN a (fplen fp)) -> GHC.Types.IO b) 
-  -> (GHC.Types.IO b)
+// `withForeignPtr` is missing from the `base` version shipped with GHC 9.0.1.
+// Foreign.ForeignPtr.withForeignPtr :: forall a b. fp:(GHC.ForeignPtr.ForeignPtr a)
+//   -> ((PtrN a (fplen fp)) -> GHC.Types.IO b)
+//   -> (GHC.Types.IO b)
 
 GHC.ForeignPtr.newForeignPtr_     :: p:(GHC.Ptr.Ptr a) -> (GHC.Types.IO (ForeignPtrN a (plen p)))
 Foreign.Concurrent.newForeignPtr  :: p:(PtrV a) -> GHC.Types.IO () -> (GHC.Types.IO (ForeignPtrN a (plen p)))

--- a/liquid-base/src/Foreign/ForeignPtr.spec
+++ b/liquid-base/src/Foreign/ForeignPtr.spec
@@ -3,8 +3,8 @@ module spec Foreign.ForeignPtr where
 import GHC.ForeignPtr
 import Foreign.Ptr
 
-GHC.ForeignPtr.withForeignPtr :: forall a b. fp:(GHC.ForeignPtr.ForeignPtr a)
-  -> ((PtrN a (fplen fp)) -> GHC.Types.IO b)
+Foreign.ForeignPtr.withForeignPtr :: forall a b. fp:(GHC.ForeignPtr.ForeignPtr a) 
+  -> ((PtrN a (fplen fp)) -> GHC.Types.IO b) 
   -> (GHC.Types.IO b)
 
 GHC.ForeignPtr.newForeignPtr_     :: p:(GHC.Ptr.Ptr a) -> (GHC.Types.IO (ForeignPtrN a (plen p)))

--- a/liquid-base/src/Foreign/ForeignPtr.spec
+++ b/liquid-base/src/Foreign/ForeignPtr.spec
@@ -3,10 +3,9 @@ module spec Foreign.ForeignPtr where
 import GHC.ForeignPtr
 import Foreign.Ptr
 
-// `withForeignPtr` is missing from the `base` version shipped with GHC 9.0.1.
-// Foreign.ForeignPtr.withForeignPtr :: forall a b. fp:(GHC.ForeignPtr.ForeignPtr a)
-//   -> ((PtrN a (fplen fp)) -> GHC.Types.IO b)
-//   -> (GHC.Types.IO b)
+GHC.ForeignPtr.withForeignPtr :: forall a b. fp:(GHC.ForeignPtr.ForeignPtr a)
+  -> ((PtrN a (fplen fp)) -> GHC.Types.IO b)
+  -> (GHC.Types.IO b)
 
 GHC.ForeignPtr.newForeignPtr_     :: p:(GHC.Ptr.Ptr a) -> (GHC.Types.IO (ForeignPtrN a (plen p)))
 Foreign.Concurrent.newForeignPtr  :: p:(PtrV a) -> GHC.Types.IO () -> (GHC.Types.IO (ForeignPtrN a (plen p)))

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -65,6 +65,11 @@ source-repository head
   type:     git
   location: https://github.com/ucsd-progsys/liquidhaskell/
 
+flag strict
+  default:     False
+  description: Enable more warnings and fail compilation when warnings occur.
+               Turn this flag on in CI.
+
 flag include
   default:     False
   description: use in-tree include directory
@@ -253,6 +258,9 @@ library
   default-extensions: PatternGuards, RecordWildCards, DoAndIfThenElse
   ghc-options:        -W -fwarn-missing-signatures
 
+  if flag(strict)
+    ghc-options:      -Wall -Wno-name-shadowing -Werror
+
   if flag(include)
     hs-source-dirs: devel
 
@@ -268,7 +276,10 @@ executable liquid
   build-depends:      base >= 4.9.1.0 && < 5, liquidhaskell
   default-language:   Haskell98
   default-extensions: PatternGuards
-  ghc-options:        -W -threaded -fdefer-typed-holes
+  ghc-options:        -W -threaded
+
+  if flag(strict)
+    ghc-options:      -Wall -Wno-name-shadowing -Werror
 
 
 test-suite test
@@ -295,6 +306,10 @@ test-suite test
                   , transformers         >= 0.3
   default-language: Haskell98
   ghc-options:      -W -threaded
+
+  if flag(strict)
+    ghc-options:      -Wall -Wno-name-shadowing -Werror
+
   if !flag(no-plugin)
     cpp-options: -DUSE_NEW_EXECUTABLE
 
@@ -316,6 +331,9 @@ test-suite liquidhaskell-parser
   default-language: Haskell2010
   ghc-options:      -W
 
+  if flag(strict)
+    ghc-options:      -Wall -Wno-name-shadowing -Werror
+
 test-suite synthesis
   type:             exitcode-stdio-1.0
   main-is:          Synthesis.hs
@@ -335,6 +353,8 @@ test-suite synthesis
   default-language: Haskell2010
   ghc-options:      -W
 
+  if flag(strict)
+    ghc-options:      -Wall -Wno-name-shadowing -Werror
 
 -- This executable can be used to generate modules for mirror-packages.
 executable mirror-modules
@@ -363,3 +383,6 @@ executable mirror-modules
     MultiWayIf
     LambdaCase
   ghc-options:        -W -threaded
+
+  if flag(strict)
+    ghc-options:      -Wall -Wno-name-shadowing -Werror

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -308,7 +308,7 @@ test-suite test
   ghc-options:      -W -threaded
 
   if flag(strict)
-    ghc-options:      -Wall -Wno-name-shadowing -Werror
+    ghc-options:    -Wall -Wno-name-shadowing -Werror
 
   if !flag(no-plugin)
     cpp-options: -DUSE_NEW_EXECUTABLE
@@ -332,7 +332,7 @@ test-suite liquidhaskell-parser
   ghc-options:      -W
 
   if flag(strict)
-    ghc-options:      -Wall -Wno-name-shadowing -Werror
+    ghc-options:    -Wall -Wno-name-shadowing -Werror
 
 test-suite synthesis
   type:             exitcode-stdio-1.0
@@ -354,7 +354,7 @@ test-suite synthesis
   ghc-options:      -W
 
   if flag(strict)
-    ghc-options:      -Wall -Wno-name-shadowing -Werror
+    ghc-options:    -Wall -Wno-name-shadowing -Werror
 
 -- This executable can be used to generate modules for mirror-packages.
 executable mirror-modules

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -65,7 +65,7 @@ source-repository head
   type:     git
   location: https://github.com/ucsd-progsys/liquidhaskell/
 
-flag strict
+flag devel
   default:     False
   description: Enable more warnings and fail compilation when warnings occur.
                Turn this flag on in CI.
@@ -258,7 +258,7 @@ library
   default-extensions: PatternGuards, RecordWildCards, DoAndIfThenElse
   ghc-options:        -W -fwarn-missing-signatures
 
-  if flag(strict)
+  if flag(devel)
     ghc-options:      -Wall -Wno-name-shadowing -Werror
 
   if flag(include)
@@ -278,7 +278,7 @@ executable liquid
   default-extensions: PatternGuards
   ghc-options:        -W -threaded
 
-  if flag(strict)
+  if flag(devel)
     ghc-options:      -Wall -Wno-name-shadowing -Werror
 
 
@@ -307,7 +307,7 @@ test-suite test
   default-language: Haskell98
   ghc-options:      -W -threaded
 
-  if flag(strict)
+  if flag(devel)
     ghc-options:    -Wall -Wno-name-shadowing -Werror
 
   if !flag(no-plugin)
@@ -331,7 +331,7 @@ test-suite liquidhaskell-parser
   default-language: Haskell2010
   ghc-options:      -W
 
-  if flag(strict)
+  if flag(devel)
     ghc-options:    -Wall -Wno-name-shadowing -Werror
 
 test-suite synthesis
@@ -353,7 +353,7 @@ test-suite synthesis
   default-language: Haskell2010
   ghc-options:      -W
 
-  if flag(strict)
+  if flag(devel)
     ghc-options:    -Wall -Wno-name-shadowing -Werror
 
 -- This executable can be used to generate modules for mirror-packages.
@@ -384,5 +384,5 @@ executable mirror-modules
     LambdaCase
   ghc-options:        -W -threaded
 
-  if flag(strict)
+  if flag(devel)
     ghc-options:      -Wall -Wno-name-shadowing -Werror

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -25,7 +25,7 @@ module Language.Haskell.Liquid.Bare (
 
 import           Prelude                                    hiding (error)
 import           Optics
-import           Control.Monad                              (unless, forM)
+import           Control.Monad                              (forM)
 import           Control.Applicative                        ((<|>))
 import qualified Control.Exception                          as Ex
 import qualified Data.Binary                                as B
@@ -87,9 +87,6 @@ loadLiftedSpec cfg srcF
 --   incDir <- Misc.getIncludeDir 
 --   unless (Misc.isIncludeFile incDir srcF)
 --     $ Ex.throw (errMissingSpec srcF specF) 
-
-errMissingSpec :: FilePath -> FilePath -> UserError 
-errMissingSpec srcF specF = ErrNoSpec Ghc.noSrcSpan (text srcF) (text specF)
 
 saveLiftedSpec :: FilePath -> Ms.BareSpec -> IO () 
 saveLiftedSpec srcF lspec = do

--- a/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -125,7 +125,7 @@ grabBody allowTC t@(Ghc.FunTy {}) e
   = (txs++xs, e') 
    where (ts,tr)  = splitFun t 
          (xs, e') = grabBody allowTC tr (foldl Ghc.App e (Ghc.Var <$> txs))
-         txs      = [ stringVar ("ls" ++ show i) t |  (t,i) <- zip ts [1..]]
+         txs      = [ stringVar ("ls" ++ show i) t |  (t,i) <- zip ts [(1::Int)..]]
 grabBody _ _ e
   = ([], e)
 

--- a/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -472,8 +472,8 @@ checkRType allowHO bsc emb env lt
 tyToBind :: F.TCEmb TyCon -> RTVar RTyVar RSort  -> [(F.Symbol, F.SortedReft)]
 tyToBind emb = go . ty_var_info
   where
-    go (RTVInfo {..})   = [(rtv_name, rTypeSortedReft emb rtv_kind)]
-    go (RTVNoInfo {..}) = []
+    go (RTVInfo {..}) = [(rtv_name, rTypeSortedReft emb rtv_kind)]
+    go (RTVNoInfo {}) = []
 
 checkAppTys :: RType RTyCon t t1 -> Maybe Doc
 checkAppTys = go

--- a/src/Language/Haskell/Liquid/Bare/Class.hs
+++ b/src/Language/Haskell/Liquid/Bare/Class.hs
@@ -256,7 +256,7 @@ resolveDictionaries env name = fmap lookupVar
 -- formerly, addIndex
 -- GHC internal postfixed same name dictionaries with ints
 addInstIndex            :: (F.Symbol, [a]) -> [(F.Symbol, a)]
-addInstIndex (x, is) = go 0 (reverse is)
+addInstIndex (x, is) = go (0::Int) (reverse is)
   where 
     go _ []          = []
     go _ [i]         = [(x, i)]

--- a/src/Language/Haskell/Liquid/Bare/Expand.hs
+++ b/src/Language/Haskell/Liquid/Bare/Expand.hs
@@ -32,7 +32,6 @@ import Data.Maybe
 import           Control.Monad.State
 import qualified Control.Exception         as Ex
 import qualified Data.HashMap.Strict       as M
-import qualified Data.HashSet              as S
 import qualified Data.Char                 as Char
 import qualified Data.List                 as L
 import qualified Text.Printf               as Printf 
@@ -110,7 +109,7 @@ renameRTVArgs rt = rt { rtVArgs = newArgs
   where 
     msg          = "renameRTVArgs: " ++ F.showpp su
     su           = F.mkSubst (zip oldArgs (F.eVar <$> newArgs)) 
-    newArgs      = zipWith rtArg (rtVArgs rt) [0..]
+    newArgs      = zipWith rtArg (rtVArgs rt) [(0::Int)..]
     oldArgs      = rtVArgs rt
     rtArg x i    = F.suffixSymbol x (F.intSymbol "rta" i) 
 

--- a/src/Language/Haskell/Liquid/Bare/Misc.hs
+++ b/src/Language/Haskell/Liquid/Bare/Misc.hs
@@ -22,7 +22,6 @@ import qualified Data.Maybe                            as Mb --(fromMaybe, isNot
 
 import qualified Text.PrettyPrint.HughesPJ             as PJ 
 import qualified Data.List                             as L
-import           Language.Fixpoint.Misc                as Misc -- (singleton, sortNub)
 import qualified Language.Fixpoint.Types as F
 import           Language.Haskell.Liquid.GHC.Misc
 import           Language.Haskell.Liquid.Types.RefType

--- a/src/Language/Haskell/Liquid/Bare/Types.hs
+++ b/src/Language/Haskell/Liquid/Bare/Types.hs
@@ -28,7 +28,6 @@ module Language.Haskell.Liquid.Bare.Types
   , failMaybe
   ) where 
 
-import qualified Control.Exception                     as Ex 
 import qualified Text.PrettyPrint.HughesPJ             as PJ 
 import qualified Data.HashSet                          as S
 import qualified Data.HashMap.Strict                   as M

--- a/src/Language/Haskell/Liquid/Constraint/Fresh.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Fresh.hs
@@ -9,6 +9,8 @@
 {-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE ConstraintKinds       #-}
 
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Language.Haskell.Liquid.Constraint.Fresh
   ( -- module Language.Haskell.Liquid.Types.Fresh
     -- , 

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -16,6 +16,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ImplicitParams            #-}
 
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 -- | This module defines the representation of Subtyping and WF Constraints,
 --   and the code for syntax-directed constraint generation.
 
@@ -305,7 +307,7 @@ consCBSizedTys γ xes
        let vs    = zipWith collectArgs ts es
        is       <- mapM makeDecrIndex (zip3 xs ts vs) >>= checkSameLens
        let xeets = (\vis -> [(vis, x) | x <- zip3 xs is $ map unTemplate ts]) <$> (zip vs is)
-       (L.transpose <$> mapM checkIndex (zip4 xs vs ts is)) >>= checkEqTypes
+       _ <- (L.transpose <$> mapM checkIndex (zip4 xs vs ts is)) >>= checkEqTypes
        let rts   = (recType autoenv <$>) <$> xeets
        let xts   = zip xs ts
        γ'       <- foldM extender γ xts
@@ -430,7 +432,7 @@ consCB _ _ γ (NonRec x def)
   | Just (w, τ) <- grepDictionary def
   , Just d      <- dlookup (denv γ) w
   = do t        <- mapM (trueTy (typeclass (getConfig γ))) τ
-       mapM addW (WfC γ <$> t)
+       _ <- mapM addW (WfC γ <$> t)
        let xts   = dmap (fmap (f t)) d
        let  γ'   = γ { denv = dinsert (denv γ) x xts }
        t        <- trueTy (typeclass (getConfig γ)) (varType x)

--- a/src/Language/Haskell/Liquid/GHC/API.hs
+++ b/src/Language/Haskell/Liquid/GHC/API.hs
@@ -5,8 +5,6 @@ The intended use of this module is to shelter LiquidHaskell from changes to the 
 
 --}
 
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
-
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveFoldable #-}

--- a/src/Language/Haskell/Liquid/GHC/API.hs
+++ b/src/Language/Haskell/Liquid/GHC/API.hs
@@ -323,7 +323,7 @@ import GHC.Core.Opt.Monad             as Ghc (CoreToDo(..))
 import GHC.Core.Opt.WorkWrap.Utils    as Ghc
 import GHC.Core.Predicate             as Ghc (getClassPredTys_maybe, getClassPredTys, isEvVarType, isEqPrimPred, isEqPred, isClassPred, isDictId)
 import GHC.Core.Subst                 as Ghc (deShadowBinds, emptySubst, extendCvSubst)
-import GHC.Core.TyCo.Rep              as Ghc hiding (extendCvSubst)
+import GHC.Core.TyCo.Rep              as Ghc
 import GHC.Core.TyCon                 as Ghc
 import GHC.Core.Type                  as Ghc hiding (typeKind , isPredTy, extendCvSubst, linear)
 import GHC.Core.Unify                 as Ghc

--- a/src/Language/Haskell/Liquid/GHC/API.hs
+++ b/src/Language/Haskell/Liquid/GHC/API.hs
@@ -186,7 +186,6 @@ import RdrName                  as Ghc
 import SrcLoc                   as Ghc hiding (RealSrcSpan, SrcSpan(UnhelpfulSpan))
 import TcRnDriver               as Ghc
 import TcRnMonad                as Ghc hiding (getGHCiMonad)
---import TcRnTypes                as Ghc
 import TysPrim                  as Ghc
 import TysWiredIn               as Ghc
 import Unify                    as Ghc
@@ -201,7 +200,6 @@ import VarSet                   as  Ghc
 import qualified                SrcLoc
 import qualified Data.Bifunctor as Bi
 import qualified Data.Data      as Data
---import qualified DataCon        as Ghc
 import qualified GhcMake
 import qualified HscTypes       as Ghc
 import qualified Id             as Ghc
@@ -285,7 +283,6 @@ import Data.Foldable        (asum)
 #ifdef MIN_VERSION_GLASGOW_HASKELL
 
 #if MIN_VERSION_GLASGOW_HASKELL(8,10,0,0) && !MIN_VERSION_GLASGOW_HASKELL (9,0,0,0)
---import DynFlags          as  Ghc (targetPlatform)
 import GHC.Platform      as  Ghc (Platform)
 import Type              as  Ghc hiding (typeKind , isPredTy, splitFunTys, extendCvSubst)
 import qualified Type    as  Ghc hiding (extendCvSubst)
@@ -297,8 +294,6 @@ import FastString        as  Ghc
 import Predicate      as Ghc (getClassPredTys_maybe, isEvVarType, getClassPredTys, isDictId)
 import TcOrigin       as Ghc (lexprCtOrigin)
 import Data.Foldable  (asum)
---import Util           (lengthIs)
--- import PrelNames      (eqPrimTyConKey, eqReprPrimTyConKey, gHC_REAL, varQual_RDR)
 #endif
 #endif
 

--- a/src/Language/Haskell/Liquid/GHC/API.hs
+++ b/src/Language/Haskell/Liquid/GHC/API.hs
@@ -282,7 +282,7 @@ import Data.Foldable        (asum)
 
 #if MIN_VERSION_GLASGOW_HASKELL(8,10,0,0) && !MIN_VERSION_GLASGOW_HASKELL (9,0,0,0)
 import GHC.Platform      as  Ghc (Platform)
-import Type              as  Ghc hiding (typeKind , isPredTy, splitFunTys, extendCvSubst)
+import Type              as  Ghc hiding (mapType, typeKind, isPredTy, splitFunTys, extendCvSubst)
 import qualified Type    as  Ghc hiding (extendCvSubst)
 import TyCon             as  Ghc
 import qualified TyCoRep as  Ty
@@ -336,7 +336,7 @@ import GHC.Driver.Finder              as Ghc
 import GHC.Driver.Main                as Ghc
 import GHC.Driver.Phases              as Ghc (Phase(StopLn))
 import GHC.Driver.Pipeline            as Ghc (compileFile)
-import GHC.Driver.Session             as Ghc
+import GHC.Driver.Session             as Ghc hiding (isHomeModule)
 import GHC.Driver.Types               as Ghc
 import GHC.Driver.Monad               as Ghc (withSession)
 import GHC.HsToCore.Monad             as Ghc

--- a/src/Language/Haskell/Liquid/GHC/API.hs
+++ b/src/Language/Haskell/Liquid/GHC/API.hs
@@ -5,6 +5,8 @@ The intended use of this module is to shelter LiquidHaskell from changes to the 
 
 --}
 
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveFoldable #-}
@@ -122,7 +124,6 @@ import           Language.Haskell.Liquid.GHC.API.StableModule      as StableModu
 import           GHC                                               as Ghc hiding ( Warning
                                                                                  , SrcSpan(RealSrcSpan, UnhelpfulSpan)
                                                                                  , exprType
-                                                                                 , dataConInstArgTys
                                                                                  )
 
 -- Shared imports for GHC < 9
@@ -185,7 +186,7 @@ import RdrName                  as Ghc
 import SrcLoc                   as Ghc hiding (RealSrcSpan, SrcSpan(UnhelpfulSpan))
 import TcRnDriver               as Ghc
 import TcRnMonad                as Ghc hiding (getGHCiMonad)
-import TcRnTypes                as Ghc
+--import TcRnTypes                as Ghc
 import TysPrim                  as Ghc
 import TysWiredIn               as Ghc
 import Unify                    as Ghc
@@ -200,7 +201,7 @@ import VarSet                   as  Ghc
 import qualified                SrcLoc
 import qualified Data.Bifunctor as Bi
 import qualified Data.Data      as Data
-import qualified DataCon        as Ghc
+--import qualified DataCon        as Ghc
 import qualified GhcMake
 import qualified HscTypes       as Ghc
 import qualified Id             as Ghc
@@ -284,7 +285,7 @@ import Data.Foldable        (asum)
 #ifdef MIN_VERSION_GLASGOW_HASKELL
 
 #if MIN_VERSION_GLASGOW_HASKELL(8,10,0,0) && !MIN_VERSION_GLASGOW_HASKELL (9,0,0,0)
-import DynFlags          as  Ghc (targetPlatform)
+--import DynFlags          as  Ghc (targetPlatform)
 import GHC.Platform      as  Ghc (Platform)
 import Type              as  Ghc hiding (typeKind , isPredTy, splitFunTys, extendCvSubst)
 import qualified Type    as  Ghc hiding (extendCvSubst)
@@ -296,7 +297,7 @@ import FastString        as  Ghc
 import Predicate      as Ghc (getClassPredTys_maybe, isEvVarType, getClassPredTys, isDictId)
 import TcOrigin       as Ghc (lexprCtOrigin)
 import Data.Foldable  (asum)
-import Util           (lengthIs)
+--import Util           (lengthIs)
 -- import PrelNames      (eqPrimTyConKey, eqReprPrimTyConKey, gHC_REAL, varQual_RDR)
 #endif
 #endif

--- a/src/Language/Haskell/Liquid/GHC/API/StableModule.hs
+++ b/src/Language/Haskell/Liquid/GHC/API/StableModule.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Language.Haskell.Liquid.GHC.API.StableModule (
     StableModule
   -- * Constructing a 'StableModule'

--- a/src/Language/Haskell/Liquid/GHC/Interface.hs
+++ b/src/Language/Haskell/Liquid/GHC/Interface.hs
@@ -65,6 +65,7 @@ import GHC.Paths (libdir)
 import           Language.Haskell.Liquid.GHC.GhcMonadLike (isBootInterface)
 import           Language.Haskell.Liquid.GHC.API as Ghc hiding ( text
                                                                , (<+>)
+                                                               , isHomeModule
                                                                , panic
                                                                , vcat
                                                                , showPpr
@@ -1036,13 +1037,14 @@ instance PPrint TargetInfo where
     , pprintCBs $ _giCbs (review targetSrcIso $ giSrc info) ]
 
 -- RJ: the silly guards below are to silence the unused-var checker
+-- LDM: GHC 9.0.1 is having none of it unfortunately: "Pattern match is redundant".
 pprintCBs :: [CoreBind] -> Doc
 pprintCBs
   | otherwise = pprintCBsTidy
-  | otherwise = pprintCBsVerbose
+  -- | otherwise = pprintCBsVerbose
   where
     pprintCBsTidy    = pprDoc . tidyCBs
-    pprintCBsVerbose = text . O.showSDocDebug unsafeGlobalDynFlags . O.ppr . tidyCBs
+    -- pprintCBsVerbose = text . O.showSDocDebug unsafeGlobalDynFlags . O.ppr . tidyCBs
 
 instance Show TargetInfo where
   show = showpp

--- a/src/Language/Haskell/Liquid/GHC/Interface.hs
+++ b/src/Language/Haskell/Liquid/GHC/Interface.hs
@@ -11,6 +11,9 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE ViewPatterns               #-}
 
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wwarn=deprecations #-}
+
 module Language.Haskell.Liquid.GHC.Interface (
 
   -- * Determine the build-order for target files
@@ -58,7 +61,6 @@ module Language.Haskell.Liquid.GHC.Interface (
 import Prelude hiding (error)
 
 import GHC.Paths (libdir)
-import GHC.Serialized
 
 import           Language.Haskell.Liquid.GHC.GhcMonadLike (isBootInterface)
 import           Language.Haskell.Liquid.GHC.API as Ghc hiding ( text
@@ -66,7 +68,6 @@ import           Language.Haskell.Liquid.GHC.API as Ghc hiding ( text
                                                                , panic
                                                                , vcat
                                                                , showPpr
-                                                               , isHomeModule
                                                                , Target
                                                                , Located
                                                                )
@@ -267,7 +268,7 @@ configureGhcTargets tgtFiles = do
                      flattenSCCs $ topSortModuleGraph False moduleGraph Nothing
   let homeNames    = moduleName . ms_mod <$> homeModules
   _               <- setTargetModules homeNames
-  liftIO $ whenLoud $ print    ("Module Dependencies", homeNames)
+  liftIO $ whenLoud $ print ("Module Dependencies" :: String, homeNames)
   return $ mkModuleGraph homeModules
 
 setTargetModules :: [ModuleName] -> Ghc ()
@@ -701,7 +702,7 @@ availableVars hscEnv modSum tcGblEnv avails =
 
 _dumpTypeEnv :: TypecheckedModule -> IO () 
 _dumpTypeEnv tm = do 
-  print "DUMP-TYPE-ENV"
+  print ("DUMP-TYPE-ENV" :: String)
   print (showpp <$> tcmTyThings tm)
 
 tcmTyThings :: TypecheckedModule -> Maybe [Name] 
@@ -717,7 +718,7 @@ tcmTyThings
 
 _dumpRdrEnv :: HscEnv -> MGIModGuts -> IO () 
 _dumpRdrEnv _hscEnv modGuts = do 
-  print "DUMP-RDR-ENV" 
+  print ("DUMP-RDR-ENV" :: String)
   print (mgNames modGuts)
   -- print (hscNames hscEnv) 
   -- print (mgDeps modGuts) 

--- a/src/Language/Haskell/Liquid/GHC/Interface.hs
+++ b/src/Language/Haskell/Liquid/GHC/Interface.hs
@@ -65,7 +65,6 @@ import GHC.Paths (libdir)
 import           Language.Haskell.Liquid.GHC.GhcMonadLike (isBootInterface)
 import           Language.Haskell.Liquid.GHC.API as Ghc hiding ( text
                                                                , (<+>)
-                                                               , isHomeModule
                                                                , panic
                                                                , vcat
                                                                , showPpr

--- a/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE ViewPatterns              #-}
 {-# LANGUAGE PatternSynonyms           #-}
 
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- Only needed for GHC <9.0.1.
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | This module contains a wrappers and utility functions for

--- a/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -12,7 +12,6 @@
 {-# LANGUAGE PatternSynonyms           #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 
 -- | This module contains a wrappers and utility functions for
 -- accessing GHC module information. It should NEVER depend on
@@ -949,7 +948,7 @@ elabRnExpr mode rdr_expr = do
              tc_infer rn_expr
 
     -- Generalise
-    (qtvs, dicts, evbs, residual, _)
+    (_qtvs, _dicts, evbs, residual, _)
          <- simplifyInfer tclvl infer_mode
                           []    {- No sig vars -}
                           [(fresh_it, res_ty)]

--- a/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -11,6 +11,9 @@
 {-# LANGUAGE ViewPatterns              #-}
 {-# LANGUAGE PatternSynonyms           #-}
 
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+
 -- | This module contains a wrappers and utility functions for
 -- accessing GHC module information. It should NEVER depend on
 -- ANY module inside the Language.Haskell.Liquid.* tree.
@@ -716,13 +719,13 @@ desugarModule tcm = do
 --------------------------------------------------------------------------------
 
 gHC_VERSION :: String
-gHC_VERSION = show __GLASGOW_HASKELL__
+gHC_VERSION = show (__GLASGOW_HASKELL__ :: Int)
 
 symbolFastString :: Symbol -> FastString
 symbolFastString = mkFastStringByteString . T.encodeUtf8 . symbolText
 
 lintCoreBindings :: [Var] -> CoreProgram -> (Bag MsgDoc, Bag MsgDoc)
-lintCoreBindings = Ghc.lintCoreBindings (defaultDynFlags undefined (undefined "LlvmTargets")) CoreDoNothing
+lintCoreBindings = Ghc.lintCoreBindings (defaultDynFlags undefined (undefined ("LlvmTargets" :: String))) CoreDoNothing
 
 synTyConRhs_maybe :: TyCon -> Maybe Type
 synTyConRhs_maybe = Ghc.synTyConRhs_maybe

--- a/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -11,7 +11,7 @@
 {-# LANGUAGE ViewPatterns              #-}
 {-# LANGUAGE PatternSynonyms           #-}
 
-{-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- Only needed for GHC <9.0.1.
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- TODO(#1918): Only needed for GHC <9.0.1.
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | This module contains a wrappers and utility functions for

--- a/src/Language/Haskell/Liquid/GHC/Play.hs
+++ b/src/Language/Haskell/Liquid/GHC/Play.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE TupleSections             #-}
 {-# LANGUAGE PatternSynonyms           #-}
 
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+
 module Language.Haskell.Liquid.GHC.Play where
 
 import Prelude hiding (error)

--- a/src/Language/Haskell/Liquid/GHC/Play.hs
+++ b/src/Language/Haskell/Liquid/GHC/Play.hs
@@ -4,8 +4,6 @@
 {-# LANGUAGE TupleSections             #-}
 {-# LANGUAGE PatternSynonyms           #-}
 
-{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
-
 module Language.Haskell.Liquid.GHC.Play where
 
 import Prelude hiding (error)

--- a/src/Language/Haskell/Liquid/GHC/Play.hs
+++ b/src/Language/Haskell/Liquid/GHC/Play.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE TupleSections             #-}
 {-# LANGUAGE PatternSynonyms           #-}
 
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- Only needed for GHC <9.0.1.
+
 module Language.Haskell.Liquid.GHC.Play where
 
 import Prelude hiding (error)

--- a/src/Language/Haskell/Liquid/GHC/Play.hs
+++ b/src/Language/Haskell/Liquid/GHC/Play.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE TupleSections             #-}
 {-# LANGUAGE PatternSynonyms           #-}
 
-{-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- Only needed for GHC <9.0.1.
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- TODO(#1918): Only needed for GHC <9.0.1.
 
 module Language.Haskell.Liquid.GHC.Play where
 

--- a/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -21,7 +21,7 @@ module Language.Haskell.Liquid.GHC.Plugin (
   ) where
 
 import qualified Language.Haskell.Liquid.GHC.API         as O
-import           Language.Haskell.Liquid.GHC.API         as GHC hiding (Target)
+import           Language.Haskell.Liquid.GHC.API         as GHC hiding (Target, Type)
 import qualified Text.PrettyPrint.HughesPJ               as PJ
 import qualified Language.Fixpoint.Types                 as F
 import qualified Language.Haskell.Liquid.GHC.Misc        as LH
@@ -48,6 +48,7 @@ import           GHC.LanguageExtensions
 import           Control.Monad
 
 import           Data.Coerce
+import           Data.Kind                                ( Type )
 import           Data.List                               as L
                                                    hiding ( intersperse )
 import           Data.IORef
@@ -164,7 +165,7 @@ customDynFlags opts dflags = do
 -- desugaring the module during /parsing/ (before that's already too late) and we cache the core binds for
 -- the rest of the program execution.
 class Unoptimise a where
-  type UnoptimisedTarget a :: *
+  type UnoptimisedTarget a :: Type
   unoptimise :: a -> UnoptimisedTarget a
 
 instance Unoptimise DynFlags where

--- a/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -46,7 +46,6 @@ import           Language.Haskell.Liquid.GHC.GhcMonadLike ( GhcMonadLike
 import           GHC.LanguageExtensions
 
 import           Control.Monad
-import           Control.Exception                        (evaluate)
 
 import           Data.Coerce
 import           Data.List                               as L

--- a/src/Language/Haskell/Liquid/GHC/Plugin/SpecFinder.hs
+++ b/src/Language/Haskell/Liquid/GHC/Plugin/SpecFinder.hs
@@ -26,7 +26,7 @@ import           Language.Fixpoint.Utils.Files            ( Ext(Spec), withExt )
 
 import           Optics
 import qualified Language.Haskell.Liquid.GHC.API         as O
-import           Language.Haskell.Liquid.GHC.API         as GHC hiding (linear)
+import           Language.Haskell.Liquid.GHC.API         as GHC
 
 import           Data.Bifunctor
 import           Data.Maybe

--- a/src/Language/Haskell/Liquid/GHC/TypeRep.hs
+++ b/src/Language/Haskell/Liquid/GHC/TypeRep.hs
@@ -12,7 +12,6 @@
 {-# LANGUAGE StandaloneDeriving        #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 
 -- | This module contains a wrappers and utility functions for
 -- accessing GHC module information. It should NEVER depend on

--- a/src/Language/Haskell/Liquid/GHC/TypeRep.hs
+++ b/src/Language/Haskell/Liquid/GHC/TypeRep.hs
@@ -11,7 +11,7 @@
 {-# LANGUAGE PatternSynonyms           #-}
 {-# LANGUAGE StandaloneDeriving        #-}
 
-{-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- Only needed for GHC <9.0.1.
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- TODO(#1918): Only needed for GHC <9.0.1.
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | This module contains a wrappers and utility functions for

--- a/src/Language/Haskell/Liquid/GHC/TypeRep.hs
+++ b/src/Language/Haskell/Liquid/GHC/TypeRep.hs
@@ -11,6 +11,9 @@
 {-# LANGUAGE PatternSynonyms           #-}
 {-# LANGUAGE StandaloneDeriving        #-}
 
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+
 -- | This module contains a wrappers and utility functions for
 -- accessing GHC module information. It should NEVER depend on
 module Language.Haskell.Liquid.GHC.TypeRep (

--- a/src/Language/Haskell/Liquid/GHC/TypeRep.hs
+++ b/src/Language/Haskell/Liquid/GHC/TypeRep.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE PatternSynonyms           #-}
 {-# LANGUAGE StandaloneDeriving        #-}
 
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- Only needed for GHC <9.0.1.
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | This module contains a wrappers and utility functions for

--- a/src/Language/Haskell/Liquid/Measure.hs
+++ b/src/Language/Haskell/Liquid/Measure.hs
@@ -154,7 +154,7 @@ noDummySyms t
   = t
   where
     rep = toRTypeRep t
-    xs' = zipWith (\_ i -> symbol ("x" ++ show i)) (ty_binds rep) [1..]
+    xs' = zipWith (\_ i -> symbol ("x" ++ show i)) (ty_binds rep) [(1::Int)..]
     su  = mkSubst $ zip (ty_binds rep) (EVar <$> xs')
 
 combineDCTypes :: String -> Type -> [RRType Reft] -> RRType Reft

--- a/src/Language/Haskell/Liquid/Misc.hs
+++ b/src/Language/Haskell/Liquid/Misc.hs
@@ -213,7 +213,7 @@ safeZip4WithError msg _      _      _      _      = errorstar msg
 
 
 mapNs :: (Eq a, Num a, Foldable t) => t a -> (a1 -> a1) -> [a1] -> [a1]
-mapNs ns f xs = foldl (\xs n -> mapN n f xs) xs ns
+mapNs ns f xs = foldl (\ys n -> mapN n f ys) xs ns
 
 mapN :: (Eq a, Num a) => a -> (a1 -> a1) -> [a1] -> [a1]
 mapN 0 f (x:xs) = f x : xs

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -47,8 +47,6 @@ import qualified Language.Haskell.Liquid.Measure        as Measure
 import           Language.Fixpoint.Parse                hiding (defineP, dataDeclP, refBindP, refP, refDefP, parseTest')
 
 import Control.Monad.State
-import qualified Language.Fixpoint.Types.PrettyPrint as F
-import qualified Language.Fixpoint.Types as F
 
 -- import Debug.Trace
 
@@ -558,7 +556,7 @@ bareAllP = do
   as  <- tyVarDefsP
   ps  <- angles inAngles
         <|> return []
-  dot
+  _ <- dot
   t <- bareTypeP
   return $ foldr rAllT (foldr (rAllP sp) t ps) (makeRTVar <$> as)
   where
@@ -706,8 +704,7 @@ monoPredicate1P
   <|> (pdVar <$>        predVarUseP)
   <?> "monoPredicate1P"
 
-predVarUseP :: IsString t
-            => Parser (PVar t)
+predVarUseP :: Parser (PVar String)
 predVarUseP
   = do (p, xs) <- funArgsP
        return   $ PV p (PVProp dummyTyId) dummySymbol [ (dummyTyId, dummySymbol, x) | x <- xs ]
@@ -1316,7 +1313,7 @@ hmeasureP = do
 measureP :: Parser (Measure (Located BareType) LocSymbol)
 measureP = do
   (x, ty) <- indentedLine tyBindP
-  optional semi
+  _ <- optional semi
   eqns    <- block $ measureDefP (rawBodyP <|> tyBodyP ty)
   return   $ Measure.mkM x ty eqns MsMeasure mempty
 

--- a/src/Language/Haskell/Liquid/Synthesize/GHC.hs
+++ b/src/Language/Haskell/Liquid/Synthesize/GHC.hs
@@ -2,6 +2,9 @@
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE CPP #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Language.Haskell.Liquid.Synthesize.GHC where
 
 import qualified Language.Fixpoint.Types       as F

--- a/src/Language/Haskell/Liquid/Synthesize/Misc.hs
+++ b/src/Language/Haskell/Liquid/Synthesize/Misc.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE BangPatterns #-}
 
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Language.Haskell.Liquid.Synthesize.Misc where
 
 import qualified Language.Fixpoint.Types        as F

--- a/src/Language/Haskell/Liquid/Synthesize/Monad.hs
+++ b/src/Language/Haskell/Liquid/Synthesize/Monad.hs
@@ -93,7 +93,7 @@ evalSM :: SM a -> SMT.Context -> SSEnv -> SState -> IO a
 evalSM act ctx env st = do 
   let st' = st {ssEnv = env}
   r <- evalStateT act st'
-  SMT.cleanupContext ctx 
+  _ <- SMT.cleanupContext ctx 
   return r 
 
 initState :: SMT.Context -> F.Config -> CGInfo -> CGEnv -> REnv -> Var -> [Var] -> SSEnv -> IO SState 

--- a/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -4,6 +4,9 @@
 {-# LANGUAGE UndecidableInstances   #-}
 {-# LANGUAGE OverloadedStrings      #-}
 {-# LANGUAGE TupleSections          #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Language.Haskell.Liquid.Transforms.CoreToLogic
   ( coreToDef
   , coreToFun
@@ -85,7 +88,7 @@ inlineSpecType  allowTC v = fromRTypeRep $ rep {ty_res = res `strengthen` r , ty
 
 -- formerly: strengthenResult'
 measureSpecType :: Bool -> Var -> SpecType
-measureSpecType allowTC v = go mkT [] [1..] t
+measureSpecType allowTC v = go mkT [] [(1::Int)..] t
   where 
     mkR | boolRes   = propReft 
         | otherwise = exprReft  
@@ -267,7 +270,7 @@ coreToLg allowTC  (C.Let b e)
 coreToLg allowTC (C.Tick _ e)          = coreToLg allowTC e
 coreToLg allowTC (C.App (C.Var v) e)
   | ignoreVar v                = coreToLg allowTC e
-coreToLg allowTC (C.Var x)
+coreToLg _allowTC (C.Var x)
   | x == falseDataConId        = return PFalse
   | x == trueDataConId         = return PTrue
   | otherwise                  = (lsSymMap <$> getState) >>= eVarWithMap x

--- a/src/Language/Haskell/Liquid/Transforms/RefSplit.hs
+++ b/src/Language/Haskell/Liquid/Transforms/RefSplit.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE UndecidableInstances #-}
 
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Language.Haskell.Liquid.Transforms.RefSplit (
 
         splitXRelatedRefs

--- a/src/Language/Haskell/Liquid/Types/Errors.hs
+++ b/src/Language/Haskell/Liquid/Types/Errors.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE DerivingStrategies  #-}
 {-# LANGUAGE DerivingVia         #-}
 
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- Only needed for GHC <9.0.1.
 {-# OPTIONS_GHC -Wno-orphans #-} -- PPrint and aeson instances.
 
 -- | This module contains the *types* related creating Errors.

--- a/src/Language/Haskell/Liquid/Types/Errors.hs
+++ b/src/Language/Haskell/Liquid/Types/Errors.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE DerivingStrategies  #-}
 {-# LANGUAGE DerivingVia         #-}
 
-{-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- GHC claims some exhaustive pattern matches aren't.
 {-# OPTIONS_GHC -Wno-orphans #-} -- PPrint and aeson instances.
 
 -- | This module contains the *types* related creating Errors.

--- a/src/Language/Haskell/Liquid/Types/Errors.hs
+++ b/src/Language/Haskell/Liquid/Types/Errors.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE DerivingStrategies  #-}
 {-# LANGUAGE DerivingVia         #-}
 
-{-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- Only needed for GHC <9.0.1.
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- TODO(#1918): Only needed for GHC <9.0.1.
 {-# OPTIONS_GHC -Wno-orphans #-} -- PPrint and aeson instances.
 
 -- | This module contains the *types* related creating Errors.

--- a/src/Language/Haskell/Liquid/Types/Errors.hs
+++ b/src/Language/Haskell/Liquid/Types/Errors.hs
@@ -9,6 +9,9 @@
 {-# LANGUAGE DerivingStrategies  #-}
 {-# LANGUAGE DerivingVia         #-}
 
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- GHC claims some exhaustive pattern matches aren't.
+{-# OPTIONS_GHC -Wno-orphans #-} -- PPrint and aeson instances.
+
 -- | This module contains the *types* related creating Errors.
 --   It depends only on Fixpoint and basic haskell libraries,
 --   and hence, should be importable everywhere.
@@ -50,7 +53,7 @@ module Language.Haskell.Liquid.Types.Errors (
   , srcSpanFileMb
   ) where
 
-import           Prelude                      hiding (error)
+import           Prelude                      hiding (error, span)
 
 import           GHC.Generics
 import           Control.DeepSeq
@@ -86,6 +89,7 @@ import           Language.Haskell.Liquid.GHC.API as Ghc hiding ( Expr
                                                                , panic
                                                                , int
                                                                , hcat
+                                                               , spans
                                                                )
 import           Language.Fixpoint.Types      (pprint, showpp, Tidy (..), PPrint (..), Symbol, Expr, SubcId)
 import qualified Language.Fixpoint.Misc       as Misc

--- a/src/Language/Haskell/Liquid/Types/PredType.hs
+++ b/src/Language/Haskell/Liquid/Types/PredType.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE TupleSections        #-}
 {-# LANGUAGE UndecidableInstances #-}
 
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Language.Haskell.Liquid.Types.PredType (
     PrType
   , TyConP (..), DataConP (..)

--- a/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
+++ b/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
@@ -10,6 +10,8 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE FlexibleInstances    #-}
 
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Language.Haskell.Liquid.Types.PrettyPrint
   ( -- * Printable RTypes
     OkRT

--- a/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -15,6 +15,7 @@
 {-# LANGUAGE ConstraintKinds           #-}
 {-# LANGUAGE ViewPatterns              #-}
 
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- Only needed for GHC <9.0.1.
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Refinement Types. Mostly mirroring the GHC Type definition, but with
@@ -119,7 +120,6 @@ import qualified Language.Haskell.Liquid.GHC.Misc as GM
 import           Language.Haskell.Liquid.GHC.Play (mapType, stringClassArg, isRecursivenewTyCon)
 import           Language.Haskell.Liquid.GHC.API        as Ghc hiding ( Expr
                                                                       , Located
-                                                                      --, mapType
                                                                       , tyConName
                                                                       , punctuate
                                                                       , hcat

--- a/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -16,7 +16,6 @@
 {-# LANGUAGE ViewPatterns              #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 
 -- | Refinement Types. Mostly mirroring the GHC Type definition, but with
 --   room for refinements of various sorts.
@@ -120,7 +119,7 @@ import qualified Language.Haskell.Liquid.GHC.Misc as GM
 import           Language.Haskell.Liquid.GHC.Play (mapType, stringClassArg, isRecursivenewTyCon)
 import           Language.Haskell.Liquid.GHC.API        as Ghc hiding ( Expr
                                                                       , Located
-                                                                      , mapType
+                                                                      --, mapType
                                                                       , tyConName
                                                                       , punctuate
                                                                       , hcat
@@ -651,13 +650,13 @@ pprt_raw = render . rtypeDoc Full
  -}
 
 strengthenRefType t1 t2
-  | True -- _meetable t1 t2
+  -- | _meetable t1 t2
   = strengthenRefType_ (\x _ -> x) t1 t2
-  | otherwise
-  = panic Nothing msg
-  where
-    msg = printf "strengthen on differently shaped reftypes \nt1 = %s [shape = %s]\nt2 = %s [shape = %s]"
-            (showpp t1) (showpp (toRSort t1)) (showpp t2) (showpp (toRSort t2))
+  -- | otherwise
+  -- = panic Nothing msg
+  -- where
+  --   msg = printf "strengthen on differently shaped reftypes \nt1 = %s [shape = %s]\nt2 = %s [shape = %s]"
+  --           (showpp t1) (showpp (toRSort t1)) (showpp t2) (showpp (toRSort t2))
 
 _meetable :: (OkRT c tv r) => RType c tv r -> RType c tv r -> Bool
 _meetable t1 t2 = toRSort t1 == toRSort t2

--- a/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -15,7 +15,7 @@
 {-# LANGUAGE ConstraintKinds           #-}
 {-# LANGUAGE ViewPatterns              #-}
 
-{-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- Only needed for GHC <9.0.1.
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- TODO(#1918): Only needed for GHC <9.0.1.
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Refinement Types. Mostly mirroring the GHC Type definition, but with

--- a/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -15,6 +15,9 @@
 {-# LANGUAGE ConstraintKinds           #-}
 {-# LANGUAGE ViewPatterns              #-}
 
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+
 -- | Refinement Types. Mostly mirroring the GHC Type definition, but with
 --   room for refinements of various sorts.
 -- TODO: Desperately needs re-organization.
@@ -1694,9 +1697,6 @@ grabArgs τs (FunTy _ _ τ1 τ2)
   -- -- = grabArgs τs τ2
 grabArgs τs τ
   = reverse (τ:τs)
-
-isNonValueTy :: Type -> Bool
-isNonValueTy = GM.isPredType-- GM.isEmbeddedDictType 
 
 
 expandProductType :: (PPrint r, Reftable r, SubsTy RTyVar (RType RTyCon RTyVar ()) r, Reftable (RTProp RTyCon RTyVar r))

--- a/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -8,8 +8,9 @@
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE DerivingVia                #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards            #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Language.Haskell.Liquid.Types.Specs (
   -- * Different types of specifications

--- a/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/src/Language/Haskell/Liquid/Types/Types.hs
@@ -18,6 +18,8 @@
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE DerivingVia                #-}
 
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 -- | This module should contain all the global type definitions and basic instances.
 
 module Language.Haskell.Liquid.Types.Types (
@@ -894,8 +896,8 @@ ty_var_is_val :: RTVar tv s -> Bool
 ty_var_is_val = rtvinfo_is_val . ty_var_info
 
 rtvinfo_is_val :: RTVInfo s -> Bool
-rtvinfo_is_val (RTVNoInfo {..}) = False
-rtvinfo_is_val (RTVInfo {..})   = rtv_is_val
+rtvinfo_is_val (RTVNoInfo {}) = False
+rtvinfo_is_val (RTVInfo {..}) = rtv_is_val
 
 instance (B.Binary tv, B.Binary s) => B.Binary (RTVar tv s)
 instance (NFData tv, NFData s)     => NFData   (RTVar tv s)

--- a/src/Language/Haskell/Liquid/UX/Annotate.hs
+++ b/src/Language/Haskell/Liquid/UX/Annotate.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE TypeSynonymInstances       #-}
 {-# LANGUAGE FlexibleInstances          #-}
 
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 ---------------------------------------------------------------------------
 -- | This module contains the code that uses the inferred types to generate

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -7,6 +7,9 @@
 {-# LANGUAGE NamedFieldPuns            #-}
 {-# LANGUAGE MultiWayIf                #-}
 {-# LANGUAGE ViewPatterns              #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wwarn=deprecations #-}
 {-# OPTIONS_GHC -fno-cse #-}
 
 -- | This module contains all the code needed to output the result which

--- a/src/Language/Haskell/Liquid/UX/DiffCheck.hs
+++ b/src/Language/Haskell/Liquid/UX/DiffCheck.hs
@@ -7,6 +7,8 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
 
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Language.Haskell.Liquid.UX.DiffCheck (
 
    -- * Changed binders + Unchanged Errors

--- a/src/Language/Haskell/Liquid/UX/Errors.hs
+++ b/src/Language/Haskell/Liquid/UX/Errors.hs
@@ -174,4 +174,4 @@ niceTemps     = mkSymbol <$> xs ++ ys
   where
     mkSymbol  = F.symbol . ('?' :)
     xs        = Misc.single <$> ['a' .. 'z']
-    ys        = ("a" ++) <$> [show n | n <- [0 ..]]
+    ys        = ("a" ++) <$> [show n | n <- [(0::Int) ..]]

--- a/src/Language/Haskell/Liquid/UX/Tidy.hs
+++ b/src/Language/Haskell/Liquid/UX/Tidy.hs
@@ -1,7 +1,8 @@
-
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 ---------------------------------------------------------------------
 -- | This module contains functions for cleaning up types before
@@ -148,13 +149,13 @@ tidyTyVars t = subsTyVarsAll αβs t
     αβs  = zipWith (\α β -> (α, toRSort β, β)) αs βs
     αs   = L.nub (tyVars t)
     βs   = map (rVar . GM.stringTyVar) pool
-    pool = [[c] | c <- ['a'..'z']] ++ [ "t" ++ show i | i <- [1..]]
+    pool = [[c] | c <- ['a'..'z']] ++ [ "t" ++ show i | i <- [(1::Int)..]]
 
 
 bindersTx :: [Symbol] -> Symbol -> Symbol
 bindersTx ds   = \y -> M.lookupDefault y y m
   where
-    m          = M.fromList $ zip ds $ var <$> [1..]
+    m          = M.fromList $ zip ds $ var <$> [(1::Int)..]
     var        = symbol . ('x' :) . show
 
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,6 @@
 flags:
+  liquidhaskell:
+    devel: true
   liquid-platform:
     devel: true
 extra-package-dbs: []

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -24,7 +24,6 @@ import Data.Maybe (fromMaybe)
 import Data.Monoid (Sum(..))
 import Data.Proxy
 import Data.String
-import Data.String.Conv
 import Data.Tagged
 import Data.Typeable
 -- import Data.List (sort, reverse)
@@ -311,9 +310,9 @@ microTests = group "Micro"
   where
     mkMicroPos name dir = testGroup name <$> dirTests dir [] ExitSuccess     (Just " SAFE ") (Just " UNSAFE ")
     mkMicroNeg name dir = testGroup name <$> dirTests dir [] (ExitFailure 1) (Just " UNSAFE ") Nothing
-    mkMicroLaw name dir = testGroup name <$> dirTests dir [] (ExitFailure 1) (Just "Law Instance Error") Nothing
+    -- mkMicroLaw name dir = testGroup name <$> dirTests dir [] (ExitFailure 1) (Just "Law Instance Error") Nothing
 
-
+posIgnored, gPosIgnored, gNegIgnored :: [FilePath]
 posIgnored    = [ "mapreduce.hs", "Variance.hs" ]
 gPosIgnored   = ["Intro.hs"]
 gNegIgnored   = ["Interpretations.hs", "Gradual.hs"]
@@ -677,6 +676,7 @@ noPleIgnored
   = "ApplicativeList.hs"         -- TODO-REBARE: TODO BLOWUP but ple version ok
   : autoIgnored
 
+esopIgnored :: [FilePath]
 esopIgnored 
   = [ "Base0.hs"
     ]
@@ -688,6 +688,7 @@ icfpIgnored
     , "TwiceM.hs"                -- TODO: BLOWUP: using 2.7GB RAM
     ]
 
+autoIgnored :: [FilePath]
 autoIgnored 
   = "Ackermann.hs" 
   : proverIgnored
@@ -922,9 +923,9 @@ loggingTestReporter = TestReporter [] $ \opts tree -> Just $ \smap -> do
 
     let dir = "tests" </> "logs" </> host ++ "-" ++ time
     let smry = "tests" </> "logs" </> "cur" </> "summary.csv"
-    system "mkdir -p tests/logs/cur"
+    _ <- system "mkdir -p tests/logs/cur"
     writeFile smry $ unlines
                    $ hdr
                    : map (\(n, t, r) -> printf "%s, %0.4f, %s" n t (show r)) summary
-    system $ "cp -r tests/logs/cur " ++ dir
+    _ <- system $ "cp -r tests/logs/cur " ++ dir
     (==0) <$> computeFailures smap


### PR DESCRIPTION
Add a `devel` flag to optionally build `liquidhaskell` such that warnings fail the build.

# Motivation

I was building https://github.com/facundominguez/stitch-lh and noticed lots of GHC warnings as it was building `liquidhaskell`. That's not a great user experience. So I wanted to see if I could fix all compiler warnings.

# Changes

This PR adds a flag called `devel` that changes the GHC flags to:

- `-Wall` to enable all warnings by default, with [these exceptions](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/using-warnings.html#ghc-flag--Wall).
- `-Wno-name-shadowing` because name shadowing is widely used in the project and this seems like a valid stylistic choice.
- `-Werror` to fail the build if there is a warning. This is useful primarily for CI.

In addition, this PR disables some warnings in specific files:

- `-Wno-orphans` wherever orphan instances are defined. This is done in lots of files. I still think it is useful to have this warning enabled by default so new code in new files is discouraged from using orphan instances.
- `-Wno-incomplete-patterns` to disable misleading warnings about inexhaustive patterns, see #1918.
- `-Wno-dodgy-imports`: see https://github.com/ucsd-progsys/liquidhaskell/issues/1913.
- `-Wno-unused-top-binds`: see https://github.com/ucsd-progsys/liquidhaskell/issues/1914.

I have made appropriate changes to the source code so there are no more GHC warnings when `liquidhaskell` is built (see #1913, #1914, #1915, #1916 for exceptions / further work on this front).

# Alternatives

The alternative to adding a new flag would have been to set the stricter GHC options by default. This is brittle: new GHC versions sometimes add new warnings to `-Wall`, which in combination with `-Werror` could lead to build failures in projects that depend on `liquidhaskell` that we as `liquidhaskell` developers are not even aware of.

# To do

- [x] Document how to set the `devel` flag when developing locally (it is enabled by default in `stack.yaml`)