### PR TITLE
Prevent name collisions in proofs using Prop

### DIFF
--- a/liquid-prelude/src/Language/Haskell/Liquid/ProofCombinators.hs
+++ b/liquid-prelude/src/Language/Haskell/Liquid/ProofCombinators.hs
@@ -177,7 +177,7 @@ impossible _ = undefined
 -------------------------------------------------------------------------------
 
 {-@ measure prop :: a -> b           @-}
-{-@ type Prop E = {v:_ | prop v = E} @-}
+{-@ type Prop E = {lhinternal_prop:_ | prop lhinternal_prop = E} @-}
 
 
 


### PR DESCRIPTION
change the name of the variable used in the liquid-fixpoint ProofCombinators.Prop type alias to prevent collisions