### PR TITLE
Move to LTS-19.33

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ commands:
 
 jobs:
 
-  stack_810:
+  stack_900:
     machine:
       image: ubuntu-2004:202107-02
     steps:
@@ -180,6 +180,6 @@ workflows:
   version: 2
   build_stack_and_cabal:
     jobs:
-      - stack_810
+      - stack_900
       - cabal_810
       - cabal_900

--- a/benchmark-timings/benchmark-timings.cabal
+++ b/benchmark-timings/benchmark-timings.cabal
@@ -34,7 +34,7 @@ executable benchmark-timings
     -- LANGUAGE extensions used by modules in this package.
     -- other-extensions:
     build-depends:    base
-                    , aeson ^>=1.5.6
+                    , aeson >= 1.5.6 && < 2.1
                     , cassava ^>=0.5.2
                     , bytestring ^>=0.10.12
                     , optparse-applicative ^>=0.16.1

--- a/liquid-base/liquid-base.cabal
+++ b/liquid-base/liquid-base.cabal
@@ -1,4 +1,4 @@
-cabal-version:      1.24
+cabal-version:      2.0
 name:               liquid-base
 version:            4.14.3.0
 synopsis:           Drop-in base replacement for LiquidHaskell
@@ -251,7 +251,7 @@ library
     build-depends:    integer-gmp < 1.0.4.0
                     , base                 == 4.14.3.0
   else
-    build-depends:    base                 == 4.15.0.0
+    build-depends:    base                 ^>= 4.15.0.0
   default-language:   Haskell2010
   default-extensions: PackageImports
                       NoImplicitPrelude

--- a/liquid-ghc-prim/liquid-ghc-prim.cabal
+++ b/liquid-ghc-prim/liquid-ghc-prim.cabal
@@ -36,7 +36,7 @@ library
                     GHC.Types
 
   hs-source-dirs:     src
-  build-depends:      ghc-prim             == 0.6.1
+  build-depends:      ghc-prim             >= 0.6.1 && < 0.8
                     , liquidhaskell        >= 0.8.10.1
   default-language:   Haskell2010
   default-extensions: PackageImports

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,7 +11,6 @@ ghc-options:
 packages:
 - liquid-fixpoint
 - liquid-ghc-prim
-- liquid-base
 - liquid-bytestring
 - liquid-prelude
 - liquid-vector
@@ -31,6 +30,8 @@ extra-deps:
   commit: 45ef3498e35897712bde8e002ce18df6d55f8b15
 # for tests
 - strip-ansi-escape-0.1.0.0@sha256:08f2ed93b16086a837ec46eab7ce8d27cf39d47783caaeb818878ea33c2ff75f,1628
+- git: https://github.com/facundominguez/liquid-base
+  commit: 8ad2378cee5ccf7937d9e08aacd5c5b7128318e8
 
 resolver: lts-19.33
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -32,7 +32,7 @@ extra-deps:
 # for tests
 - strip-ansi-escape-0.1.0.0@sha256:08f2ed93b16086a837ec46eab7ce8d27cf39d47783caaeb818878ea33c2ff75f,1628
 
-resolver: lts-18.27
+resolver: lts-19.33
 
 nix:
   packages: [cacert, git, hostname, z3]

--- a/stack.yaml
+++ b/stack.yaml
@@ -34,6 +34,7 @@ extra-deps:
   commit: 8ad2378cee5ccf7937d9e08aacd5c5b7128318e8
 
 resolver: lts-19.33
+allow-newer: true
 
 nix:
   packages: [cacert, git, hostname, z3]

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,54 +5,54 @@
 
 packages:
 - completed:
-    hackage: blaze-colonnade-1.2.2.1@sha256:b27601f0366b006e86ee33297a722fe33c94ac058e61d4eace387d132e656a21,1394
     pantry-tree:
-      size: 279
       sha256: e1a52f56ec0cab647ec7af0d75bfbb45f09cccea4a8127996cb7b132bd73bd2c
+      size: 279
+    hackage: blaze-colonnade-1.2.2.1@sha256:b27601f0366b006e86ee33297a722fe33c94ac058e61d4eace387d132e656a21,1394
   original:
     hackage: blaze-colonnade-1.2.2.1@sha256:b27601f0366b006e86ee33297a722fe33c94ac058e61d4eace387d132e656a21,1394
 - completed:
-    hackage: colonnade-1.2.0.2@sha256:e0b43a1fe4f87072f3f7cd9eaccdb790f7df8ceff5f73c3a4e242aba9337485f,2099
     pantry-tree:
-      size: 327
       sha256: 2010fda4c4af2dd9da64786d9e902f387b6a9cb034eb6573d678e752deecc319
+      size: 327
+    hackage: colonnade-1.2.0.2@sha256:e0b43a1fe4f87072f3f7cd9eaccdb790f7df8ceff5f73c3a4e242aba9337485f,2099
   original:
     hackage: colonnade-1.2.0.2@sha256:e0b43a1fe4f87072f3f7cd9eaccdb790f7df8ceff5f73c3a4e242aba9337485f,2099
 - completed:
-    hackage: hashable-1.3.5.0@sha256:3a2beeafb220f9de706568a7e4a5b3c762cc4c9f25c94d7ef795b8c2d6a691d7,4240
     pantry-tree:
-      size: 1248
       sha256: 4df2f6b536a0fcc5f7d562cb29e373f27dc4a2747452ac5cc74c1599cab22fc5
+      size: 1248
+    hackage: hashable-1.3.5.0@sha256:3a2beeafb220f9de706568a7e4a5b3c762cc4c9f25c94d7ef795b8c2d6a691d7,4240
   original:
     hackage: hashable-1.3.5.0
 - completed:
-    hackage: rest-rewrite-0.3.0@sha256:398f937a5faf6bd3329650ee9aed31bbfe7ed1c23252710908ad7295e3252c94,3890
     pantry-tree:
-      size: 3943
       sha256: 6e42cf85257cbc2abf50a9c8f3bac8777920f1b970e6f2cae9358690e1186e99
+      size: 3943
+    hackage: rest-rewrite-0.3.0@sha256:398f937a5faf6bd3329650ee9aed31bbfe7ed1c23252710908ad7295e3252c94,3890
   original:
     hackage: rest-rewrite-0.3.0
 - completed:
     name: ghc-timings
-    version: '0.1'
-    git: https://github.com/qnikst/ghc-timings-report
     pantry-tree:
-      size: 7544
       sha256: 72622264696c78cda23cf96382dee7a3d14e3eafdb8977486338f113681dcec4
+      size: 7544
     commit: 45ef3498e35897712bde8e002ce18df6d55f8b15
-  original:
     git: https://github.com/qnikst/ghc-timings-report
+    version: '0.1'
+  original:
     commit: 45ef3498e35897712bde8e002ce18df6d55f8b15
+    git: https://github.com/qnikst/ghc-timings-report
 - completed:
-    hackage: strip-ansi-escape-0.1.0.0@sha256:08f2ed93b16086a837ec46eab7ce8d27cf39d47783caaeb818878ea33c2ff75f,1628
     pantry-tree:
-      size: 671
       sha256: cf7712453587e8ea69b96f33e2e8015c22d3b448259d4cace663cc15657309d7
+      size: 671
+    hackage: strip-ansi-escape-0.1.0.0@sha256:08f2ed93b16086a837ec46eab7ce8d27cf39d47783caaeb818878ea33c2ff75f,1628
   original:
     hackage: strip-ansi-escape-0.1.0.0@sha256:08f2ed93b16086a837ec46eab7ce8d27cf39d47783caaeb818878ea33c2ff75f,1628
 snapshots:
 - completed:
-    size: 590102
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/27.yaml
-    sha256: 79a786674930a89301b0e908fad2822a48882f3d01486117693c377b8edffdbe
-  original: lts-18.27
+    sha256: 6d1532d40621957a25bad5195bfca7938e8a06d923c91bc52aa0f3c41181f2d4
+    size: 619204
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/33.yaml
+  original: lts-19.33

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,54 +5,65 @@
 
 packages:
 - completed:
+    hackage: blaze-colonnade-1.2.2.1@sha256:b27601f0366b006e86ee33297a722fe33c94ac058e61d4eace387d132e656a21,1394
     pantry-tree:
-      sha256: e1a52f56ec0cab647ec7af0d75bfbb45f09cccea4a8127996cb7b132bd73bd2c
       size: 279
-    hackage: blaze-colonnade-1.2.2.1@sha256:b27601f0366b006e86ee33297a722fe33c94ac058e61d4eace387d132e656a21,1394
+      sha256: e1a52f56ec0cab647ec7af0d75bfbb45f09cccea4a8127996cb7b132bd73bd2c
   original:
     hackage: blaze-colonnade-1.2.2.1@sha256:b27601f0366b006e86ee33297a722fe33c94ac058e61d4eace387d132e656a21,1394
 - completed:
+    hackage: colonnade-1.2.0.2@sha256:e0b43a1fe4f87072f3f7cd9eaccdb790f7df8ceff5f73c3a4e242aba9337485f,2099
     pantry-tree:
-      sha256: 2010fda4c4af2dd9da64786d9e902f387b6a9cb034eb6573d678e752deecc319
       size: 327
-    hackage: colonnade-1.2.0.2@sha256:e0b43a1fe4f87072f3f7cd9eaccdb790f7df8ceff5f73c3a4e242aba9337485f,2099
+      sha256: 2010fda4c4af2dd9da64786d9e902f387b6a9cb034eb6573d678e752deecc319
   original:
     hackage: colonnade-1.2.0.2@sha256:e0b43a1fe4f87072f3f7cd9eaccdb790f7df8ceff5f73c3a4e242aba9337485f,2099
 - completed:
-    pantry-tree:
-      sha256: 4df2f6b536a0fcc5f7d562cb29e373f27dc4a2747452ac5cc74c1599cab22fc5
-      size: 1248
     hackage: hashable-1.3.5.0@sha256:3a2beeafb220f9de706568a7e4a5b3c762cc4c9f25c94d7ef795b8c2d6a691d7,4240
+    pantry-tree:
+      size: 1248
+      sha256: 4df2f6b536a0fcc5f7d562cb29e373f27dc4a2747452ac5cc74c1599cab22fc5
   original:
     hackage: hashable-1.3.5.0
 - completed:
-    pantry-tree:
-      sha256: 6e42cf85257cbc2abf50a9c8f3bac8777920f1b970e6f2cae9358690e1186e99
-      size: 3943
     hackage: rest-rewrite-0.3.0@sha256:398f937a5faf6bd3329650ee9aed31bbfe7ed1c23252710908ad7295e3252c94,3890
+    pantry-tree:
+      size: 3943
+      sha256: 6e42cf85257cbc2abf50a9c8f3bac8777920f1b970e6f2cae9358690e1186e99
   original:
     hackage: rest-rewrite-0.3.0
 - completed:
     name: ghc-timings
-    pantry-tree:
-      sha256: 72622264696c78cda23cf96382dee7a3d14e3eafdb8977486338f113681dcec4
-      size: 7544
-    commit: 45ef3498e35897712bde8e002ce18df6d55f8b15
-    git: https://github.com/qnikst/ghc-timings-report
     version: '0.1'
-  original:
-    commit: 45ef3498e35897712bde8e002ce18df6d55f8b15
     git: https://github.com/qnikst/ghc-timings-report
-- completed:
     pantry-tree:
-      sha256: cf7712453587e8ea69b96f33e2e8015c22d3b448259d4cace663cc15657309d7
-      size: 671
+      size: 7544
+      sha256: 72622264696c78cda23cf96382dee7a3d14e3eafdb8977486338f113681dcec4
+    commit: 45ef3498e35897712bde8e002ce18df6d55f8b15
+  original:
+    git: https://github.com/qnikst/ghc-timings-report
+    commit: 45ef3498e35897712bde8e002ce18df6d55f8b15
+- completed:
     hackage: strip-ansi-escape-0.1.0.0@sha256:08f2ed93b16086a837ec46eab7ce8d27cf39d47783caaeb818878ea33c2ff75f,1628
+    pantry-tree:
+      size: 671
+      sha256: cf7712453587e8ea69b96f33e2e8015c22d3b448259d4cace663cc15657309d7
   original:
     hackage: strip-ansi-escape-0.1.0.0@sha256:08f2ed93b16086a837ec46eab7ce8d27cf39d47783caaeb818878ea33c2ff75f,1628
+- completed:
+    name: liquid-base
+    version: 4.15.0.1
+    git: https://github.com/facundominguez/liquid-base
+    pantry-tree:
+      size: 15554
+      sha256: 464e5c7c7cc77fa5c039e614232e562bf0de9e44554a22d0e6193ea4e8b2fe85
+    commit: 8ad2378cee5ccf7937d9e08aacd5c5b7128318e8
+  original:
+    git: https://github.com/facundominguez/liquid-base
+    commit: 8ad2378cee5ccf7937d9e08aacd5c5b7128318e8
 snapshots:
 - completed:
-    sha256: 6d1532d40621957a25bad5195bfca7938e8a06d923c91bc52aa0f3c41181f2d4
     size: 619204
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/33.yaml
+    sha256: 6d1532d40621957a25bad5195bfca7938e8a06d923c91bc52aa0f3c41181f2d4
   original: lts-19.33

--- a/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Data/Nat.hs
+++ b/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Data/Nat.hs
@@ -2,7 +2,6 @@ module Language.Stitch.LH.Data.Nat where
 
 import Prelude hiding (max)
 
-{-@ type Nat = { v : Int | v >= 0 } @-}
 type Nat = Int
 
 {-@ inline max @-}

--- a/tests/pos/Elim_ex_let.hs
+++ b/tests/pos/Elim_ex_let.hs
@@ -5,9 +5,9 @@ module Elim_ex_let (prop) where
 
 import LiquidHaskell
 
-[lq| type Nat = {v:Int | 0 <= v} |]
+[lq| type MyNat = {v:Int | 0 <= v} |]
 
-[lq| prop :: a -> Nat |]
+[lq| prop :: a -> MyNat |]
 prop _ = let x _ = let y = 0 
                    in
                      y - 1


### PR DESCRIPTION
- benchmark-timings: Loosen bound on aeson
- Loosen bounds for compatibility with GHC 9.0.2
- Move to LTS-19.33
