### PR TITLE
Add upper bound on ansi-wl-pprint for stitch-lh

### DIFF
--- a/tests/benchmarks/stitch-lh/stitch-lh.cabal
+++ b/tests/benchmarks/stitch-lh/stitch-lh.cabal
@@ -24,7 +24,7 @@ source-repository this
   tag:      v1.0
 
 library
-  build-depends:      ansi-wl-pprint >= 0.6.7.1
+  build-depends:      ansi-wl-pprint >= 0.6.7.1 && < 1.0.0
                     , mtl >= 2.2.1
                     , transformers >= 0.4.0.0
                     , parsec >= 3.1
@@ -86,7 +86,7 @@ test-suite tests
                     , containers
                     , stitch-lh
                     , template-haskell
-                    , ansi-wl-pprint >= 0.6.7.1
+                    , ansi-wl-pprint >= 0.6.7.1 && < 1.0.0
                     , mtl >= 2.2.1
                     , transformers >= 0.4.0.0
                     , parsec >= 3.1

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -53,7 +53,7 @@ executable benchmark-stitch-lh
     main-is:          Main.hs
     if !flag(benchmark-stitch-lh) && flag(stack)
       buildable:      False
-    build-depends:    ansi-wl-pprint >= 0.6.7.1
+    build-depends:    ansi-wl-pprint >= 0.6.7.1 && < 1.0.0
                     , mtl >= 2.2.1
                     , transformers >= 0.4.0.0
                     , parsec >= 3.1


### PR DESCRIPTION
@facundominguez It seems that version 1.0.2 of `ansi-wl-pprint` released on 2023-05-18 now breaks `stitch-lh`, a benchmark in our test suite. I propose adding this upper bound as a temporary workaround, but I think we should eventually switch to `prettyprinter` as the deprecation warning suggests.