### PR TITLE
Point Tutorial link to liquidhaskell-tutorial repo

### DIFF
--- a/docs/mkDocs/mkdocs.yml
+++ b/docs/mkDocs/mkdocs.yml
@@ -6,7 +6,7 @@ edit_uri: edit/develop/docs/mkDocs/docs
 
 nav:
   - "<div id='demo'><i aria-hidden=true class='mdi mdi-cloud-braces'></i> Try Online</div>": http://goto.ucsd.edu:8090/index.html
-  - "<i aria-hidden=true class='mdi mdi-human-greeting'></i> Tutorial": https://ucsd-progsys.github.io/intro-refinement-types/120/
+  - "<i aria-hidden=true class='mdi mdi-human-greeting'></i> Tutorial": http://ucsd-progsys.github.io/liquidhaskell-tutorial/
   - "": index.md #spacer
   - "<i aria-hidden=true class='mdi mdi-download'></i> Installation": install.md
   - "<i aria-hidden=true class='mdi mdi-script'></i> Spec Reference": specifications.md


### PR DESCRIPTION
This PR changes the "Tutorial" link at the top of the docs page to [the up-to-date tutorial book](http://ucsd-progsys.github.io/liquidhaskell-tutorial/). Previously this link pointed to a tutorial which hadn't been updated in several years and included out-of-date content. 