### PR TITLE
Revert "Prevent name collisions in proofs using Prop"

### DIFF
--- a/liquid-prelude/src/Language/Haskell/Liquid/ProofCombinators.hs
+++ b/liquid-prelude/src/Language/Haskell/Liquid/ProofCombinators.hs
@@ -177,7 +177,7 @@ impossible _ = undefined
 -------------------------------------------------------------------------------
 
 {-@ measure prop :: a -> b           @-}
-{-@ type Prop E = {lhinternal_prop:_ | prop lhinternal_prop = E} @-}
+{-@ type Prop E = {v:_ | prop v = E} @-}
 
 
 


### PR DESCRIPTION
Reverts ucsd-progsys/liquidhaskell#1987

Apparently, the fix in #1987 would address the same issue fixed in https://github.com/ucsd-progsys/liquidhaskell/pull/1943