### PR TITLE
Check Termination of Assumed Functions 

### DIFF
--- a/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -120,7 +120,7 @@ makeDecrIndex :: (Var, Template SpecType, [Var]) -> CG [Int]
 makeDecrIndex (x, Assumed t, args)
   = do dindex <- makeDecrIndexTy x t args
        case dindex of
-         Left _  -> return []
+         Left msg -> addWarning msg >> return []
          Right i -> return i
 makeDecrIndex (x, Asserted t, args)
   = do dindex <- makeDecrIndexTy x t args

--- a/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Data/Map.hs
+++ b/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Data/Map.hs
@@ -78,6 +78,7 @@ empty = goEmpty ()
 -- XXX: Making goEmpty local to empty, causes LH to crash when
 -- building Check.hs.
 {-@ reflect goEmpty @-}
+{-@ lazy    goEmpty @-} -- With PR 2069 a termination error appears 
 -- XXX: For some reason, GHC aggrees to fire emptyImpl only if
 -- empty appears in an auxiliar definition like this one.
 goEmpty :: () -> Map a b

--- a/tests/ple/pos/T1371_NNF.hs
+++ b/tests/ple/pos/T1371_NNF.hs
@@ -26,6 +26,7 @@ eval s (And f g) = (eval s f) && (eval s g)
 eval s (Or  f g) = (eval s f) || (eval s g)
 eval s (Not f)   = not (eval s f)
 
+{-@ lazy    nnf @-}
 {-@ reflect nnf @-}
 nnf :: Pred -> Pred
 nnf (Var i)    = (Var i)
@@ -33,6 +34,7 @@ nnf (And p q)  = And (nnf p) (nnf q)
 nnf (Or  p q)  = Or  (nnf p) (nnf q)
 nnf (Not f)    = nnf' f
 
+{-@ lazy    nnf' @-}
 {-@ reflect nnf' @-}
 nnf' :: Pred -> Pred
 nnf' (Not g)   = nnf g

--- a/tests/pos/AssumedRecursive.hs
+++ b/tests/pos/AssumedRecursive.hs
@@ -1,5 +1,6 @@
 module AssumedRecursive where
 
+{-@ lazy foo @-}
 {-@ assume foo :: a -> a @-}
 foo :: a -> a
 foo f = foo f

--- a/tests/pos/ReWrite10.hs
+++ b/tests/pos/ReWrite10.hs
@@ -10,10 +10,12 @@ import Prelude hiding (length, (++))
 data N = S N | Z
 
 
+{-@ lazy    f @-}
 {-@ reflect f @-}
 f :: N -> N
 f x = g x
 
+{-@ lazy    g @-}
 {-@ reflect g @-}
 g (S x) = f x
 g Z     = Z


### PR DESCRIPTION
Reflects are currently encoded internally as assumed. So a direct fix for #2068 is to check termination of assumed functions (and explicitly use `lazy` to disactivate the termination checker). Another fix would be to have a different internal representation of reflected functions. 