### PR TITLE
Fix link from ICFP'15

### DIFF
--- a/benchmarks/icfp15/README.md
+++ b/benchmarks/icfp15/README.md
@@ -1,0 +1,4 @@
+# Examples from _Bounded Refinement Types_
+
+The source code of the examples from Vazou–Bakst–Jhala's ICFP'15 paper is now
+in [tests/benchmarks/icfp15](../../tests/benchmarks/icfp15).


### PR DESCRIPTION
Commit a826d42 moves `benchmarks/` to `tests/benchmarks/`. Unfortunately this has the unintended consequence of breaking "Reference 23" on p.12 of Vazou–Bakst–Jhala's ICFP'15 paper "Bounded Refinement Types": that reference is now a 404.

This is of course not to blame commit a826d42 itself, as the problem goes all the way back to Berners-Lee's original design assuming an immutable Web; in other words we shouldn't be prohibited from making any change whatsoever just because there might exist some random link from some random outside resource.

However, in *this* case, ICFP'15 is NOT "some random outside resource". And we can't fix it retroactively to reflect the post-a826d42 codebase. Therefore, it would seem like the only solution is to fix the codebase instead so that the link works again.