### PR TITLE
Move ignores to a keeper section.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,6 +1,4 @@
 # Warnings currently triggered by your code
-- ignore: {name: "Avoid lambda"} # 4 hints
-- ignore: {name: "Eta reduce"} # 51 hints
 - ignore: {name: "Move guards forward"} # 2 hints
 - ignore: {name: "Parse error: on input `,'"} # 1 hint
 - ignore: {name: "Parse error: possibly incorrect indentation or mismatched brackets"} # 3 hints
@@ -8,4 +6,7 @@
 - ignore: {name: "Unused LANGUAGE pragma"} # 9 hints
 - ignore: {name: "Use camelCase"} # 61 hints
 - ignore: {name: "Use fewer LANGUAGE pragmas"} # 2 hints
+# The following are kept for usability and style sake
+- ignore: {name: "Avoid lambda"} # 4 hints
+- ignore: {name: "Eta reduce"} # 51 hints
 - ignore: {name: "Use infix"} # 3 hints


### PR DESCRIPTION
See #2029. Takes the ignores triggered in liquidhaskell that we are keeping in liquid-fixpoint and moves them to a different section. This includes the ignore from #2055.