### PR TITLE
Remove optics dependency

### DIFF
--- a/liquidhaskell-boot/liquidhaskell-boot.cabal
+++ b/liquidhaskell-boot/liquidhaskell-boot.cabal
@@ -145,7 +145,6 @@ library
                     , hscolour             >= 1.22
                     , liquid-fixpoint      == 0.9.0.2.1
                     , mtl                  >= 2.1
-                    , optics               >= 0.2
                     , optparse-applicative < 0.18
                     , githash
                     , megaparsec           >= 8

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/Interface.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/Interface.hs
@@ -89,8 +89,6 @@ import Language.Haskell.Liquid.Types hiding (Spec)
 import Language.Haskell.Liquid.UX.QuasiQuoter
 import Language.Haskell.Liquid.UX.Tidy
 
-import Optics hiding (ix)
-
 import qualified Debug.Trace as Debug
 
 
@@ -398,13 +396,13 @@ instance PPrint TargetInfo where
       -- , "*************** Includes ********************"
       -- , intersperse comma $ text <$> includes info
       "*************** Imported Variables **********"
-    , pprDoc $ _giImpVars (review targetSrcIso $ giSrc info)
+    , pprDoc $ _giImpVars (fromTargetSrc $ giSrc info)
     , "*************** Defined Variables ***********"
-    , pprDoc $ _giDefVars (review targetSrcIso $ giSrc info)
+    , pprDoc $ _giDefVars (fromTargetSrc $ giSrc info)
     , "*************** Specification ***************"
     , pprintTidy k $ giSpec info
     , "*************** Core Bindings ***************"
-    , pprintCBs $ _giCbs (review targetSrcIso $ giSrc info) ]
+    , pprintCBs $ _giCbs (fromTargetSrc $ giSrc info) ]
 
 pprintCBs :: [CoreBind] -> Doc
 pprintCBs = pprDoc . tidyCBs

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/SpecFinder.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/SpecFinder.hs
@@ -19,7 +19,6 @@ import qualified Language.Haskell.Liquid.Misc            as Misc
 import           Language.Haskell.Liquid.Parse            ( specSpecificationP )
 import           Language.Fixpoint.Utils.Files            ( Ext(Spec), withExt )
 
-import           Optics
 import qualified Liquid.GHC.API         as O
 import           Liquid.GHC.API         as GHC
 
@@ -142,7 +141,7 @@ lookupCompanionSpec hscEnv thisModule = do
              O.<+> O.text (errorBundlePretty peb)
       lift $ Util.pluginAbort (O.showSDoc (hsc_dflags hscEnv) errMsg)
     Right (_, spec) -> do
-      let bareSpec = view bareSpecIso spec
+      let bareSpec = toBareSpec spec
       pure $ SpecFound thisModule DiskLocation bareSpec
   where
     specFile :: FilePath -> FilePath


### PR DESCRIPTION
I saw the recent [call to arms](https://discourse.haskell.org/t/call-for-sponsors-first-class-liquid-haskell/6973) (great initiative!) and thought I'd try looking at some of the unnecessary dependencies.

The suggested candidate `optics` is easy to remove and results in a modestly lighter dependency footprint:

<details>
<summary>Click for plan diff</summary>

```diff
diff --git a/plan.json b/plan.json
index c86804268..345493033 100644
--- a/plan.json
+++ b/plan.json
@@ -2937,28 +2937,6 @@
       "exe-depends": [],
       "component-name": "lib"
     },
-    {
-      "type": "configured",
-      "id": "indexed-profunctors-0.1.1.1-12d143d1847bf8e2a7d7f3d64bcab7028038184caca314178a1cdd8464bbb2b9",
-      "pkg-name": "indexed-profunctors",
-      "pkg-version": "0.1.1.1",
-      "flags": {},
-      "style": "global",
-      "pkg-src": {
-        "type": "repo-tar",
-        "repo": {
-          "type": "secure-repo",
-          "uri": "http://hackage.haskell.org/"
-        }
-      },
-      "pkg-cabal-sha256": "c9beac8df06dda097d9dc7a8d60f9e5fb6ecaf56c40938bb30b132ee09f15c87",
-      "pkg-src-sha256": "2e69bb2900bb7e562efffff7bcf3f72daf79f013232ce603263a57595412c398",
-      "depends": [
-        "base-4.16.4.0"
-      ],
-      "exe-depends": [],
-      "component-name": "lib"
-    },
     {
       "type": "configured",
       "id": "indexed-traversable-0.1.2.1-b366289abc688ef5e286207b81f695a4606c204c6bb975c9ed94db302ae66623",
@@ -3752,7 +3730,6 @@
         "liquid-fixpoint-0.9.0.2.1-inplace",
         "megaparsec-9.4.1-a1e915ea89fc8ed2a97ded561267c5dcc8a3758ceddf7c394adc90b5ca4ad84a",
         "mtl-2.2.2",
-        "optics-0.4.2.1-492bdbe68d3e1e5223dd67c030e289c1b3728766f2b83c2da106d783585abd26",
         "optparse-applicative-0.17.1.0-18efb26668ea61c9d4954021423b1e4bd5d970ce27cb2a7aa4e3af7030fdbd9f",
         "pretty-1.1.3.6",
         "recursion-schemes-5.2.2.4-2192d6c4f98175fc1fc668df59eb0da8ba81895af47e28e66c822e83335f40cd",
@@ -4135,126 +4112,6 @@
       "component-name": "exe:operational-TicTacToe",
       "bin-file": "/home/tommy/.cabal/store/ghc-9.2.5/operational-0.2.4.2-e-operational-TicTacToe-0a4a98ba1d15b6af08d2d8a10c681042216fbc245f3611a949e423a8db69211e/bin/operational-TicTacToe"
     },
-    {
-      "type": "configured",
-      "id": "optics-0.4.2.1-492bdbe68d3e1e5223dd67c030e289c1b3728766f2b83c2da106d783585abd26",
-      "pkg-name": "optics",
-      "pkg-version": "0.4.2.1",
-      "flags": {},
-      "style": "global",
-      "pkg-src": {
-        "type": "repo-tar",
-        "repo": {
-          "type": "secure-repo",
-          "uri": "http://hackage.haskell.org/"
-        }
-      },
-      "pkg-cabal-sha256": "04875ac4aebeb36ccd7ce486353a6c0310a013d5a22f4209c41521ee2f258bff",
-      "pkg-src-sha256": "e653d86aba75454fac21ab2f4220e895ad7f6e06889bc08d3f6522de4f7c5f6b",
-      "depends": [
-        "array-0.5.4.0",
-        "base-4.16.4.0",
-        "containers-0.6.5.1",
-        "mtl-2.2.2",
-        "optics-core-0.4.1.1-f74e574430eb34233f9ef3b69b9a668711e57a0680f3202c24a23040589c58f2",
-        "optics-extra-0.4.2.1-c4cf580b67f3daf2fbfc1684f408e43ce3d2d9d352cc7512ee89f19255035ec1",
-        "optics-th-0.4.1-0b776f87913ed0398610cf3d9b560d05637964e04b82a2daa0a400187b067436",
-        "transformers-0.5.6.2"
-      ],
-      "exe-depends": [],
-      "component-name": "lib"
-    },
-    {
-      "type": "configured",
-      "id": "optics-core-0.4.1.1-f74e574430eb34233f9ef3b69b9a668711e57a0680f3202c24a23040589c58f2",
-      "pkg-name": "optics-core",
-      "pkg-version": "0.4.1.1",
-      "flags": {
-        "explicit-generic-labels": false
-      },
-      "style": "global",
-      "pkg-src": {
-        "type": "repo-tar",
-        "repo": {
-          "type": "secure-repo",
-          "uri": "http://hackage.haskell.org/"
-        }
-      },
-      "pkg-cabal-sha256": "45b92b72475c266134bfbdfcb4801df3a6487453e8a6c389623b7161661f8bfa",
-      "pkg-src-sha256": "3e817e3c66a0120ac4b4b6d790e659b75f8c0fb27c5f65f3974f4c697b7bb3fb",
-      "depends": [
-        "array-0.5.4.0",
-        "base-4.16.4.0",
-        "containers-0.6.5.1",
-        "indexed-profunctors-0.1.1.1-12d143d1847bf8e2a7d7f3d64bcab7028038184caca314178a1cdd8464bbb2b9",
-        "indexed-traversable-0.1.2.1-b366289abc688ef5e286207b81f695a4606c204c6bb975c9ed94db302ae66623",
-        "transformers-0.5.6.2"
-      ],
-      "exe-depends": [],
-      "component-name": "lib"
-    },
-    {
-      "type": "configured",
-      "id": "optics-extra-0.4.2.1-c4cf580b67f3daf2fbfc1684f408e43ce3d2d9d352cc7512ee89f19255035ec1",
-      "pkg-name": "optics-extra",
-      "pkg-version": "0.4.2.1",
-      "flags": {},
-      "style": "global",
-      "pkg-src": {
-        "type": "repo-tar",
-        "repo": {
-          "type": "secure-repo",
-          "uri": "http://hackage.haskell.org/"
-        }
-      },
-      "pkg-cabal-sha256": "d8221c4beebb8d4bdb4148a775fbf287368881e233228b04e0bcd6b3e60af92e",
-      "pkg-src-sha256": "7e23a7a325e3448354614d3d958279c9ac2fdd0831ceee2808830e7a962fca41",
-      "depends": [
-        "array-0.5.4.0",
-        "base-4.16.4.0",
-        "bytestring-0.11.3.1",
-        "containers-0.6.5.1",
-        "hashable-1.4.2.0-cd83efde5acf8903e5c98006b3dc0a9ad0c59df25dc4cfb7a8637e6a72487748",
-        "indexed-profunctors-0.1.1.1-12d143d1847bf8e2a7d7f3d64bcab7028038184caca314178a1cdd8464bbb2b9",
-        "indexed-traversable-instances-0.1.1.2-3a2b8a77a09416dfc37b6a8e231c2f06a82b33d39dfcb6ecdc557b0b4a44cfc5",
-        "mtl-2.2.2",
-        "optics-core-0.4.1.1-f74e574430eb34233f9ef3b69b9a668711e57a0680f3202c24a23040589c58f2",
-        "text-1.2.5.0",
-        "transformers-0.5.6.2",
-        "unordered-containers-0.2.19.1-e17e4eaa57041cf90fa7c8c76a10acb176295004933e8ee0b6f66d3f5c723587",
-        "vector-0.12.3.1-40e22cf970217521785a11b73a770a5d075c5e95d7391fe5859738b96e87ed28"
-      ],
-      "exe-depends": [],
-      "component-name": "lib"
-    },
-    {
-      "type": "configured",
-      "id": "optics-th-0.4.1-0b776f87913ed0398610cf3d9b560d05637964e04b82a2daa0a400187b067436",
-      "pkg-name": "optics-th",
-      "pkg-version": "0.4.1",
-      "flags": {},
-      "style": "global",
-      "pkg-src": {
-        "type": "repo-tar",
-        "repo": {
-          "type": "secure-repo",
-          "uri": "http://hackage.haskell.org/"
-        }
-      },
-      "pkg-cabal-sha256": "d3c9855366887e67f0abbfaba56a91e77a0865368cb72a16c6d3e2dca5533351",
-      "pkg-src-sha256": "d73857b79dcd8f7c7e70fa4727f134145b62902e8d3e448f8b25c38a9da4fd17",
-      "depends": [
-        "base-4.16.4.0",
-        "containers-0.6.5.1",
-        "mtl-2.2.2",
-        "optics-core-0.4.1.1-f74e574430eb34233f9ef3b69b9a668711e57a0680f3202c24a23040589c58f2",
-        "template-haskell-2.18.0.0",
-        "th-abstraction-0.4.5.0-51727d71c7b00afe1aadaa09d9b58e0713211fe9c8576b00be8753cb6095587d",
-        "transformers-0.5.6.2"
-      ],
-      "exe-depends": [],
-      "component-name": "lib"
-    },
     {
       "type": "configured",
       "id": "optparse-applicative-0.17.1.0-18efb26668ea61c9d4954021423b1e4bd5d970ce27cb2a7aa4e3af7030fdbd9f",
```

</details>

All of the changes were straightforward with the exception of [this](https://github.com/ucsd-progsys/liquidhaskell/pull/2194/files#diff-7f568476b383c6cd2b10ed1438602d515a1da133d2b280fd315735a8633acf2aL357):

```diff
diff --git a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
index d4378f7a5..08d6405d1 100644
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
@@ -354,8 +354,9 @@ makeClassAuxTypesOne elab (ldcp, inst, methods) =
-        tysubf x = F.notracepp ("cosub:" ++ F.showpp cosub) $ tysub ^. at x % non x
+        tysubf x = F.notracepp ("cosub:" ++ F.showpp cosub) $ M.lookupDefault x x tysub
```

We have

```haskell
tysub :: HashMap RTyVar RTyVar
tysubf :: RTyVar -> RTyVar
```

I _think_ this is equivalent to indexing `tysub` at `x` and, if the key does not exist, returning `x` itself. This seems to line up with a quick example that I just ran through:

```haskell
λ. xs = Map.fromList [(x, x*2) | x <- [1 .. 10]]
λ. xs
fromList [(1,2),(2,4),(3,6),(4,8),(5,10),(6,12),(7,14),(8,16),(9,18),(10,20)]

-- 0th index does not exist, hence default value
λ. (\i -> xs ^. (at i % non 100)) <$> [0 .. 10]
[100,2,4,6,8,10,12,14,16,18,20]
```

But someone more familiar with this [`at x % non y`](https://hackage.haskell.org/package/optics-core-0.4.1.1/docs/Optics-Iso.html#v:non) idiom should double-check.