### PR TITLE
Follow hlint suggestion: redundant uncurry.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -19,7 +19,6 @@
 - ignore: {name: "Redundant multi-way if"} # 1 hint
 - ignore: {name: "Redundant pure"} # 1 hint
 - ignore: {name: "Redundant return"} # 3 hints
-- ignore: {name: "Redundant uncurry"} # 1 hint
 - ignore: {name: "Replace case with fromMaybe"} # 2 hints
 - ignore: {name: "Unused LANGUAGE pragma"} # 9 hints
 - ignore: {name: "Use ++"} # 1 hint

--- a/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -381,7 +381,7 @@ checkTerminationExpr emb env (v, Loc l _ t, les)
     mkErr :: Doc -> Maybe (F.Expr, Doc) -> Diagnostics
     mkErr _ Nothing = emptyDiagnostics
     mkErr k (Just e) =
-      mkDiagnostics mempty [uncurry (\ e d -> ErrTermSpec (GM.sourcePosSrcSpan l) (pprint v) k e t d) e]
+      mkDiagnostics mempty [(\ (e, d) -> ErrTermSpec (GM.sourcePosSrcSpan l) (pprint v) k e t d) e]
     -- mkErr   = uncurry (\ e d -> ErrTermSpec (GM.sourcePosSrcSpan l) (pprint v) (text "ill-sorted" ) e t d)
     -- mkErr'  = uncurry (\ e d -> ErrTermSpec (GM.sourcePosSrcSpan l) (pprint v) (text "non-numeric") e t d)
 


### PR DESCRIPTION
A one-liner for #2029.