### PR TITLE
Fail tests when there is a non-parsing failure too

### DIFF
--- a/tests/harness/Test/Parse.hs
+++ b/tests/harness/Test/Parse.hs
@@ -289,7 +289,7 @@ stripStackExtraneousMessages = T.stripStart
                                . filter (\x ->
                                            not $
                                               "configure (exe)" `T.isSuffixOf` x
-                                           || "contigure (lib)" `T.isSuffixOf` x
+                                           || "configure (lib)" `T.isSuffixOf` x
                                            || "build (lib)" `T.isSuffixOf` x
                                            || "copy/register" `T.isSuffixOf` x
                                            || "build (exe)" `T.isSuffixOf` x

--- a/tests/harness/Test/Types.hs
+++ b/tests/harness/Test/Types.hs
@@ -195,6 +195,10 @@ numberRan :: FlavorSummary -> NumberRan
 numberRan (FSAllGood ran) = ran
 numberRan (FSUnexpected ran _ _) = ran
 
+isAllGood :: FlavorSummary -> Bool
+isAllGood (FSAllGood _) = True
+isAllGood FSUnexpected {} = False
+
 instance Pretty FlavorSummary where
   pretty (FSAllGood ran) =
     PP.indent nesting $


### PR DESCRIPTION
Renames `flag` to more descriptive `isBadFlag`.

Fixes issue where only _parse_ errors caused the test suite to fail.  As of right now, there are failing tests that aren't being caught properly.  This should fail in CI, until I disable those specific tests.