### PR TITLE
Stop parsing arguments using the thread-unsafe withArgs

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -28,6 +28,9 @@ allow-newer: ghc-timings:base, rest-rewrite:time
 package liquid-fixpoint
   flags: +devel
 
+package liquidhaskell
+  ghc-options: -j
+
 package liquidhaskell-boot
   ghc-options: -j
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -632,22 +632,21 @@ withPragmas cfg fp ps action
        res <- action cfg'
        liftIO $ setVerbosity (loggingVerbosity cfg) -- restore the original verbosity.
        pure res
-  where
-    processPragmas :: Config -> [Located String] -> IO Config
-    processPragmas c pragmas =
-      withArgs (val <$> pragmas) $
-        cmdArgsRun config { modeValue = (modeValue config) { cmdArgsValue = c } }
+
+processPragmas :: Config -> [Located String] -> IO Config
+processPragmas c pragmas =
+    processValueIO
+      config { modeValue = (modeValue config) { cmdArgsValue = c } }
+      (val <$> pragmas)
+    >>=
+      cmdArgsApply
 
 -- | Note that this function doesn't process list arguments properly, like
 -- 'cFiles' or 'expectErrorContaining'
 -- TODO: This is only used to parse the contents of the env var LIQUIDHASKELL_OPTS
 -- so it should be able to parse multiple arguments instead. See issue #1990.
-withPragma :: Config -> Located String -> IO Config
-withPragma c s = withArgs [val s] $ cmdArgsRun
-                   config { modeValue = (modeValue config) { cmdArgsValue = c } }
-
 parsePragma :: Located String -> IO Config
-parsePragma = withPragma defConfig
+parsePragma = processPragmas defConfig . (:[])
 
 defConfig :: Config
 defConfig = Config

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,6 +9,7 @@ extra-package-dbs: []
 ghc-options:
   hscolour: -w
   liquidhaskell-boot: -j
+  liquidhaskell: -j
 packages:
 - liquid-fixpoint
 - liquid-prelude

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -755,7 +755,6 @@ executable parser-pos
                     , TokensAsPrefixes
                     , Tuples
 
-                    -- XXX(matt.walker): Double frees with -j
     ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
@@ -1339,7 +1338,6 @@ executable unit-neg
                     -- , QQTySyn2
                     -- , Variance1
 
-                    -- XXX(matt.walker): double frees on -j
     ghc-options:      -fplugin=LiquidHaskell -ddump-to-file -fkeep-going -O0
     build-depends:    base
                     , liquid-prelude
@@ -1693,7 +1691,6 @@ executable unit-pos-1
 
     -- LANGUAGE extensions used by modules in this package.
     -- other-extensions:
-    -- XXX(matt.walker): Double frees on -j
     ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
@@ -2339,7 +2336,6 @@ executable ple-pos
     --   other-modules:  T1302b
 
 
-    -- XXX(matt.walker): RANDOM FAILURES in T1302b when -j provided
     ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file


### PR DESCRIPTION
Fixes #1978

This doesn't work well when arguments are parsed in a GHC plugin and GHC is trying to compile multiple modules concurrently with -j

Tested that similar errors were gone in tests with this fix, but didn't enabled parallelism for them in GHC because CI already has enough parallelism.