### PR TITLE
Parse filenames for `benchmark-timings` instead of module names

### DIFF
--- a/benchmark-timings/app/Main.hs
+++ b/benchmark-timings/app/Main.hs
@@ -75,14 +75,14 @@ opts = info (options <**> helper)
 -- | Parse the original filename from the .dump-timings filename
 dumpFilenameParser :: MP.Parsec Void String FilePath
 dumpFilenameParser = do
-  _arch <- element
-  _ghcVersion <- element
-  _pkg <- element
-  pathPieces <- MP.manyTill element "dump-timings.json"
+  _arch <- element "--"
+  _ghcVersion <- element "--"
+  _pkg <- element "--"
+  pathPieces <- MP.manyTill (element ("--" <|> ".")) "dump-timings.json"
   MP.eof
   pure . mconcat $ intersperse "/" pathPieces
   where
-    element = MP.manyTill MP.anySingle ("--" <|> ".")
+    element = MP.manyTill MP.anySingle
 
 program :: Options -> IO ()
 program Options {..} = do

--- a/benchmark-timings/app/Main.hs
+++ b/benchmark-timings/app/Main.hs
@@ -72,7 +72,7 @@ program Options {..} = do
     Just (phases :: [Phase]) <- decodeFileStrict' fp
     let (modName, time) = foldr (\Phase {..} (_, acc) -> (phaseModule,
                                                           if init phaseName `elem` optsPhasesToCount then acc + phaseTime else acc)) ("", 0) phases
-     -- convert milliseconds -> seconds
+    -- convert milliseconds -> seconds
     if modName == "" then pure Nothing else pure $ Just $ PhasesSummary modName (time / 1000) True
   let csvData = encodeDefaultOrderedByNameWith (defaultEncodeOptions { encUseCrLf = False }) $ catMaybes csvFields
   writeFile optsOutputFile csvData

--- a/benchmark-timings/benchmark-timings.cabal
+++ b/benchmark-timings/benchmark-timings.cabal
@@ -33,5 +33,6 @@ executable benchmark-timings
                     , cassava ^>=0.5.2
                     , bytestring ^>=0.10.12
                     , optparse-applicative ^>=0.16.1
+                    , megaparsec ^>= 9.2
     hs-source-dirs:   app
     default-language: Haskell2010


### PR DESCRIPTION
Closes #1996.