### PR TITLE
Move GHC modules to src-ghc tree.

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -22,5 +22,5 @@ jobs:
     - uses: haskell/actions/hlint-run@v2
       name: hlint
       with:
-        path: '["src/"]'
+        path: '["src/", "src-ghc/"]'
         fail-on: suggestion

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,13 +1,13 @@
 # To be compatible with GHC naming turn off the camelCase rule.
-- ignore: {name: "Use camelCase", within: [Language.Haskell.Liquid.GHC.Misc]} # 4 hints
+- ignore: {name: "Use camelCase", within: [Liquid.GHC.Misc]} # 4 hints
 # Linting LANGUAGE pragmas with complex CPP ifdefs is too hard.
 - ignore: {
     name: "Unused LANGUAGE pragma",
     within: [
-      Language.Haskell.Liquid.GHC.API,
-      Language.Haskell.Liquid.GHC.Interface,
-      Language.Haskell.Liquid.GHC.GhcMonadLike,
-      Language.Haskell.Liquid.GHC.Misc
+      Liquid.GHC.API,
+      Liquid.GHC.Interface,
+      Liquid.GHC.GhcMonadLike,
+      Liquid.GHC.Misc
     ]
   }
 # The following are kept for usability and style sake

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -118,17 +118,17 @@ library
                       Language.Haskell.Liquid.Constraint.Split
                       Language.Haskell.Liquid.Constraint.ToFixpoint
                       Language.Haskell.Liquid.Constraint.Types
-                      Language.Haskell.Liquid.GHC.API
-                      Language.Haskell.Liquid.GHC.API.StableModule
-                      Language.Haskell.Liquid.GHC.GhcMonadLike
-                      Language.Haskell.Liquid.GHC.Interface
-                      Language.Haskell.Liquid.GHC.Logging
-                      Language.Haskell.Liquid.GHC.Misc
-                      Language.Haskell.Liquid.GHC.Play
-                      Language.Haskell.Liquid.GHC.Resugar
-                      Language.Haskell.Liquid.GHC.SpanStack
-                      Language.Haskell.Liquid.GHC.Types
-                      Language.Haskell.Liquid.GHC.TypeRep
+                      Liquid.GHC.API
+                      Liquid.GHC.API.StableModule
+                      Liquid.GHC.GhcMonadLike
+                      Liquid.GHC.Interface
+                      Liquid.GHC.Logging
+                      Liquid.GHC.Misc
+                      Liquid.GHC.Play
+                      Liquid.GHC.Resugar
+                      Liquid.GHC.SpanStack
+                      Liquid.GHC.Types
+                      Liquid.GHC.TypeRep
                       Language.Haskell.Liquid.Interactive.Handler
                       Language.Haskell.Liquid.Interactive.Types
                       Language.Haskell.Liquid.LawInstances
@@ -195,9 +195,9 @@ library
       other-modules:      Language.Haskell.Liquid.GHC.Plugin.SpecFinder
                           Language.Haskell.Liquid.GHC.Plugin.Types
                           Language.Haskell.Liquid.GHC.Plugin.Util
-      hs-source-dirs:     src
+      hs-source-dirs:     src src-ghc
   else
-      hs-source-dirs:     src include
+      hs-source-dirs:     src src-ghc include
       exposed-modules:    Language.Haskell.Liquid.RTick
                           Language.Haskell.Liquid.Prelude
                           Language.Haskell.Liquid.Foreign

--- a/src-ghc/Liquid/GHC.hs
+++ b/src-ghc/Liquid/GHC.hs
@@ -1,0 +1,6 @@
+-- | This module re-exports the GHC API as a single blob.
+
+module Liquid.GHC (module X) where
+
+import Liquid.GHC.Interface as X
+import Liquid.GHC.Misc      as X

--- a/src-ghc/Liquid/GHC/API.hs
+++ b/src-ghc/Liquid/GHC/API.hs
@@ -15,7 +15,7 @@ The intended use of this module is to shelter LiquidHaskell from changes to the 
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE BangPatterns #-}
 
-module Language.Haskell.Liquid.GHC.API (
+module Liquid.GHC.API (
     module Ghc
   , module StableModule
 
@@ -116,7 +116,7 @@ module Language.Haskell.Liquid.GHC.API (
 
   ) where
 
-import           Language.Haskell.Liquid.GHC.API.StableModule      as StableModule
+import           Liquid.GHC.API.StableModule      as StableModule
 import           GHC                                               as Ghc hiding ( Warning
                                                                                  , SrcSpan(RealSrcSpan, UnhelpfulSpan)
                                                                                  , exprType

--- a/src-ghc/Liquid/GHC/API/StableModule.hs
+++ b/src-ghc/Liquid/GHC/API/StableModule.hs
@@ -3,7 +3,7 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Language.Haskell.Liquid.GHC.API.StableModule (
+module Liquid.GHC.API.StableModule (
     StableModule
   -- * Constructing a 'StableModule'
   , mkStableModule

--- a/src-ghc/Liquid/GHC/GhcMonadLike.hs
+++ b/src-ghc/Liquid/GHC/GhcMonadLike.hs
@@ -6,7 +6,7 @@
 -- 'ExceptionMonad', and can therefore be used for both 'CoreM' and 'Ghc'.
 --
 
-module Language.Haskell.Liquid.GHC.GhcMonadLike (
+module Liquid.GHC.GhcMonadLike (
   -- * Types and type classes
     HasHscEnv
   , GhcMonadLike
@@ -37,8 +37,8 @@ import Control.Exception (throwIO)
 
 import Data.IORef (readIORef)
 
-import qualified Language.Haskell.Liquid.GHC.API   as Ghc
-import           Language.Haskell.Liquid.GHC.API   hiding ( ModuleInfo
+import qualified Liquid.GHC.API   as Ghc
+import           Liquid.GHC.API   hiding ( ModuleInfo
                                                           , findModule
                                                           , desugarModule
                                                           , typecheckModule

--- a/src-ghc/Liquid/GHC/Interface.hs
+++ b/src-ghc/Liquid/GHC/Interface.hs
@@ -14,7 +14,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wwarn=deprecations #-}
 
-module Language.Haskell.Liquid.GHC.Interface (
+module Liquid.GHC.Interface (
 
   -- * Determine the build-order for target files
    realTargets
@@ -62,7 +62,7 @@ import Prelude hiding (error)
 
 import GHC.Paths (libdir)
 
-import           Language.Haskell.Liquid.GHC.API as Ghc hiding ( text
+import           Liquid.GHC.API as Ghc hiding ( text
                                                                , (<+>)
                                                                , panic
                                                                , vcat
@@ -71,8 +71,8 @@ import           Language.Haskell.Liquid.GHC.API as Ghc hiding ( text
                                                                , Target
                                                                , Located
                                                                )
-import qualified Language.Haskell.Liquid.GHC.API as Ghc
-import qualified Language.Haskell.Liquid.GHC.API as O
+import qualified Liquid.GHC.API as Ghc
+import qualified Liquid.GHC.API as O
 import GHC.LanguageExtensions
 
 import Control.Exception
@@ -99,11 +99,11 @@ import Text.PrettyPrint.HughesPJ        hiding (first, (<>))
 import Language.Fixpoint.Types          hiding (err, panic, Error, Result, Expr)
 import qualified Language.Fixpoint.Misc as Misc
 import Language.Haskell.Liquid.Bare
-import Language.Haskell.Liquid.GHC.Misc
-import Language.Haskell.Liquid.GHC.Types (MGIModGuts(..), miModGuts)
-import Language.Haskell.Liquid.GHC.Play
-import qualified Language.Haskell.Liquid.GHC.GhcMonadLike as GhcMonadLike
-import Language.Haskell.Liquid.GHC.GhcMonadLike (GhcMonadLike, isBootInterface, askHscEnv)
+import Liquid.GHC.Misc
+import Liquid.GHC.Types (MGIModGuts(..), miModGuts)
+import Liquid.GHC.Play
+import qualified Liquid.GHC.GhcMonadLike as GhcMonadLike
+import Liquid.GHC.GhcMonadLike (GhcMonadLike, isBootInterface, askHscEnv)
 import Language.Haskell.Liquid.WiredIn (isDerivedInstance)
 import qualified Language.Haskell.Liquid.Measure  as Ms
 import qualified Language.Haskell.Liquid.Misc     as Misc

--- a/src-ghc/Liquid/GHC/Logging.hs
+++ b/src-ghc/Liquid/GHC/Logging.hs
@@ -11,14 +11,14 @@
 
 {-# LANGUAGE CPP #-}
 
-module Language.Haskell.Liquid.GHC.Logging (
+module Liquid.GHC.Logging (
     fromPJDoc
   , putWarnMsg
   , putErrMsg
   , mkLongErrAt
   ) where
 
-import qualified Language.Haskell.Liquid.GHC.API as GHC
+import qualified Liquid.GHC.API as GHC
 import qualified Text.PrettyPrint.HughesPJ as PJ
 
 -- Unfortunately we need the import below to bring in scope 'PPrint' instances.

--- a/src-ghc/Liquid/GHC/Misc.hs
+++ b/src-ghc/Liquid/GHC/Misc.hs
@@ -18,21 +18,21 @@
 -- accessing GHC module information. It should NEVER depend on
 -- ANY module inside the Language.Haskell.Liquid.* tree.
 
-module Language.Haskell.Liquid.GHC.Misc where
+module Liquid.GHC.Misc where
 
 import           Data.String
 import qualified Data.List as L
 import           Debug.Trace
 
 import           Prelude                                    hiding (error)
-import           Language.Haskell.Liquid.GHC.API            as Ghc hiding ( L
+import           Liquid.GHC.API            as Ghc hiding ( L
                                                                           , sourceName
                                                                           , showPpr
                                                                           , showSDocDump
                                                                           , panic
                                                                           , showSDoc
                                                                           )
-import qualified Language.Haskell.Liquid.GHC.API            as Ghc (GenLocated (L), showSDoc, panic, showSDocDump)
+import qualified Liquid.GHC.API            as Ghc (GenLocated (L), showSDoc, panic, showSDocDump)
 
 
 import           Data.Char                                  (isLower, isSpace, isUpper)
@@ -1074,7 +1074,7 @@ withWiredIn m = discardConstraints $ do
   cppExt = []
 #endif
 
-  locSpan = UnhelpfulSpan (UnhelpfulOther "Language.Haskell.Liquid.GHC.Misc: WiredIn")
+  locSpan = UnhelpfulSpan (UnhelpfulOther "Liquid.GHC.Misc: WiredIn")
 
   mkHsFunTy :: LHsType GhcRn -> LHsType GhcRn -> LHsType GhcRn
   mkHsFunTy a b = nlHsFunTy a b

--- a/src-ghc/Liquid/GHC/Play.hs
+++ b/src-ghc/Liquid/GHC/Play.hs
@@ -3,7 +3,7 @@
 
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- TODO(#1918): Only needed for GHC <9.0.1.
 
-module Language.Haskell.Liquid.GHC.Play where
+module Liquid.GHC.Play where
 
 import Prelude hiding (error)
 
@@ -12,8 +12,8 @@ import qualified Data.HashMap.Strict as M
 import qualified Data.List           as L
 import qualified Data.Maybe          as Mb
 
-import Language.Haskell.Liquid.GHC.API as Ghc hiding (substTysWith, panic,showPpr)
-import Language.Haskell.Liquid.GHC.Misc ()
+import Liquid.GHC.API as Ghc hiding (substTysWith, panic,showPpr)
+import Liquid.GHC.Misc ()
 import Language.Haskell.Liquid.Types.Errors
 import Language.Haskell.Liquid.Types.Variance
 

--- a/src-ghc/Liquid/GHC/Resugar.hs
+++ b/src-ghc/Liquid/GHC/Resugar.hs
@@ -10,7 +10,7 @@
 --   into high-level patterns, that can receive special case handling in
 --   different phases (e.g. ANF, Constraint Generation, etc.)
 
-module Language.Haskell.Liquid.GHC.Resugar (
+module Liquid.GHC.Resugar (
   -- * High-level Source Patterns
     Pattern (..)
 
@@ -22,8 +22,8 @@ module Language.Haskell.Liquid.GHC.Resugar (
   ) where
 
 import qualified Data.List as L
-import           Language.Haskell.Liquid.GHC.API  as Ghc hiding (PatBind)
-import qualified Language.Haskell.Liquid.GHC.Misc as GM
+import           Liquid.GHC.API  as Ghc hiding (PatBind)
+import qualified Liquid.GHC.Misc as GM
 import qualified Language.Fixpoint.Types          as F 
 import qualified Text.PrettyPrint.HughesPJ        as PJ 
 -- import           Debug.Trace

--- a/src-ghc/Liquid/GHC/SpanStack.hs
+++ b/src-ghc/Liquid/GHC/SpanStack.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 
-module Language.Haskell.Liquid.GHC.SpanStack
+module Liquid.GHC.SpanStack
    ( -- * Stack of positions
      Span (..)
    , SpanStack
@@ -17,9 +17,9 @@ module Language.Haskell.Liquid.GHC.SpanStack
 
 import           Prelude                   hiding (error)
 import           Data.Maybe                       (listToMaybe, fromMaybe)
-import           Language.Haskell.Liquid.GHC.Misc (tickSrcSpan, showPpr)
-import qualified Language.Haskell.Liquid.GHC.API  as Ghc
-import           Language.Haskell.Liquid.GHC.API  ( SrcSpan
+import           Liquid.GHC.Misc (tickSrcSpan, showPpr)
+import qualified Liquid.GHC.API  as Ghc
+import           Liquid.GHC.API  ( SrcSpan
                                                   , fsLit
                                                   , getSrcSpan
                                                   , isGoodSrcSpan

--- a/src-ghc/Liquid/GHC/TypeRep.hs
+++ b/src-ghc/Liquid/GHC/TypeRep.hs
@@ -12,14 +12,14 @@
 
 -- | This module contains a wrappers and utility functions for
 -- accessing GHC module information. It should NEVER depend on
-module Language.Haskell.Liquid.GHC.TypeRep (
+module Liquid.GHC.TypeRep (
   mkTyArg, 
 
   showTy
   ) where
 
-import           Language.Haskell.Liquid.GHC.Misc (showPpr)
-import           Language.Haskell.Liquid.GHC.API as Ghc hiding (mkTyArg, showPpr, panic)
+import           Liquid.GHC.Misc (showPpr)
+import           Liquid.GHC.API as Ghc hiding (mkTyArg, showPpr, panic)
 import           Language.Fixpoint.Types (symbol)
 
 -- e368f3265b80aeb337fbac3f6a70ee54ab14edfd

--- a/src-ghc/Liquid/GHC/TypeRep.hs
+++ b/src-ghc/Liquid/GHC/TypeRep.hs
@@ -10,8 +10,6 @@
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- TODO(#1918): Only needed for GHC <9.0.1.
 {-# OPTIONS_GHC -Wno-orphans #-}
 
--- | This module contains a wrappers and utility functions for
--- accessing GHC module information. It should NEVER depend on
 module Liquid.GHC.TypeRep (
   mkTyArg, 
 

--- a/src-ghc/Liquid/GHC/Types.hs
+++ b/src-ghc/Liquid/GHC/Types.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE DeriveGeneric #-}
-module Language.Haskell.Liquid.GHC.Types where
+module Liquid.GHC.Types where
 
 import           Data.HashSet (HashSet, fromList)
 import           Data.Hashable
 import           GHC.Generics hiding (moduleName)
-import           Language.Haskell.Liquid.GHC.API
+import           Liquid.GHC.API
 
 -- | A 'StableName' is virtually isomorphic to a GHC's 'Name' but crucially we don't use
 -- the 'Eq' instance defined on a 'Name' because it's 'Unique'-based. In particular, GHC

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -42,9 +42,9 @@ import           Language.Fixpoint.Misc                     as Misc
 import           Language.Fixpoint.Types                    hiding (dcFields, DataDecl, Error, panic)
 import qualified Language.Fixpoint.Types                    as F
 import qualified Language.Haskell.Liquid.Misc               as Misc -- (nubHashOn)
-import qualified Language.Haskell.Liquid.GHC.Misc           as GM
-import qualified Language.Haskell.Liquid.GHC.API            as Ghc
-import           Language.Haskell.Liquid.GHC.Types          (StableName)
+import qualified Liquid.GHC.Misc           as GM
+import qualified Liquid.GHC.API            as Ghc
+import           Liquid.GHC.Types          (StableName)
 import           Language.Haskell.Liquid.Types
 import           Language.Haskell.Liquid.WiredIn
 import qualified Language.Haskell.Liquid.Measure            as Ms

--- a/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -23,11 +23,11 @@ import Control.Monad.Trans.State.Lazy (runState, get, put)
 import           Language.Fixpoint.Misc
 import qualified Language.Haskell.Liquid.Measure as Ms
 import qualified Language.Fixpoint.Types as F
-import qualified Language.Haskell.Liquid.GHC.API as Ghc
-import qualified Language.Haskell.Liquid.GHC.Misc as GM
+import qualified Liquid.GHC.API as Ghc
+import qualified Liquid.GHC.Misc as GM
 import           Language.Haskell.Liquid.Types.RefType
 import           Language.Haskell.Liquid.Transforms.CoreToLogic
-import           Language.Haskell.Liquid.GHC.Misc
+import           Liquid.GHC.Misc
 import           Language.Haskell.Liquid.Types
 
 import           Language.Haskell.Liquid.Bare.Resolve as Bare

--- a/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -15,7 +15,7 @@ module Language.Haskell.Liquid.Bare.Check
 
 import           Language.Haskell.Liquid.Constraint.ToFixpoint
 
-import           Language.Haskell.Liquid.GHC.API                   as Ghc hiding ( Located
+import           Liquid.GHC.API                   as Ghc hiding ( Located
                                                                                  , text
                                                                                  , (<+>)
                                                                                  , panic
@@ -34,8 +34,8 @@ import           Data.Hashable
 import qualified Language.Fixpoint.Misc                    as Misc
 import           Language.Fixpoint.SortCheck               (checkSorted, checkSortedReftFull, checkSortFull)
 import qualified Language.Fixpoint.Types                   as F
-import qualified Language.Haskell.Liquid.GHC.Misc          as GM
-import           Language.Haskell.Liquid.GHC.Play          (getNonPositivesTyCon)
+import qualified Liquid.GHC.Misc          as GM
+import           Liquid.GHC.Play          (getNonPositivesTyCon)
 import           Language.Haskell.Liquid.Misc              (condNull, thd5)
 import           Language.Haskell.Liquid.Types
 import           Language.Haskell.Liquid.WiredIn

--- a/src/Language/Haskell/Liquid/Bare/Class.hs
+++ b/src/Language/Haskell/Liquid/Bare/Class.hs
@@ -24,8 +24,8 @@ import qualified Language.Fixpoint.Types                    as F
 import qualified Language.Fixpoint.Types.Visitor            as F
 
 import           Language.Haskell.Liquid.Types.Dictionaries
-import qualified Language.Haskell.Liquid.GHC.Misc           as GM
-import qualified Language.Haskell.Liquid.GHC.API            as Ghc
+import qualified Liquid.GHC.Misc           as GM
+import qualified Liquid.GHC.API            as Ghc
 import           Language.Haskell.Liquid.Misc
 import           Language.Haskell.Liquid.Types.RefType
 import           Language.Haskell.Liquid.Types              hiding (freeTyVars)

--- a/src/Language/Haskell/Liquid/Bare/DataType.hs
+++ b/src/Language/Haskell/Liquid/Bare/DataType.hs
@@ -32,8 +32,8 @@ import qualified Data.HashSet                           as S
 import qualified Data.Maybe                             as Mb
 
 import qualified Language.Fixpoint.Types                as F
-import qualified Language.Haskell.Liquid.GHC.Misc       as GM
-import qualified Language.Haskell.Liquid.GHC.API        as Ghc
+import qualified Liquid.GHC.Misc       as GM
+import qualified Liquid.GHC.API        as Ghc
 import           Language.Haskell.Liquid.Types.PredType (dataConPSpecType)
 import qualified Language.Haskell.Liquid.Types.RefType  as RT
 import           Language.Haskell.Liquid.Types.Types

--- a/src/Language/Haskell/Liquid/Bare/Elaborate.hs
+++ b/src/Language/Haskell/Liquid/Bare/Elaborate.hs
@@ -26,8 +26,8 @@ where
 
 import qualified Language.Fixpoint.Types       as F
 -- import           Control.Arrow
-import           Language.Haskell.Liquid.GHC.API hiding (panic, varName)
-import qualified Language.Haskell.Liquid.GHC.Misc
+import           Liquid.GHC.API hiding (panic, varName)
+import qualified Liquid.GHC.Misc
                                                as GM
 import           Language.Haskell.Liquid.Types.Types
 import           Language.Haskell.Liquid.Types.RefType
@@ -57,7 +57,7 @@ import           OccName
 -- import           FastString
 -- import           CoreSyn
 -- import           PrelNames
-import qualified Language.Haskell.Liquid.GHC.API as Ghc
+import qualified Liquid.GHC.API as Ghc
                                                 (noExtField)
 
 -- import qualified Outputable                    as O

--- a/src/Language/Haskell/Liquid/Bare/Expand.hs
+++ b/src/Language/Haskell/Liquid/Bare/Expand.hs
@@ -41,8 +41,8 @@ import qualified Language.Fixpoint.Types               as F
 -- import qualified Language.Fixpoint.Types.Visitor       as F 
 import qualified Language.Fixpoint.Misc                as Misc
 import           Language.Fixpoint.Types (Expr(..)) -- , Symbol, symbol) 
-import qualified Language.Haskell.Liquid.GHC.Misc      as GM
-import qualified Language.Haskell.Liquid.GHC.API       as Ghc
+import qualified Liquid.GHC.Misc      as GM
+import qualified Liquid.GHC.API       as Ghc
 import qualified Language.Haskell.Liquid.Types.RefType as RT
 import           Language.Haskell.Liquid.Types         hiding (fresh)
 import qualified Language.Haskell.Liquid.Misc          as Misc

--- a/src/Language/Haskell/Liquid/Bare/Laws.hs
+++ b/src/Language/Haskell/Liquid/Bare/Laws.hs
@@ -7,12 +7,12 @@ import           Control.Monad ((<=<))
 
 import qualified Language.Haskell.Liquid.Measure            as Ms
 import qualified Language.Fixpoint.Types                    as F
-import qualified Language.Haskell.Liquid.GHC.Misc           as GM
+import qualified Liquid.GHC.Misc           as GM
 import           Language.Haskell.Liquid.Bare.Types         as Bare
 import           Language.Haskell.Liquid.Bare.Resolve       as Bare
 import           Language.Haskell.Liquid.Bare.Expand        as Bare
 import           Language.Haskell.Liquid.Types
-import           Language.Haskell.Liquid.GHC.API
+import           Liquid.GHC.API
 
 
 

--- a/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -36,8 +36,8 @@ import           Language.Haskell.Liquid.Transforms.CoreToLogic
 import qualified Language.Fixpoint.Misc                as Misc
 import qualified Language.Haskell.Liquid.Misc          as Misc
 import           Language.Haskell.Liquid.Misc             ((.||.))
-import qualified Language.Haskell.Liquid.GHC.API       as Ghc
-import qualified Language.Haskell.Liquid.GHC.Misc      as GM
+import qualified Liquid.GHC.API       as Ghc
+import qualified Liquid.GHC.Misc      as GM
 import qualified Language.Haskell.Liquid.Types.RefType as RT
 import           Language.Haskell.Liquid.Types
 -- import           Language.Haskell.Liquid.Types.Bounds

--- a/src/Language/Haskell/Liquid/Bare/Misc.hs
+++ b/src/Language/Haskell/Liquid/Bare/Misc.hs
@@ -16,7 +16,7 @@ module Language.Haskell.Liquid.Bare.Misc
 
 import           Prelude                               hiding (error)
 
-import           Language.Haskell.Liquid.GHC.API       as Ghc  hiding (Located, showPpr)
+import           Liquid.GHC.API       as Ghc  hiding (Located, showPpr)
 
 import           Control.Monad.Except                  (MonadError, throwError)
 import           Control.Monad.State
@@ -25,7 +25,7 @@ import qualified Data.Maybe                            as Mb --(fromMaybe, isNot
 import qualified Text.PrettyPrint.HughesPJ             as PJ
 import qualified Data.List                             as L
 import qualified Language.Fixpoint.Types as F
-import           Language.Haskell.Liquid.GHC.Misc
+import           Liquid.GHC.Misc
 import           Language.Haskell.Liquid.Types.RefType
 import           Language.Haskell.Liquid.Types.Types
 

--- a/src/Language/Haskell/Liquid/Bare/Plugged.hs
+++ b/src/Language/Haskell/Liquid/Bare/Plugged.hs
@@ -20,9 +20,9 @@ import qualified Data.Maybe                        as Mb
 import qualified Data.List                         as L
 import qualified Language.Fixpoint.Types           as F
 import qualified Language.Fixpoint.Types.Visitor   as F
-import qualified Language.Haskell.Liquid.GHC.Misc  as GM
-import qualified Language.Haskell.Liquid.GHC.API   as Ghc
-import           Language.Haskell.Liquid.GHC.Types (StableName, mkStableName)
+import qualified Liquid.GHC.Misc  as GM
+import qualified Liquid.GHC.API   as Ghc
+import           Liquid.GHC.Types (StableName, mkStableName)
 import           Language.Haskell.Liquid.Types.RefType ()
 import           Language.Haskell.Liquid.Types
 import qualified Language.Haskell.Liquid.Misc       as Misc

--- a/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -67,8 +67,8 @@ import qualified Language.Fixpoint.Utils.Files         as F
 import qualified Language.Fixpoint.Types               as F
 import qualified Language.Fixpoint.Types.Visitor       as F
 import qualified Language.Fixpoint.Misc                as Misc
-import qualified Language.Haskell.Liquid.GHC.API       as Ghc
-import qualified Language.Haskell.Liquid.GHC.Misc      as GM
+import qualified Liquid.GHC.API       as Ghc
+import qualified Liquid.GHC.Misc      as GM
 import qualified Language.Haskell.Liquid.Misc          as Misc
 import qualified Language.Haskell.Liquid.Types.RefType as RT
 import qualified Language.Haskell.Liquid.Types.Errors  as Errors

--- a/src/Language/Haskell/Liquid/Bare/ToBare.hs
+++ b/src/Language/Haskell/Liquid/Bare/ToBare.hs
@@ -16,8 +16,8 @@ import           Data.Bifunctor
 
 import           Language.Fixpoint.Misc (mapSnd)
 import qualified Language.Fixpoint.Types as F
-import           Language.Haskell.Liquid.GHC.Misc
-import           Language.Haskell.Liquid.GHC.API
+import           Liquid.GHC.Misc
+import           Liquid.GHC.API
 import           Language.Haskell.Liquid.Types
 -- import           Language.Haskell.Liquid.Measure
 -- import           Language.Haskell.Liquid.Types.RefType

--- a/src/Language/Haskell/Liquid/Bare/Typeclass.hs
+++ b/src/Language/Haskell/Liquid/Bare/Typeclass.hs
@@ -22,9 +22,9 @@ import qualified Language.Fixpoint.Types       as F
 import qualified Language.Fixpoint.Misc        as Misc
 import           Optics
 import           Language.Haskell.Liquid.Bare.Elaborate
-import qualified Language.Haskell.Liquid.GHC.Misc
+import qualified Liquid.GHC.Misc
                                                as GM
-import qualified Language.Haskell.Liquid.GHC.API
+import qualified Liquid.GHC.API
                                                as Ghc
 import qualified Language.Haskell.Liquid.Misc  as Misc
 import           Language.Haskell.Liquid.Types

--- a/src/Language/Haskell/Liquid/Bare/Types.hs
+++ b/src/Language/Haskell/Liquid/Bare/Types.hs
@@ -36,8 +36,8 @@ import qualified Language.Haskell.Liquid.Measure       as Ms
 import qualified Language.Haskell.Liquid.Types.RefType as RT 
 import           Language.Haskell.Liquid.Types.Types
 import           Language.Haskell.Liquid.Types.Specs   hiding (BareSpec)
-import           Language.Haskell.Liquid.GHC.API       as Ghc hiding (Located, Env)
-import           Language.Haskell.Liquid.GHC.Types     (StableName)
+import           Liquid.GHC.API       as Ghc hiding (Located, Env)
+import           Liquid.GHC.Types     (StableName)
 
 
 type ModSpecs = M.HashMap ModName Ms.BareSpec

--- a/src/Language/Haskell/Liquid/Constraint/Env.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Env.hs
@@ -68,9 +68,9 @@ import           Language.Fixpoint.SortCheck (pruneUnsortedReft)
 
 
 
-import           Language.Haskell.Liquid.GHC.API hiding (panic)
+import           Liquid.GHC.API hiding (panic)
 import           Language.Haskell.Liquid.Types.RefType
-import qualified Language.Haskell.Liquid.GHC.SpanStack as Sp
+import qualified Liquid.GHC.SpanStack as Sp
 import           Language.Haskell.Liquid.Types            hiding (binds, Loc, loc, freeTyVars, Def)
 import           Language.Haskell.Liquid.Constraint.Types
 import           Language.Haskell.Liquid.Constraint.Fresh ()

--- a/src/Language/Haskell/Liquid/Constraint/Fresh.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Fresh.hs
@@ -37,8 +37,8 @@ import           Language.Haskell.Liquid.Types
 -- import           Language.Haskell.Liquid.Types.RefType
 -- import           Language.Haskell.Liquid.Types.Fresh
 import           Language.Haskell.Liquid.Constraint.Types
-import qualified Language.Haskell.Liquid.GHC.Misc as GM
-import           Language.Haskell.Liquid.GHC.API as Ghc
+import qualified Liquid.GHC.Misc as GM
+import           Liquid.GHC.API as Ghc
 
 --------------------------------------------------------------------------------
 -- | This is all hardwiring stuff to CG ----------------------------------------

--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -25,13 +25,13 @@ import Control.Monad.Fail
 
 import           Prelude                                       hiding (error)
 import           GHC.Stack
-import           Language.Haskell.Liquid.GHC.API                   as Ghc hiding ( panic
+import           Liquid.GHC.API                   as Ghc hiding ( panic
                                                                                  , checkErr
                                                                                  , (<+>)
                                                                                  , text
                                                                                  , vcat
                                                                                  )
-import           Language.Haskell.Liquid.GHC.TypeRep           ()
+import           Liquid.GHC.TypeRep           ()
 import           Text.PrettyPrint.HughesPJ hiding ((<>))
 import           Control.Monad.State
 import           Data.Functor ((<&>))
@@ -52,10 +52,10 @@ import           Language.Haskell.Liquid.Constraint.Env
 import           Language.Haskell.Liquid.Constraint.Monad
 import           Language.Haskell.Liquid.Constraint.Split
 import           Language.Haskell.Liquid.Types.Dictionaries
-import           Language.Haskell.Liquid.GHC.Play          (isHoleVar)
-import qualified Language.Haskell.Liquid.GHC.Resugar           as Rs
-import qualified Language.Haskell.Liquid.GHC.SpanStack         as Sp
-import qualified Language.Haskell.Liquid.GHC.Misc         as GM -- ( isInternal, collectArguments, tickSrcSpan, showPpr )
+import           Liquid.GHC.Play          (isHoleVar)
+import qualified Liquid.GHC.Resugar           as Rs
+import qualified Liquid.GHC.SpanStack         as Sp
+import qualified Liquid.GHC.Misc         as GM -- ( isInternal, collectArguments, tickSrcSpan, showPpr )
 import           Language.Haskell.Liquid.Misc
 import           Language.Haskell.Liquid.Constraint.Types
 import           Language.Haskell.Liquid.Constraint.Constraint

--- a/src/Language/Haskell/Liquid/Constraint/Init.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Init.hs
@@ -29,9 +29,9 @@ import qualified Language.Haskell.Liquid.UX.CTags              as Tg
 import           Language.Haskell.Liquid.Constraint.Fresh
 import           Language.Haskell.Liquid.Constraint.Env
 import           Language.Haskell.Liquid.WiredIn               (dictionaryVar)
-import qualified Language.Haskell.Liquid.GHC.SpanStack         as Sp
-import           Language.Haskell.Liquid.GHC.Misc             ( idDataConM, hasBaseTypeVar, isDataConId) -- dropModuleNames, simplesymbol)
-import           Language.Haskell.Liquid.GHC.API               as Ghc hiding (mapSndM)
+import qualified Liquid.GHC.SpanStack         as Sp
+import           Liquid.GHC.Misc             ( idDataConM, hasBaseTypeVar, isDataConId) -- dropModuleNames, simplesymbol)
+import           Liquid.GHC.API               as Ghc hiding (mapSndM)
 import           Language.Haskell.Liquid.Misc
 import           Language.Fixpoint.Misc
 import           Language.Haskell.Liquid.Constraint.Types

--- a/src/Language/Haskell/Liquid/Constraint/Monad.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Monad.hs
@@ -17,9 +17,9 @@ import           Language.Haskell.Liquid.Types hiding (loc)
 import           Language.Haskell.Liquid.Constraint.Types
 import           Language.Haskell.Liquid.Constraint.Env
 import           Language.Fixpoint.Misc hiding (errorstar)
-import           Language.Haskell.Liquid.GHC.Misc -- (concatMapM)
-import           Language.Haskell.Liquid.GHC.SpanStack (srcSpan)
-import           Language.Haskell.Liquid.GHC.API as Ghc hiding (panic, showPpr)
+import           Liquid.GHC.Misc -- (concatMapM)
+import           Liquid.GHC.SpanStack (srcSpan)
+import           Liquid.GHC.API as Ghc hiding (panic, showPpr)
 
 --------------------------------------------------------------------------------
 -- | `addC` adds a subtyping constraint into the global pool.

--- a/src/Language/Haskell/Liquid/Constraint/Qualifier.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Qualifier.hs
@@ -19,10 +19,10 @@ import           Language.Fixpoint.Types                  hiding (panic, mkQual)
 import qualified Language.Fixpoint.Types.Config as FC
 import           Language.Fixpoint.SortCheck
 import           Language.Haskell.Liquid.Types.RefType
-import           Language.Haskell.Liquid.GHC.Misc         (getSourcePos)
+import           Liquid.GHC.Misc         (getSourcePos)
 import           Language.Haskell.Liquid.Misc             (condNull)
 import           Language.Haskell.Liquid.Types.PredType
-import           Language.Haskell.Liquid.GHC.API hiding (Expr, mkQual, panic)
+import           Liquid.GHC.API hiding (Expr, mkQual, panic)
 
 import           Language.Haskell.Liquid.Types
 

--- a/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
+++ b/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
@@ -10,8 +10,8 @@ module Language.Haskell.Liquid.Constraint.ToFixpoint
   ) where
 
 import           Prelude hiding (error)
-import qualified Language.Haskell.Liquid.GHC.API as Ghc
-import           Language.Haskell.Liquid.GHC.API (Var, Id, TyCon)
+import qualified Liquid.GHC.API as Ghc
+import           Liquid.GHC.API (Var, Id, TyCon)
 import qualified Language.Fixpoint.Types.Config as FC
 import           System.Console.CmdArgs.Default (def)
 import qualified Language.Fixpoint.Types        as F
@@ -26,7 +26,7 @@ import qualified Data.Maybe as Mb
 -- imports for AxiomEnv
 import qualified Language.Haskell.Liquid.UX.Config as Config
 import           Language.Haskell.Liquid.UX.DiffCheck (coreDefs, coreDeps, dependsOn, Def(..))
-import qualified Language.Haskell.Liquid.GHC.Misc  as GM -- (simplesymbol)
+import qualified Liquid.GHC.Misc  as GM -- (simplesymbol)
 import qualified Data.List                         as L
 import qualified Data.HashMap.Strict               as M
 import qualified Data.HashSet                      as S

--- a/src/Language/Haskell/Liquid/Constraint/Types.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Types.hs
@@ -65,8 +65,8 @@ import           Control.DeepSeq
 import           Data.Maybe               (isJust, mapMaybe)
 import           Control.Monad.State
 
-import           Language.Haskell.Liquid.GHC.SpanStack
-import           Language.Haskell.Liquid.GHC.API    as Ghc hiding ( (<+>)
+import           Liquid.GHC.SpanStack
+import           Liquid.GHC.API    as Ghc hiding ( (<+>)
                                                                   , vcat
                                                                   , parens
                                                                   , ($+$)

--- a/src/Language/Haskell/Liquid/GHC.hs
+++ b/src/Language/Haskell/Liquid/GHC.hs
@@ -1,6 +1,0 @@
--- | This module re-exports the GHC API as a single blob.
-
-module Language.Haskell.Liquid.GHC (module X) where
-
-import Language.Haskell.Liquid.GHC.Interface as X
-import Language.Haskell.Liquid.GHC.Misc      as X

--- a/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -16,29 +16,29 @@ module Language.Haskell.Liquid.GHC.Plugin (
 
   ) where
 
-import qualified Language.Haskell.Liquid.GHC.API         as O
-import           Language.Haskell.Liquid.GHC.API         as GHC hiding (Target, Type)
+import qualified Liquid.GHC.API         as O
+import           Liquid.GHC.API         as GHC hiding (Target, Type)
 import qualified Text.PrettyPrint.HughesPJ               as PJ
 import qualified Language.Fixpoint.Types                 as F
-import qualified Language.Haskell.Liquid.GHC.Misc        as LH
+import qualified Liquid.GHC.Misc        as LH
 import qualified Language.Haskell.Liquid.UX.CmdLine      as LH
-import qualified Language.Haskell.Liquid.GHC.Interface   as LH
+import qualified Liquid.GHC.Interface   as LH
 import qualified Language.Haskell.Liquid.Liquid          as LH
 import qualified Language.Haskell.Liquid.Types.PrettyPrint as LH ( filterReportErrors
                                                                  , filterReportErrorsWith
                                                                  , defaultFilterReporter
                                                                  , reduceFilters )
-import qualified Language.Haskell.Liquid.GHC.Logging     as LH   (fromPJDoc)
+import qualified Liquid.GHC.Logging     as LH   (fromPJDoc)
 
 import           Language.Haskell.Liquid.GHC.Plugin.Types
 import           Language.Haskell.Liquid.GHC.Plugin.Util as Util
 import           Language.Haskell.Liquid.GHC.Plugin.SpecFinder
                                                          as SpecFinder
 
-import           Language.Haskell.Liquid.GHC.Types       (MGIModGuts(..), miModGuts)
-import qualified Language.Haskell.Liquid.GHC.GhcMonadLike
+import           Liquid.GHC.Types       (MGIModGuts(..), miModGuts)
+import qualified Liquid.GHC.GhcMonadLike
                                                          as GhcMonadLike
-import           Language.Haskell.Liquid.GHC.GhcMonadLike ( GhcMonadLike
+import           Liquid.GHC.GhcMonadLike ( GhcMonadLike
                                                           , askHscEnv
                                                           , isBootInterface
                                                           )

--- a/src/Language/Haskell/Liquid/GHC/Plugin/SpecFinder.hs
+++ b/src/Language/Haskell/Liquid/GHC/Plugin/SpecFinder.hs
@@ -11,7 +11,7 @@ module Language.Haskell.Liquid.GHC.Plugin.SpecFinder
     , configToRedundantDependencies
     ) where
 
-import           Language.Haskell.Liquid.GHC.GhcMonadLike as GhcMonadLike ( GhcMonadLike
+import           Liquid.GHC.GhcMonadLike as GhcMonadLike ( GhcMonadLike
                                                                           , lookupModSummary
                                                                           , askHscEnv
                                                                           )
@@ -24,8 +24,8 @@ import           Language.Haskell.Liquid.Parse            ( specSpecificationP )
 import           Language.Fixpoint.Utils.Files            ( Ext(Spec), withExt )
 
 import           Optics
-import qualified Language.Haskell.Liquid.GHC.API         as O
-import           Language.Haskell.Liquid.GHC.API         as GHC
+import qualified Liquid.GHC.API         as O
+import           Liquid.GHC.API         as GHC
 
 import           Data.Bifunctor
 import           Data.Maybe

--- a/src/Language/Haskell/Liquid/GHC/Plugin/Types.hs
+++ b/src/Language/Haskell/Liquid/GHC/Plugin/Types.hs
@@ -62,8 +62,8 @@ import           Data.Hashable
 
 import           Language.Fixpoint.Types.Spans
 import           Language.Haskell.Liquid.Types.Specs
-import           Language.Haskell.Liquid.GHC.API         as GHC
-import qualified Language.Haskell.Liquid.GHC.Interface   as LH
+import           Liquid.GHC.API         as GHC
+import qualified Liquid.GHC.Interface   as LH
 import           Language.Fixpoint.Types.Names            ( Symbol )
 
 

--- a/src/Language/Haskell/Liquid/GHC/Plugin/Util.hs
+++ b/src/Language/Haskell/Liquid/GHC/Plugin/Util.hs
@@ -25,7 +25,7 @@ import           Data.Maybe                               ( listToMaybe )
 import           Data.Data
 import           Data.Either                              ( partitionEithers )
 
-import           Language.Haskell.Liquid.GHC.API
+import           Liquid.GHC.API
 import           Language.Haskell.Liquid.GHC.Plugin.Types ( SpecComment
                                                           , LiquidLib
                                                           )

--- a/src/Language/Haskell/Liquid/LawInstances.hs
+++ b/src/Language/Haskell/Liquid/LawInstances.hs
@@ -7,7 +7,7 @@ import           Text.PrettyPrint.HughesPJ                  hiding ((<>))
 
 import           Language.Haskell.Liquid.Types
 import           Language.Haskell.Liquid.Types.Equality
-import           Language.Haskell.Liquid.GHC.API            hiding ((<+>), text)
+import           Liquid.GHC.API            hiding ((<+>), text)
 import qualified Language.Fixpoint.Types                    as F
 
 checkLawInstances :: GhcSpecLaws -> Diagnostics

--- a/src/Language/Haskell/Liquid/Liquid.hs
+++ b/src/Language/Haskell/Liquid/Liquid.hs
@@ -39,15 +39,15 @@ import           Language.Haskell.Liquid.Synthesize (synthesize)
 import           Language.Haskell.Liquid.UX.Errors
 import           Language.Haskell.Liquid.UX.CmdLine
 import           Language.Haskell.Liquid.UX.Tidy
-import           Language.Haskell.Liquid.GHC.Misc (showCBs, ignoreCoreBinds) -- howPpr)
-import           Language.Haskell.Liquid.GHC.Interface
+import           Liquid.GHC.Misc (showCBs, ignoreCoreBinds) -- howPpr)
+import           Liquid.GHC.Interface
 import           Language.Haskell.Liquid.Constraint.Generate
 import           Language.Haskell.Liquid.Constraint.ToFixpoint
 import           Language.Haskell.Liquid.Constraint.Types
 import           Language.Haskell.Liquid.UX.Annotate (mkOutput)
 import qualified Language.Haskell.Liquid.Termination.Structural as ST
-import qualified Language.Haskell.Liquid.GHC.Misc          as GM 
-import           Language.Haskell.Liquid.GHC.API as GHC hiding (text, vcat, ($+$), getOpts, (<+>))
+import qualified Liquid.GHC.Misc          as GM 
+import           Liquid.GHC.API as GHC hiding (text, vcat, ($+$), getOpts, (<+>))
 
 type MbEnv = Maybe HscEnv
 

--- a/src/Language/Haskell/Liquid/Measure.hs
+++ b/src/Language/Haskell/Liquid/Measure.hs
@@ -34,8 +34,8 @@ import qualified Data.Maybe                             as Mb -- (fromMaybe, isN
 
 import           Language.Fixpoint.Misc
 import           Language.Fixpoint.Types                hiding (panic, R, DataDecl, SrcSpan, LocSymbol)
-import           Language.Haskell.Liquid.GHC.API        as Ghc hiding (Expr, showPpr, panic, (<+>))
-import           Language.Haskell.Liquid.GHC.Misc
+import           Liquid.GHC.API        as Ghc hiding (Expr, showPpr, panic, (<+>))
+import           Liquid.GHC.Misc
 -- import qualified Language.Haskell.Liquid.Misc as Misc
 import           Language.Haskell.Liquid.Types.Types    -- hiding (GhcInfo(..), GhcSpec (..))
 import           Language.Haskell.Liquid.Types.RefType

--- a/src/Language/Haskell/Liquid/Parse.hs
+++ b/src/Language/Haskell/Liquid/Parse.hs
@@ -39,7 +39,7 @@ import           GHC                                    (ModuleName, mkModuleNam
 import qualified Text.PrettyPrint.HughesPJ              as PJ
 import           Text.PrettyPrint.HughesPJ.Compat       ((<+>))
 import           Language.Fixpoint.Types                hiding (panic, SVar, DDecl, DataDecl, DataCtor (..), Error, R, Predicate)
-import           Language.Haskell.Liquid.GHC.Misc       hiding (getSourcePos)
+import           Liquid.GHC.Misc       hiding (getSourcePos)
 import           Language.Haskell.Liquid.Types
 -- import           Language.Haskell.Liquid.Types.Errors
 import qualified Language.Fixpoint.Misc                 as Misc

--- a/src/Language/Haskell/Liquid/Synthesize.hs
+++ b/src/Language/Haskell/Liquid/Synthesize.hs
@@ -23,7 +23,7 @@ import           Language.Fixpoint.Types hiding (SEnv, SVar, Error)
 import qualified Language.Fixpoint.Types        as F
 import qualified Language.Fixpoint.Types.Config as F
 import           Language.Haskell.Liquid.Synthesize.Env
-import           Language.Haskell.Liquid.GHC.API as GHC hiding (text, ($+$))
+import           Liquid.GHC.API as GHC hiding (text, ($+$))
 
 import           Text.PrettyPrint.HughesPJ (text, ($+$))
 import           Control.Monad.State.Lazy

--- a/src/Language/Haskell/Liquid/Synthesize/Check.hs
+++ b/src/Language/Haskell/Liquid/Synthesize/Check.hs
@@ -21,11 +21,11 @@ import           Language.Haskell.Liquid.Constraint.Fresh
 import           Language.Haskell.Liquid.Constraint.ToFixpoint
 import           Language.Haskell.Liquid.Synthesize.Monad
 import           Language.Haskell.Liquid.Synthesize.GHC
-import           Language.Haskell.Liquid.GHC.API as Ghc
+import           Liquid.GHC.API as Ghc
 import           Language.Haskell.Liquid.Misc   ( mapThd3 )
 import           Control.Monad.State.Lazy
 import           System.Console.CmdArgs.Verbosity
-import           Language.Haskell.Liquid.GHC.TypeRep
+import           Liquid.GHC.TypeRep
 import           Language.Haskell.Liquid.Types
 
 hasType :: SpecType -> CoreExpr -> SM Bool

--- a/src/Language/Haskell/Liquid/Synthesize/Env.hs
+++ b/src/Language/Haskell/Liquid/Synthesize/Env.hs
@@ -3,7 +3,7 @@
 module Language.Haskell.Liquid.Synthesize.Env where 
 
 import           Language.Fixpoint.Types
-import           Language.Haskell.Liquid.GHC.API as GHC
+import           Liquid.GHC.API as GHC
 import           Language.Haskell.Liquid.Constraint.Types
 import           Language.Haskell.Liquid.Types
 import           Language.Haskell.Liquid.Synthesize.Monad

--- a/src/Language/Haskell/Liquid/Synthesize/GHC.hs
+++ b/src/Language/Haskell/Liquid/Synthesize/GHC.hs
@@ -11,8 +11,8 @@ import qualified Language.Fixpoint.Types       as F
 import           Language.Haskell.Liquid.Types
 import           Data.Default
 import           Data.Maybe                     ( fromMaybe )
-import           Language.Haskell.Liquid.GHC.TypeRep
-import           Language.Haskell.Liquid.GHC.API as GHC
+import           Liquid.GHC.TypeRep
+import           Liquid.GHC.API as GHC
 import           Language.Fixpoint.Types
 import qualified Data.HashMap.Strict           as M
 

--- a/src/Language/Haskell/Liquid/Synthesize/Generate.hs
+++ b/src/Language/Haskell/Liquid/Synthesize/Generate.hs
@@ -6,7 +6,7 @@
 
 module Language.Haskell.Liquid.Synthesize.Generate where
 
-import           Language.Haskell.Liquid.GHC.API as GHC hiding (Depth)
+import           Liquid.GHC.API as GHC hiding (Depth)
 import           Language.Haskell.Liquid.Types
 import           Language.Haskell.Liquid.Synthesize.GHC
                                          hiding ( SSEnv )

--- a/src/Language/Haskell/Liquid/Synthesize/Misc.hs
+++ b/src/Language/Haskell/Liquid/Synthesize/Misc.hs
@@ -9,8 +9,8 @@ import qualified Language.Fixpoint.Types        as F
 import           Control.Monad.State.Lazy
 import           Text.PrettyPrint.HughesPJ (text, Doc, vcat, ($+$))
 import           Language.Haskell.Liquid.Synthesize.GHC
-import           Language.Haskell.Liquid.GHC.TypeRep
-import           Language.Haskell.Liquid.GHC.API hiding (text, ($+$), vcat)
+import           Liquid.GHC.TypeRep
+import           Liquid.GHC.API hiding (text, ($+$), vcat)
 import           Language.Fixpoint.Types
 
 

--- a/src/Language/Haskell/Liquid/Synthesize/Monad.hs
+++ b/src/Language/Haskell/Liquid/Synthesize/Monad.hs
@@ -6,7 +6,7 @@
 module Language.Haskell.Liquid.Synthesize.Monad where
 
 
-import           Language.Haskell.Liquid.GHC.API as GHC
+import           Liquid.GHC.API as GHC
 import           Language.Haskell.Liquid.Bare.Resolve
                                                as B
 import           Language.Haskell.Liquid.Types

--- a/src/Language/Haskell/Liquid/Synthesize/Termination.hs
+++ b/src/Language/Haskell/Liquid/Synthesize/Termination.hs
@@ -8,7 +8,7 @@ import           Language.Haskell.Liquid.Types
 import qualified Language.Haskell.Liquid.Types.RefType
                                                as R
 import qualified Language.Fixpoint.Types       as F
-import           Language.Haskell.Liquid.GHC.API
+import           Liquid.GHC.API
 
 decrType :: Var -> SpecType -> [Var] -> [(F.Symbol, SpecType)] -> SpecType
 decrType _x ti xs _xts =

--- a/src/Language/Haskell/Liquid/Termination/Structural.hs
+++ b/src/Language/Haskell/Liquid/Termination/Structural.hs
@@ -7,8 +7,8 @@
 module Language.Haskell.Liquid.Termination.Structural (terminationVars) where
 
 import Language.Haskell.Liquid.Types hiding (isDecreasing)
-import Language.Haskell.Liquid.GHC.Misc (showPpr)
-import Language.Haskell.Liquid.GHC.API  as GHC hiding ( showPpr
+import Liquid.GHC.Misc (showPpr)
+import Liquid.GHC.API  as GHC hiding ( showPpr
                                                       , Env
                                                       , text
                                                       )

--- a/src/Language/Haskell/Liquid/Transforms/ANF.hs
+++ b/src/Language/Haskell/Liquid/Transforms/ANF.hs
@@ -13,12 +13,12 @@
 module Language.Haskell.Liquid.Transforms.ANF (anormalize) where
 
 import           Prelude                          hiding (error)
-import           Language.Haskell.Liquid.GHC.TypeRep
-import           Language.Haskell.Liquid.GHC.API  as Ghc hiding ( mkTyArg
+import           Liquid.GHC.TypeRep
+import           Liquid.GHC.API  as Ghc hiding ( mkTyArg
                                                                 , showPpr
                                                                 , DsM
                                                                 , panic)
-import qualified Language.Haskell.Liquid.GHC.API  as Ghc
+import qualified Liquid.GHC.API  as Ghc
 import           Control.Monad.State.Lazy
 import           System.Console.CmdArgs.Verbosity (whenLoud)
 import qualified Language.Fixpoint.Misc     as F
@@ -26,14 +26,14 @@ import qualified Language.Fixpoint.Types    as F
 
 import           Language.Haskell.Liquid.UX.Config  as UX
 import qualified Language.Haskell.Liquid.Misc       as Misc
-import           Language.Haskell.Liquid.GHC.Misc   as GM
+import           Liquid.GHC.Misc   as GM
 import           Language.Haskell.Liquid.Transforms.Rec
 import           Language.Haskell.Liquid.Transforms.InlineAux
 import           Language.Haskell.Liquid.Transforms.Rewrite
 import           Language.Haskell.Liquid.Types.Errors
 
-import qualified Language.Haskell.Liquid.GHC.SpanStack as Sp
-import qualified Language.Haskell.Liquid.GHC.Resugar   as Rs
+import qualified Liquid.GHC.SpanStack as Sp
+import qualified Liquid.GHC.Resugar   as Rs
 import           Data.Maybe                       (fromMaybe)
 import           Data.List                        (sortBy, (\\))
 import           Data.Function                    (on)

--- a/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -24,10 +24,10 @@ module Language.Haskell.Liquid.Transforms.CoreToLogic
 
 import           Data.ByteString                       (ByteString)
 import           Prelude                               hiding (error)
-import           Language.Haskell.Liquid.GHC.TypeRep   () -- needed for Eq 'Type'
-import           Language.Haskell.Liquid.GHC.API       hiding (Expr, Located, panic)
-import qualified Language.Haskell.Liquid.GHC.API       as Ghc
-import qualified Language.Haskell.Liquid.GHC.API       as C
+import           Liquid.GHC.TypeRep   () -- needed for Eq 'Type'
+import           Liquid.GHC.API       hiding (Expr, Located, panic)
+import qualified Liquid.GHC.API       as Ghc
+import qualified Liquid.GHC.API       as C
 import qualified Data.List                             as L
 import           Data.Maybe                            (listToMaybe)
 import qualified Data.Text                             as T
@@ -42,13 +42,13 @@ import qualified Language.Fixpoint.Misc                as Misc
 import qualified Language.Haskell.Liquid.Misc          as Misc
 import           Language.Fixpoint.Types               hiding (panic, Error, R, simplify)
 import qualified Language.Fixpoint.Types               as F
-import qualified Language.Haskell.Liquid.GHC.Misc      as GM
+import qualified Liquid.GHC.Misc      as GM
 
 
 import           Language.Haskell.Liquid.Bare.Types
 import           Language.Haskell.Liquid.Bare.DataType
 import           Language.Haskell.Liquid.Bare.Misc     (simpleSymbolVar)
-import           Language.Haskell.Liquid.GHC.Play
+import           Liquid.GHC.Play
 import           Language.Haskell.Liquid.Types.Types   --     hiding (GhcInfo(..), GhcSpec (..), LM)
 import           Language.Haskell.Liquid.Types.RefType
 

--- a/src/Language/Haskell/Liquid/Transforms/InlineAux.hs
+++ b/src/Language/Haskell/Liquid/Transforms/InlineAux.hs
@@ -8,9 +8,9 @@ module Language.Haskell.Liquid.Transforms.InlineAux
   )
 where
 import qualified Language.Haskell.Liquid.UX.Config  as UX
-import           Language.Haskell.Liquid.GHC.API
+import           Liquid.GHC.API
 import           Control.Arrow                  (second)
-import qualified Language.Haskell.Liquid.GHC.Misc
+import qualified Liquid.GHC.Misc
                                                as GM
 import qualified Data.HashMap.Strict           as M
 

--- a/src/Language/Haskell/Liquid/Transforms/Rec.hs
+++ b/src/Language/Haskell/Liquid/Transforms/Rec.hs
@@ -15,9 +15,9 @@ import           Control.Arrow                        (second)
 import           Control.Monad.State
 import qualified Data.HashMap.Strict                  as M
 import           Data.Hashable
-import           Language.Haskell.Liquid.GHC.API      as Ghc hiding (panic, mapSndM)
-import           Language.Haskell.Liquid.GHC.Misc
-import           Language.Haskell.Liquid.GHC.Play
+import           Liquid.GHC.API      as Ghc hiding (panic, mapSndM)
+import           Liquid.GHC.Misc
+import           Liquid.GHC.Play
 import           Language.Haskell.Liquid.Misc         (mapSndM)
 import           Language.Fixpoint.Misc               (mapSnd) -- , traceShow)
 import           Language.Haskell.Liquid.Types.Errors

--- a/src/Language/Haskell/Liquid/Transforms/Rewrite.hs
+++ b/src/Language/Haskell/Liquid/Transforms/Rewrite.hs
@@ -25,16 +25,16 @@ module Language.Haskell.Liquid.Transforms.Rewrite
 
   ) where
 
-import           Language.Haskell.Liquid.GHC.API as Ghc hiding (showPpr, substExpr)
-import           Language.Haskell.Liquid.GHC.TypeRep ()
+import           Liquid.GHC.API as Ghc hiding (showPpr, substExpr)
+import           Liquid.GHC.TypeRep ()
 import           Data.Maybe     (fromMaybe)
 import           Control.Monad.State hiding (lift)
 import           Language.Fixpoint.Misc       ({- mapFst, -}  mapSnd)
 import qualified          Language.Fixpoint.Types as F
 import           Language.Haskell.Liquid.Misc (safeZipWithError, mapThd3, Nat)
-import           Language.Haskell.Liquid.GHC.Play (substExpr)
-import           Language.Haskell.Liquid.GHC.Resugar
-import           Language.Haskell.Liquid.GHC.Misc (unTickExpr, isTupleId, showPpr, mkAlive) -- , showPpr, tracePpr)
+import           Liquid.GHC.Play (substExpr)
+import           Liquid.GHC.Resugar
+import           Liquid.GHC.Misc (unTickExpr, isTupleId, showPpr, mkAlive) -- , showPpr, tracePpr)
 import           Language.Haskell.Liquid.UX.Config  (Config, noSimplifyCore)
 import qualified Data.List as L
 import qualified Data.HashMap.Strict as M

--- a/src/Language/Haskell/Liquid/Types/Dictionaries.hs
+++ b/src/Language/Haskell/Liquid/Types/Dictionaries.hs
@@ -18,8 +18,8 @@ import           Data.Hashable
 import           Prelude                                   hiding (error)
 import qualified Language.Fixpoint.Types as F
 import           Language.Haskell.Liquid.Types.PrettyPrint ()
-import qualified Language.Haskell.Liquid.GHC.Misc       as GM
-import qualified Language.Haskell.Liquid.GHC.API        as Ghc
+import qualified Liquid.GHC.Misc       as GM
+import qualified Liquid.GHC.API        as Ghc
 import           Language.Haskell.Liquid.Types.Types
 -- import           Language.Haskell.Liquid.Types.Visitors (freeVars)
 import           Language.Haskell.Liquid.Types.RefType ()

--- a/src/Language/Haskell/Liquid/Types/Equality.hs
+++ b/src/Language/Haskell/Liquid/Types/Equality.hs
@@ -8,7 +8,7 @@ module Language.Haskell.Liquid.Types.Equality where
 
 import qualified Language.Fixpoint.Types as F
 import           Language.Haskell.Liquid.Types
-import qualified Language.Haskell.Liquid.GHC.API as Ghc
+import qualified Liquid.GHC.API as Ghc
 
 import Control.Monad.Writer.Lazy
 -- import Control.Monad

--- a/src/Language/Haskell/Liquid/Types/Errors.hs
+++ b/src/Language/Haskell/Liquid/Types/Errors.hs
@@ -68,7 +68,7 @@ import           System.FilePath
 import           Text.PrettyPrint.HughesPJ
 import qualified Text.Megaparsec              as P
 
-import           Language.Haskell.Liquid.GHC.API as Ghc hiding ( Expr
+import           Liquid.GHC.API as Ghc hiding ( Expr
                                                                , panicDoc
                                                                , ($+$)
                                                                , nest

--- a/src/Language/Haskell/Liquid/Types/Literals.hs
+++ b/src/Language/Haskell/Liquid/Types/Literals.hs
@@ -8,8 +8,8 @@ module Language.Haskell.Liquid.Types.Literals
   ) where
 
 import Prelude hiding (error)
-import Language.Haskell.Liquid.GHC.TypeRep ()
-import Language.Haskell.Liquid.GHC.API hiding (panic)
+import Liquid.GHC.TypeRep ()
+import Liquid.GHC.API hiding (panic)
 
 import Language.Haskell.Liquid.Types.Types
 import Language.Haskell.Liquid.Types.RefType

--- a/src/Language/Haskell/Liquid/Types/Meet.hs
+++ b/src/Language/Haskell/Liquid/Types/Meet.hs
@@ -8,7 +8,7 @@ import           Text.PrettyPrint.HughesPJ (Doc)
 import qualified Language.Fixpoint.Types as F
 import           Language.Haskell.Liquid.Types.Types
 import           Language.Haskell.Liquid.Types.RefType ()
-import           Language.Haskell.Liquid.GHC.API as Ghc
+import           Liquid.GHC.API as Ghc
 
 meetVarTypes :: F.TCEmb TyCon -> Doc -> (SrcSpan, SpecType) -> (SrcSpan, SpecType) -> SpecType
 meetVarTypes _emb _v hs lq = {- meetError emb err -} F.meet hsT lqT

--- a/src/Language/Haskell/Liquid/Types/PredType.hs
+++ b/src/Language/Haskell/Liquid/Types/PredType.hs
@@ -34,7 +34,7 @@ module Language.Haskell.Liquid.Types.PredType (
 
 import           Prelude                         hiding (error)
 import           Text.PrettyPrint.HughesPJ
-import           Language.Haskell.Liquid.GHC.API hiding ( panic
+import           Liquid.GHC.API hiding ( panic
                                                         , (<+>)
                                                         , hsep
                                                         , punctuate
@@ -42,7 +42,7 @@ import           Language.Haskell.Liquid.GHC.API hiding ( panic
                                                         , parens
                                                         , showPpr
                                                         )
-import           Language.Haskell.Liquid.GHC.TypeRep ()
+import           Liquid.GHC.TypeRep ()
 import           Data.Hashable
 import qualified Data.HashMap.Strict             as M
 import qualified Data.Maybe                                 as Mb
@@ -53,8 +53,8 @@ import           Language.Fixpoint.Misc
 
 -- import           Language.Fixpoint.Types         hiding (Expr, Predicate)
 import qualified Language.Fixpoint.Types                    as F
-import qualified Language.Haskell.Liquid.GHC.API            as Ghc
-import           Language.Haskell.Liquid.GHC.Misc
+import qualified Liquid.GHC.API            as Ghc
+import           Liquid.GHC.Misc
 import           Language.Haskell.Liquid.Misc
 import           Language.Haskell.Liquid.Types.RefType hiding (generalize)
 import           Language.Haskell.Liquid.Types.Types

--- a/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
+++ b/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
@@ -50,8 +50,8 @@ import qualified Data.Set                         as Set
 import           Data.String
 import           Language.Fixpoint.Misc
 import qualified Language.Fixpoint.Types          as F
-import qualified Language.Haskell.Liquid.GHC.API  as Ghc
-import           Language.Haskell.Liquid.GHC.API  as Ghc ( Class
+import qualified Liquid.GHC.API  as Ghc
+import           Liquid.GHC.API  as Ghc ( Class
                                                          , SrcSpan
                                                          , PprPrec
                                                          , DynFlags
@@ -66,8 +66,8 @@ import           Language.Haskell.Liquid.GHC.API  as Ghc ( Class
                                                          , srcSpanStartLine
                                                          , srcSpanStartCol
                                                          )
-import           Language.Haskell.Liquid.GHC.Logging (putErrMsg, mkLongErrAt)
-import           Language.Haskell.Liquid.GHC.Misc
+import           Liquid.GHC.Logging (putErrMsg, mkLongErrAt)
+import           Liquid.GHC.Misc
 import           Language.Haskell.Liquid.Misc
 import           Language.Haskell.Liquid.Types.Types
 import           Prelude                          hiding (error)

--- a/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -116,9 +116,9 @@ import           Language.Haskell.Liquid.Types.Types hiding (R, DataConP (..))
 import           Language.Haskell.Liquid.Types.Variance
 import           Language.Haskell.Liquid.Misc
 import           Language.Haskell.Liquid.Types.Names
-import qualified Language.Haskell.Liquid.GHC.Misc as GM
-import           Language.Haskell.Liquid.GHC.Play (mapType, stringClassArg, isRecursivenewTyCon)
-import           Language.Haskell.Liquid.GHC.API        as Ghc hiding ( Expr
+import qualified Liquid.GHC.Misc as GM
+import           Liquid.GHC.Play (mapType, stringClassArg, isRecursivenewTyCon)
+import           Liquid.GHC.API        as Ghc hiding ( Expr
                                                                       , Located
                                                                       , tyConName
                                                                       , punctuate
@@ -133,7 +133,7 @@ import           Language.Haskell.Liquid.GHC.API        as Ghc hiding ( Expr
                                                                       , panic
                                                                       , text
                                                                       )
-import           Language.Haskell.Liquid.GHC.TypeRep () -- Eq Type instance
+import           Liquid.GHC.TypeRep () -- Eq Type instance
 import Data.List (foldl')
 
 

--- a/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -78,8 +78,8 @@ import           Language.Haskell.Liquid.Types.Types
 import           Language.Haskell.Liquid.Types.Generics
 import           Language.Haskell.Liquid.Types.Variance
 import           Language.Haskell.Liquid.Types.Bounds 
-import           Language.Haskell.Liquid.GHC.API hiding (text, (<+>))
-import           Language.Haskell.Liquid.GHC.Types
+import           Liquid.GHC.API hiding (text, (<+>))
+import           Liquid.GHC.Types
 import           Text.PrettyPrint.HughesPJ              (text, (<+>))
 
 

--- a/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/src/Language/Haskell/Liquid/Types/Types.hs
@@ -242,7 +242,7 @@ module Language.Haskell.Liquid.Types.Types (
   )
   where
 
-import           Language.Haskell.Liquid.GHC.API as Ghc hiding ( Expr
+import           Liquid.GHC.API as Ghc hiding ( Expr
                                                                , Target
                                                                , isFunTy
                                                                , LM
@@ -296,8 +296,8 @@ import           Language.Fixpoint.Misc
 import qualified Language.Fixpoint.Types as F
 
 import           Language.Haskell.Liquid.Types.Generics
-import           Language.Haskell.Liquid.GHC.Misc
-import           Language.Haskell.Liquid.GHC.Logging as GHC
+import           Liquid.GHC.Misc
+import           Liquid.GHC.Logging as GHC
 import           Language.Haskell.Liquid.Types.Variance
 import           Language.Haskell.Liquid.Types.Errors
 import           Language.Haskell.Liquid.Misc

--- a/src/Language/Haskell/Liquid/Types/Variance.hs
+++ b/src/Language/Haskell/Liquid/Types/Variance.hs
@@ -26,8 +26,8 @@ import qualified Data.HashSet            as S
 import qualified Language.Fixpoint.Types as F
 
 import           Language.Haskell.Liquid.Types.Generics
-import qualified Language.Haskell.Liquid.GHC.Misc as GM
-import           Language.Haskell.Liquid.GHC.API        as Ghc hiding (text)
+import qualified Liquid.GHC.Misc as GM
+import           Liquid.GHC.API        as Ghc hiding (text)
 
 type VarianceInfo = [Variance]
 

--- a/src/Language/Haskell/Liquid/Types/Visitors.hs
+++ b/src/Language/Haskell/Liquid/Types/Visitors.hs
@@ -20,8 +20,8 @@ import           Data.List                        (foldl', (\\), delete)
 import qualified Data.HashSet                     as S
 import           Prelude                          hiding (error)
 import           Language.Fixpoint.Misc
-import           Language.Haskell.Liquid.GHC.API
-import           Language.Haskell.Liquid.GHC.Misc ()
+import           Liquid.GHC.API
+import           Liquid.GHC.Misc ()
 
 
 ------------------------------------------------------------------------------

--- a/src/Language/Haskell/Liquid/UX/ACSS.hs
+++ b/src/Language/Haskell/Liquid/UX/ACSS.hs
@@ -12,7 +12,7 @@ module Language.Haskell.Liquid.UX.ACSS (
   ) where
 
 import Prelude hiding (error)
-import qualified Language.Haskell.Liquid.GHC.API as SrcLoc
+import qualified Liquid.GHC.API as SrcLoc
 
 import Language.Haskell.HsColour.Anchors
 import Language.Haskell.HsColour.Classify as Classify
@@ -25,7 +25,7 @@ import qualified Data.HashMap.Strict as M
 import Data.List   (find, isPrefixOf, findIndex, elemIndices, intercalate, elemIndex)
 import Data.Char   (isSpace)
 import Text.Printf
-import Language.Haskell.Liquid.GHC.Misc
+import Liquid.GHC.Misc
 import Language.Haskell.Liquid.Types.Errors (panic, impossible)
 
 data AnnMap  = Ann

--- a/src/Language/Haskell/Liquid/UX/Annotate.hs
+++ b/src/Language/Haskell/Liquid/UX/Annotate.hs
@@ -56,8 +56,8 @@ import qualified Language.Haskell.Liquid.UX.ACSS              as ACSS
 import           Language.Haskell.HsColour.Classify
 import           Language.Fixpoint.Utils.Files
 import           Language.Fixpoint.Misc
-import           Language.Haskell.Liquid.GHC.Misc
-import qualified Language.Haskell.Liquid.GHC.API              as SrcLoc
+import           Liquid.GHC.Misc
+import qualified Liquid.GHC.API              as SrcLoc
 import           Language.Fixpoint.Types                      hiding (panic, Error, Loc, Constant (..), Located (..))
 import           Language.Haskell.Liquid.Misc
 import           Language.Haskell.Liquid.Types.PrettyPrint

--- a/src/Language/Haskell/Liquid/UX/CTags.hs
+++ b/src/Language/Haskell/Liquid/UX/CTags.hs
@@ -28,7 +28,7 @@ import qualified Data.HashMap.Strict    as M
 import qualified Data.Graph             as G
 
 import Language.Fixpoint.Types          (Tag)
-import Language.Haskell.Liquid.GHC.API
+import Liquid.GHC.API
 import Language.Haskell.Liquid.Types.Visitors (freeVars)
 import Language.Haskell.Liquid.Types.PrettyPrint ()
 import Language.Fixpoint.Misc     (mapSnd)

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -77,13 +77,13 @@ import Language.Fixpoint.Solver.Stats as Solver
 import Language.Haskell.Liquid.UX.Annotate
 import Language.Haskell.Liquid.UX.Config
 import Language.Haskell.Liquid.UX.SimpleVersion (simpleVersion)
-import Language.Haskell.Liquid.GHC.Misc
+import Liquid.GHC.Misc
 import Language.Haskell.Liquid.Misc
 import Language.Haskell.Liquid.Types.PrettyPrint ()
 import Language.Haskell.Liquid.Types       hiding (typ)
 import qualified Language.Haskell.Liquid.UX.ACSS as ACSS
 
-import qualified Language.Haskell.Liquid.GHC.API as GHC
+import qualified Liquid.GHC.API as GHC
 import           Language.Haskell.TH.Syntax.Compat (fromCode, toCode)
 
 import Text.PrettyPrint.HughesPJ           hiding (Mode, (<>))

--- a/src/Language/Haskell/Liquid/UX/DiffCheck.hs
+++ b/src/Language/Haskell/Liquid/UX/DiffCheck.hs
@@ -52,8 +52,8 @@ import           Language.Fixpoint.Types                (atLoc, FixResult (..), 
 import           Language.Fixpoint.Utils.Files
 import           Language.Fixpoint.Solver.Stats ()     
 import           Language.Haskell.Liquid.Misc           (mkGraph)
-import           Language.Haskell.Liquid.GHC.Misc
-import           Language.Haskell.Liquid.GHC.API        as Ghc hiding ( Located
+import           Liquid.GHC.Misc
+import           Liquid.GHC.API        as Ghc hiding ( Located
                                                                       , sourceName
                                                                       , text
                                                                       , panic

--- a/src/Language/Haskell/Liquid/UX/Errors.hs
+++ b/src/Language/Haskell/Liquid/UX/Errors.hs
@@ -21,7 +21,7 @@ import           Language.Haskell.Liquid.Types.RefType
 import           Language.Haskell.Liquid.Transforms.Simplify
 import           Language.Haskell.Liquid.UX.Tidy
 import           Language.Haskell.Liquid.Types
-import qualified Language.Haskell.Liquid.GHC.Misc    as GM
+import qualified Liquid.GHC.Misc    as GM
 import qualified Language.Haskell.Liquid.Misc        as Misc
 import qualified Language.Fixpoint.Misc              as Misc
 

--- a/src/Language/Haskell/Liquid/UX/QuasiQuoter.hs
+++ b/src/Language/Haskell/Liquid/UX/QuasiQuoter.hs
@@ -29,8 +29,8 @@ import Language.Haskell.TH.Quote
 import Language.Fixpoint.Types hiding (Error, Loc, SrcSpan)
 import qualified Language.Fixpoint.Types as F
 
-import Language.Haskell.Liquid.GHC.Misc (fSrcSpan)
-import Language.Haskell.Liquid.GHC.API  (SrcSpan)
+import Liquid.GHC.Misc (fSrcSpan)
+import Liquid.GHC.API  (SrcSpan)
 import Language.Haskell.Liquid.Parse
 import Language.Haskell.Liquid.Types
 

--- a/src/Language/Haskell/Liquid/UX/Tidy.hs
+++ b/src/Language/Haskell/Liquid/UX/Tidy.hs
@@ -36,7 +36,7 @@ import qualified Data.HashSet                              as S
 import qualified Data.List                                 as L
 import qualified Data.Text                                 as T
 import qualified Control.Exception                         as Ex
-import qualified Language.Haskell.Liquid.GHC.Misc          as GM 
+import qualified Liquid.GHC.Misc          as GM 
 -- (dropModuleNames, showPpr, stringTyVar)
 import           Language.Fixpoint.Types                   hiding (Result, SrcSpan, Error)
 import           Language.Haskell.Liquid.Types.Types

--- a/src/Language/Haskell/Liquid/WiredIn.hs
+++ b/src/Language/Haskell/Liquid/WiredIn.hs
@@ -28,9 +28,9 @@ module Language.Haskell.Liquid.WiredIn
 import Prelude                                hiding (error)
 
 -- import Language.Fixpoint.Misc           (mapSnd)
-import Language.Haskell.Liquid.GHC.Misc
-import qualified Language.Haskell.Liquid.GHC.API as Ghc
-import Language.Haskell.Liquid.GHC.API (Var, Arity, TyVar, Bind(..), Boxity(..), Expr(..), ArgFlag(..))
+import Liquid.GHC.Misc
+import qualified Liquid.GHC.API as Ghc
+import Liquid.GHC.API (Var, Arity, TyVar, Bind(..), Boxity(..), Expr(..), ArgFlag(..))
 import Language.Haskell.Liquid.Types.Types
 import Language.Haskell.Liquid.Types.RefType
 import Language.Haskell.Liquid.Types.Variance
@@ -41,7 +41,7 @@ import Language.Haskell.Liquid.Types.Names (selfSymbol)
 import qualified Language.Fixpoint.Types as F
 import qualified Data.HashSet as S 
 
-import Language.Haskell.Liquid.GHC.TypeRep ()
+import Liquid.GHC.TypeRep ()
 
 -- | Horrible hack to support hardwired symbols like
 --      `head`, `tail`, `fst`, `snd`


### PR DESCRIPTION
See #2065. Drops the `Language.Haskell` prefix for modules wrapping or shimming GHC. Just a small step for now. We may move these modules into their own package later on. We're not using automatic code formatting and with the search and replace I did, I've not re-aligned columns in the imports.