### PR TITLE
Reproducible Nixpkgs

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,9 @@
+let
+  # NixOS/Nixpkgs master 2022-11-27
+  rev = "a115bb9bd56831941be3776c8a94005867f316a7";
+  sha256 = "1501jzl4661qwr45b9ip7c7bpmbl94816draybhh60s9wgxn068d";
+in
+import (fetchTarball {
+  inherit sha256;
+  url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+})

--- a/stack.yaml
+++ b/stack.yaml
@@ -36,3 +36,4 @@ resolver: lts-18.27
 
 nix:
   packages: [cacert, git, hostname, z3]
+  path: [nixpkgs=./nixpkgs.nix]


### PR DESCRIPTION
Pin the Nixpkgs version when using `stack --nix`.

Closes #2114
