### PR TITLE
More -Wno-name-shadowing Removals

### DIFF
--- a/src/Language/Haskell/Liquid/Bare/Expand.hs
+++ b/src/Language/Haskell/Liquid/Bare/Expand.hs
@@ -6,8 +6,6 @@
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE OverloadedStrings     #-}
 
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
-
 module Language.Haskell.Liquid.Bare.Expand
   ( -- * Create alias expansion environment
     makeRTEnv
@@ -58,7 +56,7 @@ import qualified Language.Haskell.Liquid.Bare.Plugged  as Bare
 makeRTEnv :: Bare.Env -> ModName -> Ms.BareSpec -> Bare.ModSpecs -> LogicMap
           -> BareRTEnv
 --------------------------------------------------------------------------------
-makeRTEnv env m mySpec iSpecs lmap
+makeRTEnv env modName mySpec iSpecs lmap
           = renameRTArgs $ makeRTAliases tAs $ makeREAliases eAs
   where
     tAs   = [ t                   | (_, s)  <- specs, t <- Ms.aliases  s ]
@@ -68,9 +66,9 @@ makeRTEnv env m mySpec iSpecs lmap
                                               -- this clearly breaks things if a signature
                                               -- contains lmap functions but never gets
                                               -- elaborated
-              else [ specREAlias env m e | (_, xl) <- M.toList (lmSymDefs lmap)
+              else [ specREAlias env modName e | (_, xl) <- M.toList (lmSymDefs lmap)
                                   , let e    = lmapEAlias xl             ]
-    specs = (m, mySpec) : M.toList iSpecs
+    specs = (modName, mySpec) : M.toList iSpecs
 
 -- | We apply @renameRTArgs@ *after* expanding each alias-definition, to 
 --   ensure that the substitutions work properly (i.e. don't miss expressions 
@@ -90,11 +88,11 @@ makeREAliases = graphExpand buildExprEdges f mempty
 -- | @renameTys@ ensures that @RTAlias@ type parameters have distinct names 
 --   to avoid variable capture e.g. as in T1556.hs
 renameTys :: RTAlias F.Symbol BareType -> RTAlias F.Symbol BareType
-renameTys rt = rt { rtTArgs = ys, rtBody = subts (rtBody rt) (zip xs ys) }
+renameTys rt = rt { rtTArgs = ys, rtBody = sbts (rtBody rt) (zip xs ys) }
   where
     xs    = rtTArgs rt
     ys    = (`F.suffixSymbol` rtName rt) <$> xs
-    subts = foldl (flip subt)
+    sbts  = foldl (flip subt)
 
 
 renameVV :: RTAlias F.Symbol BareType -> RTAlias F.Symbol BareType
@@ -187,8 +185,8 @@ checkCyclicAliases table graph
 
 cycleAliasErr :: AliasTable x t -> [F.Symbol] -> Error
 cycleAliasErr _ []          = panic Nothing "checkCyclicAliases: No type aliases in reported cycle"
-cycleAliasErr t scc@(rta:_) = ErrAliasCycle { pos    = fst (locate rta)
-                                            , acycle = map locate scc }
+cycleAliasErr t symList@(rta:_) = ErrAliasCycle { pos    = fst (locate rta)
+                                                , acycle = map locate symList }
   where
     locate sym = ( GM.fSrcSpan $ fromAliasSymbol t sym
                  , pprint sym )

--- a/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -2,8 +2,6 @@
 {-# LANGUAGE RecordWildCards  #-}
 {-# LANGUAGE TupleSections    #-}
 
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
-
 -- | This module contains (most of) the code needed to lift Haskell entitites,
 --   . code- (CoreBind), and data- (Tycon) definitions into the spec level.
 
@@ -65,21 +63,21 @@ makeMeasureDefinition :: Bool -> Bare.TycEnv -> LogicMap -> [Ghc.CoreBind] -> Lo
                       -> Measure LocSpecType Ghc.DataCon
 makeMeasureDefinition allowTC tycEnv lmap cbs x =
   case GM.findVarDef (val x) cbs of
-    Nothing       -> Ex.throw $ errHMeas x "Cannot extract measure from haskell function"
-    Just (v, def) -> Ms.mkM vx vinfo mdef MsLifted (makeUnSorted allowTC (Ghc.varType v) mdef)
+    Nothing        -> Ex.throw $ errHMeas x "Cannot extract measure from haskell function"
+    Just (v, cexp) -> Ms.mkM vx vinfo mdef MsLifted (makeUnSorted allowTC (Ghc.varType v) mdef)
                      where
                        vx           = F.atLoc x (F.symbol v)
-                       mdef         = coreToDef' allowTC tycEnv lmap vx v def
+                       mdef         = coreToDef' allowTC tycEnv lmap vx v cexp
                        vinfo        = GM.varLocInfo (logicType allowTC) v
 
 makeUnSorted :: Bool -> Ghc.Type -> [Def LocSpecType Ghc.DataCon] -> UnSortedExprs
-makeUnSorted allowTC t defs
+makeUnSorted allowTC ty defs
   | isMeasureType ta
   = mempty
   | otherwise
   = map defToUnSortedExpr defs
   where
-    ta = go $ Ghc.expandTypeSynonyms t
+    ta = go $ Ghc.expandTypeSynonyms ty
 
     go (Ghc.ForAllTy _ t) = go t
     go Ghc.FunTy{ Ghc.ft_arg = p, Ghc.ft_res = t} | isErasable p = go t
@@ -89,16 +87,16 @@ makeUnSorted allowTC t defs
     isMeasureType (Ghc.TyConApp _ ts) = all Ghc.isTyVarTy ts
     isMeasureType _                   = False
 
-    defToUnSortedExpr def = (xx:(fst <$> binds def),
-                             Ms.bodyPred (F.mkEApp (measure def) [F.expr xx]) (body def))
+    defToUnSortedExpr defn = (xx:(fst <$> binds defn),
+                             Ms.bodyPred (F.mkEApp (measure defn) [F.expr xx]) (body defn))
 
     xx = F.vv $ Just 10000
     isErasable = if allowTC then GM.isEmbeddedDictType else Ghc.isClassPred
 
 coreToDef' :: Bool -> Bare.TycEnv -> LogicMap -> LocSymbol -> Ghc.Var -> Ghc.CoreExpr
            -> [Def LocSpecType Ghc.DataCon]
-coreToDef' allowTC tycEnv lmap vx v def =
-  case runToLogic embs lmap dm (errHMeas vx) (coreToDef allowTC vx v def) of
+coreToDef' allowTC tycEnv lmap vx v defn =
+  case runToLogic embs lmap dm (errHMeas vx) (coreToDef allowTC vx v defn) of
     Right l -> l
     Left e  -> Ex.throw e
   where
@@ -122,8 +120,8 @@ makeMeasureInline :: Bool -> F.TCEmb Ghc.TyCon -> LogicMap -> [Ghc.CoreBind] -> 
                   -> (LocSymbol, LMap)
 makeMeasureInline allowTC embs lmap cbs x =
   case GM.findVarDef (val x) cbs of
-    Nothing       -> Ex.throw $ errHMeas x "Cannot inline haskell function"
-    Just (v, def) -> (vx, coreToFun' allowTC embs Nothing lmap vx v def ok)
+    Nothing        -> Ex.throw $ errHMeas x "Cannot inline haskell function"
+    Just (v, defn) -> (vx, coreToFun' allowTC embs Nothing lmap vx v defn ok)
                      where
                        vx         = F.atLoc x (F.symbol v)
                        ok (xs, e) = LMap vx (F.symbol <$> xs) (either id id e)
@@ -135,10 +133,10 @@ makeMeasureInline allowTC embs lmap cbs x =
 
 coreToFun' :: Bool -> F.TCEmb Ghc.TyCon -> Maybe Bare.DataConMap -> LogicMap -> LocSymbol -> Ghc.Var -> Ghc.CoreExpr
            -> (([Ghc.Var], Either F.Expr F.Expr) -> a) -> a
-coreToFun' allowTC embs dmMb lmap x v def ok = either Ex.throw ok act
+coreToFun' allowTC embs dmMb lmap x v defn ok = either Ex.throw ok act
   where
     act  = runToLogic embs lmap dm err xFun
-    xFun = coreToFun allowTC x v def
+    xFun = coreToFun allowTC x v defn
     err  = errHMeas x
     dm   = Mb.fromMaybe mempty dmMb
 
@@ -186,20 +184,20 @@ zipMapMaybe :: (a -> Maybe b) -> [a] -> [(a, b)]
 zipMapMaybe f = Mb.mapMaybe (\x -> (x, ) <$> f x)
 
 hasDataDecl :: ModName -> Ms.BareSpec -> Ghc.TyCon -> HasDataDecl
-hasDataDecl mod spec
-                 = \tc -> F.notracepp (msg tc) $ M.lookupDefault def (tcName tc) decls
+hasDataDecl modName spec
+                 = \tc -> F.notracepp (msg tc) $ M.lookupDefault defn (tcName tc) decls
   where
     msg tc       = "hasDataDecl " ++ show (tcName tc)
-    def          = NoDecl Nothing
-    tcName       = fmap (qualifiedDataName mod) . tyConDataName True
-    dcName       =       qualifiedDataName mod  . tycName
+    defn         = NoDecl Nothing
+    tcName       = fmap (qualifiedDataName modName) . tyConDataName True
+    dcName       =       qualifiedDataName modName  . tycName
     decls        = M.fromList [ (Just dn, hasDecl d)
                                 | d     <- Ms.dataDecls spec
                                 , let dn = dcName d]
 
 qualifiedDataName :: ModName -> DataName -> DataName
-qualifiedDataName mod (DnName lx) = DnName (qualifyModName mod <$> lx)
-qualifiedDataName mod (DnCon  lx) = DnCon  (qualifyModName mod <$> lx)
+qualifiedDataName modName (DnName lx) = DnName (qualifyModName modName <$> lx)
+qualifiedDataName modName (DnCon  lx) = DnCon  (qualifyModName modName <$> lx)
 
 {-tyConDataDecl :: {tc:TyCon | isAlgTyCon tc} -> Maybe DataDecl @-}
 tyConDataDecl :: ((Ghc.TyCon, DataName), HasDataDecl) -> Maybe DataDecl
@@ -236,11 +234,11 @@ dataConDecl d     = {- F.notracepp msg $ -} DataCtor dx (F.symbol <$> as) [] xts
     xts           = [(Bare.makeDataConSelector Nothing d i, RT.bareOfType t) | (i, t) <- its ]
     dx            = F.symbol <$> GM.locNamedThing d
     its           = zip [1..] ts
-    (as,_ps,ts,t)  = Ghc.dataConSig d
-    outT          = Just (RT.bareOfType t :: BareType)
+    (as,_ps,ts,ty)  = Ghc.dataConSig d
+    outT          = Just (RT.bareOfType ty :: BareType)
     _outT :: Maybe BareType
     _outT
-      | isGadt    = Just (RT.bareOfType t)
+      | isGadt    = Just (RT.bareOfType ty)
       | otherwise = Nothing
 
 
@@ -295,18 +293,18 @@ dataConSel permitTC dc n (Proj i) = mkArrow (zip as (repeat mempty)) [] [] [xt] 
 
 -- bkDataCon :: DataCon -> Int -> ([RTVar RTyVar RSort], [SpecType], (Symbol, SpecType, RReft))
 bkDataCon :: (F.Reftable (RTProp RTyCon RTyVar r), PPrint r, F.Reftable r) => Bool -> Ghc.DataCon -> Int -> ([RTVar RTyVar RSort], [RRType r], (F.Symbol, RFInfo, RRType r, r))
-bkDataCon permitTC dc nFlds  = (as, ts, (F.dummySymbol, classRFInfo permitTC, t, mempty))
+bkDataCon permitTC dcn nFlds  = (as, ts, (F.dummySymbol, classRFInfo permitTC, t, mempty))
   where
     ts                = RT.ofType <$> Misc.takeLast nFlds (map Ghc.irrelevantMult _ts)
     t                 = -- Misc.traceShow ("bkDataConResult" ++ GM.showPpr (dc, _t, _t0)) $
                           RT.ofType  $ Ghc.mkTyConApp tc tArgs'
     as                = makeRTVar . RT.rTyVar <$> (αs ++ αs')
-    ((αs,αs',_,_,_ts,_t), _t0) = hammer dc
+    ((αs,αs',_,_,_ts,_t), _t0) = hammer dcn
     tArgs'            = take (nArgs - nVars) tArgs ++ (Ghc.mkTyVarTy <$> αs)
     nVars             = length αs
     nArgs             = length tArgs
     (tc, tArgs)       = Mb.fromMaybe err (Ghc.splitTyConApp_maybe _t)
-    err               = GM.namedPanic dc ("Cannot split result type of DataCon " ++ show dc)
+    err               = GM.namedPanic dcn ("Cannot split result type of DataCon " ++ show dcn)
     hammer dc         = (Ghc.dataConFullSig dc, Ghc.varType . Ghc.dataConWorkId $ dc)
 
 data DataConSel = Check | Proj Int

--- a/src/Language/Haskell/Liquid/Bare/Misc.hs
+++ b/src/Language/Haskell/Liquid/Bare/Misc.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleContexts         #-}
 
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
 
 module Language.Haskell.Liquid.Bare.Misc
   ( joinVar
@@ -167,7 +166,7 @@ mapTyRVar α a s@(MTVST αas err)
       Nothing             -> return $ MTVST ((α,a):αas) err
 
 matchKindArgs' :: [Type] -> [SpecType] -> [SpecType]
-matchKindArgs' ts1 ts2 = reverse $ go (reverse ts1) (reverse ts2)
+matchKindArgs' ts1' = reverse . go (reverse ts1') . reverse
   where
     go (_:ts1) (t2:ts2) = t2:go ts1 ts2
     go ts      []       | all isKind ts
@@ -176,7 +175,7 @@ matchKindArgs' ts1 ts2 = reverse $ go (reverse ts1) (reverse ts2)
 
 
 matchKindArgs :: [SpecType] -> [SpecType] -> [SpecType]
-matchKindArgs ts1 ts2 = reverse $ go (reverse ts1) (reverse ts2)
+matchKindArgs ts1' = reverse . go (reverse ts1') . reverse
   where
     go (_:ts1) (t2:ts2) = t2:go ts1 ts2
     go ts      []       = ts

--- a/src/Language/Haskell/Liquid/Bare/Plugged.hs
+++ b/src/Language/Haskell/Liquid/Bare/Plugged.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
-
 module Language.Haskell.Liquid.Bare.Plugged
   ( makePluggedSig
   , makePluggedDataCon
@@ -159,7 +157,7 @@ plugHolesOld, plugHolesNew
   -> LocSpecType
 
 -- NOTE: this use of toType is safe as rt' is derived from t.
-plugHolesOld allowTC tce tyi x f t0 zz@(Loc l l' st0)
+plugHolesOld allowTC tce tyi xx f t0 zz@(Loc l l' st0)
     = Loc l l'
     . mkArrow (zip (updateRTVar <$> αs') rs) ps' [] []
     . makeCls cs'
@@ -175,22 +173,22 @@ plugHolesOld allowTC tce tyi x f t0 zz@(Loc l l' st0)
     su'          = [(y, RVar (rTyVar x) ()) | (x, y) <- tyvsmap] :: [(RTyVar, RSort)]
     coSub        = M.fromList [(F.symbol y, F.FObj (F.symbol x)) | (y, x) <- su]
     ps'          = fmap (subts su') <$> ps
-    cs'          = [(F.dummySymbol, RApp c ts [] mempty) | (c, ts) <- cs ]
+    cs'          = [(F.dummySymbol, RApp c ts [] mempty) | (c, ts) <- cs2 ]
     (αs', rs)    = unzip αs
-    (αs,_,cs,rt) = bkUnivClass (F.notracepp "hs-spec" $ ofType (Ghc.expandTypeSynonyms t0) :: SpecType)
+    (αs,_,cs2,rt) = bkUnivClass (F.notracepp "hs-spec" $ ofType (Ghc.expandTypeSynonyms t0) :: SpecType)
     (_,ps,_ ,st) = bkUnivClass (F.notracepp "lq-spec" st0)
 
     makeCls cs t = foldr (uncurry (rFun' (classRFInfo allowTC))) t cs
-    err hsT lqT  = ErrMismatch (GM.fSrcSpan zz) (pprint x)
+    err hsT lqT  = ErrMismatch (GM.fSrcSpan zz) (pprint xx)
                           (text "Plugged Init types old")
                           (pprint $ Ghc.expandTypeSynonyms t0)
                           (pprint $ toRSort st0)
                           (Just (hsT, lqT))
-                          (Ghc.getSrcSpan x)
+                          (Ghc.getSrcSpan xx)
 
 
 
-plugHolesNew allowTC@False tce tyi x f t0 zz@(Loc l l' st0)
+plugHolesNew allowTC@False tce tyi xx f t0 zz@(Loc l l' st0)
     = Loc l l'
     . mkArrow (zip (updateRTVar <$> as'') rs) ps [] []
     . makeCls cs'
@@ -200,24 +198,24 @@ plugHolesNew allowTC@False tce tyi x f t0 zz@(Loc l l' st0)
     rt'          = tx rt
     as''         = subRTVar su <$> as'
     (as',rs)     = unzip as
-    cs'          = [ (F.dummySymbol, ct) | (c, t) <- cs, let ct = tx (RApp c t [] mempty) ]
+    cs'          = [ (F.dummySymbol, ct) | (c, t) <- tyCons, let ct = tx (RApp c t [] mempty) ]
     tx           = subts su
     su           = case Bare.runMapTyVars allowTC (toType False rt) st err of
                           Left e  -> Ex.throw e
                           Right s -> [ (rTyVar x, y) | (x, y) <- Bare.vmap s]
-    (as,_,cs,rt) = bkUnivClass (ofType (Ghc.expandTypeSynonyms t0) :: SpecType)
+    (as,_,tyCons,rt) = bkUnivClass (ofType (Ghc.expandTypeSynonyms t0) :: SpecType)
     (_,ps,_ ,st) = bkUnivClass st0
 
     makeCls cs t = foldr (uncurry (rFun' (classRFInfo allowTC))) t cs
-    err hsT lqT  = ErrMismatch (GM.fSrcSpan zz) (pprint x)
+    err hsT lqT  = ErrMismatch (GM.fSrcSpan zz) (pprint xx)
                           (text "Plugged Init types new")
                           (pprint $ Ghc.expandTypeSynonyms t0)
                           (pprint $ toRSort st0)
                           (Just (hsT, lqT))
-                          (Ghc.getSrcSpan x)
+                          (Ghc.getSrcSpan xx)
 
 
-plugHolesNew allowTC@True tce tyi x f t0 zz@(Loc l l' st0)
+plugHolesNew allowTC@True tce tyi a f t0 zz@(Loc l l' st0)
     = Loc l l'
     . mkArrow (zip (updateRTVar <$> as'') rs) ps [] (if length cs > length cs' then cs else cs')
     -- . makeCls cs' 
@@ -237,12 +235,12 @@ plugHolesNew allowTC@True tce tyi x f t0 zz@(Loc l l' st0)
     cs  = [ (x, classRFInfo allowTC, t, r) | (x,t,r)<-cs0]
     cs' = [ (x, classRFInfo allowTC, t, r) | (x,t,r)<-cs0']
 
-    err hsT lqT  = ErrMismatch (GM.fSrcSpan zz) (pprint x)
+    err hsT lqT  = ErrMismatch (GM.fSrcSpan zz) (pprint a)
                           (text "Plugged Init types new")
                           (pprint $ Ghc.expandTypeSynonyms t0)
                           (pprint $ toRSort st0)
                           (Just (hsT, lqT))
-                          (Ghc.getSrcSpan x)
+                          (Ghc.getSrcSpan a)
 
 subRTVar :: [(RTyVar, RTyVar)] -> SpecRTVar -> SpecRTVar
 subRTVar su a@(RTVar v i) = Mb.maybe a (`RTVar` i) (lookup v su)
@@ -251,9 +249,9 @@ goPlug :: F.TCEmb Ghc.TyCon -> Bare.TyConMap -> (Doc -> Doc -> Error) -> (SpecTy
        -> SpecType
 goPlug tce tyi err f = go
   where
-    go t (RHole r) = (addHoles t') { rt_reft = f t r }
+    go st (RHole r) = (addHoles t') { rt_reft = f st r }
       where
-        t'         = everywhere (mkT $ addRefs tce tyi) t
+        t'         = everywhere (mkT $ addRefs tce tyi) st
         addHoles   = everywhere (mkT addHole)
         -- NOTE: make sure we only add holes to RVar and RApp (NOT RFun)
         addHole :: SpecType -> SpecType

--- a/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -11,8 +11,6 @@
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE TupleSections         #-}
 
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
-
 module Language.Haskell.Liquid.Bare.Resolve
   ( -- * Creating the Environment
     makeEnv
@@ -125,8 +123,8 @@ localBinds                    = concatMap (bgo S.empty)
   where
     add  x g                  = maybe g (`S.insert` g) (localKey x)
     adds b g                  = foldr add g (Ghc.bindersOf b)
-    take x g                  = maybe [] (\k -> [x | not (S.member k g)]) (localKey x)
-    pgo g (x, e)              = take x g ++ go (add x g) e
+    take' x g                 = maybe [] (\k -> [x | not (S.member k g)]) (localKey x)
+    pgo g (x, e)              = take' x g ++ go (add x g) e
     bgo g (Ghc.NonRec x e)    = pgo g (x, e)
     bgo g (Ghc.Rec xes)       = concatMap (pgo g) xes
     go  g (Ghc.App e a)       = concatMap (go  g) [e, a]
@@ -640,16 +638,16 @@ rankedThings f ias = case Misc.sortOn fst (Misc.groupList ibs) of
 -------------------------------------------------------------------------------
 lookupTyThing :: Env -> ModName -> LocSymbol -> [((Int, F.Symbol), Ghc.TyThing)]
 -------------------------------------------------------------------------------
-lookupTyThing env name lsym = [ (k, t) | (k, ts) <- ordMatches, t <- ts]
+lookupTyThing env mdname lsym = [ (k, t) | (k, ts) <- ordMatches, t <- ts]
 
   where
     ordMatches             = Misc.sortOn fst (Misc.groupList matches)
     matches                = myTracepp ("matches-" ++ msg)
                              [ ((k, m), t) | (m, t) <- lookupThings env x
-                                           , k      <- myTracepp msg $ mm nameSym m mods ]
-    msg                    = "lookupTyThing: " ++ F.showpp (lsym, x, mods)
-    (x, mods)              = symbolModules env (F.val lsym)
-    nameSym                = F.symbol name
+                                           , k      <- myTracepp msg $ mm nameSym m mds ]
+    msg                    = "lookupTyThing: " ++ F.showpp (lsym, x, mds)
+    (x, mds)               = symbolModules env (F.val lsym)
+    nameSym                = F.symbol mdname
     allowExt               = allowExtResolution env lsym
     mm name m mods         = myTracepp ("matchMod: " ++ F.showpp (lsym, name, m, mods, allowExt)) $
                                matchMod env name m allowExt mods
@@ -776,9 +774,9 @@ maybeResolveSym env name kind x = case resolveLocSym env name kind x of
 -- | @ofBareType@ and @ofBareTypeE@ should be the _only_ @SpecType@ constructors
 -------------------------------------------------------------------------------
 ofBareType :: Env -> ModName -> F.SourcePos -> Maybe [PVar BSort] -> BareType -> SpecType
-ofBareType env name l ps t = either fail id (ofBareTypeE env name l ps t)
+ofBareType env name l ps t = either fail' id (ofBareTypeE env name l ps t)
   where
-    fail                   = Ex.throw
+    fail'                  = Ex.throw
     -- fail                   = Misc.errorP "error-ofBareType" . F.showpp 
 
 ofBareTypeE :: Env -> ModName -> F.SourcePos -> Maybe [PVar BSort] -> BareType -> Lookup SpecType
@@ -845,7 +843,7 @@ type Expandable r = ( PPrint r
 
 ofBRType :: (Expandable r) => Env -> ModName -> ([F.Symbol] -> r -> r) -> F.SourcePos -> BRType r
          -> Lookup (RRType r)
-ofBRType env name f l t  = go [] t
+ofBRType env name f l = go []
   where
     goReft bs r             = return (f bs r)
     goRImpF bs x i t1 t2 r  = RImpF x i <$> (rebind x <$> go bs t1) <*> go (x:bs) t2 <*> goReft bs r
@@ -967,13 +965,13 @@ txRefSort :: TyConMap -> F.TCEmb Ghc.TyCon -> LocSpecType -> LocSpecType
 txRefSort tyi tce t = F.atLoc t $ mapBot (addSymSort (GM.fSrcSpan t) tce tyi) (val t)
 
 addSymSort :: Ghc.SrcSpan -> F.TCEmb Ghc.TyCon -> TyConMap -> SpecType -> SpecType
-addSymSort sp tce tyi (RApp rc@RTyCon{} ts rs r)
-  = RApp rc ts (zipWith3 (addSymSortRef sp rc) pvs rargs [1..]) r'
+addSymSort sp tce tyi (RApp rc@RTyCon{} ts rs rr)
+  = RApp rc ts (zipWith3 (addSymSortRef sp rc) pvs rargs [1..]) r2
   where
     (_, pvs)           = RT.appRTyCon tce tyi rc ts
     -- pvs             = rTyConPVs rc'
     (rargs, rrest)     = splitAt (length pvs) rs
-    r'                 = L.foldl' go r rrest
+    r2                 = L.foldl' go rr rrest
     go r (RProp _ (RHole r')) = r' `F.meet` r
     go r (RProp  _ t' )       = let r' = Mb.fromMaybe mempty (stripRTypeBase t') in r `F.meet` r'
 
@@ -1014,7 +1012,7 @@ addSymSortRef' _ _ _ p (RProp s t)
       xs = spliceArgs "addSymSortRef 2" s p
 
 spliceArgs :: String  -> [(F.Symbol, b)] -> PVar t -> [(F.Symbol, t)]
-spliceArgs msg s p = go (fst <$> s) (pargs p)
+spliceArgs msg syms p = go (fst <$> syms) (pargs p)
   where
     go []     []           = []
     go []     ((s,x,_):as) = (x, s):go [] as

--- a/src/Language/Haskell/Liquid/Bare/ToBare.hs
+++ b/src/Language/Haskell/Liquid/Bare/ToBare.hs
@@ -1,8 +1,6 @@
 -- | This module contains functions that convert things
 --   to their `Bare` versions, e.g. SpecType -> BareType etc.
 
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
-
 module Language.Haskell.Liquid.Bare.ToBare
   ( -- * Types
     specToBare
@@ -85,7 +83,7 @@ txRTV :: (c1 -> c2) -> (tv1 -> tv2) -> RTVU c1 tv1 -> RTVU c2 tv2
 txRTV cF vF (RTVar α z) = RTVar (vF α) (txRType cF vF <$> z)
 
 txPV :: (c1 -> c2) -> (tv1 -> tv2) -> PVU c1 tv1 -> PVU c2 tv2
-txPV cF vF (PV x k y txes) = PV x k' y txes'
+txPV cF vF (PV sym k y txes) = PV sym k' y txes'
   where
     txes'                  = [ (tx t, x, e) | (t, x, e) <- txes]
     k'                     = tx <$> k

--- a/src/Language/Haskell/Liquid/Bare/Typeclass.hs
+++ b/src/Language/Haskell/Liquid/Bare/Typeclass.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE OverloadedStrings         #-}
 {-# LANGUAGE FlexibleContexts          #-}
 
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
-
 module Language.Haskell.Liquid.Bare.Typeclass
   ( compileClasses
   , elaborateClassDcp
@@ -48,7 +46,7 @@ compileClasses
   -> [(ModName, Ms.BareSpec)]
   -> (Ms.BareSpec, [(Ghc.ClsInst, [Ghc.Var])])
 compileClasses src env (name, spec) rest =
-  (spec { sigs = sigs' } <> clsSpec, instmethods)
+  (spec { sigs = sigsNew } <> clsSpec, instmethods)
  where
   clsSpec = mempty
     { dataDecls = clsDecls
@@ -65,13 +63,13 @@ compileClasses src env (name, spec) rest =
     }
   clsDecls                = makeClassDataDecl (M.toList refinedMethods)
       -- class methods
-  (refinedMethods, sigs') = foldr grabClassSig (mempty, mempty) (sigs spec)
+  (refinedMethods, sigsNew) = foldr grabClassSig (mempty, mempty) (sigs spec)
   grabClassSig
     :: (F.LocSymbol, ty)
     -> (M.HashMap Ghc.Class [(Ghc.Id, ty)], [(F.LocSymbol, ty)])
     -> (M.HashMap Ghc.Class [(Ghc.Id, ty)], [(F.LocSymbol, ty)])
-  grabClassSig sig@(lsym, ref) (refs, sigs') = case clsOp of
-    Nothing         -> (refs, sig : sigs')
+  grabClassSig sigPair@(lsym, ref) (refs, sigs') = case clsOp of
+    Nothing         -> (refs, sigPair : sigs')
     Just (cls, sig) -> (M.alter (merge sig) cls refs, sigs')
    where
     clsOp = do
@@ -234,19 +232,19 @@ elaborateClassDcp coreToLg simplifier dcp = do
     t
   -- YL: is this redundant if we already have strengthenClassSel?
   strengthenTy :: F.Symbol -> SpecType -> SpecType
-  strengthenTy x t = mkUnivs tvs pvs (RFun z i cls (t' `RT.strengthen` mt) r)
+  strengthenTy x t = mkUnivs tvs pvs (RFun z i clas (t' `RT.strengthen` mt) r)
    where
-    (tvs, pvs, RFun z i cls t' r) = bkUniv t
+    (tvs, pvs, RFun z i clas t' r) = bkUniv t
     vv = rTypeValueVar t'
     mt = RT.uReft (vv, F.PAtom F.Eq (F.EVar vv) (F.EApp (F.EVar x) (F.EVar z)))
 
 
 elaborateMethod :: F.Symbol -> S.HashSet F.Symbol -> SpecType -> SpecType
-elaborateMethod dc methods t = mapExprReft
-  (\_ -> substClassOpBinding tcbind dc methods)
-  t
+elaborateMethod dc methods st = mapExprReft
+  (\_ -> substClassOpBinding tcbindSym dc methods)
+  st
  where
-  tcbind = grabtcbind t
+  tcbindSym = grabtcbind st
   grabtcbind :: SpecType -> F.Symbol
   grabtcbind t =
     F.notracepp "grabtcbind"
@@ -263,7 +261,7 @@ elaborateMethod dc methods t = mapExprReft
 -- After: Funcctor.fmap ($p1Applicative##GHC.Base.Applicative)
 substClassOpBinding
   :: F.Symbol -> F.Symbol -> S.HashSet F.Symbol -> F.Expr -> F.Expr
-substClassOpBinding tcbind dc methods e = go e
+substClassOpBinding tcbind dc methods = go
  where
   go :: F.Expr -> F.Expr
   go (F.EApp e0 e1)
@@ -404,7 +402,7 @@ makeClassAuxTypesOne elab (ldcp, inst, methods) =
     subst ((a, ta):su) t = subsTyVarMeet' (a, ta) (subst su t)
 
 substAuxMethod :: F.Symbol -> M.HashMap F.Symbol F.Symbol -> F.Expr -> F.Expr
-substAuxMethod dfun methods e = F.notracepp "substAuxMethod" $ go e
+substAuxMethod dfun methods = F.notracepp "substAuxMethod" . go
   where go :: F.Expr -> F.Expr
         go (F.EApp e0 e1)
           | F.EVar x <- F.notracepp "e0" e0


### PR DESCRIPTION
Removes shadowing from `Language.Haskell.Liquid.Bare.*`.

See https://github.com/ucsd-progsys/liquidhaskell/issues/1962.