### PR TITLE
Remove shadowing 7

### DIFF
--- a/src/Language/Haskell/Liquid/Types/Visitors.hs
+++ b/src/Language/Haskell/Liquid/Types/Visitors.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleInstances         #-}
 {-# LANGUAGE FlexibleContexts          #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
 
 module Language.Haskell.Liquid.Types.Visitors (
 
@@ -160,7 +159,7 @@ data CoreVisitor env acc = CoreVisitor
   }
 
 coreVisitor :: CoreVisitor env acc -> env -> acc -> [CoreBind] -> acc
-coreVisitor vis env acc cbs   = snd (foldl' step (env, acc) cbs)
+coreVisitor vis cenv cacc cbs = snd (foldl' step (cenv, cacc) cbs)
   where
     stepXE (env, acc) (x,e)   = (env', stepE env' acc'   e)
       where

--- a/src/Language/Haskell/Liquid/UX/ACSS.hs
+++ b/src/Language/Haskell/Liquid/UX/ACSS.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -Wno-name-shadowing -Wno-incomplete-uni-patterns #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 -- | Formats Haskell source code as HTML with CSS and Mouseover Type Annotations
 module Language.Haskell.Liquid.UX.ACSS (
@@ -97,11 +97,11 @@ annotTokenise baseLoc tx (src, annm) = zipWith (\(x,y) z -> (x,y,z)) toks annots
     linWidth   = length $ show $ length $ lines src
 
 spanAnnot :: Int -> AnnMap -> Loc -> Annotation
-spanAnnot w (Ann ts es _ _) span = A t e b
+spanAnnot w (Ann ts es _ _) loc = A t e b
   where
-    t = fmap snd (M.lookup span ts)
-    e = "ERROR" <$ find (span `inRange`) [(x,y) | (x,y,_) <- es]
-    b = spanLine w span
+    t = fmap snd (M.lookup loc ts)
+    e = "ERROR" <$ find (loc `inRange`) [(x,y) | (x,y,_) <- es]
+    b = spanLine w loc
 
 spanLine :: t -> Loc -> Maybe (Int, t)
 spanLine w (L (l, c))
@@ -114,7 +114,7 @@ inRange (L (l0, c0)) (L (l, c), L (l', c'))
 
 tokeniseWithCommentTransform :: Maybe (String -> [(TokenType, String)]) -> String -> [(TokenType, String)]
 tokeniseWithCommentTransform Nothing  = tokenise
-tokeniseWithCommentTransform (Just f) = concatMap (expand f) . tokenise
+tokeniseWithCommentTransform (Just g) = concatMap (expand g) . tokenise
   where expand f (Comment, s) = f s
         expand _ z            = [z]
 
@@ -261,7 +261,7 @@ data Lit = Code {unL :: String} | Lit {unL :: String} deriving (Show)
 -- Also, importantly, accepts non-standard DOS and Mac line ending characters.
 -- And retains the trailing '\n' character in each resultant string.
 inlines :: String -> [String]
-inlines s = lines' s id
+inlines str = lines' str id
   where
   lines' []             acc = [acc []]
   lines' ('\^M':'\n':s) acc = acc ['\n'] : lines' s id  -- DOS
@@ -296,4 +296,4 @@ joinL :: [Lit] -> [Lit]
 joinL []                  = []
 joinL (Code c:Code c2:xs) = joinL (Code (c++c2):xs)
 joinL (Lit c :Lit c2 :xs) = joinL (Lit  (c++c2):xs)
-joinL (any:xs)            = any: joinL xs
+joinL (lit:xs)            = lit: joinL xs

--- a/src/Language/Haskell/Liquid/UX/Annotate.hs
+++ b/src/Language/Haskell/Liquid/UX/Annotate.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE FlexibleInstances          #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
 
 ---------------------------------------------------------------------------
 -- | This module contains the code that uses the inferred types to generate
@@ -427,7 +426,7 @@ instance ToJSON Loc where
                              , "column"   .= toJSON c ]
 
 instance ToJSON AnnErrors where
-  toJSON (AnnErrors errs) = Array $ V.fromList (toJ <$> errs)
+  toJSON (AnnErrors errors) = Array $ V.fromList (toJ <$> errors)
     where
       toJ (l,l',s)        = object [ "start"   .= toJSON l
                                    , "stop"    .= toJSON l'
@@ -445,9 +444,9 @@ dropErrorLoc msg
     (_, msg') = break (' ' ==) msg
 
 instance (Show k, ToJSON a) => ToJSON (Assoc k a) where
-  toJSON (Asc kas) = object [ tshow k .= toJSON a | (k, a) <- M.toList kas ]
+  toJSON (Asc kas) = object [ tshow' k .= toJSON a | (k, a) <- M.toList kas ]
     where
-      tshow        = fromString . show
+      tshow'       = fromString . show
 
 instance ToJSON ACSS.AnnMap where
   toJSON a = object [ "types"   .= toJSON (annTypes     a)
@@ -466,11 +465,11 @@ annErrors :: ACSS.AnnMap -> AnnErrors
 annErrors = AnnErrors . ACSS.errors
 
 annTypes         :: ACSS.AnnMap -> AnnTypes
-annTypes a       = grp [(l, c, ann1 l c x s) | (l, c, x, s) <- binders]
+annTypes a       = grp [(l, c, ann1 l c x s) | (l, c, x, s) <- binders']
   where
     ann1 l c x s = A1 x s l c
     grp          = L.foldl' (\m (r,c,x) -> ins r c x m) (Asc M.empty)
-    binders      = [(l, c, x, s) | (L (l, c), (x, s)) <- M.toList $ ACSS.types a]
+    binders'     = [(l, c, x, s) | (L (l, c), (x, s)) <- M.toList $ ACSS.types a]
 
 ins :: (Eq k, Eq k1, Hashable k, Hashable k1)
     => k -> k1 -> a -> Assoc k (Assoc k1 a) -> Assoc k (Assoc k1 a)
@@ -499,25 +498,29 @@ tokeniseWithLoc = ACSS.tokeniseWithLoc (Just tokAnnot)
 --------------------------------------------------------------------------------
 
 _anns :: AnnTypes
-_anns = i [(5,   i [( 14, A1 { ident = "foo"
-                             , ann   = "int -> int"
-                             , row   = 5
-                             , col   = 14
-                             })
-                  ]
-          )
-         ,(9,   i [( 22, A1 { ident = "map"
-                            , ann   = "(a -> b) -> [a] -> [b]"
-                            , row   = 9
-                            , col   = 22
-                            })
-                  ,( 28, A1 { ident = "xs"
-                            , ann   = "[b]"
-                            , row   = 9
-                            , col   = 28
-                            })
-                  ])
-         ]
+_anns =
+  mkAssoc
+    [ (5, mkAssoc
+            [ ( 14, A1 { ident = "foo"
+                       , ann   = "int -> int"
+                       , row   = 5
+                       , col   = 14
+                       })
+            ]
+      )
+    , (9, mkAssoc
+            [ ( 22, A1 { ident = "map"
+                       , ann   = "(a -> b) -> [a] -> [b]"
+                       , row   = 9
+                       , col   = 22
+                       })
+            , ( 28, A1 { ident = "xs"
+                       , ann   = "[b]"
+                       , row   = 9
+                       , col   = 28
+                       })
+            ])
+    ]
 
-i :: (Eq k, Hashable k) => [(k, a)] -> Assoc k a
-i = Asc . M.fromList
+mkAssoc :: (Eq k, Hashable k) => [(k, a)] -> Assoc k a
+mkAssoc = Asc . M.fromList

--- a/src/Language/Haskell/Liquid/UX/DiffCheck.hs
+++ b/src/Language/Haskell/Liquid/UX/DiffCheck.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE TupleSections     #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 module Language.Haskell.Liquid.UX.DiffCheck (

--- a/src/Language/Haskell/Liquid/UX/Errors.hs
+++ b/src/Language/Haskell/Liquid/UX/Errors.hs
@@ -3,8 +3,6 @@
 {-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE BangPatterns      #-}
 
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
-
 -- | This module contains the functions related to @Error@ type,
 -- in particular, to @tidyError@ using a solution, and @pprint@ errors.
 

--- a/src/Language/Haskell/Liquid/UX/QuasiQuoter.hs
+++ b/src/Language/Haskell/Liquid/UX/QuasiQuoter.hs
@@ -4,8 +4,6 @@
 {-# LANGUAGE TupleSections         #-}
 {-# LANGUAGE OverloadedStrings     #-}
 
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
-
 module Language.Haskell.Liquid.UX.QuasiQuoter
 -- (
 --     -- * LiquidHaskell Specification QuasiQuoter
@@ -62,14 +60,14 @@ lqDec src = do
       prg <- pragAnnD ModuleAnnotation $
                conE 'LiquidQuote `appE` dataToExpQ' spec
       case mkSpecDecs spec of
-        Left err ->
-          throwErrorInQ err
+        Left uerr ->
+          throwErrorInQ uerr
         Right decs ->
           return $ prg : decs
 
 throwErrorInQ :: UserError -> Q a
-throwErrorInQ err =
-  fail . showpp =<< runIO (errorsWithContext [err])
+throwErrorInQ uerr =
+  fail . showpp =<< runIO (errorsWithContext [uerr])
 
 --------------------------------------------------------------------------------
 -- Liquid Haskell to Template Haskell ------------------------------------------
@@ -154,10 +152,10 @@ simplifyBareType'' (tvs, cls) (RFun _ _ i o _)
 simplifyBareType'' (tvs, cls) (RAllT tv t _) =
   simplifyBareType'' (ty_var_value tv : tvs, cls) t
 
-simplifyBareType'' (tvs, cls) t =
+simplifyBareType'' (tvs, cls) bt =
   ForallT ((\t -> PlainTV (symbolName t) SpecifiedSpec) <$> reverse tvs)
     <$> mapM simplifyBareType' (reverse cls)
-    <*> simplifyBareType' t
+    <*> simplifyBareType' bt
 
 
 data Simpl a = Simplified a


### PR DESCRIPTION
Resolves https://github.com/ucsd-progsys/liquidhaskell/issues/1962.

After this, all shadowing has been removed from `liquidhaskell`! Note there is a natural follow-up for `liquid-fixpoint`, mentioned in [this issue](https://github.com/ucsd-progsys/liquid-fixpoint/issues/538#issuecomment-1146863689).