### PR TITLE
Strengthen the lookup of assumption identifiers

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -927,10 +927,7 @@ allAsmSigs env myName specs = do
     lookupImportedSymMaybe (mm, s) = do
       mts <- M.lookup s (Bare._reTyThings env)
       m <- mm
-      ty <- lookup m mts
-      case ty of
-        Ghc.AnId v -> Just v
-        _ -> Nothing
+      Mb.listToMaybe [ v | (k, Ghc.AnId v) <- mts, k == m ]
 
     isAbsoluteQualifiedSym (Just m) =
        not $ M.member m $ qiNames (Bare.reQualImps env)


### PR DESCRIPTION
The needed TyThing may not be the first found, and this causes LH to fail on some GHCs but not in others.