### PR TITLE
Totality checker case hinting and assuming in proofs

### DIFF
--- a/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -884,7 +884,7 @@ isUndefined (_, _, e) = isUndefinedExpr e
   where
    -- auto generated undefined case: (\_ -> (patError @type "error message")) void
    isUndefinedExpr (App (Var x) _) | (show x) `elem` perrors = True
-   isUndefinedExpr (Let _ e) = isUndefinedExpr e
+   isUndefinedExpr (Let _ e') = isUndefinedExpr e'
    -- otherwise
    isUndefinedExpr _ = False
 

--- a/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -884,6 +884,7 @@ isUndefined (_, _, e) = isUndefinedExpr e
   where
    -- auto generated undefined case: (\_ -> (patError @type "error message")) void
    isUndefinedExpr (App (Var x) _) | (show x) `elem` perrors = True
+   isUndefinedExpr (App e' _) = isUndefinedExpr e'
    isUndefinedExpr (Let _ e') = isUndefinedExpr e'
    -- otherwise
    isUndefinedExpr _ = False

--- a/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -875,6 +875,21 @@ defaultDataCons (TyConApp tc argτs) ds = do
 defaultDataCons _ _ = 
   Nothing
 
+-- | 'isUndefined alt' answers: Is the body of @alt@ an expression injected by
+-- GHC containing a pattern error?
+--
+-- QQQ: should we also check whether the AltCon is DEFAULT?
+isUndefined :: (t, t1, Ghc.Expr t2) -> Bool
+isUndefined (_, _, e) = isUndefinedExpr e
+  where
+   -- auto generated undefined case: (\_ -> (patError @type "error message")) void
+   isUndefinedExpr (App (Var x) _) | (show x) `elem` perrors = True
+   isUndefinedExpr (Let _ e) = isUndefinedExpr e
+   -- otherwise
+   isUndefinedExpr _ = False
+
+   perrors = ["Control.Exception.Base.patError"]
+
 
 
 isEvVar :: Id -> Bool 

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -267,7 +267,6 @@ solveCs cfg tgt cgi info names = do
                                  `addErrors` makeFailErrors (S.toList failBs) rf 
                                  `addErrors` makeFailUseErrors (S.toList failBs) (giCbs $ giSrc info)
                                  `addErrors` (fmap (e2u cfg sol) . Mb.catMaybes . fmap ci_err $ if totalityCheck cfg then ntErrs else [])
-
   let lErrors       = applySolution sol <$> logErrors cgi
   hErrors          <- if typedHoles cfg 
                         then synthesize tgt fcfg (cgi{holesMap = applySolution sol <$> holesMap  cgi}) 

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -266,7 +266,7 @@ solveCs cfg tgt cgi info names = do
   let resModel'     = resModel_  `addErrors` (e2u cfg sol <$> logErrors cgi)
                                  `addErrors` makeFailErrors (S.toList failBs) rf 
                                  `addErrors` makeFailUseErrors (S.toList failBs) (giCbs $ giSrc info)
-                                 `addErrors` (fmap (e2u cfg sol) . Mb.catMaybes . fmap ci_err $ if totalityCheck cfg then ntErrs else [])
+                                 `addErrors` (fmap (e2u cfg sol) $ Mb.mapMaybe ci_err $ if totalityCheck cfg then ntErrs else [])
   let lErrors       = applySolution sol <$> logErrors cgi
   hErrors          <- if typedHoles cfg 
                         then synthesize tgt fcfg (cgi{holesMap = applySolution sol <$> holesMap  cgi}) 
@@ -323,7 +323,7 @@ splitNontotalErrors cbs (F.Unsafe s xs)  = (mkRes r, ciInflateTotalityError . sn
   where
     (rtots,r) = L.partition (ciMatchesTotalityAnnot . snd) xs -- partition to those which match something in tts
 
-    totalityAnnotSpans = Mb.catMaybes . fmap unTickTotalityAnnot $ ticks cbs
+    totalityAnnotSpans = Mb.mapMaybe unTickTotalityAnnot $ ticks cbs
 
     ciMatchesTotalityAnnot :: Cinfo -> Bool
     ciMatchesTotalityAnnot Ci{ci_loc=RealSrcSpan ta _} = elem ta totalityAnnotSpans

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -325,7 +325,7 @@ splitNontotalErrors cbs (F.Unsafe s xs)  = (mkRes r, injectMatchingTotalityError
     (rtots,r) = L.partition (errorMatchesTotalityAnnot . snd) xs -- partition to those which match something in tts
 
     totalityAnnot :: Tickish Id -> Maybe (RealSrcSpan, String)
-    totalityAnnot (SourceNote span note) | "Totality error:" `L.isPrefixOf` note = Just (span, note)
+    totalityAnnot (SourceNote sp note) | "Totality error:" `L.isPrefixOf` note = Just (sp, note)
     totalityAnnot _ = Nothing
 
     totalityAnnots

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -266,7 +266,8 @@ solveCs cfg tgt cgi info names = do
   let resModel'     = resModel_  `addErrors` (e2u cfg sol <$> logErrors cgi)
                                  `addErrors` makeFailErrors (S.toList failBs) rf 
                                  `addErrors` makeFailUseErrors (S.toList failBs) (giCbs $ giSrc info)
-                                 `addErrors` (fmap (e2u cfg sol) . Mb.catMaybes . fmap ci_err $ ntErrs)
+                                 `addErrors` (fmap (e2u cfg sol) . Mb.catMaybes . fmap ci_err $ if totalityCheck cfg then ntErrs else [])
+
   let lErrors       = applySolution sol <$> logErrors cgi
   hErrors          <- if typedHoles cfg 
                         then synthesize tgt fcfg (cgi{holesMap = applySolution sol <$> holesMap  cgi}) 

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -314,8 +314,6 @@ makeFailErrors bs cis = [ mkError x | x <- bs, notElem (val x) vs ]
     mkError  x = ErrFail (GM.sourcePosSrcSpan $ loc x) (pprint $ val x)
     vs         = Mb.mapMaybe ci_var cis
 
--- | DRY_UP: Merged bits of splitFails and makeFailUseErrors to detect &
--- extract totality errors
 splitNontotalErrors :: [CoreBind] -> F.FixResult (a, Cinfo) -> (F.FixResult (a, Cinfo),  [Cinfo])
 splitNontotalErrors _ r@(F.Crash _ _) = (r,mempty)
 splitNontotalErrors _ r@(F.Safe _)    = (r,mempty)

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -27,7 +27,6 @@ import           Text.PrettyPrint.HughesPJ
 import           System.Console.CmdArgs.Verbosity (whenLoud, whenNormal)
 import           Control.Monad (when, unless)
 import qualified Data.Maybe as Mb
-import qualified Data.Map.Strict as Map
 import qualified Data.List  as L 
 import qualified Control.Exception as Ex
 import qualified Language.Haskell.Liquid.UX.DiffCheck as DC
@@ -329,17 +328,16 @@ splitNontotalErrors cbs (F.Unsafe s xs)  = (mkRes r, injectMatchingTotalityError
     totalityAnnot _ = Nothing
 
     totalityAnnots
-        = Map.fromList
-        . fmap (Bif.first $ \rss -> RealSrcSpan rss Nothing)
+        = fmap (Bif.first $ \rss -> RealSrcSpan rss Nothing)
         . Mb.catMaybes
         . fmap totalityAnnot
         $ ticks cbs
 
     errorMatchesTotalityAnnot :: Cinfo -> Bool
-    errorMatchesTotalityAnnot ci = Map.member (ci_loc ci) totalityAnnots
+    errorMatchesTotalityAnnot ci = Mb.isJust $ lookup (ci_loc ci) totalityAnnots
 
     injectMatchingTotalityError :: Cinfo -> Cinfo
-    injectMatchingTotalityError ci = case Map.lookup (ci_loc ci) totalityAnnots of
+    injectMatchingTotalityError ci = case lookup (ci_loc ci) totalityAnnots of
         Just s -> ci { ci_err = Just ErrOther { pos = ci_loc ci, msg = text $ s } }
         Nothing -> ci
 

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -266,7 +266,7 @@ solveCs cfg tgt cgi info names = do
   let resModel'     = resModel_  `addErrors` (e2u cfg sol <$> logErrors cgi)
                                  `addErrors` makeFailErrors (S.toList failBs) rf 
                                  `addErrors` makeFailUseErrors (S.toList failBs) (giCbs $ giSrc info)
-                                 `addErrors` (fmap (e2u cfg sol) $ Mb.mapMaybe ci_err $ if totalityCheck cfg then ntErrs else [])
+                                 `addErrors` fmap (e2u cfg sol) (Mb.mapMaybe ci_err $ if totalityCheck cfg then ntErrs else [])
   let lErrors       = applySolution sol <$> logErrors cgi
   hErrors          <- if typedHoles cfg 
                         then synthesize tgt fcfg (cgi{holesMap = applySolution sol <$> holesMap  cgi}) 

--- a/src/Language/Haskell/Liquid/Transforms/ANF.hs
+++ b/src/Language/Haskell/Liquid/Transforms/ANF.hs
@@ -294,10 +294,12 @@ normalizePattern γ p@(Rs.PatSelfRecBind {}) = do
   e'    <- normalize γ (Rs.patE p)
   return $ Rs.lower p { Rs.patE = e' }
 
+-- | Replace the DEFAULT case expression body with unit, if totality checking
+-- is on, the type of the case is unit, and the case body isn't user defined.
 replaceDefaultCaseBody :: AnfEnv -> Type -> [(AltCon, a, CoreExpr)] -> [(AltCon, a, CoreExpr)]
-replaceDefaultCaseBody γ t ((DEFAULT, as, _body) : dcs)
-    | t == Ghc.unitTy && totalityCheck γ =
-        ((DEFAULT, as, Ghc.Var Ghc.unitDataConId) : dcs)
+replaceDefaultCaseBody γ t (dc@(DEFAULT, as, _body) : dcs)
+    | totalityCheck γ && t == Ghc.unitTy && isUndefined dc =
+        (DEFAULT, as, Ghc.Var Ghc.unitDataConId) : dcs
 replaceDefaultCaseBody _ _ z = z
 
 --------------------------------------------------------------------------------

--- a/src/Language/Haskell/Liquid/Transforms/ANF.hs
+++ b/src/Language/Haskell/Liquid/Transforms/ANF.hs
@@ -342,7 +342,7 @@ cloneCase γ e (d, as, ts) = do
   return (DataAlt d, as ++ xs, Tick tt e)
   where
     RealSrcSpan sp _ = Sp.srcSpan (aeSrcSpan γ) -- FIXME: irrefutable pattern
-    tt = SourceNote sp $ "Totality error: missing `" ++ showPpr d ++ "` case"
+    tt = SourceNote sp $ "Totality error: missing case for `" ++ showPpr d ++ "`"
 
 sortCases :: [(AltCon, b, c)] -> [(AltCon, b, c)]
 sortCases = sortBy (cmpAltCon `on` F.fst3)

--- a/src/Language/Haskell/Liquid/Transforms/ANF.hs
+++ b/src/Language/Haskell/Liquid/Transforms/ANF.hs
@@ -343,7 +343,7 @@ cloneCase γ e (d, as, ts) = do
   return (DataAlt d, as ++ xs, Tick tt e)
   where
     RealSrcSpan sp _ = Sp.srcSpan (aeSrcSpan γ) -- FIXME: irrefutable pattern
-    tt = SourceNote sp $ "Totality error: missing case for `" ++ showPpr d ++ "`"
+    tt = totalityAnnot (showPpr d) sp
 
 sortCases :: [(AltCon, b, c)] -> [(AltCon, b, c)]
 sortCases = sortBy (cmpAltCon `on` F.fst3)

--- a/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -629,7 +629,7 @@ instance Simplify C.CoreExpr where
     = -- Misc.traceShow ("To simplify allowTC case") $ 
        sub (M.singleton x (simplify allowTC e)) (simplify allowTC ee)
   simplify allowTC (C.Case e x t alts)
-    = C.Case (simplify allowTC e) x t (filter (not . isUndefined) (simplify allowTC <$> alts))
+    = C.Case (simplify allowTC e) x t (filter (not . GM.isUndefined) (simplify allowTC <$> alts))
   simplify allowTC (C.Cast e c)
     = C.Cast (simplify allowTC e) c
   simplify allowTC (C.Tick _ e)
@@ -651,17 +651,6 @@ instance Simplify C.CoreExpr where
   inline _ (C.Lit l)           = C.Lit l
   inline _ (C.Coercion c)      = C.Coercion c
   inline _ (C.Type t)          = C.Type t
-
-isUndefined :: (t, t1, C.Expr t2) -> Bool
-isUndefined (_, _, e) = isUndefinedExpr e
-  where
-   -- auto generated undefined case: (\_ -> (patError @type "error message")) void
-   isUndefinedExpr (C.App (C.Var x) _) | show x `elem` perrors = True
-   isUndefinedExpr (C.Let _ e) = isUndefinedExpr e
-   -- otherwise
-   isUndefinedExpr _ = False
-
-   perrors = ["Control.Exception.Base.patError"]
 
 
 instance Simplify C.CoreBind where

--- a/src/Language/Haskell/Liquid/Types/Errors.hs
+++ b/src/Language/Haskell/Liquid/Types/Errors.hs
@@ -755,26 +755,33 @@ errSaved sp body = ErrSaved sp (text n) (text $ unlines m)
   where
     n : m        = lines body
 
--- | Store a 'Show' in the filename field of a source span.
+-- | Store a 'Show' in the filename field of a 'RealSrcSpan'.
 pushRealSrcSpan :: Show a => a -> RealSrcSpan -> RealSrcSpan
 pushRealSrcSpan x rss = realSrcSpan (show (f, x)) l1 c1 l2 c2
   where (f, l1, c1, l2, c2) = unpackRealSrcSpan rss
 
--- | Extract a 'Read' from the filename field of a source span.
+-- | Extract a 'Read' from the filename field of a 'RealSrcSpan'.
 popRealSrcSpan :: Read a => RealSrcSpan -> Maybe (RealSrcSpan, a)
 popRealSrcSpan rss
     | Just (f, x) <- readMaybe fEnc = Just (realSrcSpan f l1 c1 l2 c2, x)
     | otherwise = Nothing
   where (fEnc, l1, c1, l2, c2) = unpackRealSrcSpan rss
 
+-- | Push 'String' into a stack stored in the 'RealSrcSpan' filename field and
+-- package the result in a 'Tickish' labeled as a totality-annotation.
 totalityAnnot :: String -> RealSrcSpan -> Tickish a
 totalityAnnot d rss = SourceNote uniqueSp "totality-annotation"
     where uniqueSp = d `pushRealSrcSpan` rss
 
+-- | Extract the 'RealSrcsSpan' from a 'Tickish' that was produced by
+-- 'totalityAnnot'.
 unTickTotalityAnnot :: Tickish a -> Maybe RealSrcSpan
 unTickTotalityAnnot (SourceNote rss "totality-annotation") = Just rss
 unTickTotalityAnnot _ = Nothing
 
+-- | Pop the 'String' and restore the original 'RealSrcSpan' from a
+-- 'RealSrcSpan' produced by 'totalityAnnot'. Use 'unTickTotalityAnnot' before
+-- this function.
 unSpanTotalityAnnot :: RealSrcSpan -> Maybe (RealSrcSpan, String)
 unSpanTotalityAnnot = popRealSrcSpan
 

--- a/tests/errors/Totality00.hs
+++ b/tests/errors/Totality00.hs
@@ -1,0 +1,24 @@
+
+-- | Demonstrate the three kinds of cases in a proof. There's no error.
+
+module Totality00 where
+
+data Cases = A | B | C
+
+opaque :: Cases -> Bool
+opaque _ = True
+{-@ reflect opaque @-}
+
+{-@
+proofGetNumIsNat :: { x:Cases | x /= B } -> { x == A || opaque x } @-}
+proofGetNumIsNat :: Cases -> ()
+proofGetNumIsNat A = () -- trivial-holds
+proofGetNumIsNat B = () -- trivial-impossible
+proofGetNumIsNat C = () `const` opaque C -- nontrivial-subgoal-holds
+
+-- {-@
+-- proofGetNumIsNat' :: { x:Cases | x /= B } -> { x == A || opaque x } @-}
+-- proofGetNumIsNat' :: Cases -> Proof
+-- proofGetNumIsNat' A = trivial
+-- proofGetNumIsNat' B = impossible ""
+-- proofGetNumIsNat' C = opaque C *** QED

--- a/tests/errors/Totality01.hs
+++ b/tests/errors/Totality01.hs
@@ -1,0 +1,19 @@
+{-@ LIQUID "--expect-error-containing=is not a subtype of the required type" @-}
+
+-- | Demonstrate that case C is indeed a subgoal by removing the evidence.
+-- (Compare to Totality00)
+
+module Totality01 where
+
+data Cases = A | B | C
+
+opaque :: Cases -> Bool
+opaque _ = True
+{-@ reflect opaque @-}
+
+{-@
+proofGetNumIsNat :: { x:Cases | x /= B } -> { x == A || opaque x } @-}
+proofGetNumIsNat :: Cases -> ()
+proofGetNumIsNat A = () -- trivial-holds
+proofGetNumIsNat B = () -- trivial-impossible
+proofGetNumIsNat C = () -- FAIL

--- a/tests/errors/Totality02.hs
+++ b/tests/errors/Totality02.hs
@@ -1,4 +1,4 @@
-{-@ LIQUID "--expect-error-containing=Totality error: missing `Totality02.C` case" @-}
+{-@ LIQUID "--expect-error-containing=Totality error: missing case for `Totality02.C`" @-}
 
 -- | Demonstrate that handling only A is nontotal, because C is a subgoal that
 -- LH cannot prove by itself. (Compare to Totality00)

--- a/tests/errors/Totality02.hs
+++ b/tests/errors/Totality02.hs
@@ -1,4 +1,4 @@
-{-@ LIQUID "--expect-error-containing=totalityError" @-}
+{-@ LIQUID "--expect-error-containing=Totality error: missing `Totality02.C` case" @-}
 
 -- | Demonstrate that handling only A is nontotal, because C is a subgoal that
 -- LH cannot prove by itself. (Compare to Totality00)

--- a/tests/errors/Totality02.hs
+++ b/tests/errors/Totality02.hs
@@ -1,0 +1,17 @@
+{-@ LIQUID "--expect-error-containing=totalityError" @-}
+
+-- | Demonstrate that handling only A is nontotal, because C is a subgoal that
+-- LH cannot prove by itself. (Compare to Totality00)
+
+module Totality02 where
+
+data Cases = A | B | C
+
+opaque :: Cases -> Bool
+opaque _ = True
+{-@ reflect opaque @-}
+
+{-@
+proofGetNumIsNat :: { x:Cases | x /= B } -> { x == A || opaque x } @-}
+proofGetNumIsNat :: Cases -> ()
+proofGetNumIsNat A = () -- trivial-holds

--- a/tests/errors/Totality03.hs
+++ b/tests/errors/Totality03.hs
@@ -1,0 +1,18 @@
+{-@ LIQUID "--expect-error-containing=totalityError" @-}
+
+-- | Demonstrate that handling only C is total, because A trivially-holds and B
+-- is trivially-impossible. There's no error. (Compare to Totality02 and
+-- Totality00)
+
+module Totality03 where
+
+data Cases = A | B | C
+
+opaque :: Cases -> Bool
+opaque _ = True
+{-@ reflect opaque @-}
+
+{-@
+proofGetNumIsNat :: { x:Cases | x /= B } -> { x == A || opaque x } @-}
+proofGetNumIsNat :: Cases -> ()
+proofGetNumIsNat C = () `const` opaque C -- nontrivial-subgoal-holds

--- a/tests/errors/Totality03.hs
+++ b/tests/errors/Totality03.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--expect-error-containing=totalityError" @-}
 
 -- | Demonstrate that handling only C is total, because A trivially-holds and B
 -- is trivially-impossible. There's no error. (Compare to Totality02 and

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -703,6 +703,10 @@ executable errors
                     , TerminationExprUnb
                     -- , TODOUnboundAbsRef
                     -- , TODOVarInTypeAlias
+                    , Totality00
+                    , Totality01
+                    , Totality02
+                    , Totality03
                     , UnboundAbsRef
                     -- , UnboundCheckVar
                     , UnboundFunInSpec1


### PR DESCRIPTION
Currently if you want to write a proof with a lot of cases, you have no way of knowing which ones are necessary. The process that I've used is to [write out all the cases](https://github.com/plredmond/lh-playground/blob/4143086351a064faec40eb4a42686ba233fad008/lib/TypesPLF.hs#L122-L235) and then [whittle down to necessary cases](https://github.com/plredmond/lh-playground/blob/eb274fd3a5835ac422d1ae22ae5bc3beb6e20eec/lib/TypesPLF.hs#L143-L183). This can be time consuming. This PR changes how we elaborate cases to make this process easier:

* **Case_Hinting** -- When a user writes a proof that pattern matches one constructor but doesn't handle all of them, we'll tell them which additional cases require proofs. Eg. See test [Totality00](https://github.com/ucsd-progsys/liquidhaskell/compare/develop...plredmond:proof-cases-feature_rebase?expand=1#diff-d51e69e5fef948a2094520cdeee2bd36aff1aad01e5a36faea2887b41442c41d) and compare with the error expected by [Totality02](https://github.com/ucsd-progsys/liquidhaskell/compare/develop...plredmond:proof-cases-feature_rebase?expand=1#diff-75361a5e09808df0e58f18174264d9f4f75425e87e8d894d2782a134514e6534). 

* **Case_Assuming** -- When a user writes a proof with a lot of cases, LH won't require them to write down trivially-discharged cases. Eg. See test [Totality00](https://github.com/ucsd-progsys/liquidhaskell/compare/develop...plredmond:proof-cases-feature_rebase?expand=1#diff-d51e69e5fef948a2094520cdeee2bd36aff1aad01e5a36faea2887b41442c41d) and compare with cases in [Totality03](https://github.com/ucsd-progsys/liquidhaskell/compare/develop...plredmond:proof-cases-feature_rebase?expand=1#diff-15531f1136dee400ed29ca7b4f3e244e7df100877b49c6785637ce8bd298476e).

<h3>Implementation</h3>

* In ANF transform `normalize`: For a `case .. of` expression of type `()` we replace the body of a GHC generated case alternative (patError) with `()`.
* In ANF transform`cloneCase`: Inject a `Tick` with a unique `RealSrcSpan` into the body of the case alternative to mark the injected case.
* In `solveCs`: Extract all the unique `RealSrcSpan` values injected by `cloneCase` and compare them with the spans on constraint errors returned by liquid fixpoint. If there's a match, produce an `ErrOther` that explains there's a missing case.

<img width="377" alt="Screen Shot 2022-07-14 at 5 25 32 PM" src="https://user-images.githubusercontent.com/51248199/179122670-cad75f7d-7bb6-4bc5-84db-801ceb9fcf5f.png">

### Followup

#### TODO before merging

* [ ] I don't know what the coding conventions are, and I duplicated some code here and there. Please comment on any TODOs/FIXMEs to let me know how to resolve them.
* [ ] **Case_Hinting** -- Need to make it show an error for each missing case, not just one. Currently `solveCs` has errors for all the cases which should be added, but only one is displayed to the user. (Essentially, it only shows you the "next" missing case, but would be quicker if it showed you all missing cases.)
* [ ] Fix conflicts

#### Possible future concerns

* [ ] **Case_Hinting** -- The span used for the missing cases is one that is anchored to the first pattern clause, and so it's not very helpful for determining which match needs additional cases.
* [ ] **Case_Hinting** -- With our change, hints are displayed after the user pattern matches on a constructor. If they just use the wildcard, then no elaboration takes place and no hints are given.
* [ ] **Case_Assuming** -- Essentially, we're allowing possible cases to be undefined in the code. This could cause crashes if somebody forces the value returned by a proof.

