### PR TITLE
Fix cabal exec -- liquidhaskell test.hs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,17 @@ This is how you can use this:
 #### Stack
 
 ```
-env LIQUID_DEV_MODE=true stack build
+LIQUID_DEV_MODE=true stack build
 ```
+
+If on NixOS
+
+```
+LIQUID_DEV_MODE=true stack --no-nix-pure build
+```
+
+With the above, `stack` will unregister and re-register the libraries,
+but hopefully it won't rebuild any modules.
 
 #### Cabal
 

--- a/liquid-platform/liquid-platform.cabal
+++ b/liquid-platform/liquid-platform.cabal
@@ -31,6 +31,7 @@ executable liquidhaskell
                       , liquid-vector     >= 0.12.1.2 && < 0.13
                       , liquid-bytestring >= 0.10.0.0 && < 0.11
                       , liquidhaskell     >= 0.8.10.2
+                      , filepath
                       , process           >= 1.6.0.0 && < 1.7
                       , cmdargs           >= 0.10    && < 0.11
 

--- a/liquid-platform/src/Liquid.hs
+++ b/liquid-platform/src/Liquid.hs
@@ -7,9 +7,10 @@
 import Control.Monad
 
 import System.Environment (lookupEnv, getArgs, unsetEnv)
-import System.FilePath ((</>), takeDirectory)
+import System.FilePath ((</>), takeDirectory, takeExtension)
 import System.Process
 import System.Exit
+import Data.Char (toLower)
 import Data.Maybe
 import Data.Either (partitionEithers)
 import Data.Bifunctor
@@ -67,7 +68,8 @@ main = do
 
   -- Strip targets out of the arguments, so that we can forward them to GHC before they
   -- get intercepted by the LH parser.
-  let (cliArgs, targets)    = partition (isPrefixOf "-") args
+  let (targets, cliArgs)    =
+        partition ((`elem` [".o", ".hs", ".lhs"]) . map toLower . takeExtension) args
   let (ghcArgs, liquidArgs) = partitionArgs cliArgs
 
   let p = proc ghcPath $

--- a/liquid-platform/src/Liquid.hs
+++ b/liquid-platform/src/Liquid.hs
@@ -1,8 +1,14 @@
 {-# LANGUAGE LambdaCase #-}
 
-{-| Calling LiquidHaskell via the source plugin.
-  This executable is a simple wrapper around 'ghc', which gets passed an '-fplugin' option.
--}
+-- Calling LiquidHaskell via the source plugin
+--
+-- This executable is a wrapper around 'ghc', which gets passed an '-fplugin'
+-- option. In addition, it hides all core libraries that might colide with a
+-- package coming from liquid haskell.
+--
+-- The command line options of ghc and liquid haskell are merged together.
+-- This script injects flags -fplugin-opt=LiquidHaskell:--opt for every
+-- argument --opt intended for LiquidHaskell and occurring in the command line.
 
 import Control.Monad
 

--- a/liquid-platform/src/Liquid.hs
+++ b/liquid-platform/src/Liquid.hs
@@ -55,12 +55,6 @@ main = do
   let (cliArgs, targets)    = partition (isPrefixOf "-") args
   let (ghcArgs, liquidArgs) = partitionArgs cliArgs
 
-  -- NOTE: Typically for the executable we want to recompile everything-everytime so that
-  -- we could always get an "answer" out of LH. However, using `-fforce-recomp` as the default
-  -- is dangerous, because the executable is used also during tests, so runtime is going to be
-  -- badly affected. If users wants to enable recompilation, they would simply pass
-  -- '-fforce-recomp' as a CLI argument.
-
   let p = proc ghcPath $ [ "-O0"
                          , "-no-link"
                          , "-fplugin=LiquidHaskell"


### PR DESCRIPTION
`cabal exec -- liquidhaskell test.hs` would fail with an error about an ambiguous Prelude module that comes from two packages.

The problem would be that `cabal-install` exposes both `liquid-base` and `base` to `ghc`. Both modules contain the `Prelude` module. These exposure is done via an environment variable `GHC_ENVIRONMENT` which points to an package environment file which exposes the packages. Apparently, once exposed in this way there is no way to hide them again, or I couldn't find a way to hide them at least.

Therefore this PR unsets `GHC_ENVIRONMENT` and extracts from the package environment file the package databases of interest.