### PR TITLE
Removing shadowing 1

### DIFF
--- a/devel/Paths_liquidhaskell.hs
+++ b/devel/Paths_liquidhaskell.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
 
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
-
 module Paths_liquidhaskell where
 
 import Language.Haskell.TH
@@ -10,10 +8,10 @@ import System.FilePath
 import Data.Version (Version, makeVersion)
 
 getDataFileName :: FilePath -> IO FilePath
-getDataFileName f = do
-  let loc = $(do { loc <- location; f <- runIO (canonicalizePath (loc_filename loc)); litE (stringL f); })
-  let root = takeDirectory (takeDirectory loc)
-  return (root </> f)
+getDataFileName fp = do
+  let loc' = $(do { loc <- location; f <- runIO (canonicalizePath (loc_filename loc)); litE (stringL f); })
+  let root = takeDirectory (takeDirectory loc')
+  return (root </> fp)
 
 -- | dummy version (devel only)
 version :: Version

--- a/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -2,8 +2,6 @@
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE FlexibleInstances    #-}
 
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
-
 -- | This module contains the code that DOES reflection; i.e. converts Haskell
 --   definitions into refinements.
 
@@ -82,23 +80,23 @@ makeAssumeType
   -> F.TCEmb Ghc.TyCon -> LogicMap -> DataConMap -> LocSymbol -> Maybe SpecType
   -> Ghc.Var -> Ghc.CoreExpr
   -> (LocSpecType, F.Equation)
-makeAssumeType allowTC tce lmap dm x mbT v def
-  = (x {val = aty at `strengthenRes` F.subst su ref},  F.mkEquation (val x) xts (F.subst su le) out)
+makeAssumeType allowTC tce lmap dm sym mbT v def
+  = (sym {val = aty at `strengthenRes` F.subst su ref},  F.mkEquation (val sym) xts (F.subst su le) out)
   where
-    t     = fromRTypeRep .
+    rt    = fromRTypeRep .
             (\trep@RTypeRep{..} ->
                 trep{ty_info = fmap (\rinfo -> rinfo{permitTC = Just allowTC}) ty_info}) .
             toRTypeRep $ Mb.fromMaybe (ofType τ) mbT
     τ     = Ghc.varType v
-    at    = axiomType allowTC x t
+    at    = axiomType allowTC sym rt
     out   = rTypeSort tce $ ares at
     xArgs = F.EVar . fst <$> aargs at
-    _msg  = unwords [showpp x, showpp mbT]
+    _msg  = unwords [showpp sym, showpp mbT]
     le    = case runToLogicWithBoolBinds bbs tce lmap dm mkErr (coreToLogic allowTC def') of
               Right e -> e
               Left  e -> panic Nothing (show e)
     ref        = F.Reft (F.vv_, F.PAtom F.Eq (F.EVar F.vv_) le)
-    mkErr s    = ErrHMeas (sourcePosSrcSpan $ loc x) (pprint $ val x) (PJ.text s)
+    mkErr s    = ErrHMeas (sourcePosSrcSpan $ loc sym) (pprint $ val sym) (PJ.text s)
     bbs        = filter isBoolBind xs
     (xs, def') = GM.notracePpr "grabBody" $ grabBody allowTC (Ghc.expandTypeSynonyms τ) $ normalize allowTC def
     su         = F.mkSubst  $ zip (F.symbol     <$> xs) xArgs
@@ -110,8 +108,8 @@ rTypeSortExp tce = typeSort tce . Ghc.expandTypeSynonyms . toType False
 
 grabBody :: Bool -- ^ typeclass enabled
          -> Ghc.Type -> Ghc.CoreExpr -> ([Ghc.Var], Ghc.CoreExpr)
-grabBody allowTC (Ghc.ForAllTy _ t) e
-  = grabBody allowTC t e
+grabBody allowTC (Ghc.ForAllTy _ ty) e
+  = grabBody allowTC ty e
 grabBody allowTC@False Ghc.FunTy{ Ghc.ft_arg = tx, Ghc.ft_res = t} e | Ghc.isClassPred tx
   = grabBody allowTC t e
 grabBody allowTC@True Ghc.FunTy{ Ghc.ft_arg = tx, Ghc.ft_res = t} e | isEmbeddedDictType tx
@@ -122,9 +120,9 @@ grabBody allowTC Ghc.FunTy{ Ghc.ft_res = t} (Ghc.Lam x e)
   = (x:xs, e') where (xs, e') = grabBody allowTC t e
 grabBody allowTC t (Ghc.Tick _ e)
   = grabBody allowTC t e
-grabBody allowTC t@Ghc.FunTy{} e
+grabBody allowTC ty@Ghc.FunTy{} e
   = (txs++xs, e')
-   where (ts,tr)  = splitFun t
+   where (ts,tr)  = splitFun ty
          (xs, e') = grabBody allowTC tr (foldl Ghc.App e (Ghc.Var <$> txs))
          txs      = [ stringVar ("ls" ++ show i) t |  (t,i) <- zip ts [(1::Int)..]]
 grabBody _ _ e
@@ -140,12 +138,12 @@ isBoolBind :: Ghc.Var -> Bool
 isBoolBind v = isBool (ty_res $ toRTypeRep ((ofType $ Ghc.varType v) :: RRType ()))
 
 strengthenRes :: SpecType -> F.Reft -> SpecType
-strengthenRes t r = go t
+strengthenRes st rf = go st
   where
     go (RAllT a t r)   = RAllT a (go t) r
     go (RAllP p t)     = RAllP p $ go t
     go (RFun x i tx t r) = RFun x i tx (go t) r
-    go t               =  t `strengthen` F.ofReft r
+    go t               =  t `strengthen` F.ofReft rf
 
 class Subable a where
   subst :: (Ghc.Var, Ghc.CoreExpr) -> a -> a
@@ -183,16 +181,16 @@ data AxiomType = AT { aty :: SpecType, aargs :: [(F.Symbol, SpecType)], ares :: 
 
 -- | Specification for Haskell function
 axiomType :: Bool -> LocSymbol -> SpecType -> AxiomType
-axiomType allowTC s t = AT to (reverse xts) res
+axiomType allowTC s st = AT to (reverse xts) res
   where
-    (to, (_,xts, Just res)) = runState (go t) (1,[], Nothing)
+    (to, (_,xts, Just res)) = runState (go st) (1,[], Nothing)
     go (RAllT a t r) = RAllT a <$> go t <*> return r
     go (RAllP p t) = RAllP p <$> go t
     go (RFun x i tx t r) | isErasable tx = (\t' -> RFun x i tx t' r) <$> go t
     go (RFun x ii tx t r) = do
-      (i,bs,res) <- get
+      (i,bs,mres) <- get
       let x' = unDummy x i
-      put (i+1, (x', tx):bs,res)
+      put (i+1, (x', tx):bs,mres)
       t' <- go t
       return $ RFun x' ii tx t' r
     go t = do
@@ -240,20 +238,20 @@ wiredDefs cfg env name spSig
 
 
 makeCompositionExpression :: Ghc.Id -> Ghc.CoreExpr
-makeCompositionExpression x
+makeCompositionExpression gid
   =  go $ Ghc.varType $ F.notracepp ( -- tracing to find  the body of . from the inline spec, 
                                       -- replace F.notrace with F.trace to print 
-      "\nv = " ++ GM.showPpr x ++
-      "\n realIdUnfolding = " ++ GM.showPpr (Ghc.realIdUnfolding x) ++
-      "\n maybeUnfoldingTemplate . realIdUnfolding = " ++ GM.showPpr (Ghc.maybeUnfoldingTemplate $ Ghc.realIdUnfolding x ) ++
-      "\n inl_src . inlinePragInfo . Ghc.idInfo = "    ++ GM.showPpr (Ghc.inl_src $ Ghc.inlinePragInfo $ Ghc.idInfo x) ++
-      "\n inl_inline . inlinePragInfo . Ghc.idInfo = " ++ GM.showPpr (Ghc.inl_inline $ Ghc.inlinePragInfo $ Ghc.idInfo x) ++
-      "\n inl_sat . inlinePragInfo . Ghc.idInfo = "    ++ GM.showPpr (Ghc.inl_sat $ Ghc.inlinePragInfo $ Ghc.idInfo x) ++
-      "\n inl_act . inlinePragInfo . Ghc.idInfo = "    ++ GM.showPpr (Ghc.inl_act $ Ghc.inlinePragInfo $ Ghc.idInfo x) ++
-      "\n inl_rule . inlinePragInfo . Ghc.idInfo = "   ++ GM.showPpr (Ghc.inl_rule $ Ghc.inlinePragInfo $ Ghc.idInfo x) ++
-      "\n inl_rule rule = " ++ GM.showPpr (Ghc.inl_rule $ Ghc.inlinePragInfo $ Ghc.idInfo x) ++
-      "\n inline spec = " ++ GM.showPpr (Ghc.inl_inline $ Ghc.inlinePragInfo $ Ghc.idInfo x)
-     ) x
+      "\nv = " ++ GM.showPpr gid ++
+      "\n realIdUnfolding = " ++ GM.showPpr (Ghc.realIdUnfolding gid) ++
+      "\n maybeUnfoldingTemplate . realIdUnfolding = " ++ GM.showPpr (Ghc.maybeUnfoldingTemplate $ Ghc.realIdUnfolding gid ) ++
+      "\n inl_src . inlinePragInfo . Ghc.idInfo = "    ++ GM.showPpr (Ghc.inl_src $ Ghc.inlinePragInfo $ Ghc.idInfo gid) ++
+      "\n inl_inline . inlinePragInfo . Ghc.idInfo = " ++ GM.showPpr (Ghc.inl_inline $ Ghc.inlinePragInfo $ Ghc.idInfo gid) ++
+      "\n inl_sat . inlinePragInfo . Ghc.idInfo = "    ++ GM.showPpr (Ghc.inl_sat $ Ghc.inlinePragInfo $ Ghc.idInfo gid) ++
+      "\n inl_act . inlinePragInfo . Ghc.idInfo = "    ++ GM.showPpr (Ghc.inl_act $ Ghc.inlinePragInfo $ Ghc.idInfo gid) ++
+      "\n inl_rule . inlinePragInfo . Ghc.idInfo = "   ++ GM.showPpr (Ghc.inl_rule $ Ghc.inlinePragInfo $ Ghc.idInfo gid) ++
+      "\n inl_rule rule = " ++ GM.showPpr (Ghc.inl_rule $ Ghc.inlinePragInfo $ Ghc.idInfo gid) ++
+      "\n inline spec = " ++ GM.showPpr (Ghc.inl_inline $ Ghc.inlinePragInfo $ Ghc.idInfo gid)
+     ) gid
    where
     go (Ghc.ForAllTy a (Ghc.ForAllTy b (Ghc.ForAllTy c Ghc.FunTy{ Ghc.ft_arg = tf, Ghc.ft_res = Ghc.FunTy { Ghc.ft_arg = tg, Ghc.ft_res = tx}})))
       = let f = stringVar "f" tf

--- a/src/Language/Haskell/Liquid/Measure.hs
+++ b/src/Language/Haskell/Liquid/Measure.hs
@@ -4,8 +4,6 @@
 {-# LANGUAGE OverloadedStrings      #-}
 {-# LANGUAGE ConstraintKinds        #-}
 
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
-
 module Language.Haskell.Liquid.Measure (
   -- * Specifications
     Spec (..)
@@ -70,14 +68,14 @@ mkMSpec ms cms ims = MSpec cm mm cmm ims
 
 
 checkDuplicateMeasure :: [Measure ty ctor] -> [Measure ty ctor]
-checkDuplicateMeasure ms
+checkDuplicateMeasure measures
   = case M.toList dups of
-      []         -> ms
-      (m,ms):_   -> uError $ err m (msName <$> ms)
+      []         -> measures
+      (m,ms):_   -> uError $ mkErr m (msName <$> ms)
     where
-      gms        = group [(msName m , m) | m <- ms]
+      gms        = group [(msName m , m) | m <- measures]
       dups       = M.filter ((1 <) . length) gms
-      err m ms   = ErrDupMeas (fSrcSpan m) (pprint (val m)) (fSrcSpan <$> ms)
+      mkErr m ms = ErrDupMeas (fSrcSpan m) (pprint (val m)) (fSrcSpan <$> ms)
 
 
 dataConTypes :: Bool -> MSpec (RRType Reft) DataCon -> ([(Var, RRType Reft)], [(LocSymbol, RRType Reft)])

--- a/src/Language/Haskell/Liquid/WiredIn.hs
+++ b/src/Language/Haskell/Liquid/WiredIn.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
-
 module Language.Haskell.Liquid.WiredIn
        ( wiredTyCons
        , wiredDataCons
@@ -53,10 +51,10 @@ isWiredIn :: F.LocSymbol -> Bool
 isWiredIn x = isWiredInLoc x  || isWiredInName (val x) || isWiredInShape x
 
 isWiredInLoc :: F.LocSymbol -> Bool
-isWiredInLoc x  = l == l' && l == F.safePos 1 && c == c' && c' == F.safePos 1
+isWiredInLoc sym  = ln == ln' && ln == F.safePos 1 && c == c' && c' == F.safePos 1
   where
-    (l , c)  = spe (loc x)
-    (l', c') = spe (locE x)
+    (ln , c)  = spe (loc sym)
+    (ln', c') = spe (locE sym)
     spe l    = (x, y) where (_, x, y) = F.sourcePosElts l
 
 isWiredInName :: F.Symbol -> Bool


### PR DESCRIPTION
Follow up to #2004.

Apologies for taking a while to get back to this. Each commit is restricted to a single file, as planned. I have attempted to strike a balance between number of PRs and manageable diffs, thus aiming for ~100 lines (there are 47 more files with `-Wno-name-shadowing`). But let me know if I should further split these PRs up to 1 commit each.

In general my strategy is:
* Keep changes local to the function themselves.
* _Within_ the function, favor changing the widest scope possible. Imo this is safest due to the following example, which is somewhat common (and presumably caused the original bug):

```haskell
-- want to change the 'x' shadowing.
silly x = go (x+1)
  where
    go x = x * x

sillyBad x = go (x+1)
  where
    -- missed one, semantics changed!
    go x' = x' * x

-- compilation errors instead, no silent errors
sillyGood x' = go (x+1)
  where
    go x = x * x
```