### PR TITLE
Add stitch-lh as an extra-dep and add to circleci stack job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,7 @@ commands:
             mkdir -p /tmp/junit/stack
             stack --no-terminal --stack-yaml << parameters.stack_yaml_file >> test -j1 liquidhaskell:test << parameters.extra_build_flags >> << parameters.extra_test_flags >> --ta="--liquid-runner \"<< parameters.liquid_runner >>\"" --ta="-t 1200s --xml=/tmp/junit/stack/main-test-results.xml": #--liquid-opts='--cores=1'":
             stack --no-terminal --stack-yaml << parameters.stack_yaml_file >> test -j1 liquidhaskell:liquidhaskell-parser << parameters.extra_build_flags >> --ta="--xml=/tmp/junit/stack/parser-test-results.xml":
+            stack --no-terminal  --stack-yaml << parameters.stack_yaml_file >> test -j1 stitch-lh:stitch-lh << parameters.extra_build_flags >>
           no_output_timeout: 30m
       - run:
           name: Generate haddock

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,12 @@ commands:
             mkdir -p /tmp/junit/stack
             stack --no-terminal --stack-yaml << parameters.stack_yaml_file >> test -j1 liquidhaskell:test << parameters.extra_build_flags >> << parameters.extra_test_flags >> --ta="--liquid-runner \"<< parameters.liquid_runner >>\"" --ta="-t 1200s --xml=/tmp/junit/stack/main-test-results.xml": #--liquid-opts='--cores=1'":
             stack --no-terminal --stack-yaml << parameters.stack_yaml_file >> test -j1 liquidhaskell:liquidhaskell-parser << parameters.extra_build_flags >> --ta="--xml=/tmp/junit/stack/parser-test-results.xml":
-            stack --no-terminal  --stack-yaml << parameters.stack_yaml_file >> test -j1 stitch-lh << parameters.extra_build_flags >>
+          no_output_timeout: 30m
+      - run:
+          # Used to catch regressions in verification
+          name: Test benchmarks
+          command: |
+            stack --no-terminal --stack-yaml << parameters.stack_yaml_file >> build -j1 stitch-lh << parameters.extra_build_flags >>
           no_output_timeout: 30m
       - run:
           name: Generate haddock

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ commands:
             mkdir -p /tmp/junit/stack
             stack --no-terminal --stack-yaml << parameters.stack_yaml_file >> test -j1 liquidhaskell:test << parameters.extra_build_flags >> << parameters.extra_test_flags >> --ta="--liquid-runner \"<< parameters.liquid_runner >>\"" --ta="-t 1200s --xml=/tmp/junit/stack/main-test-results.xml": #--liquid-opts='--cores=1'":
             stack --no-terminal --stack-yaml << parameters.stack_yaml_file >> test -j1 liquidhaskell:liquidhaskell-parser << parameters.extra_build_flags >> --ta="--xml=/tmp/junit/stack/parser-test-results.xml":
-            stack --no-terminal  --stack-yaml << parameters.stack_yaml_file >> test -j1 stitch-lh:stitch-lh << parameters.extra_build_flags >>
+            stack --no-terminal  --stack-yaml << parameters.stack_yaml_file >> test -j1 stitch-lh << parameters.extra_build_flags >>
           no_output_timeout: 30m
       - run:
           name: Generate haddock

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,6 +21,8 @@ extra-deps:
 - hashable-1.3.0.0
 - git: https://github.com/facundominguez/rest
   commit: 31e974979c90e910efe5199ee0d3721b791667f6
+- git: https://github.com/facundominguez/stitch-lh
+  commit: 8e130a40376cdf9afaeb6e3e4322e1069339bb51
 
 resolver: lts-18.14
 compiler: ghc-8.10.7


### PR DESCRIPTION
Related to #1933.

The implements part 1 of the plan as described in the above issue, whereby stitch-lh is added directly as a stack extra-dep

**NOTE**: This does not run the tests on cabal!