### PR TITLE
Drop dependency on optparse-simple

### DIFF
--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -177,6 +177,7 @@ library
                       Language.Haskell.Liquid.UX.DiffCheck
                       Language.Haskell.Liquid.UX.Errors
                       Language.Haskell.Liquid.UX.QuasiQuoter
+                      Language.Haskell.Liquid.UX.SimpleVersion
                       Language.Haskell.Liquid.UX.Tidy
                       Language.Haskell.Liquid.WiredIn
                       LiquidHaskell
@@ -234,7 +235,6 @@ library
                     , mtl                  >= 2.1
                     , optics               >= 0.2
                     , optparse-applicative < 0.17
-                    , optparse-simple
                     , githash
                     , megaparsec           >= 8
                     , pretty               >= 1.1
@@ -252,7 +252,7 @@ library
                     , free
                     , recursion-schemes    < 5.3
                     , data-fix
-                    , extra 
+                    , extra
   default-language:   Haskell98
   default-extensions: PatternGuards, RecordWildCards, DoAndIfThenElse
   ghc-options:        -W -fwarn-missing-signatures

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -52,7 +52,6 @@ import Data.Maybe
 import Data.Aeson (encode)
 import qualified Data.ByteString.Lazy.Char8 as B
 import Development.GitRev (gitCommitCount)
-import Options.Applicative.Simple (simpleVersion)
 import qualified Paths_liquidhaskell as Meta
 import System.Directory
 import System.Exit
@@ -76,6 +75,7 @@ import qualified Language.Fixpoint.Types as F
 import Language.Fixpoint.Solver.Stats as Solver
 import Language.Haskell.Liquid.UX.Annotate
 import Language.Haskell.Liquid.UX.Config
+import Language.Haskell.Liquid.UX.SimpleVersion (simpleVersion)
 import Language.Haskell.Liquid.GHC.Misc
 import Language.Haskell.Liquid.Misc
 import Language.Haskell.Liquid.Types.PrettyPrint ()
@@ -421,10 +421,10 @@ config = cmdArgsMode $ Config {
     rwTerminationCheck
     = def
         &= name "rw-termination-check"
-        &= help (   "Enable the rewrite divergence checker. " 
+        &= help (   "Enable the rewrite divergence checker. "
                  ++ "Can speed up verification if rewriting terminates, but can also cause divergence."
                 )
-  , 
+  ,
     skipModule
     = def
         &= name "skip-module"
@@ -434,9 +434,9 @@ config = cmdArgsMode $ Config {
     = def
         &= name "no-lazy-ple"
         &= help "Don't use Lazy PLE"
- 
-  , fuel 
-    = Nothing 
+
+  , fuel
+    = Nothing
         &= help "Maximum fuel (per-function unfoldings) for PLE"
 
   , environmentReduction
@@ -458,8 +458,8 @@ config = cmdArgsMode $ Config {
           , "Sometimes improves performance and sometimes worsens it."
           , "Disabled by --no-environment-reduction"
           ])
-  , pandocHtml 
-    = False 
+  , pandocHtml
+    = False
       &= name "pandoc-html"
       &= help "Use pandoc to generate html."
   } &= program "liquid"
@@ -794,7 +794,7 @@ writeResultStdout (orMessages -> messages) = do
   forM_ messages $ \(sSpan, doc) -> putStrLn (render $ mkErrorDoc sSpan doc {- pprint sSpan <> (text ": error: " <+> doc)-})
 
 mkErrorDoc :: PPrint a => a -> Doc -> Doc
-mkErrorDoc sSpan doc = 
+mkErrorDoc sSpan doc =
   -- Gross on screen, nice for Ghcid
   -- pprint sSpan <> (text ": error: " <+> doc)
 

--- a/src/Language/Haskell/Liquid/UX/SimpleVersion.hs
+++ b/src/Language/Haskell/Liquid/UX/SimpleVersion.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Language.Haskell.Liquid.UX.SimpleVersion (simpleVersion) where
+
+import Data.Version (Version, showVersion)
+import GitHash (GitInfo, giDirty, giHash, tGitInfoCwdTry)
+import Language.Haskell.TH (Exp, Q)
+import qualified Language.Haskell.TH.Syntax as TH.Syntax
+import qualified Language.Haskell.TH.Syntax.Compat as TH.Syntax.Compat
+
+-- | Generate a string like @Version 1.2, Git revision 1234@.
+--
+-- @$(simpleVersion …)@ @::@ 'String'
+-- Taken from <https://hackage.haskell.org/package/optparse-simple-0.1.1.4/docs/Options-Applicative-Simple.html#v:simpleVersion>
+-- so we can drop the dependency on optparse-simple.
+simpleVersion :: Version -> Q Exp
+simpleVersion version =
+  [|
+    concat
+      ( [ "Version ",
+          $(TH.Syntax.lift $ showVersion version)
+        ]
+          ++ case $(TH.Syntax.Compat.unTypeSplice tGitInfoCwdTry) :: Either String GitInfo of
+            Left _ -> []
+            Right gi ->
+              [ ", Git revision ",
+                giHash gi,
+                if giDirty gi then " (dirty)" else ""
+              ]
+      )
+    |]


### PR DESCRIPTION
We were only using it to generate some version info. Instead, we inlined
the simpleVersion function from optparse-simple.

Fixes #1751 