### PR TITLE
Fix some broken external links as well in the docs

### DIFF
--- a/docs/mkDocs/docs/blogposts/2013-01-01-refinement-types-101.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2013-01-01-refinement-types-101.lhs.md
@@ -239,7 +239,7 @@ deducing that `n` is trivially non-negative when `0 < n` and that in
 the `otherwise` case, i.e. when `not (0 < n)` the value `0 - n` is
 indeed non-negative (lets not worry about underflows for the moment.)
 LiquidHaskell is able to automatically make these arithmetic deductions
-by using an [SMT solver](http://rise4fun.com/Z3/) which has decision
+by using an [SMT solver](https://github.com/Z3Prover/z3) which has decision
 built-in procedures for arithmetic, to reason about the logical
 refinements.
 
@@ -310,8 +310,8 @@ Modular Verification
 --------------------
 
 Incidentally, note the `import` statement at the top. Rather than rolling
-our own `lAssert` we can import and use a pre-defined version `liquidAssert` 
-defined in an external [module](https://github.com/ucsd-progsys/liquidhaskell/blob/master/include/Language/Haskell/Liquid/Prelude.hs)
+our own `lAssert` we can import and use a pre-defined version `liquidAssert`
+defined in an external [module](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/liquid-prelude/src/Language/Haskell/Liquid/Prelude.hs)
 
 
 <pre><span class=hs-linenum>286: </span><span class='hs-keyword'>{-@</span> <span class='hs-varid'>truncate''</span> <span class='hs-keyglyph'>::</span> <span class='hs-conid'>Int</span> <span class='hs-keyglyph'>-&gt;</span> <span class='hs-conid'>Int</span> <span class='hs-keyglyph'>-&gt;</span> <span class='hs-conid'>Int</span> <span class='hs-keyword'>@-}</span>

--- a/docs/mkDocs/docs/blogposts/2013-01-31-safely-catching-a-list-by-its-tail.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2013-01-31-safely-catching-a-list-by-its-tail.lhs.md
@@ -44,7 +44,7 @@ That is, measures will appear in specifications but *never* inside code.
 
 
 
- Let's reuse this mechanism, this time, providing a [definition](https://github.com/ucsd-progsys/liquidhaskell/blob/master/include/GHC/Base.spec) for the measure
+ Let's reuse this mechanism, this time, providing a [definition](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/liquid-base/src/GHC/Base.spec) for the measure
 <pre><span class=hs-linenum>48: </span><span class='hs-definition'>measure</span> <span class='hs-varid'>len</span> <span class='hs-keyglyph'>::</span> <span class='hs-keyword'>forall</span> <span class='hs-varid'>a</span><span class='hs-varop'>.</span> <span class='hs-keyglyph'>[</span><span class='hs-varid'>a</span><span class='hs-keyglyph'>]</span> <span class='hs-keyglyph'>-&gt;</span> <span class='hs-conid'>GHC</span><span class='hs-varop'>.</span><span class='hs-conid'>Types</span><span class='hs-varop'>.</span><span class='hs-conid'>Int</span>
 <span class=hs-linenum>49: </span><span class='hs-definition'>len</span> <span class='hs-layout'>(</span><span class='hs-conid'>[]</span><span class='hs-layout'>)</span>     <span class='hs-keyglyph'>=</span> <span class='hs-num'>0</span>
 <span class=hs-linenum>50: </span><span class='hs-definition'>len</span> <span class='hs-layout'>(</span><span class='hs-varid'>y</span><span class='hs-conop'>:</span><span class='hs-varid'>ys</span><span class='hs-layout'>)</span>   <span class='hs-keyglyph'>=</span> <span class='hs-num'>1</span> <span class='hs-varop'>+</span> <span class='hs-layout'>(</span><span class='hs-varid'>len</span> <span class='hs-varid'>ys</span><span class='hs-layout'>)</span> 

--- a/docs/mkDocs/docs/blogposts/2020-08-20-lh-as-a-ghc-plugin.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2020-08-20-lh-as-a-ghc-plugin.lhs.md
@@ -110,9 +110,9 @@ run LH on the changed modules! If you use `stack` you may have to specify
 a few more dependencies, as the various packages are not (yet) on stackage, 
 as shown in the [demo `stack.yaml`](https://github.com/ucsd-progsys/lh-plugin-demo/blob/main/stack.yaml).
 No extra dependencies are needede if you use `cabal-v2`. In both cases,
-you can use the respective files [`stack.yaml`](https://github.com/ucsd-progsys/lh-plugin-demo/blob/main/stack.yaml.github) 
-and [`cabal.project`](https://github.com/ucsd-progsys/lh-plugin-demo/blob/main/cabal.project.github) 
-point to specific git snapshots if you want to use the most recent versions. 
+you can use the respective files [`stack.yaml`](https://github.com/ucsd-progsys/lh-plugin-demo/blob/main/stack.yaml)
+and [`cabal.project`](https://github.com/ucsd-progsys/lh-plugin-demo/blob/main/cabal.project)
+point to specific git snapshots if you want to use the most recent versions.
 If you clone the repo and run, e.g. `cabal v2-build` or `stack build` you'll get the following result, after the relevant dependencies 
 are downloaded and built of course...
 

--- a/docs/mkDocs/docs/install.md
+++ b/docs/mkDocs/docs/install.md
@@ -7,7 +7,7 @@ This sections documents how to install LH and its dependencies.
 In order to use LiquidHaskell, you will need a [SMT solver](https://en.wikipedia.org/wiki/Satisfiability_modulo_theories)
 installed on your system. Download and install at least one of:
 
-* [Z3](https://github.com/Z3Prover/z3) or [Microsoft official binary](https://www.microsoft.com/en-us/download/details.aspx?id=52270)
+* [Z3](https://github.com/Z3Prover/z3) or [Microsoft official binary](https://github.com/Z3Prover/z3/releases)
 * [CVC4](https://cvc4.github.io/)
 * [MathSat](https://mathsat.fbk.eu/)
 

--- a/docs/mkDocs/docs/specifications.md
+++ b/docs/mkDocs/docs/specifications.md
@@ -50,7 +50,7 @@ refinements for external packages (cfr. **"Providing Specifications for Existing
 ## Modules WITH code: Data
 
 Write the specification directly into the .hs or .lhs file,
-above the data definition. See, for example, [tests/pos/Map.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/Map.hs):
+above the data definition. See, for example, [tests/pos/Map.hs](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/Map.hs):
 
 ```haskell
 {-@
@@ -67,7 +67,7 @@ data Map k a = Tip
 ```
 
 You can also write invariants for data type definitions
-together with the types. For example, see [tests/pos/record0.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/record0.hs):
+together with the types. For example, see [tests/pos/record0.hs](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/Record0.hs):
 
 ```haskell
 {-@ 
@@ -97,7 +97,7 @@ as  `data size (M1 a, M2 a) msize`.
 
 
 Finally you can specify the variance of type variables for data types.
-For example, see [tests/pos/Variance.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/Variance.hs), where data type `Foo` has four
+For example, see [tests/pos/Variance.hs](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/Variance.hs), where data type `Foo` has four
 type variables `a`, `b`, `c`, `d`, specified as invariant, bivariant,
 covariant and contravariant, respectively.
 
@@ -109,7 +109,7 @@ data Foo a b c d
 ## Modules WITH code: Functions
 
 Write the specification directly into the .hs or .lhs file,
-above the function definition. [For example](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/spec0.hs):
+above the function definition. [For example](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/Spec0.hs):
 
 ```haskell
 {-@ incr :: x:{v: Int | v > 0} -> {v: Int | v > x} @-}
@@ -119,7 +119,7 @@ incr x = x + 1
 
 ## Modules WITH code: Type Classes
 
-Write the specification directly into the .hs or .lhs file. The constrained variable must match the one from the class definition. A class must have at least one refinement signature (even if it's a trivial one) to be lifted to the refinement logic. [For example](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/Class.hs):
+Write the specification directly into the .hs or .lhs file. The constrained variable must match the one from the class definition. A class must have at least one refinement signature (even if it's a trivial one) to be lifted to the refinement logic. [For example](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/Class.hs):
 ```haskell
 class Semigroup a where
     {-@ mappend :: a -> a -> a @-}
@@ -151,7 +151,7 @@ The example above inlines the proofs directly into the instance definition. This
 ## Modules WITH code: Type Classes (Legacy)
 
 Write the specification directly into the .hs or .lhs file,
-above the type class definition. [For example](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/Class.hs):
+above the type class definition. [For example](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/Class.hs):
 
 ```haskell
 {-@ class Sized s where
@@ -165,7 +165,7 @@ Any measures used in the refined class definition will need to be
 *generic* (see [Specifying Measures](#specifying-measures)).
 
 As an alternative, you can refine class instances.
-[For example](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/classes/pos/Inst00.hs):
+[For example](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/classes/pos/Inst00.hs):
 
 ```haskell
 instance Compare Int where
@@ -298,7 +298,7 @@ following examples for details:
 
 **Status:** `experimental`
 
-There is experimental support for implicit arguments, solved for with congruence closure. For example, consider [Implicit1.hs](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/Implicit1.hs):
+There is experimental support for implicit arguments, solved for with congruence closure. For example, consider [Implicit1.hs](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/implicit/pos/Implicit1.hs):
 
 ```haskell
 {-@ type IntN N = {v:Int | v = N} @-}
@@ -325,7 +325,7 @@ verbose. You can write predicate aliases like so:
 {-@ predicate Ge X Y = not (Lt X Y) @-}
 ```
 
-and then use the aliases inside refinements, [for example](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/pred.hs)
+and then use the aliases inside refinements, [for example](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/Pred.hs)
 
 ```haskell
 {-@ incr :: x:{v:Int | (Pos v)} -> { v:Int | ((Pos v) && (Ge v x))} @-}
@@ -333,7 +333,7 @@ incr :: Int -> Int
 incr x = x + 1
 ```
 
-See [Data.Map](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/benchmarks/esop2013-submission/Base.hs) for a more substantial
+See [Data.Map](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/benchmarks/esop2013-submission/Base.hs) for a more substantial
 and compelling example.
 
 **Syntax:** The key requirements for type aliases are:
@@ -388,13 +388,13 @@ and:
 
     {-@ assert insert :: (Ord a) => a -> SortedList a -> SortedList a @-}
 
-see [tests/pos/ListSort.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/ListSort.hs)
+see [tests/pos/ListSort.hs](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/ListSort.hs)
 
 and:
 
     {-@ assert insert :: (Ord k) => k -> a -> OMap k a -> OMap k a @-}
 
-see [tests/pos/Map.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/Map.hs)
+see [tests/pos/Map.hs](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/Map.hs)
 
 **Syntax:** The key requirements for type aliases are:
 
@@ -410,7 +410,7 @@ For example, if `(+++)` is defined as a measure or reflected function, you can u
 
 Note: infix operators cannot contain the dot character `.`.
 
-If `(==>)` is a Haskell infix type ([see](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/T1567.hs)) 
+If `(==>)` is a Haskell infix type ([see](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/T1567.hs))
 
     infixr 1 ==> 
 
@@ -423,13 +423,13 @@ then to use it as infix in the refinements types you need to add the refinement 
 
 They can be placed in a `.spec` file or in a .hs/.lhs file wrapped around `{-@ @-}`.
 
-Value measures: [GHC/Base.spec](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/liquid-base/src/GHC/Base.spec)
+Value measures: [GHC/Base.spec](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/liquid-base/src/GHC/Base.spec)
 
     measure len :: forall a. [a] -> GHC.Types.Int
     len ([])     = 0
     len (y:ys)   = 1 + len(ys)
 
-Propositional measures: [tests/pos/LambdaEval.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/LambdaEval.hs)
+Propositional measures: [tests/pos/LambdaEval.hs](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/LambdaEval.hs)
 
 ```haskell
 {-@
@@ -445,7 +445,7 @@ isValue (Pair e1 e2) = ((? (isValue(e1))) && (? (isValue(e2))))
 @-}
 ```
 
-Raw measures: [tests/pos/meas8.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/meas8.hs)
+Raw measures: [tests/pos/meas8.hs](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/Meas8.hs)
 
 ```haskell
 {-@ measure rlen :: [a] -> Int
@@ -454,7 +454,7 @@ rlen (y:ys) = {v | v = (1 + rlen(ys))}
 @-}
 ```
 
-Generic measures: [tests/pos/Class.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/Class.hs)
+Generic measures: [tests/pos/Class.hs](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/Class.hs)
 
 ```haskell
 {-@ class measure size :: a -> Int @-}
@@ -470,9 +470,9 @@ Generic measures: [tests/pos/Class.hs](https://github.com/ucsd-progsys/liquidhas
 
 **Note:** Measure names **do not** have to be the same as
 field name, e.g. we could call the measure `sz` in the above
-as shown in [tests/pos/Class2.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/Class2.hs).
+as shown in [tests/pos/Class2.hs](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/Class2.hs).
 
-Haskell Functions as Measures (beta): [tests/pos/HaskellMeasure.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/HaskellMeasure.hs)
+Haskell Functions as Measures (beta): [tests/pos/HaskellMeasure.hs](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/HaskellMeasure.hs)
 
 Inductive Haskell Functions from Data Types to some type can be lifted to logic
 
@@ -535,7 +535,7 @@ states that the *inner* `a` enjoys the property that the *outer* container
 is definitely a `Just` and furthermore, the inner value is exactly the same
 as the `fromJust` property of the outer container.
 
-As another example, suppose we have a [measure](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/liquid-containers/src/Data/Set.spec):
+As another example, suppose we have a [measure](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/liquid-containers/src/Data/Set.spec):
 
     measure listElts :: [a] -> (Set a)
     listElts([])   = {v | (? Set_emp(v))}
@@ -550,16 +550,16 @@ set of the elements belonging to the entire list.
 
 One often needs these *circular* or *self* invariants to connect different
 levels (or rather, to *reify* the connections between the two levels.) See
-[this test](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/maybe4.hs) for a simple example and `hedgeUnion` and
-[Data.Map.Base](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/benchmarks/esop2013-submission/Base.hs) for a complex one.
+[this test](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/Maybe4.hs) for a simple example and `hedgeUnion` and
+[Data.Map.Base](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/benchmarks/esop2013-submission/Base.hs) for a complex one.
 
 
 # Abstract and Bounded Refinements
 
 This is probably the best example of the abstract refinement syntax:
 
-+ [Abstract Refinements](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/Map.hs)
-+ [Bounded Refinements](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/benchmarks/icfp15/pos/Overview.lhs)
++ [Abstract Refinements](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/Map.hs)
++ [Bounded Refinements](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/benchmarks/icfp15/pos/Overview.lhs)
 
 Unfortunately, the best documentation for these two advanced features
 is the relevant papers at:
@@ -587,7 +587,7 @@ Invariants
 
 LH lets you locally associate invariants with specific data types.
 
-For example, in [tests/measure/pos/Using00.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/measure/pos/Using00.hs) every
+For example, in [tests/measure/pos/Using00.hs](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/measure/pos/Using00.hs) every
 list is treated as a `Stream`. To establish this local invariant one can use the
 `using` declaration
 
@@ -600,9 +600,9 @@ calls* to List's constructors (ie., `:` and `[]`) satisfy it, and
 will assume that each list element that is created satisfies
 this invariant.
 
-With this, at the [above](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/measure/neg/Using00.hs) test LiquidHaskell
+With this, at the [above](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/measure/neg/Using00.hs) test LiquidHaskell
 proves that taking the `head` of a list is safe.
-But, at [tests/measure/neg/Using00.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/measure/neg/Using00.hs) the usage of
+But, at [tests/measure/neg/Using00.hs](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/measure/neg/Using00.hs) the usage of
 `[]` falsifies this local invariant resulting in an "Invariant Check" error.
 
 **WARNING:** There is an older _global_ invariant mechanism that
@@ -653,7 +653,7 @@ You can also annotate a function as being a global rewrite rule by using the
 ## Limitations
 
 Currently, rewriting does not work if the equality that uses the rewrite rule
-includes parameters that contain inner refinements ([test](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/errors/ReWrite5.hs)).
+includes parameters that contain inner refinements ([test](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/errors/ReWrite5.hs)).
 
 Rewriting works by pattern-matching expressions to determine if there is a
 variable substitution that would allow it to match against either side of a
@@ -662,7 +662,7 @@ corresponding equality is generated. If one side of the equality contains any
 parameters that are not bound on the other side, it will not be possible to
 generate a rewrite in that direction, because those variables cannot be
 instantiated. Likewise, if there are free variables on both sides of an
-equality, no rewrite can be generated at all ([test](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/errors/ReWrite7.hs)).
+equality, no rewrite can be generated at all ([test](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/errors/ReWrite7.hs)).
 
 It's possible in theory for rewriting rules to diverge. We have a simple check 
 to ensure that rewriting rules that will always diverge do not get instantiated. 
@@ -715,7 +715,7 @@ There are several ways to specify qualifiers.
 
 ## By Separate `.hquals` Files
 
-You can write qualifier files e.g. [Prelude.hquals](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/include/Prelude.hquals)..
+You can write qualifier files e.g. [Prelude.hquals](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/include/Prelude.hquals)..
 
 If a module is called or imports
 
@@ -731,13 +731,13 @@ Additional qualifiers may be used by adding lines of the form:
 
     {-@ include <path/to/file.hquals> @-}
 
-to the Haskell source. See, [this](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/meas5.hs) for example.
+to the Haskell source. See, [this](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/Meas5.hs) for example.
 
 
 ## In Haskell Source or Spec Files
 
 Finally, you can specifiers directly inside source (.hs or .lhs) or spec (.spec)
-files by writing as shown [here](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/qualTest.hs)
+files by writing as shown [here](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/QualTest.hs)
 
     {-@ qualif Foo(v:Int, a: Int) : (v = a + 100)   @-}
 
@@ -870,7 +870,7 @@ isOdd  n = not $ isEven n
 thus recovering a decreasing measure for the pair of functions, the
 pair of arguments. This can be encoded with the lexicographic
 termination annotation as shown above.
-See [tests/pos/mutrec.hs](https://github.com/ucsd-progsys/liquidhaskell/tree/develop/tests/pos/mutrec.hs) 
+See [tests/pos/mutrec.hs](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/Mutrec.hs)
 for the full example.
 
 ## Automatic Termination Metrics


### PR DESCRIPTION
I couldn't figure out where 'Prelude.hquals' is now:

```
liquidhaskell/docs/mkDocs/docs/specifications.md:
[✖] https://github.com/ucsd-progsys/liquidhaskell/blob/develop/include/Prelude.hquals
```