### PR TITLE
Remove alternative fix to hlint dependencies

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -10,9 +10,6 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:    
-    - name: fix ncurses version
-      run: sudo apt-get install libncurses5
-      
     - uses: actions/checkout@v3
       with:
         submodules: true


### PR DESCRIPTION
Installing libncurses5 also gets hlint succeeding.

LF and LH now pin the version of ubuntu though, and this requires a bit less trouble in CI to get a usable environment.