### PR TITLE
Make ExactDC default

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1308,6 +1308,7 @@ GHC 7.10
 
     to
 
+ 
       D:Foo foo
 
     but it still breaks when we don't have an LH class decl

--- a/docs/blog/2016-10-06-structural-induction.lhs
+++ b/docs/blog/2016-10-06-structural-induction.lhs
@@ -108,7 +108,7 @@ Reflecting Lists into the Logic
 To talk about lists in the logic, we use the annotation
 
 \begin{code}
-{-@ LIQUID "--exact-data-cons" @-}
+{- LIQUID "--exact-data-cons" @-}
 \end{code}
 
 which **automatically** derives measures for

--- a/docs/blog/2016-12-25-isomorphisms.lhs
+++ b/docs/blog/2016-12-25-isomorphisms.lhs
@@ -49,7 +49,6 @@ are provably **isomorphic**.
 \begin{code}
 {-@ LIQUID "--higherorder" @-}
 {-@ LIQUID "--totalhaskell" @-}
-{-@ LIQUID "--exactdc" @-}
 {-@ LIQUID "--diffcheck" @-}
 {-@ LIQUID "--eliminate=some" @-}
 

--- a/docs/blog/2017-01-06-reductions.lhs
+++ b/docs/blog/2017-01-06-reductions.lhs
@@ -45,7 +45,6 @@ This proof reduction is possible since Peano numbers are homomorphic to Natural 
 \begin{code}
 {-@ LIQUID "--higherorder"    @-}
 {-@ LIQUID "--totalhaskell"   @-}
-{-@ LIQUID "--exactdc"        @-}
 {-@ LIQUID "--diffcheck"      @-}
 {-@ LIQUID "--pruneunsorted"  @-}
 {-@ LIQUID "--eliminate=some" @-}

--- a/docs/blog/2017-12-15-splitting-and-splicing-intervals-I.lhs
+++ b/docs/blog/2017-12-15-splitting-and-splicing-intervals-I.lhs
@@ -39,7 +39,6 @@ their [nifty new tool][hs-to-coq].
 <div class="hidden">
 \begin{code}
 {-@ LIQUID "--short-names"    @-}
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--no-adt"         @-}
 {-@ LIQUID "--prune-unsorted" @-}
 {-@ LIQUID "--higherorder"    @-}

--- a/docs/blog/2017-12-24-splitting-and-splicing-intervals-II.lhs
+++ b/docs/blog/2017-12-24-splitting-and-splicing-intervals-II.lhs
@@ -40,7 +40,6 @@ simplify the overhead of proof.
 <div class="hidden">
 \begin{code}
 {-@ LIQUID "--short-names"    @-}
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--no-adt"         @-}
 {-@ LIQUID "--higherorder"    @-}
 {-@ LIQUID "--diff"           @-}

--- a/docs/blog/todo/Iso.lhs
+++ b/docs/blog/todo/Iso.lhs
@@ -14,7 +14,6 @@ demo: Iso.hs
 \begin{code}
 {-@ LIQUID "--higherorder" @-}
 {-@ LIQUID "--totalhaskell" @-}
-{-@ LIQUID "--exactdc" @-}
 {-@ LIQUID "--diffcheck" @-}
 
 module Iso where

--- a/include/Language/Haskell/Liquid/ProofCombinators.hs
+++ b/include/Language/Haskell/Liquid/ProofCombinators.hs
@@ -1,11 +1,5 @@
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE IncoherentInstances   #-}
-
 module Language.Haskell.Liquid.ProofCombinators (
 
-  -- ATTENTION! `Admit` and `(==!)` are UNSAFE: they should not belong the final proof term
 
   -- * Proof is just a () alias
   Proof
@@ -20,7 +14,7 @@ module Language.Haskell.Liquid.ProofCombinators (
   -- * These two operators check all intermediate equalities
   , (===) -- proof of equality is implicit eg. x === y
   , (=<=) -- proof of equality is implicit eg. x <= y
-  , (=>=)  -- proof of equality is implicit eg. x =>= y 
+  , (=>=) -- proof of equality is implicit eg. x =>= y 
 
   -- * This operator does not check intermediate equalities
   , (==.) 
@@ -63,17 +57,12 @@ unreachable =  ()
 
 -- | proof casting
 -- | `x *** QED`: x is a proof certificate* strong enough for SMT to prove your theorem
--- | `x *** Admit`: x is an unfinished proof
 
 infixl 3 ***
-{-@ assume (***) :: a -> p:QED -> { if (isAdmit p) then false else true } @-}
 (***) :: a -> QED -> Proof
 _ *** _ = ()
 
-data QED = Admit | QED
-
-{-@ measure isAdmit :: QED -> Bool @-}
-{-@ Admit :: {v:QED | isAdmit v } @-}
+data QED = QED
 
 
 -------------------------------------------------------------------------------

--- a/liquid-base/liquid-base.cabal
+++ b/liquid-base/liquid-base.cabal
@@ -256,5 +256,5 @@ library
   default-extensions: PackageImports
                       NoImplicitPrelude
   if impl(ghc >= 8.10)
-    ghc-options: -fplugin=LiquidHaskell -fplugin-opt=LiquidHaskell:--no-positivity-check
+    ghc-options: -fplugin=LiquidHaskell -fplugin-opt=LiquidHaskell:--no-positivity-check -fplugin-opt=LiquidHaskell:--no-exact-data-cons
   

--- a/liquid-bytestring/liquid-bytestring.cabal
+++ b/liquid-bytestring/liquid-bytestring.cabal
@@ -53,5 +53,5 @@ library
   default-language:   Haskell2010
   default-extensions: PackageImports
   if impl(ghc >= 8.10)
-    ghc-options: -fplugin=LiquidHaskell
+    ghc-options: -fplugin=LiquidHaskell -fplugin-opt=LiquidHaskell:--no-exact-data-cons
   

--- a/liquid-bytestring/src/Data/ByteString/Lazy.hs
+++ b/liquid-bytestring/src/Data/ByteString/Lazy.hs
@@ -1,3 +1,5 @@
+{-@ LIQUID "--no-exact-data-types" @-}
+
 module Data.ByteString.Lazy ( module Exports ) where
 
 import Data.String

--- a/liquid-bytestring/src/Data/ByteString/Lazy.hs
+++ b/liquid-bytestring/src/Data/ByteString/Lazy.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--no-exact-data-types" @-}
-
 module Data.ByteString.Lazy ( module Exports ) where
 
 import Data.String

--- a/liquid-containers/liquid-containers.cabal
+++ b/liquid-containers/liquid-containers.cabal
@@ -54,5 +54,5 @@ library
   default-language:   Haskell2010
   default-extensions: PackageImports
   if impl(ghc >= 8.10)
-    ghc-options: -fplugin=LiquidHaskell
+    ghc-options: -fplugin=LiquidHaskell -fplugin-opt=LiquidHaskell:--no-exact-data-cons
   

--- a/liquid-ghc-prim/src/GHC/Classes.spec
+++ b/liquid-ghc-prim/src/GHC/Classes.spec
@@ -7,23 +7,23 @@ not     :: x:GHC.Types.Bool -> {v:GHC.Types.Bool | ((v) <=> ~(x))}
         -> {v:GHC.Types.Bool | ((v) <=> ((x) && (y)))}
 (||)    :: x:GHC.Types.Bool -> y:GHC.Types.Bool
         -> {v:GHC.Types.Bool | ((v) <=> ((x) || (y)))}
-(==)    :: (GHC.Classes.Eq  a) => x:a -> y:a
+(==)    :: GHC.Classes.Eq  a => x:a -> y:a
         -> {v:GHC.Types.Bool | ((v) <=> x = y)}
-(/=)    :: (GHC.Classes.Eq  a) => x:a -> y:a
+(/=)    :: GHC.Classes.Eq  a => x:a -> y:a
         -> {v:GHC.Types.Bool | ((v) <=> x != y)}
-(>)     :: (GHC.Classes.Ord a) => x:a -> y:a
+(>)     :: GHC.Classes.Ord a => x:a -> y:a
         -> {v:GHC.Types.Bool | ((v) <=> x > y)}
-(>=)    :: (GHC.Classes.Ord a) => x:a -> y:a
+(>=)    :: GHC.Classes.Ord a => x:a -> y:a
         -> {v:GHC.Types.Bool | ((v) <=> x >= y)}
-(<)     :: (GHC.Classes.Ord a) => x:a -> y:a
+(<)     :: GHC.Classes.Ord a => x:a -> y:a
         -> {v:GHC.Types.Bool | ((v) <=> x < y)}
-(<=)    :: (GHC.Classes.Ord a) => x:a -> y:a
+(<=)    :: GHC.Classes.Ord a => x:a -> y:a
         -> {v:GHC.Types.Bool | ((v) <=> x <= y)}
 
-compare :: (GHC.Classes.Ord a) => x:a -> y:a
+compare :: GHC.Classes.Ord a => x:a -> y:a
         -> {v:GHC.Types.Ordering | (((v = GHC.Types.EQ) <=> (x = y)) &&
                                     ((v = GHC.Types.LT) <=> (x < y)) &&
                                     ((v = GHC.Types.GT) <=> (x > y))) }
 
-max :: (GHC.Classes.Ord a) => x:a -> y:a -> {v:a | v = (if x > y then x else y) }
-min :: (GHC.Classes.Ord a) => x:a -> y:a -> {v:a | v = (if x < y then x else y) }
+max :: GHC.Classes.Ord a => x:a -> y:a -> {v:a | v = (if x > y then x else y) }
+min :: GHC.Classes.Ord a => x:a -> y:a -> {v:a | v = (if x < y then x else y) }

--- a/liquid-ghc-prim/src/GHC/Types.hs
+++ b/liquid-ghc-prim/src/GHC/Types.hs
@@ -2,6 +2,7 @@ module GHC.Types (module Exports) where
 
 import "ghc-prim" GHC.Types as Exports
 
+{-@ LIQUID "--no-exact-data-cons"   @-}
 {-@ embed GHC.Prim.Int#     as int  @-}
 {-@ embed GHC.Prim.Addr#    as Str  @-}
 {-@ embed GHC.Prim.Char#    as Char @-}

--- a/liquid-prelude/src/Language/Haskell/Liquid/ProofCombinators.hs
+++ b/liquid-prelude/src/Language/Haskell/Liquid/ProofCombinators.hs
@@ -1,11 +1,6 @@
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE IncoherentInstances   #-}
-
 module Language.Haskell.Liquid.ProofCombinators (
 
-  -- ATTENTION! `Admit` and `(==!)` are UNSAFE: they should not belong the final proof term
+  -- ATTENTION! `(==!)` is UNSAFE: it should not belong the final proof term
 
   -- * Proof is just a () alias
   Proof
@@ -65,18 +60,12 @@ unreachable =  ()
 
 -- | proof casting
 -- | `x *** QED`: x is a proof certificate* strong enough for SMT to prove your theorem
--- | `x *** Admit`: x is an unfinished proof
 
 infixl 3 ***
-{-@ assume (***) :: a -> p:QED -> { if (isAdmit p) then false else true } @-}
 (***) :: a -> QED -> Proof
 _ *** _ = ()
 
-data QED = Admit | QED
-
-{-@ measure isAdmit :: QED -> Bool @-}
-{-@ Admit :: {v:QED | isAdmit v } @-}
-
+data QED = QED
 
 -------------------------------------------------------------------------------
 -- | * Checked Proof Certificates ---------------------------------------------

--- a/liquid-vector/liquid-vector.cabal
+++ b/liquid-vector/liquid-vector.cabal
@@ -51,5 +51,5 @@ library
   default-language:   Haskell2010
   default-extensions: PackageImports
   if impl(ghc >= 8.10)
-    ghc-options: -fplugin=LiquidHaskell -fplugin-opt=LiquidHaskell:--no-positivity-check
+    ghc-options: -fplugin=LiquidHaskell -fplugin-opt=LiquidHaskell:--no-positivity-check -fplugin-opt=LiquidHaskell:--no-exact-data-cons
   

--- a/src/Language/Haskell/Liquid/Bare.hs
+++ b/src/Language/Haskell/Liquid/Bare.hs
@@ -356,9 +356,11 @@ makeEmbeds src env
 
 makeTyConEmbeds :: Bare.Env -> (ModName, Ms.BareSpec) -> F.TCEmb Ghc.TyCon
 makeTyConEmbeds env (name, spec)
-  = F.tceFromList [ (tc, t) | (c,t) <- F.tceToList (Ms.embeds spec), tc <- symTc c ]
+  = F.tceFromList (booltce:[ (tc, t) | (c,t) <- F.tceToList (Ms.embeds spec)
+                                     , tc    <- symTc c ])
     where
       symTc = Mb.maybeToList . Bare.maybeResolveSym env name "embed-tycon"
+      booltce = (Ghc.boolTyCon, (boolSort, F.NoArgs))
 
 --------------------------------------------------------------------------------
 -- | [NOTE]: REFLECT-IMPORTS

--- a/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -898,7 +898,7 @@ matchTyCon env name lc@(Loc _ _ c) arity
   | isTuple c               = Right tuplTc
   | otherwise               = resolveLocSym env name msg lc
   where
-    msg                     = "matchTyCon: " ++ F.showpp c
+    msg                     = "matchTyCon: " ++ F.showpp c ++ "\n\n Try using the \"--no-exact-data-cons\" flag"
     tuplTc                  = Ghc.tupleTyCon Ghc.Boxed arity
 
 

--- a/src/Language/Haskell/Liquid/Measure.hs
+++ b/src/Language/Haskell/Liquid/Measure.hs
@@ -177,7 +177,7 @@ mapArgumens allowTC lc t1 t2 = go xts1' xts2'
       = Just $ mkSubst $ zipWith (\y x -> (fst x, EVar $ fst y)) xts1' xts2'
       | otherwise
       = panic (Just $ sourcePosSrcSpan lc) ("The types for the wrapper and worker data constructors cannot be merged\n"
-          ++ show t1 ++ "\n" ++ show t2 )
+          ++ show t1 ++ "\n" ++ show t2 ++ "\n\n Try using the \"--no-exact-data-cons\" flag")
 
 -- should constructors have implicits? probably not
 defRefType :: Bool -> Type -> Def (RRType Reft) DataCon -> RRType Reft

--- a/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -275,9 +275,9 @@ config = cmdArgsMode $ Config {
           &= name "port"
           &= help "Port at which lhi should listen"
 
- , exactDC
-    = def &= help "Exact Type for Data Constructors"
-          &= name "exact-data-cons"
+ , noexactDC
+    = def &= help "Not Exact Type for Data Constructors"
+          &= name "no-exact-data-cons"
 
  , noADT
     = def &= help "Do not generate ADT representations in refinement logic"
@@ -600,7 +600,6 @@ gitMsg gi = concat
   , "] "
   ]
 
-
 -- [NOTE:searchpath]
 -- 1. we used to add the directory containing the file to the searchpath,
 --    but this is bad because GHC does NOT do this, and it causes spurious
@@ -693,7 +692,7 @@ defConfig = Config
   , notruetypes              = def
   , nototality               = False
   , pruneUnsorted            = def
-  , exactDC                  = def
+  , noexactDC                = def
   , noADT                    = def
   , expectErrorContaining    = def
   , expectAnyError           = False

--- a/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/src/Language/Haskell/Liquid/UX/Config.hs
@@ -7,6 +7,7 @@ module Language.Haskell.Liquid.UX.Config (
      Config (..)
    , HasConfig (..)
    , allowPLE, allowLocalPLE, allowGlobalPLE
+   , exactDC
    , patternFlag
    , higherOrderFlag
    , pruneFlag
@@ -68,7 +69,7 @@ data Config = Config
   , cFiles                   :: [String]   -- ^ .c files to compile and link against (for GHC)
   , eliminate                :: Eliminate  -- ^ eliminate (i.e. don't use qualifs for) for "none", "cuts" or "all" kvars
   , port                     :: Int        -- ^ port at which lhi should listen
-  , exactDC                  :: Bool       -- ^ Automatically generate singleton types for data constructors
+  , noexactDC                :: Bool       -- ^ Do not automatically generate singleton types for data constructors
   , noADT                    :: Bool       -- ^ Disable ADTs (only used with exactDC)
   , expectErrorContaining    :: [String]   -- ^ expect failure from Liquid with at least one of the following messages
   , expectAnyError           :: Bool       -- ^ expect failure from Liquid with any message
@@ -142,6 +143,9 @@ exactDCFlag :: (HasConfig t) => t -> Bool
 exactDCFlag x = exactDC cfg || reflection cfg
   where
     cfg       = getConfig x
+
+exactDC :: Config -> Bool 
+exactDC = not . noexactDC
 
 pruneFlag :: (HasConfig t) => t -> Bool
 pruneFlag = pruneUnsorted . getConfig

--- a/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/src/Language/Haskell/Liquid/UX/Config.hs
@@ -94,7 +94,7 @@ data Config = Config
   , proofLogicEvalLocal      :: Bool       -- ^ Enable proof-by-logical-evaluation locally, per function
   , extensionality           :: Bool       -- ^ Enable extensional interpretation of function equality
   , nopolyinfer              :: Bool       -- ^ No inference of polymorphic type application.
-  , reflection               :: Bool       -- ^ Allow "reflection"; switches on "--higherorder" and "--exactdc"
+  , reflection               :: Bool       -- ^ Allow "reflection"; switches on "--higherorder"
   , compileSpec              :: Bool       -- ^ Only "compile" the spec -- into .bspec file -- don't do any checking.
   , noCheckImports           :: Bool       -- ^ Do not check the transitive imports
   , typedHoles               :: Bool       -- ^ Warn about "typed-holes"

--- a/tests/DependentHaskell/todo/LF326.hs
+++ b/tests/DependentHaskell/todo/LF326.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-cons"   @-}
 {-@ LIQUID "--ple" @-}
 module Foo where
 import Prelude hiding (Maybe (..))

--- a/tests/benchmarks/bytestring-0.9.2.1/Data/ByteString/Lazy.hs
+++ b/tests/benchmarks/bytestring-0.9.2.1/Data/ByteString/Lazy.hs
@@ -1,5 +1,6 @@
 {-@ LIQUID "--no-totality"   @-}
 {-@ LIQUID "--pruneunsorted" @-}
+{-@ LIQUID "--no-exact-data-types" @-}
 
 {-# OPTIONS_GHC -cpp -fglasgow-exts -fno-warn-orphans -fno-warn-incomplete-patterns #-}
 

--- a/tests/benchmarks/cse230/src/Week10/ProofCombinators.hs
+++ b/tests/benchmarks/cse230/src/Week10/ProofCombinators.hs
@@ -5,7 +5,7 @@
 
 module ProofCombinators (
 
-  -- ATTENTION! `Admit` and `(==!)` are UNSAFE: they should not belong the final proof term
+  -- ATTENTION! `(==!)` is UNSAFE: it should not belong the final proof term
 
   -- * Proof is just a () alias
   Proof
@@ -70,10 +70,7 @@ infixl 3 ***
 (***) :: a -> QED -> Proof
 _ *** _ = ()
 
-data QED = Admit | QED
-
-{-@ measure isAdmit :: QED -> Bool @-}
-{-@ Admit :: {v:QED | isAdmit v } @-}
+data QED = QED
 
 
 -------------------------------------------------------------------------------

--- a/tests/benchmarks/haskell16/pos/tmp/MonoidPeano.hs
+++ b/tests/benchmarks/haskell16/pos/tmp/MonoidPeano.hs
@@ -1,6 +1,5 @@
 {-#LH LIQUID "--higherorder"     @-}
 {-#LH LIQUID "--totality"        @-}
-{-#LH LIQUID "--exact-data-cons" @-}
 {-#LH LIQUID "--higherorderqs" @-}
 
 module Peano where

--- a/tests/benchmarks/icfp15/neg/DataBase.hs
+++ b/tests/benchmarks/icfp15/neg/DataBase.hs
@@ -1,6 +1,7 @@
 {-@ LIQUID "--expect-any-error" @-}
 {-@ LIQUID "--no-termination" @-}
-{-@ LIQUID "totality" @-}
+{-@ LIQUID "--totality" @-}
+{-@ LIQUID "--no-exact-data-con" @-}
 {-# OPTIONS_GHC -Wno-overlapping-patterns #-}
 
 module DataBase (

--- a/tests/benchmarks/icfp15/pos/DataBase.hs
+++ b/tests/benchmarks/icfp15/pos/DataBase.hs
@@ -1,5 +1,6 @@
 {-@ LIQUID "--no-termination" @-}
-{-@ LIQUID "totality"         @-}
+{-@ LIQUID "--totality"         @-}
+{-@ LIQUID "--no-exact-data-con" @-}
 
 module DataBase (
 

--- a/tests/benchmarks/popl18/nople/neg/BasicLambdas.hs
+++ b/tests/benchmarks/popl18/nople/neg/BasicLambdas.hs
@@ -1,8 +1,6 @@
 {-@ LIQUID "--expect-any-error" @-}
 
-{-@ LIQUID "--higherorder"      @-}
-{- LIQUID "--autoproofs"      @-}
-{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--reflection" @-}
 module BasicLambdas where
 
 import Proves 

--- a/tests/benchmarks/popl18/nople/neg/MonadReader.hs
+++ b/tests/benchmarks/popl18/nople/neg/MonadReader.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--expect-any-error" @-}
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--extensionality"  @-}
 
 

--- a/tests/benchmarks/popl18/nople/pos/ApplicativeReader.hs
+++ b/tests/benchmarks/popl18/nople/pos/ApplicativeReader.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--alphaequivalence" @-}
 {-@ LIQUID "--betaequivalence" @-}
 

--- a/tests/benchmarks/popl18/nople/pos/Euclide.hs
+++ b/tests/benchmarks/popl18/nople/pos/Euclide.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--higherorder"      @-}
-{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--reflection" @-}
 
 module Euclide where
 

--- a/tests/benchmarks/popl18/nople/pos/FunctorReader.hs
+++ b/tests/benchmarks/popl18/nople/pos/FunctorReader.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--alphaequivalence" @-}
 {-@ LIQUID "--betaequivalence"  @-}
 

--- a/tests/benchmarks/popl18/nople/pos/FunctorReader_NoExtensionality.hs
+++ b/tests/benchmarks/popl18/nople/pos/FunctorReader_NoExtensionality.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--betaequivalence"  @-}
 
 

--- a/tests/benchmarks/popl18/nople/pos/MonadReader.hs
+++ b/tests/benchmarks/popl18/nople/pos/MonadReader.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--higherorder"       @-}
-{-@ LIQUID "--exact-data-cons"   @-}
+{-@ LIQUID "--reflection" @-}
 
 -- NOPROP probably breaks some fixpoint flag 
 

--- a/tests/benchmarks/popl18/nople/pos/NatInduction.hs
+++ b/tests/benchmarks/popl18/nople/pos/NatInduction.hs
@@ -4,8 +4,7 @@ import Language.Haskell.Liquid.ProofCombinators
 
 import Prelude hiding (sum, range)
 
-{-@ LIQUID "--higherorder" @-}
-{-@ LIQUID "--exactdc" @-}
+{-@ LIQUID "--reflection" @-}
 
 {-@ natinduction :: p:(Nat-> Bool) -> PAnd {v:Proof | p 0} (n:Nat -> {v:Proof | p (n-1)} -> {v:Proof | p n})
                  -> n:Nat -> {v:Proof | p n}  @-}

--- a/tests/benchmarks/popl18/nople/pos/NaturalDeduction.hs
+++ b/tests/benchmarks/popl18/nople/pos/NaturalDeduction.hs
@@ -5,8 +5,7 @@
 
 module NaturalDeduction where
 
-{-@ LIQUID "--higherorder" @-}
-{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--reflection" @-}
 
 import Language.Haskell.Liquid.ProofCombinators
 

--- a/tests/benchmarks/popl18/nople/pos/OverviewListInfix.hs
+++ b/tests/benchmarks/popl18/nople/pos/OverviewListInfix.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--eliminate" @-}
 {-@ LIQUID "--maxparams=10"  @-}
 {-@ LIQUID "--higherorderqs" @-}

--- a/tests/benchmarks/popl18/nople/pos/Peano.hs
+++ b/tests/benchmarks/popl18/nople/pos/Peano.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--higherorderqs" @-}
 
 module Peano where

--- a/tests/benchmarks/popl18/nople/pos/Solver.hs
+++ b/tests/benchmarks/popl18/nople/pos/Solver.hs
@@ -5,8 +5,7 @@
 -- | Should use cases and auto translate like in the paper's theory
 -- | Also, &&, not and rest logical operators are not in scope in the axioms
 
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--pruneunsorted"   @-}
 
 -- TAG: absref

--- a/tests/benchmarks/popl18/nople/pos/Unification.hs
+++ b/tests/benchmarks/popl18/nople/pos/Unification.hs
@@ -5,8 +5,7 @@
 -- nonlinear-cuts (i.e. they add new cut vars that require qualifiers.) why?
 -- where? switch off non-lin-cuts in higher-order mode?
 
-{-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--eliminate=all"   @-}
 
 module Unification where

--- a/tests/benchmarks/popl18/nople/todo/Soundness.hs
+++ b/tests/benchmarks/popl18/nople/todo/Soundness.hs
@@ -1,6 +1,5 @@
-{-@ LIQUID "--higherorder"     @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--totality"        @-}
-{-@ LIQUID "--exact-data-cons" @-}
 
 module Soundness where
 

--- a/tests/benchmarks/popl18/ple/pos/NatInduction.hs
+++ b/tests/benchmarks/popl18/ple/pos/NatInduction.hs
@@ -4,8 +4,8 @@ import Language.Haskell.Liquid.ProofCombinators
 
 import Prelude hiding (sum, range)
 
-{-@ LIQUID "--higherorder" @-}
-{-@ LIQUID "--exactdc" @-}
+{-@ LIQUID "--reflection" @-}
+
 
 {-@ natinduction :: p:(Nat-> Bool) -> PAnd {v:Proof | p 0} (n:Nat -> {v:Proof | p (n-1)} -> {v:Proof | p n})
                  -> n:Nat -> {v:Proof | p n}  @-}

--- a/tests/benchmarks/popl18/ple/pos/NaturalDeduction.hs
+++ b/tests/benchmarks/popl18/ple/pos/NaturalDeduction.hs
@@ -5,8 +5,7 @@
 
 module NaturalDeduction where
 
-{-@ LIQUID "--higherorder" @-}
-{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--reflection" @-}
 
 import Language.Haskell.Liquid.ProofCombinators
 

--- a/tests/benchmarks/sf/Induction.hs
+++ b/tests/benchmarks/sf/Induction.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--exact-data-con"                      @-}
-{-@ LIQUID "--higherorder"                         @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--ple" @-}
 
 module Induction where

--- a/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Check.hs
+++ b/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Check.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
-{-@ LIQUID "--exact-data-cons" @-}
 -- ple is necessary to reason about the evaluation of checkBindings
 {-@ LIQUID "--ple" @-}
 

--- a/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Data/List.hs
+++ b/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Data/List.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--ple" @-}
 
 -----------------------------------------------------------------------------

--- a/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Eval.hs
+++ b/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Eval.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE EmptyCase #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--ple" @-}
 {-@ LIQUID "--no-positivity-check" @-}
 

--- a/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Repl.hs
+++ b/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Repl.hs
@@ -1,8 +1,6 @@
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 {-# LANGUAGE FlexibleInstances, UndecidableInstances, ViewPatterns,
              NondecreasingIndentation #-}
--- XXX: Why do we need --exact-data-cons here?
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--ple" @-}
 
 -----------------------------------------------------------------------------

--- a/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Step.hs
+++ b/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Step.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE EmptyCase #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--ple" @-}
 
 -----------------------------------------------------------------------------

--- a/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Unchecked.hs
+++ b/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Unchecked.hs
@@ -11,7 +11,6 @@
 ----------------------------------------------------------------------------
 
 {-# LANGUAGE LambdaCase #-}
-{- LIQUID "--exact-data-cons" @-}
 
 module Language.Stitch.LH.Unchecked where
 

--- a/tests/benchmarks/stitch-lh/tests/Tests/Check.hs
+++ b/tests/benchmarks/stitch-lh/tests/Tests/Check.hs
@@ -1,5 +1,4 @@
 {-# OPTIONS_GHC -fplugin=LiquidHaskell #-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--ple" @-}
 module Tests.Check where
 

--- a/tests/benchmarks/vector-algorithms-0.5.4.2/Data/Vector/Algorithms/Optimal.hs
+++ b/tests/benchmarks/vector-algorithms-0.5.4.2/Data/Vector/Algorithms/Optimal.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-
+{-@ LIQUID "--no-exact-data-con" @-}
 -- ---------------------------------------------------------------------------
 -- |
 -- Module      : Data.Vector.Algorithms.Optimal

--- a/tests/classes/pos/TypeEquality00.hs
+++ b/tests/classes/pos/TypeEquality00.hs
@@ -18,7 +18,6 @@
 
 module TypeEquality00 where
 
-{-@ LIQUID "--exact-data-con" @-}
 
 {-@ data EntityFieldPerson typ where                                                                                     
       PersonNums :: EntityFieldPerson {v:_ | len v > 0}                                                               

--- a/tests/classes/pos/TypeEquality01.hs
+++ b/tests/classes/pos/TypeEquality01.hs
@@ -13,8 +13,7 @@
 {-# LANGUAGE TypeFamilies               #-}
 
 {-@ LIQUID "--no-adt"         @-}
-{-@ LIQUID "--exact-data-con" @-}
-{-@ LIQUID "--higherorder"    @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--no-termination" @-}
 
 

--- a/tests/datacon/pos/T1476.hs
+++ b/tests/datacon/pos/T1476.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE GADTs, TypeFamilies, GeneralizedNewtypeDeriving, OverloadedStrings, TemplateHaskell, QuasiQuotes, MultiParamTypeClasses #-}
 
 {-@ LIQUID "--no-adt"                   @-}
-{-@ LIQUID "--exact-data-cons"           @-}
-{-@ LIQUID "--higherorder"              @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--no-termination" @-}
 -- | Description of database records.
 module T1476

--- a/tests/errors/BadData1.hs
+++ b/tests/errors/BadData1.hs
@@ -1,6 +1,4 @@
 {-@ LIQUID "--expect-error-containing=Data constructors in refinement do not match original datatype for `EntityField`" @-}
-{-@ LIQUID "--no-adt"         @-}
-{-@ LIQUID "--exact-data-con" @-}
 
 {-# LANGUAGE ExistentialQuantification, KindSignatures, TypeFamilies, GADTs #-}
 

--- a/tests/errors/BadData2.hs
+++ b/tests/errors/BadData2.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--expect-error-containing=Data constructors in refinement do not match original datatype for `Hog`" @-}
-{-@ LIQUID "--exact-data-cons" @-}
 
 module BadData2 where
 

--- a/tests/errors/BadSig1.hs
+++ b/tests/errors/BadSig1.hs
@@ -1,8 +1,6 @@
 {-@ LIQUID "--expect-error-containing=Illegal type specification for `BadSig1.EZ`" @-}
 {-# LANGUAGE GADTs #-}
 
-{-@ LIQUID "--exact-data-con" @-}
-
 module BadSig1 where
 
 data Peano where

--- a/tests/errors/ExportReflect0.hs
+++ b/tests/errors/ExportReflect0.hs
@@ -1,7 +1,6 @@
 -- LH issue #1023
 
-{-@ LIQUID "--exactdc"     @-}
-{-@ LIQUID "--higherorder" @-}
+{-@ LIQUID "--reflection" @-}
 
 module ExportReflect0 (foo, zogbert) where
 

--- a/tests/errors/ShadowFieldInline.hs
+++ b/tests/errors/ShadowFieldInline.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--expect-error-containing=Multiple specifications for `pig`" @-}
-{-@ LIQUID "--exactdc" @-}
 
 module ShadowFieldInline where
 

--- a/tests/errors/ShadowFieldReflect.hs
+++ b/tests/errors/ShadowFieldReflect.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--expect-error-containing=Multiple specifications for `pig`" @-}
-{-@ LIQUID "--exactdc" @-}
 
 module ShadowFieldReflect where
 

--- a/tests/errors/TODOVarInTypeAlias.hs
+++ b/tests/errors/TODOVarInTypeAlias.hs
@@ -1,7 +1,6 @@
 -- VS.hs
-{-@ LIQUID "--higherorder"    @-}
 {-@ LIQUID "--totality"       @-}
-{-@ LIQUID "--exactdc"        @-}
+{-@ LIQUID "--reflection" @-}
 
 module TODOVarInTypeAlias where
 

--- a/tests/import/client/RC1015.hs
+++ b/tests/import/client/RC1015.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--exactdc" @-}
-{-@ LIQUID "--higherorder" @-}
+{-@ LIQUID "--reflection" @-}
 
 module RC1015 where
 

--- a/tests/import/client/T1180.hs
+++ b/tests/import/client/T1180.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE GADTs #-}
 
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--noadt" @-}
 
 module T1180 where

--- a/tests/import/lib/PeanoLib.hs
+++ b/tests/import/lib/PeanoLib.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE GADTs #-}
 
-{-@ LIQUID "--exact-data-con" @-}
-{-@ LIQUID "--higherorder"    @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--ple"            @-}
 {-@ LIQUID "--noadt"          @-}
 

--- a/tests/import/lib/RL1015Lib.hs
+++ b/tests/import/lib/RL1015Lib.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--exactdc" @-}
-{-@ LIQUID "--higherorder" @-}
+{-@ LIQUID "--reflection" @-}
 
 module RL1015Lib where
 

--- a/tests/import/lib/ReflectLib7.hs
+++ b/tests/import/lib/ReflectLib7.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--higherorder"    @-}
-{-@ LIQUID "--exactdc"        @-}
+{-@ LIQUID "--reflection" @-}
 
 module ReflectLib7 where
 

--- a/tests/import/lib/T1102_LibX.hs
+++ b/tests/import/lib/T1102_LibX.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
-
 module T1102_LibX where
 
 import T1102_LibY 

--- a/tests/import/lib/T1102_LibY.hs
+++ b/tests/import/lib/T1102_LibY.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
-
 module T1102_LibY where 
 
 import T1102_LibZ 

--- a/tests/import/lib/T1102_LibZ.hs
+++ b/tests/import/lib/T1102_LibZ.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
-
 module T1102_LibZ where
 
 {-@ data Foo a b = Foo { fooA :: a, fooB :: b} @-}

--- a/tests/import/lib/T1112.hs
+++ b/tests/import/lib/T1112.hs
@@ -1,6 +1,5 @@
+{-@ LIQUID "--reflection" @-}
 
-{-@ LIQUID "--higherorder"    @-}
-{-@ LIQUID "--exact-data-con" @-}
 
 module T1112 where
 

--- a/tests/import/lib/T1117Lib.hs
+++ b/tests/import/lib/T1117Lib.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--higherorder"        @-}
-{-@ LIQUID "--exactdc"            @-}
+{-@ LIQUID "--reflection" @-}
 
 module T1117Lib where
 

--- a/tests/import/lib/T1118Lib1.hs
+++ b/tests/import/lib/T1118Lib1.hs
@@ -1,5 +1,5 @@
-{-@ LIQUID "--higherorder"        @-}
-{-@ LIQUID "--exactdc"            @-}
+{-@ LIQUID "--reflection" @-}
+
 module T1118Lib1 where
 
 import T1118Lib2 

--- a/tests/neg/AdtPeano0.hs
+++ b/tests/neg/AdtPeano0.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--expect-any-error" @-}
-{-@ LIQUID "--exact-data-con" @-}
-{-@ LIQUID "--higherorder"    @-}
+{-@ LIQUID "--reflection" @-}
 
 module AdtPeano0 where
 

--- a/tests/neg/AdtPeano1.hs
+++ b/tests/neg/AdtPeano1.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--expect-any-error" @-}
-{-@ LIQUID "--exact-data-con"                      @-}
-{-@ LIQUID "--higherorder"                         @-}
+{-@ LIQUID "--reflection" @-}
 
 module AdtPeano1 where
 

--- a/tests/neg/ExactADT6.hs
+++ b/tests/neg/ExactADT6.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--expect-any-error" @-}
 {-@ LIQUID "--no-adt"         @-}
-{-@ LIQUID "--exact-data-con" @-}
 
 {-# LANGUAGE ExistentialQuantification, KindSignatures, TypeFamilies, GADTs #-}
 

--- a/tests/neg/ExactGADT6.hs
+++ b/tests/neg/ExactGADT6.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--expect-any-error" @-}
 {-@ LIQUID "--no-adt"         @-}
-{-@ LIQUID "--exact-data-con" @-}
 
 {-# LANGUAGE ExistentialQuantification, KindSignatures, TypeFamilies, GADTs #-}
 

--- a/tests/neg/ExactGADT7.hs
+++ b/tests/neg/ExactGADT7.hs
@@ -4,7 +4,6 @@
 
 {-@ LIQUID "--prune-unsorted" @-}
 {-@ LIQUID "--no-adt"         @-}
-{-@ LIQUID "--exact-data-con" @-}
 
 module ExactGADT7 where
 

--- a/tests/parser/pos/NestedTuples.hs
+++ b/tests/parser/pos/NestedTuples.hs
@@ -1,6 +1,4 @@
-{-@ LIQUID "--exact-data-cons" @-}
-
-module NestedTuples where
+qmodule NestedTuples where
 
 {-@ reflect f @-}
 f :: Int -> Int

--- a/tests/parser/pos/ReflectedInfix.hs
+++ b/tests/parser/pos/ReflectedInfix.hs
@@ -1,6 +1,5 @@
 module ReflectedInfix where
-{-@ LIQUID "--higherorder"    @-}
-{-@ LIQUID "--exact-data-con" @-}
+{-@ LIQUID "--reflection" @-}
 
 import Language.Haskell.Liquid.ProofCombinators 
 import Prelude hiding ((++))

--- a/tests/parser/pos/Tuples.hs
+++ b/tests/parser/pos/Tuples.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--exact-data-cons" @-}
-
 module Tuples where
 
 {-@ reflect f @-}

--- a/tests/ple/neg/BinahQuery.hs
+++ b/tests/ple/neg/BinahQuery.hs
@@ -1,7 +1,6 @@
 {-@ LIQUID "--expect-any-error" @-}
 {-@ LIQUID "--no-adt" 	                           @-}
-{-@ LIQUID "--exact-data-con"                      @-}
-{-@ LIQUID "--higherorder"                         @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--no-termination"                      @-}
 {-@ LIQUID "--ple" @-} 
 

--- a/tests/ple/neg/BinahUpdate.hs
+++ b/tests/ple/neg/BinahUpdate.hs
@@ -1,7 +1,6 @@
 {-@ LIQUID "--expect-any-error" @-}
 {-@ LIQUID "--no-adt" 	                           @-}
-{-@ LIQUID "--exact-data-con"                      @-}
-{-@ LIQUID "--higherorder"                         @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--no-termination"                      @-}
 {-@ LIQUID "--ple" @-} 
 

--- a/tests/ple/neg/BinahUpdateClient.hs
+++ b/tests/ple/neg/BinahUpdateClient.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--no-adt" 	                           @-}
-{-@ LIQUID "--exact-data-con"                      @-}
-{-@ LIQUID "--higherorder"                         @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--no-termination"                      @-}
 {-@ LIQUID "--ple" @-} 
 

--- a/tests/ple/neg/BinahUpdateLib.hs
+++ b/tests/ple/neg/BinahUpdateLib.hs
@@ -1,7 +1,6 @@
 {-@ LIQUID "--expect-any-error" @-}
 {-@ LIQUID "--no-adt" 	                           @-}
-{-@ LIQUID "--exact-data-con"                      @-}
-{-@ LIQUID "--higherorder"                         @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--no-termination"                      @-}
 {-@ LIQUID "--ple" @-}
 

--- a/tests/ple/neg/BinahUpdateLib1.hs
+++ b/tests/ple/neg/BinahUpdateLib1.hs
@@ -1,7 +1,6 @@
 {-@ LIQUID "--expect-any-error" @-}
 {-@ LIQUID "--no-adt" 	                           @-}
-{-@ LIQUID "--exact-data-con"                      @-}
-{-@ LIQUID "--higherorder"                         @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--no-termination"                      @-}
 {-@ LIQUID "--ple" @-}
 

--- a/tests/ple/neg/ExactGADT5.hs
+++ b/tests/ple/neg/ExactGADT5.hs
@@ -1,7 +1,6 @@
 {-@ LIQUID "--expect-any-error" @-}
 {-@ LIQUID "--no-adt" 	                           @-}
-{-@ LIQUID "--exact-data-con"                      @-}
-{-@ LIQUID "--higherorder"                         @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--no-termination"                      @-}
 {-@ LIQUID "--ple" @-}
 

--- a/tests/ple/neg/T1173.hs
+++ b/tests/ple/neg/T1173.hs
@@ -2,8 +2,7 @@
 module T1173 where
 
 {-@ LIQUID "--no-adt" 	      @-}
-{-@ LIQUID "--exact-data-con" @-}
-{-@ LIQUID "--higherorder"    @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--ple"            @-}
 
 import Prelude hiding (length, filter)

--- a/tests/ple/pos/BinahQuery.hs
+++ b/tests/ple/pos/BinahQuery.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--no-adt" 	                           @-}
-{-@ LIQUID "--exact-data-con"                      @-}
-{-@ LIQUID "--higherorder"                         @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--no-termination"                      @-}
 {-@ LIQUID "--ple" @-} 
 

--- a/tests/ple/pos/BinahUpdate.hs
+++ b/tests/ple/pos/BinahUpdate.hs
@@ -3,8 +3,7 @@
 module BinahUpdate where
 
 {-@ LIQUID "--no-adt" 	                           @-}
-{-@ LIQUID "--exact-data-con"                      @-}
-{-@ LIQUID "--higherorder"                         @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--no-termination"                      @-}
 {-@ LIQUID "--ple" @-} 
 

--- a/tests/ple/pos/Compiler.hs
+++ b/tests/ple/pos/Compiler.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--exact-data-con" @-}
-{-@ LIQUID "--higherorder"    @-}
+{-@ LIQUID "--reflection"     @-}
 {-@ LIQUID "--ple"            @-} 
 {-@ LIQUID "--no-totality"    @-} 
 

--- a/tests/ple/pos/ExactGADT5.hs
+++ b/tests/ple/pos/ExactGADT5.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--no-adt"         @-}
-{-@ LIQUID "--exact-data-con" @-}
-{-@ LIQUID "--higherorder"    @-}
+{-@ LIQUID "--reflection"     @-}
 {-@ LIQUID "--no-termination" @-}
 {-@ LIQUID "--ple"            @-}
 

--- a/tests/ple/pos/ExactGADT7.hs
+++ b/tests/ple/pos/ExactGADT7.hs
@@ -3,7 +3,6 @@
 
 {-@ LIQUID "--prune-unsorted" @-}
 {-@ LIQUID "--no-adt"         @-}
-{-@ LIQUID "--exact-data-con" @-}
 {- LIQUID "--ple" @-}
 
 module ExactGADT7 where

--- a/tests/ple/pos/FilterPLE.hs
+++ b/tests/ple/pos/FilterPLE.hs
@@ -1,7 +1,6 @@
 {-@ LIQUID "--no-termination" @-}
 {-@ LIQUID "--short-names"    @-}
-{-@ LIQUID "--higherorder"    @-}
-{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--reflection"     @-}
 {-@ LIQUID "--ple"            @-}
 
 module FilterPLE where

--- a/tests/ple/pos/IndPerm.hs
+++ b/tests/ple/pos/IndPerm.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE GADTs            #-}
-{-@ LIQUID "--exact-data-con" @-}
-{-@ LIQUID "--higherorder"    @-}
-{-@ LIQUID "--ple"            @-}
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 
 module IndPerm where
 

--- a/tests/ple/pos/PleORM.hs
+++ b/tests/ple/pos/PleORM.hs
@@ -1,8 +1,7 @@
 module PleORM where
 
-{-@ LIQUID "--exact-data-con" @-}
-{-@ LIQUID "--higherorder"    @-}
-{-@ LIQUID "--ple"            @-}
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 
 import Prelude hiding (length, filter)
 

--- a/tests/ple/pos/T1173.hs
+++ b/tests/ple/pos/T1173.hs
@@ -1,9 +1,8 @@
 module T1173 where
 
-{-@ LIQUID "--no-adt" 	      @-}
-{-@ LIQUID "--exact-data-con" @-}
-{-@ LIQUID "--higherorder"    @-}
-{-@ LIQUID "--ple"            @-}
+{-@ LIQUID "--no-adt" 	  @-}
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 
 import Prelude hiding (length, filter)
 

--- a/tests/ple/pos/T1302b.hs
+++ b/tests/ple/pos/T1302b.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE EmptyDataDecls, GADTs, ExistentialQuantification #-}
 
 {-@ LIQUID "--no-adt" 	      @-}
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
 {-@ LIQUID "--no-termination" @-}
 {-@ LIQUID "--no-totality"    @-}

--- a/tests/pos/AdtList0.hs
+++ b/tests/pos/AdtList0.hs
@@ -1,6 +1,3 @@
-
-{-@ LIQUID "--exact-data-cons" @-}
-
 module AdtList0 where
 
 data LL a = Emp | Cons a (LL a) 

--- a/tests/pos/AdtList1.hs
+++ b/tests/pos/AdtList1.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--exact-data-cons" @-}
-
 module AdtList1 where
 
 data LL a = Emp | Cons a (LL a) 

--- a/tests/pos/AdtList3.hs
+++ b/tests/pos/AdtList3.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--exact-data-cons" @-}
-
 module AdtList3 where
 
 data LL a = Emp | Cons a (LL a) 

--- a/tests/pos/AdtList4.hs
+++ b/tests/pos/AdtList4.hs
@@ -2,8 +2,6 @@
 --   we instantiate the output of `app` with quals like `v < xs` `v > xs` etc.
 --   where v, xs are of the ADT sort `List a`.
 
-{-@ LIQUID "--exact-data-cons" @-}
-
 module AdtList4 where
 
 data LL a = Emp | Cons a (LL a) 

--- a/tests/pos/AdtList5.hs
+++ b/tests/pos/AdtList5.hs
@@ -2,8 +2,6 @@
 --   are "holes" in the data-decl specification, presumably because the lifting
 --   happens BEFORE the holes are resolved.
 
-{-@ LIQUID "--exact-data-cons" @-}
-
 module AdtList5 where
 
 data Zing = ZZ (Int -> ())

--- a/tests/pos/AdtPeano0.hs
+++ b/tests/pos/AdtPeano0.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--exact-data-con" @-}
-{-@ LIQUID "--higherorder"    @-}
+{-@ LIQUID "--reflection" @-}
 
 module AdtPeano0 where
 

--- a/tests/pos/AdtPeano1.hs
+++ b/tests/pos/AdtPeano1.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--exact-data-con"                      @-}
-{-@ LIQUID "--higherorder"                         @-}
+{-@ LIQUID "--reflection" @-}
 
 module AdtPeano1 where
 

--- a/tests/pos/CasesToLogic.hs
+++ b/tests/pos/CasesToLogic.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-cons"     @-}
 {-@ LIQUID "--higherorder"        @-}
 
 module CasesToLogic where

--- a/tests/pos/ExactADT6.hs
+++ b/tests/pos/ExactADT6.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
-
 {-# LANGUAGE ExistentialQuantification, KindSignatures, TypeFamilies, GADTs #-}
 
 module ExactADT6 where

--- a/tests/pos/ExactGADT0.hs
+++ b/tests/pos/ExactGADT0.hs
@@ -1,8 +1,5 @@
 {-# LANGUAGE GADTs #-}
 
-{-@ LIQUID "--exact-data-con" @-}
-
-
 module ExactGADT0 where
 
 data Value a where

--- a/tests/pos/ExactGADT1.hs
+++ b/tests/pos/ExactGADT1.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
-
 {-# LANGUAGE  GADTs #-}
 
 module ExactGADT1 where

--- a/tests/pos/ExactGADT2.hs
+++ b/tests/pos/ExactGADT2.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
-
 {-# LANGUAGE  GADTs #-}
 
 module ExactGADT2 where

--- a/tests/pos/ExactGADT6.hs
+++ b/tests/pos/ExactGADT6.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
-
 {-# LANGUAGE ExistentialQuantification, KindSignatures, TypeFamilies, GADTs #-}
 
 module ExactGADT6 where

--- a/tests/pos/ListISort_perm.hs
+++ b/tests/pos/ListISort_perm.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE GADTs            #-}
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
 
 module ListISort_perm where

--- a/tests/pos/MutuallyDependentADT.hs
+++ b/tests/pos/MutuallyDependentADT.hs
@@ -1,7 +1,5 @@
 module MutuallyDependentADT where
 
-{-@ LIQUID "--exactdc"  @-}
-
 data Pred l 
   = PTerm (Term l)
 

--- a/tests/pos/ORM.hs
+++ b/tests/pos/ORM.hs
@@ -1,8 +1,6 @@
 module ORM where
 
-{-@ LIQUID "--exactdc"  @-}
-{-@ LIQUID "--higherorder" @-}
-
+{-@ LIQUID "--reflection" @-}
 
 import Prelude hiding (length, filter)
 import Language.Haskell.Liquid.ProofCombinators

--- a/tests/pos/Record0.hs
+++ b/tests/pos/Record0.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--exact-data-cons" @-}
-
 module Record0 () where
 
 import Language.Haskell.Liquid.Prelude

--- a/tests/pos/ReflectBooleanFunctions.hs
+++ b/tests/pos/ReflectBooleanFunctions.hs
@@ -1,5 +1,5 @@
-{-@ LIQUID "--exactdc"      @-}
-{-@ LIQUID "--higherorder"  @-}
+{-@ LIQUID "--reflection" @-}
+
 module ReflectBooleanFunctions where
 
 

--- a/tests/pos/ReflectMutual.hs
+++ b/tests/pos/ReflectMutual.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--exactdc" @-}
-
 module ReflectMutual where
 
 data Foo = Foo {getFoo :: Int}

--- a/tests/pos/Rest.hs
+++ b/tests/pos/Rest.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--ple" @-}
 
 module Rest where

--- a/tests/pos/T1024.hs
+++ b/tests/pos/T1024.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--exactdc"     @-}
-{-@ LIQUID "--higherorder" @-}
+{-@ LIQUID "--reflection" @-}
 
 module T1024 where
 

--- a/tests/pos/T1025a.hs
+++ b/tests/pos/T1025a.hs
@@ -1,6 +1,5 @@
-{-@ LIQUID "--exactdc"     @-}                                                            
-{-@ LIQUID "--higherorder" @-}                                                            
-
+{-@ LIQUID "--reflection" @-}
+                                                          
 module T1025a where
                                                                                           
 import Language.Haskell.Liquid.ProofCombinators                                           

--- a/tests/pos/T1060.hs
+++ b/tests/pos/T1060.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--ple" @-}
 

--- a/tests/pos/T1085.hs
+++ b/tests/pos/T1085.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--exact-data-cons"   @-}
-
 module T1085 where
 
 {-@ data HEither a b = HLeft a | HRight b @-}

--- a/tests/pos/T1092.hs
+++ b/tests/pos/T1092.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--higherorder"        @-}
-{-@ LIQUID "--exactdc"            @-}
+{-@ LIQUID "--reflection" @-}
 module T1092 where
 
 import Language.Haskell.Liquid.ProofCombinators

--- a/tests/pos/T1100.hs
+++ b/tests/pos/T1100.hs
@@ -2,7 +2,6 @@
 
 module T1100 where
 
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--no-termination"                      @-}
 

--- a/tests/pos/T1220.hs
+++ b/tests/pos/T1220.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--exactdc" @-}
-
 module T1220 where
 
 {-@ unsafe :: {t : AB | not (isA t)} -> {t /= A}  @-}

--- a/tests/pos/T1223.hs
+++ b/tests/pos/T1223.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--exactdc" @-}
-{-@ LIQUID "--higherorder" @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--ple-local" @-}
 {-@ infix   ++ @-}
 

--- a/tests/pos/T1267.hs
+++ b/tests/pos/T1267.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--max-case-expand=0" @-}
-{-@ LIQUID "--exactdc" @-}
 
 module T1267 where
 

--- a/tests/pos/T1278_2.hs
+++ b/tests/pos/T1278_2.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--exact-data-cons" @-}
-
 module T1278_2 where
 
 {-@ data List [sz] @-}

--- a/tests/pos/T1302.hs
+++ b/tests/pos/T1302.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE EmptyDataDecls, GADTs, ExistentialQuantification #-}
 
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
 
 module T1302 where

--- a/tests/pos/T1363.hs
+++ b/tests/pos/T1363.hs
@@ -2,8 +2,6 @@
 
 module T1363 where
 
-{-@ LIQUID "--exact-data-cons" @-}
-
 {-@ mySum :: Integer -> xs:[Integer] -> Integer / [len xs] @-}
 mySum :: Integer -> [Integer] -> Integer
 mySum z []     = z

--- a/tests/pos/T1874.hs
+++ b/tests/pos/T1874.hs
@@ -1,6 +1,5 @@
 module T1874 where
 
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--reflection"      @-}
 {-@ LIQUID "--ple"             @-}
 

--- a/tests/pos/T820.hs
+++ b/tests/pos/T820.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--exactdc"      @-}
-{-@ LIQUID "--higherorder"  @-}
+{-@ LIQUID "--reflection" @-}
 
 module T820 where
 

--- a/tests/pos/WhyLH.hs
+++ b/tests/pos/WhyLH.hs
@@ -1,7 +1,6 @@
 module WhyLH where
 
 {-@ LIQUID "--ple" @-}
-{-@ LIQUID "--exact-data-cons" @-}
 
 -- This test contains the examples of the blogpost at
 -- https://www.tweag.io/blog/2022-01-19-why-liquid-haskell/

--- a/tests/pos/WrapUnWrap.hs
+++ b/tests/pos/WrapUnWrap.hs
@@ -1,5 +1,5 @@
-{-@ LIQUID "--higherorder"  @-}
-{-@ LIQUID "--exactdc"      @-}
+{-@ LIQUID "--reflection" @-}
+
 module WrapUnWrap where
 
 

--- a/tests/strings/pos/DivideAndQunquer.hs
+++ b/tests/strings/pos/DivideAndQunquer.hs
@@ -1,6 +1,5 @@
-{-@ LIQUID "--higherorder"         @-}
 {-@ LIQUID "--totality"            @-}
-{-@ LIQUID "--exactdc"             @-}
+{-@ LIQUID "--reflection" @-}
 
 
 module DivideAndQunquer where 

--- a/tests/strings/pos/StringIndexing.hs
+++ b/tests/strings/pos/StringIndexing.hs
@@ -7,9 +7,8 @@
 
 
 {-@ LIQUID "--cores=10"            @-}
-{-@ LIQUID "--higherorder"         @-}
 {-@ LIQUID "--totality"            @-}
-{-@ LIQUID "--exactdc"             @-}
+{-@ LIQUID "--reflection" @-}
 
 module Main where
 

--- a/tests/strings/pos/StringIndexingStep3.hs
+++ b/tests/strings/pos/StringIndexingStep3.hs
@@ -15,9 +15,8 @@ NV TODO
 {-# LANGUAGE GADTs               #-}
 
 
-{-@ LIQUID "--higherorder"         @-}
 {-@ LIQUID "--totality"            @-}
-{-@ LIQUID "--exactdc"             @-}
+{-@ LIQUID "--reflection" @-}
 
 module Main where
 

--- a/tests/strings/pos/StringLib.hs
+++ b/tests/strings/pos/StringLib.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 
-{-@ LIQUID "--higherorder"         @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--totality"            @-}
-{-@ LIQUID "--exactdc"             @-}
 
 module StringLib where
 

--- a/tests/strings/todo/Boyer_Moore.hs
+++ b/tests/strings/todo/Boyer_Moore.hs
@@ -1,6 +1,5 @@
-{-@ LIQUID "--higherorder"       @-}
 {-@ LIQUID "--totality"          @-}
-{-@ LIQUID "--exactdc"           @-}
+{-@ LIQUID "--reflection" @-}
 
 module BoyerMoore where
 

--- a/tests/terminate/neg/T1404_3.hs
+++ b/tests/terminate/neg/T1404_3.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--expect-any-error" @-}
-{-@ LIQUID "--exactdc" @-}
 module T1404_3 where
 
 data Peano = Z | S Peano

--- a/tests/terminate/pos/Ackermann.hs
+++ b/tests/terminate/pos/Ackermann.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exactdc" @-}
 module Ackermann where
 
 data Peano = Z | S Peano

--- a/tests/todo/AALib.hs
+++ b/tests/todo/AALib.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--exactdc" @-}
-
 module AALib where 
 
 data Foo a b = Foo {fooA :: a, fooB :: b}  |  Bar

--- a/tests/todo/Adt0.hs
+++ b/tests/todo/Adt0.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--totality"                            @-}
 {-@ LIQUID "--ple" @-}

--- a/tests/todo/ApplicativeMaybe0.hs
+++ b/tests/todo/ApplicativeMaybe0.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--higherorder"     @-}
 {- LIQUID "--totality"        @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--ple" @-}
 {-@ LIQUID "--fuel=10" @-}
 

--- a/tests/todo/ApplicativeMaybe1.hs
+++ b/tests/todo/ApplicativeMaybe1.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--higherorder"     @-}
 {- LIQUID "--totality"        @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--ple" @-}
 {-@ LIQUID "--fuel=10" @-}
 

--- a/tests/todo/ExactGADT3.hs
+++ b/tests/todo/ExactGADT3.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
-
 {-# LANGUAGE  GADTs #-}
 
 module Query where

--- a/tests/todo/ExactGADT6.hs
+++ b/tests/todo/ExactGADT6.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
-
 {-# LANGUAGE  GADTs #-}
 
 module Query where

--- a/tests/todo/MaybeReflect0Lib.hs
+++ b/tests/todo/MaybeReflect0Lib.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--higherorder"     @-}
 {-@ LIQUID "--totality"        @-}
-{-@ LIQUID "--exact-data-cons" @-}
 
 
 {-# LANGUAGE IncoherentInstances   #-}

--- a/tests/todo/MaybeReflect1Lib.hs
+++ b/tests/todo/MaybeReflect1Lib.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--higherorder"     @-}
 {-@ LIQUID "--totality"        @-}
-{-@ LIQUID "--exact-data-cons" @-}
 
 
 {-# LANGUAGE IncoherentInstances   #-}

--- a/tests/todo/MeasureImport.hs
+++ b/tests/todo/MeasureImport.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--exactdc" @-}
-
 import AALib
 
 {-@ lazy bar @-}

--- a/tests/todo/ReflImp.hs
+++ b/tests/todo/ReflImp.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--higherorder"     @-}
 {-@ LIQUID "--totality"        @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--higherorderqs"   @-}
 
 module Peano where

--- a/tests/todo/SearchTree.hs
+++ b/tests/todo/SearchTree.hs
@@ -2,7 +2,6 @@
 -- This file takes nearly a MINUTE when automatic-instances is off,
 -- and FOREVER when automatic-instances is on.
 
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--totality"                            @-}
 

--- a/tests/todo/T1037A.hs
+++ b/tests/todo/T1037A.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--higherorder"        @-}
-{-@ LIQUID "--exactdc"            @-}
+{-@ LIQUID "--reflection" @-}
 
 module T1037A where
 

--- a/tests/todo/T1037B.hs
+++ b/tests/todo/T1037B.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--higherorder"        @-}
-{-@ LIQUID "--exactdc"            @-}
+{-@ LIQUID "--reflection" @-}
 
 module T1037B where
 

--- a/tests/todo/T1089.hs
+++ b/tests/todo/T1089.hs
@@ -1,5 +1,4 @@
 
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--no-termination"                      @-}
 {-@ LIQUID "--ple" @-}

--- a/tests/todo/T1094_Lib.hs
+++ b/tests/todo/T1094_Lib.hs
@@ -1,5 +1,4 @@
-{-@ LIQUID "--higherorder" @-}
-{-@ LIQUID "--exactdc"     @-}
+{-@ LIQUID "--reflection" @-}
 
 module T1094_Lib where
 

--- a/tests/todo/T1189.hs
+++ b/tests/todo/T1189.hs
@@ -2,7 +2,6 @@
 
 {-# LANGUAGE GADTs #-}
 
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
 {-@ LIQUID "--ple"            @-}
 

--- a/tests/todo/T1278.1.hs
+++ b/tests/todo/T1278.1.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-cons" @-}
 module Term where
 
 {-@ data Tree [sz] @-}

--- a/tests/todo/T995.hs
+++ b/tests/todo/T995.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--ple" @-}
 
 module Basics

--- a/tests/todo/T996.hs
+++ b/tests/todo/T996.hs
@@ -1,5 +1,3 @@
-{-@ LIQUID "--exact-data-con"                      @-}
-
 module Induction where
 
 import qualified Prelude

--- a/tests/todo/T997.hs
+++ b/tests/todo/T997.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--totality"                            @-}
 {-@ LIQUID "--ple" @-}

--- a/tests/todo/T997a.hs
+++ b/tests/todo/T997a.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--totality"                            @-}
 {-@ LIQUID "--ple" @-}

--- a/tests/todo/TypeError.hs
+++ b/tests/todo/TypeError.hs
@@ -4,7 +4,6 @@
 
 {-@ LIQUID "--autoproofs"      @-}
 {-@ LIQUID "--totality"        @-}
-{-@ LIQUID "--exact-data-cons" @-}
 module Append where
 
 import AxiomatizeLib

--- a/tests/todo/mapreduce.hs
+++ b/tests/todo/mapreduce.hs
@@ -1,6 +1,5 @@
-{-@ LIQUID "--higherorder"         @-}
+{-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--totality"            @-}
-{-@ LIQUID "--exactdc"             @-}
 {-@ LIQUID "--no-measure-fields"   @-}
 
 

--- a/typeclass-tests/Data/List/Functor.hs
+++ b/typeclass-tests/Data/List/Functor.hs
@@ -1,7 +1,6 @@
 {-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--ple" @-}
 {-@ LIQUID "--aux-inline" @-}
-{-@ LIQUID "--exactdc" @-}
 
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}


### PR DESCRIPTION
This can create errors when fancy types are defined (e.g., the worker and wrapper constructor do not match) in which case LH suggests using the `no-exact-data-con` flag.