### PR TITLE
Parallelize tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,6 @@ jobs:
       - cabal_build_and_test:
           ghc_version: "9.0.1"
           project_file: "cabal.ghc9.project"
-          extra_test_flags: ' --test-options '' -p "$0 != \"Tests.Benchmarks.text.Data/Text/Foreign.hs\" && ! /Tests.Micro.typeclass-pos./"'' '
           liquid_runner: "--liquid-runner=cabal -v0 v2-exec --project-file cabal.ghc9.project liquidhaskell -- -v0 \
                           -package-env=$(./scripts/generate_testing_ghc_env cabal.ghc9.project) \
                           -package=liquidhaskell -package=Cabal "

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -305,7 +305,7 @@ test-suite test
                   , text
                   , transformers         >= 0.3
   default-language: Haskell98
-  ghc-options:      -W -threaded
+  ghc-options:      -W -threaded -with-rtsopts=-N
 
   if flag(devel)
     ghc-options:    -Wall -Wno-name-shadowing -Werror

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -305,7 +305,7 @@ test-suite test
                   , text
                   , transformers         >= 0.3
   default-language: Haskell98
-  ghc-options:      -W -threaded -with-rtsopts=-N2
+  ghc-options:      -W -threaded -with-rtsopts=-N
 
   if flag(devel)
     ghc-options:    -Wall -Wno-name-shadowing -Werror

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -305,7 +305,7 @@ test-suite test
                   , text
                   , transformers         >= 0.3
   default-language: Haskell98
-  ghc-options:      -W -threaded -with-rtsopts=-N
+  ghc-options:      -W -threaded -with-rtsopts=-N2
 
   if flag(devel)
     ghc-options:    -Wall -Wno-name-shadowing -Werror

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -310,7 +310,9 @@ microTests = group "Micro"
   -- RJ: disabling because broken by adt PR #1068
   -- , tesGoupsWithLibs "gradual/pos"    <$> dirTests "tests/gradual/pos"                    []                ExitSuccess
   -- , tesGoupsWithLibs "gradual/neg"    <$> dirTests "tests/gradual/neg"                    []                (ExitFailure 1)
-  , mkMicroPos "typeclass-pos"  "tests/typeclasses/pos"
+#if !MIN_VERSION_GLASGOW_HASKELL(9,0,0,0)
+  , mkMicroPos "typeclass-pos"  "tests/typeclasses/pos" -- breaks on GHC 9.0.1
+#endif
   ]
   where
     mkMicroPos name dir = testGroupsWithLibs name <$> dirTests dir [] ExitSuccess     (Just " SAFE ") (Just " UNSAFE ")
@@ -779,7 +781,9 @@ textIgnored :: [FilePath]
 textIgnored 
   = [ "Setup.lhs"
     -- , "Data/Text/Axioms.hs"
+#if MIN_VERSION_GLASGOW_HASKELL(9,0,0,0)
     , "Data/Text/Foreign.hs"                -- Breaks on GHC 9.0.1
+#endif
     , "Data/Text/Encoding/Error.hs"
     , "Data/Text/Encoding/Fusion.hs"        -- has nothing in int (compile-spec) but triggers 18 import-builds
     , "Data/Text/Encoding/Fusion/Common.hs"

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -779,6 +779,7 @@ textIgnored :: [FilePath]
 textIgnored 
   = [ "Setup.lhs"
     -- , "Data/Text/Axioms.hs"
+    , "Data/Text/Foreign.hs"                -- Breaks on GHC 9.0.1
     , "Data/Text/Encoding/Error.hs"
     , "Data/Text/Encoding/Fusion.hs"        -- has nothing in int (compile-spec) but triggers 18 import-builds
     , "Data/Text/Encoding/Fusion/Common.hs"

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -442,7 +442,7 @@ testGroupsWithLibs name (DependentTests libTests nonlibTests) =
 -- | Creates a [TestTree] that runs without parallelism
 testSequentially :: String -> SequentialTests -> [TestTree]
 testSequentially name (SequentialTests indexedTests) =
-  let grouped = (\(t, n) -> (testGroup (name <> show n) [t], n)) <$> indexedTests
+  let grouped = reverse $ (\(t, n) -> (testGroup (name <> show n) [t], n)) <$> indexedTests
       -- turns i.e. [a, b, c, d] into [(a, b), (b, c), (c, d)]
       pairs = zip <*> tail $ grouped
       deps = (\((_, n1), (t2, _)) -> after AllFinish (name <> show n1) t2) <$> pairs
@@ -466,6 +466,7 @@ sequentialOdirTests root ignored fo ecode yesLog noLog = do
   DependentTests libs nonlibs <- odirTests root ignored (Just (getFileOrder fo)) ecode yesLog noLog
   pure $ SequentialTests $ zip (libs <> nonlibs) [0..]
 
+-- | Allow parallelism for these tests, but run any tests with `Lib` in its name before the others.
 --------------------------------------------------------------------------------
 odirTests :: FilePath -> [FilePath] -> Maybe FileOrder -> ExitCode -> Maybe T.Text -> Maybe T.Text -> IO DependentTests
 --------------------------------------------------------------------------------

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -446,6 +446,8 @@ testGroupsWithLibs name (DependentTests libTests nonlibTests) =
 -- | Creates a [TestTree] that runs without parallelism
 testSequentially :: String -> SequentialTests -> [TestTree]
 testSequentially name (SequentialTests tests) =
+  -- We need to create a singleton testGroup here so that we know the test name to
+  -- match on in `deps` below.
   let grouped = (\(t, n) -> (testGroup (mkName n) [t], n)) <$> (zip tests [0 :: Int ..])
       pairs = zip grouped (tail grouped)
       deps = (\((_, n1), (t2, _)) -> after AllFinish (mkName n1) t2) <$> pairs


### PR DESCRIPTION
Requires adding dependency annotations still.

Performance impact is relatively significant: tests run ~2x faster on my machine with 8 logical cores.  Where a single test took ~2.5 seconds to run, now 8 are run in parallel at roughly 6-8s per test.