### PR TITLE
Translate crashes to OutputResult with a message

### DIFF
--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -811,6 +811,11 @@ resDocs _ (F.Safe  stats) =
     orHeader   = text $ "LIQUID: SAFE (" <> show (Solver.numChck stats) <> " constraints checked)"
   , orMessages = mempty
   }
+resDocs _k (F.Crash [] s)  =
+  OutputResult {
+    orHeader = text "LIQUID: ERROR"
+  , orMessages = [(GHC.noSrcSpan, text s)]
+  }
 resDocs k (F.Crash xs s)  =
   OutputResult {
     orHeader = text "LIQUID: ERROR" <+> text s


### PR DESCRIPTION
If PLE crashes, sometimes LH would not print the message in the console.

Turns out that in some cases only the `orMessages` field of `OutputResult` would be printed when the interesting information is in `orHeader`.

This PR strives to only have non-empty `orMessages` produced from crashes.