### PR TITLE
Allow to run LiquidHaskell even with -haddock enabled

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -118,27 +118,10 @@ plugin = GHC.defaultPlugin {
       if skipModule cfg then return gblEnv
       else liquidPluginGo summary gblEnv
 
-    -- Unfortunately, we can't make Haddock run the LH plugin, because the former
-    -- does mangle the '.hi' files, causing annotations to not be persisted in the
-    -- 'ExternalPackageState' and/or 'HomePackageTable'. For this reason we disable
-    -- the plugin altogether if the module is being compiled with Haddock.
-    -- See also: https://github.com/ucsd-progsys/liquidhaskell/issues/1727
-    -- for a post-mortem.
     liquidPluginGo summary gblEnv = do
       logger <- getLogger
       dynFlags <- getDynFlags
       withTiming logger dynFlags (text "LiquidHaskell" <+> brackets (ppr $ ms_mod_name summary)) (const ()) $ do
-        if gopt Opt_Haddock dynFlags
-          then do
-            -- Warn the user
-            let msg     = PJ.vcat [ PJ.text "LH can't be run with Haddock."
-                                  , PJ.nest 4 $ PJ.text "Documentation will still be created."
-                                  ]
-            let srcLoc  = mkSrcLoc (mkFastString $ ms_hspp_file summary) 1 1
-            let warning = mkWarning (mkSrcSpan srcLoc srcLoc) msg
-            liftIO $ printWarning logger dynFlags warning
-            pure gblEnv
-          else do
             newGblEnv <- typecheckHook summary gblEnv
             case newGblEnv of
               -- Exit with success if all expected errors were found


### PR DESCRIPTION
Verification with haddock was disabled in #1786, but currently no test seems to fail if haddock is enabled.