### PR TITLE
Remove redundant dependency.

### DIFF
--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -245,7 +245,6 @@ library
                     , temporary            >= 1.2
                     , text                 >= 1.2
                     , time                 >= 1.4
-                    , time
                     , transformers         >= 0.3
                     , unordered-containers >= 0.2.11
                     , vector               >= 0.10


### PR DESCRIPTION
Removes a duplicate dependency on the time package in the .cabal file.