### PR TITLE
Double import

### DIFF
--- a/include/GHC/Num.spec
+++ b/include/GHC/Num.spec
@@ -1,8 +1,8 @@
 module spec GHC.Num where
 
-embed GHC.Integer.Type.Integer as int 
+// embed GHC.Integer.Type.Integer as int 
 
-GHC.Num.fromInteger :: (GHC.Num.Num a) => x:GHC.Integer.Type.Integer -> {v:a | v = x }
+GHC.Num.fromInteger :: (GHC.Num.Num a) => x:_ -> {v:a | v = x }
 
 GHC.Num.negate :: (GHC.Num.Num a)
                => x:a

--- a/src/Language/Haskell/Liquid/Bare/DataType.hs
+++ b/src/Language/Haskell/Liquid/Bare/DataType.hs
@@ -359,10 +359,11 @@ meetDataConSpec :: Bool -> F.TCEmb Ghc.TyCon -> [(Ghc.Var, SpecType)] -> [DataCo
 --------------------------------------------------------------------------------
 meetDataConSpec allowTC emb xts dcs  = M.toList $ snd <$> L.foldl' upd dcm0 xts
   where
-    dcm0                     = M.fromList (dataConSpec' allowTC dcs)
+    dcm0                     = M.fromListWith meetM (dataConSpec' allowTC dcs)
     upd dcm (x, t)           = M.insert x (Ghc.getSrcSpan x, tx') dcm
                                 where
                                   tx' = maybe t (meetX x t) (M.lookup x dcm)
+    meetM (l,t) (_,t')       = (l, t `F.meet` t')
     meetX x t (sp', t')      = F.notracepp (_msg x t t') $ meetVarTypes emb (pprint x) (Ghc.getSrcSpan x, t) (sp', t')
     _msg x t t'              = "MEET-VAR-TYPES: " ++ showpp (x, t, t')
 

--- a/tests/import/client/C.hs
+++ b/tests/import/client/C.hs
@@ -1,0 +1,9 @@
+{-@ LIQUID "--reflection" @-}
+
+module C where 
+import Language
+import B
+
+{-@ getVal :: {e:Expr l st r | isEFalse e } -> {v:Int | false} @-}
+getVal :: Expr l st r -> Int
+getVal (EFalse v) = v 

--- a/tests/import/lib/B.hs
+++ b/tests/import/lib/B.hs
@@ -1,0 +1,8 @@
+{-@ LIQUID "--reflection" @-}
+module B  where 
+import Language
+
+{-@ reflect subst @-}
+subst :: Expr l st r -> Expr l st r 
+subst EUnit  = EUnit
+subst e  = e 

--- a/tests/import/lib/Language.hs
+++ b/tests/import/lib/Language.hs
@@ -1,0 +1,10 @@
+module Language where
+
+data Expr l st r = EUnit | EFalse Int 
+{-@ data Expr l st r = EUnit | EFalse { elb1 :: {xxx:Int | false}}  @-}
+
+
+{-@ measure isEFalse @-}
+isEFalse :: Expr l st r -> Bool 
+isEFalse (EFalse _ ) = True 
+isEFalse _ = False 

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2224,6 +2224,9 @@ executable import-cli
                     , T1738Lib
                     , WrapLib
                     , WrapLibCode
+                    , Language 
+                    , B
+                    , C
 
     ghc-options:      -fplugin=LiquidHaskell
                       -fkeep-going


### PR DESCRIPTION
This fixes a name resolution/import bug. 
Assume three modules `A`, `B`, and `C`. `A` defines a refined data type that is imported by both `B` and `C`. When `C` also imports `B` the refinements of the data type are lost (but only when the name of `A` is greater than the name of `B`....). 

The edit in `Num.spec` is irrelevant, but it was required to make the executable work (which is strange before it worked before Xmas). 

