### PR TITLE
Isolate files describing the GHC API features in use

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,8 @@ commands:
       - run: git ls-tree HEAD liquid-fixpoint > liquid-fixpoint-commit
       - restore_cache:
           keys:
-            - cabal-cache-v3-{{ checksum "liquidhaskell.cabal" }}-{{ checksum "<< parameters.project_file >>" }}-{{ checksum "liquid-fixpoint-commit" }}
-            - cabal-cache-v3-{{ checksum "liquidhaskell.cabal" }}-{{ checksum "<< parameters.project_file >>" }}
+            - cabal-cache-v3-{{ checksum "liquidhaskell-boot/liquidhaskell-boot.cabal" }}-{{ checksum "liquidhaskell.cabal" }}-{{ checksum "<< parameters.project_file >>" }}-{{ checksum "liquid-fixpoint-commit" }}
+            - cabal-cache-v3-{{ checksum "liquidhaskell-boot/liquidhaskell-boot.cabal" }}-{{ checksum "liquidhaskell.cabal" }}-{{ checksum "<< parameters.project_file >>" }}
       - run:
           name: Dependencies
           command: |
@@ -65,9 +65,9 @@ commands:
             echo 'export PATH=~/.ghcup/bin:$PATH' >> $BASH_ENV
             << parameters.cabal_update_command >>
             cabal v2-clean
-            cabal v2-build --project-file << parameters.project_file >> --flag devel -j --enable-tests liquidhaskell-parser liquid-prelude liquid-parallel liquid-vector liquid-platform test-driver
+            cabal v2-build --project-file << parameters.project_file >> --flag devel -j --enable-tests liquidhaskell-boot liquid-prelude liquid-parallel liquid-vector liquid-platform test-driver
       - save_cache:
-          key: cabal-cache-v3-{{ checksum "liquidhaskell.cabal" }}-{{ checksum "<< parameters.project_file >>" }}-{{ checksum "liquid-fixpoint-commit" }}
+          key: cabal-cache-v3-{{ checksum "liquidhaskell-boot/liquidhaskell-boot.cabal" }}-{{ checksum "liquidhaskell.cabal" }}-{{ checksum "<< parameters.project_file >>" }}-{{ checksum "liquid-fixpoint-commit" }}
           paths:
             - ~/.cabal/store
             - ~/.ghcup
@@ -82,7 +82,7 @@ commands:
           command: |
             LIQUID_CABAL_PROJECT_FILE=<<parameters.project_file>> cabal v2-run --project-file << parameters.project_file >> test-driver || (<<parameters.allow_test_failures>>)
             cabal v2-test --project-file << parameters.project_file >> tests:tasty || (<<parameters.allow_test_failures>>)
-            (liquidhaskell_datadir=$PWD/liquidhaskell-boot cabal v2-test -j1 --project-file << parameters.project_file >> liquidhaskell-boot:liquidhaskell-parser --flag devel --test-show-details=streaming --test-options="--xml=/tmp/junit/cabal/parser-test-results.xml") || (<<parameters.allow_test_failures>>)
+            (cabal v2-test -j1 --project-file << parameters.project_file >> --enable-test liquidhaskell-boot --flag devel --test-show-details=streaming --test-options="--xml=/tmp/junit/cabal/parser-test-results.xml") || (<<parameters.allow_test_failures>>)
           no_output_timeout: 30m
 
       - run:
@@ -108,8 +108,8 @@ commands:
       - run: git ls-tree HEAD liquid-fixpoint > liquid-fixpoint-commit
       - restore_cache:
           keys:
-            - stack-cache-v1-{{ checksum "<< parameters.stack_yaml_file >>" }}-{{ checksum "liquidhaskell.cabal" }}-{{ checksum "liquid-fixpoint-commit" }}
-            - stack-cache-v1-{{ checksum "<< parameters.stack_yaml_file >>" }}-{{ checksum "liquidhaskell.cabal" }}
+            - stack-cache-v1-{{ checksum "<< parameters.stack_yaml_file >>" }}-{{ checksum "liquidhaskell-boot/liquidhaskell-boot.cabal" }}-{{ checksum "liquidhaskell.cabal" }}-{{ checksum "liquid-fixpoint-commit" }}
+            - stack-cache-v1-{{ checksum "<< parameters.stack_yaml_file >>" }}-{{ checksum "liquidhaskell-boot/liquidhaskell-boot.cabal" }}-{{ checksum "liquidhaskell.cabal" }}
             - stack-cache-v1-{{ checksum "<< parameters.stack_yaml_file >>" }}
       - run:
           name: Dependencies
@@ -118,7 +118,7 @@ commands:
             stack --no-terminal --stack-yaml << parameters.stack_yaml_file >> setup
             stack --no-terminal --stack-yaml << parameters.stack_yaml_file >> build -j4 --only-dependencies --test --no-run-tests << parameters.extra_build_flags >> 
       - save_cache:
-          key: stack-cache-v1-{{ checksum "<< parameters.stack_yaml_file >>" }}-{{ checksum "liquidhaskell.cabal" }}-{{ checksum "liquid-fixpoint-commit" }}
+          key: stack-cache-v1-{{ checksum "<< parameters.stack_yaml_file >>" }}-{{ checksum "liquidhaskell-boot/liquidhaskell-boot.cabal" }}-{{ checksum "liquidhaskell.cabal" }}-{{ checksum "liquid-fixpoint-commit" }}
           paths:
             - ~/.stack
             - ./.stack-work
@@ -129,7 +129,7 @@ commands:
             mkdir -p /tmp/junit/stack
             stack --no-terminal --stack-yaml << parameters.stack_yaml_file >> run test-driver
             stack --no-terminal --stack-yaml << parameters.stack_yaml_file >> test tests:tasty
-            stack --no-terminal --stack-yaml << parameters.stack_yaml_file >> test -j1 liquidhaskell-boot:liquidhaskell-parser << parameters.extra_build_flags >>
+            stack --no-terminal --stack-yaml << parameters.stack_yaml_file >> test -j1 liquidhaskell-boot << parameters.extra_build_flags >>
           no_output_timeout: 30m
       - run:
           name: Generate haddock

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,13 +1,12 @@
 # To be compatible with GHC naming turn off the camelCase rule.
-- ignore: {name: "Use camelCase", within: [Liquid.GHC.Misc]} # 4 hints
+- ignore: {name: "Use camelCase", within: [Language.Haskell.Liquid.GHC.Misc]} # 4 hints
 # Linting LANGUAGE pragmas with complex CPP ifdefs is too hard.
 - ignore: {
     name: "Unused LANGUAGE pragma",
     within: [
       Liquid.GHC.API,
-      Liquid.GHC.Interface,
-      Liquid.GHC.GhcMonadLike,
-      Liquid.GHC.Misc
+      Language.Haskell.Liquid.GHC.Interface,
+      Language.Haskell.Liquid.GHC.Misc
     ]
   }
 # The following are kept for usability and style sake

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ using**.
 [GHC.API]:             liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
 [Plugin]:              liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
 [GHC.Plugin]:          liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
-[GHC.Interface]:       liquidhaskell-boot/src-ghc/Liquid/GHC/Interface.hs
+[GHC.Interface]:       liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Interface.hs
 [SpecFinder]:          liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/SpecFinder.hs
 [BareSpec]:            liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs#L362
 [LiftedSpec]:          liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs#L559
@@ -366,7 +366,7 @@ using**.
 [ghcide]:              https://github.com/haskell/ghcide
 [findRelevantSpecs]:   liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/SpecFinder.hs#L65
 [core binds]:          https://hackage.haskell.org/package/ghc-9.2.5/docs/CoreSyn.html#t:CoreBind
-[configureGhcTargets]: liquidhaskell-boot/src-ghc/Liquid/GHC/Interface.hs#L254
-[processTargetModule]: liquidhaskell-boot/src-ghc/Liquid/GHC/Interface.hs#L483
+[configureGhcTargets]: liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Interface.hs#L254
+[processTargetModule]: liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Interface.hs#L483
 [processModule]:       liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs#L509
 

--- a/liquidhaskell-boot/liquidhaskell-boot.cabal
+++ b/liquidhaskell-boot/liquidhaskell-boot.cabal
@@ -65,14 +65,14 @@ library
                       Liquid.GHC.API
                       Liquid.GHC.API.Extra
                       Liquid.GHC.API.StableModule
-                      Liquid.GHC.Interface
-                      Liquid.GHC.Logging
-                      Liquid.GHC.Misc
-                      Liquid.GHC.Play
-                      Liquid.GHC.Resugar
-                      Liquid.GHC.SpanStack
-                      Liquid.GHC.Types
-                      Liquid.GHC.TypeRep
+                      Language.Haskell.Liquid.GHC.Interface
+                      Language.Haskell.Liquid.GHC.Logging
+                      Language.Haskell.Liquid.GHC.Misc
+                      Language.Haskell.Liquid.GHC.Play
+                      Language.Haskell.Liquid.GHC.Resugar
+                      Language.Haskell.Liquid.GHC.SpanStack
+                      Language.Haskell.Liquid.GHC.Types
+                      Language.Haskell.Liquid.GHC.TypeRep
                       Language.Haskell.Liquid.GHC.Plugin
                       Language.Haskell.Liquid.GHC.Plugin.Tutorial
                       Language.Haskell.Liquid.LawInstances

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -286,7 +286,7 @@ import GHC.Unit.Finder                as Ghc
     , findImportedModule
     )
 import GHC.Unit.Home.ModInfo          as Ghc
-    ( HomePackageTable, HomeModInfo(hm_iface) )
+    ( HomePackageTable, HomeModInfo(hm_iface), lookupHpt )
 import GHC.Unit.Module                as Ghc
     ( GenWithIsBoot(gwib_isBoot, gwib_mod)
     , IsBootInterface(NotBoot, IsBoot)

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -1,9 +1,14 @@
-{-| This module re-exports a bunch of the GHC API.
+{-| This module re-exports all identifiers that LH needs
+    from the GHC API.
 
-The intended use of this module is to shelter LiquidHaskell from changes to the GHC API, so this is the
-/only/ module LiquidHaskell should import when trying to access any ghc-specific functionality.
+The intended use of this module is to provide a quick look of what
+GHC API features LH depends upon.
 
---}
+The transitive dependencies of this module shouldn't contain modules
+from Language.Haskell.Liquid.* or other non-boot libraries. This makes
+it easy to discover breaking changes in the GHC API.
+
+-}
 
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE LambdaCase #-}

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -73,52 +73,220 @@ import GHC.Plugins                    as Ghc ( deserializeWithData
                                              )
 import GHC.Core.FVs                   as Ghc (exprFreeVarsList)
 import GHC.Core.Opt.OccurAnal         as Ghc
+    ( occurAnalysePgm )
 import GHC.Driver.Env                 as Ghc
+    ( HscEnv(hsc_EPS, hsc_HPT, hsc_dflags, hsc_plugins, hsc_static_plugins) )
 import GHC.Driver.Ppr                 as Ghc
+    ( showPpr
+    , showSDoc
+    , showSDocDump
+    )
 import GHC.HsToCore.Expr              as Ghc
+    ( dsLExpr )
 import GHC.Iface.Load                 as Ghc
+    ( cannotFindModule
+    , loadInterface
+    )
 import GHC.Rename.Expr                as Ghc (rnLExpr)
-import GHC.Runtime.Context            as Ghc
 import GHC.Tc.Gen.App                 as Ghc (tcInferSigma)
 import GHC.Tc.Gen.Bind                as Ghc (tcValBinds)
 import GHC.Tc.Gen.Expr                as Ghc (tcInferRho)
-import GHC.Tc.Instance.Family         as Ghc
 import GHC.Tc.Module                  as Ghc
+    ( getModuleInterface
+    , tcRnLookupRdrName
+    )
 import GHC.Tc.Solver                  as Ghc
+    ( InferMode(NoRestrictions)
+    , captureTopConstraints
+    , simplifyInfer
+    , simplifyInteractive
+    )
 import GHC.Tc.Types                   as Ghc
+    ( Env(env_top)
+    , TcGblEnv(tcg_anns, tcg_exports, tcg_insts, tcg_mod, tcg_rdr_env, tcg_rn_imports)
+    , TcM
+    , TcRn
+    , WhereFrom(ImportBySystem)
+    )
 import GHC.Tc.Types.Evidence          as Ghc
+    ( TcEvBinds(EvBinds) )
 import GHC.Tc.Types.Origin            as Ghc (lexprCtOrigin)
-import GHC.Tc.Utils.Monad             as Ghc hiding (getGHCiMonad)
+import GHC.Tc.Utils.Monad             as Ghc
+    ( captureConstraints
+    , discardConstraints
+    , getEnv
+    , failIfErrsM
+    , failM
+    , failWithTc
+    , initIfaceTcRn
+    , liftIO
+    , mkLongErrAt
+    , pushTcLevelM
+    , reportError
+    , reportErrors
+    )
 import GHC.Tc.Utils.TcType            as Ghc (tcSplitDFunTy, tcSplitMethodTy)
 import GHC.Tc.Utils.Zonk              as Ghc
+    ( zonkTopLExpr )
 import GHC.Types.Annotations          as Ghc
+    ( AnnPayload
+    , AnnTarget(ModuleTarget)
+    , Annotation(Annotation, ann_target, ann_value)
+    , findAnns
+    )
 import GHC.Types.Avail                as Ghc
+    ( AvailInfo(Avail, AvailTC)
+    , availNames
+    , greNameMangledName
+    )
 import GHC.Types.Basic                as Ghc
+    ( Arity
+    , Boxity(Boxed)
+    , PprPrec
+    , PromotionFlag(NotPromoted)
+    , TopLevelFlag(NotTopLevel)
+    , funPrec
+    , InlinePragma(inl_act, inl_inline, inl_rule, inl_sat, inl_src)
+    , isDeadOcc
+    , isStrongLoopBreaker
+    , noOccInfo
+    , topPrec
+    )
 import GHC.Types.CostCentre           as Ghc
+    ( CostCentre(cc_loc)
+    )
 import GHC.Types.Error                as Ghc
+    ( Messages
+    , DecoratedSDoc
+    , MsgEnvelope(errMsgSpan)
+    )
 import GHC.Types.Fixity               as Ghc
-import GHC.Types.Id                   as Ghc hiding (lazySetIdInfo, setIdExported, setIdNotExported)
+    ( Fixity(Fixity) )
+import GHC.Types.Id                   as Ghc
+    ( idDetails
+    , isDFunId
+    , idInfo
+    , idOccInfo
+    , isConLikeId
+    , modifyIdInfo
+    , mkExportedLocalId
+    , mkUserLocal
+    , realIdUnfolding
+    , setIdInfo
+    )
 import GHC.Types.Id.Info              as Ghc
+    ( CafInfo(NoCafRefs)
+    , IdDetails(DataConWorkId, DataConWrapId, RecSelId, VanillaId)
+    , IdInfo(occInfo, unfoldingInfo)
+    , cafInfo
+    , inlinePragInfo
+    , mayHaveCafRefs
+    , setCafInfo
+    , setOccInfo
+    , vanillaIdInfo
+    )
 import GHC.Types.Literal              as Ghc
-import GHC.Types.Name                 as Ghc hiding (varName, isWiredIn)
+    ( LitNumType(LitNumInt)
+    , Literal(LitChar, LitDouble, LitFloat, LitNumber, LitString)
+    , literalType
+    )
+import GHC.Types.Name                 as Ghc
+    ( OccName
+    , getOccString
+    , getSrcSpan
+    , isInternalName
+    , isSystemName
+    , mkInternalName
+    , mkSystemName
+    , mkTcOcc
+    , mkTyVarOcc
+    , mkVarOcc
+    , mkVarOccFS
+    , nameModule_maybe
+    , nameOccName
+    , nameSrcLoc
+    , nameStableString
+    , occNameFS
+    , occNameString
+    , stableNameCmp
+    )
 import GHC.Types.Name.Reader          as Ghc
-import GHC.Types.Name.Set             as Ghc
+    ( ImpDeclSpec(ImpDeclSpec, is_as, is_dloc, is_mod, is_qual)
+    , ImportSpec(ImpSpec)
+    , ImpItemSpec(ImpAll)
+    , getRdrName
+    , globalRdrEnvElts
+    , gresFromAvails
+    , greMangledName
+    , lookupGRE_RdrName
+    , mkGlobalRdrEnv
+    , mkQual
+    , mkVarUnqual
+    , mkUnqual
+    , nameRdrName
+    )
 import GHC.Types.SourceError          as Ghc
+    ( SourceError
+    , srcErrorMessages
+    )
 import GHC.Types.SourceText           as Ghc
+    ( SourceText(SourceText,NoSourceText)
+    , mkIntegralLit
+    , mkTHFractionalLit
+    )
 import GHC.Types.SrcLoc               as Ghc
+    ( SrcSpan(RealSrcSpan, UnhelpfulSpan)
+    , UnhelpfulSpanReason
+        ( UnhelpfulGenerated
+        , UnhelpfulInteractive
+        , UnhelpfulNoLocationInfo
+        , UnhelpfulOther
+        , UnhelpfulWiredIn
+        )
+    , combineSrcSpans
+    , mkGeneralSrcSpan
+    , mkRealSrcLoc
+    , mkRealSrcSpan
+    , realSrcSpanStart
+    , srcSpanFileName_maybe
+    , srcSpanToRealSrcSpan
+    )
 import GHC.Types.Tickish              as Ghc (CoreTickish, GenTickish(..))
-import GHC.Types.TypeEnv              as Ghc
 import GHC.Types.Unique               as Ghc
-import GHC.Types.Unique.DFM           as Ghc
-import GHC.Types.Unique.FM            as Ghc
+    ( getKey, mkUnique )
 import GHC.Types.Unique.Set           as Ghc (mkUniqSet)
 import GHC.Types.Unique.Supply        as Ghc
+    ( MonadUnique, getUniqueM )
 import GHC.Types.Var                  as Ghc
+    ( VarBndr(Bndr)
+    , mkLocalVar
+    , mkTyVar
+    , setVarName
+    , setVarType
+    , setVarUnique
+    , varName
+    , varUnique
+    )
 import GHC.Types.Var.Env              as Ghc
+    ( emptyInScopeSet, mkRnEnv2 )
 import GHC.Types.Var.Set              as Ghc
+    ( VarSet
+    , elemVarSet
+    , emptyVarSet
+    , extendVarSet
+    , extendVarSetList
+    , unitVarSet
+    )
 import GHC.Unit.External              as Ghc
+    ( ExternalPackageState (eps_ann_env)
+    )
 import GHC.Unit.Finder                as Ghc
+    ( FindResult(Found, NoPackage, FoundMultiple, NotFound)
+    , findExposedPackageModule
+    , findImportedModule
+    )
 import GHC.Unit.Home.ModInfo          as Ghc
+    ( HomePackageTable, HomeModInfo(hm_iface) )
 import GHC.Unit.Module                as Ghc
     ( GenWithIsBoot(gwib_isBoot, gwib_mod)
     , IsBootInterface(NotBoot, IsBoot)

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -16,10 +16,8 @@ The intended use of this module is to shelter LiquidHaskell from changes to the 
 
 module Liquid.GHC.API (
     module Ghc
-  , module StableModule
   ) where
 
-import           Liquid.GHC.API.StableModule      as StableModule
 import Liquid.GHC.API.Extra as Ghc
 
 import           GHC                                               as Ghc hiding ( Warning

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API/Extra.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API/Extra.hs
@@ -4,7 +4,8 @@
 {-# LANGUAGE RankNTypes #-}
 
 module Liquid.GHC.API.Extra (
-    ApiComment(..)
+    module StableModule
+  , ApiComment(..)
   , apiComments
   , dataConSig
   , desugarModuleIO

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/Types.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/Types.hs
@@ -3,8 +3,27 @@ module Liquid.GHC.Types where
 
 import           Data.HashSet (HashSet, fromList)
 import           Data.Hashable
-import           GHC.Generics hiding (moduleName)
+import           GHC.Generics (Generic)
 import           Liquid.GHC.API
+    ( AvailInfo
+    , ClsInst
+    , CoreProgram
+    , ModGuts(mg_binds, mg_exports, mg_module, mg_tcs)
+    , Module
+    , Name
+    , NameSet
+    , TyCon
+    , availNames
+    , moduleName
+    , moduleNameString
+    , nameModule
+    , nameOccName
+    , nameSetElemsStable
+    , nameSrcLoc
+    , nameSrcSpan
+    , nameStableString
+    , occNameString
+    )
 
 -- | A 'StableName' is virtually isomorphic to a GHC's 'Name' but crucially we don't use
 -- the 'Eq' instance defined on a 'Name' because it's 'Unique'-based. In particular, GHC

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/Types.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/Types.hs
@@ -11,14 +11,12 @@ import           Liquid.GHC.API
     , ModGuts(mg_binds, mg_exports, mg_module, mg_tcs)
     , Module
     , Name
-    , NameSet
     , TyCon
     , availNames
     , moduleName
     , moduleNameString
     , nameModule
     , nameOccName
-    , nameSetElemsStable
     , nameSrcLoc
     , nameSrcSpan
     , nameStableString
@@ -79,9 +77,6 @@ miModGuts cls mg  = MI
   , mgi_exports   = availsToStableNameSet $ mg_exports mg
   , mgi_cls_inst  = cls
   }
-
-nameSetToStableNameSet :: NameSet -> HashSet StableName
-nameSetToStableNameSet = fromList . map mkStableName . nameSetElemsStable
 
 mgiNamestring :: MGIModGuts -> String
 mgiNamestring = moduleNameString . moduleName . mgi_module

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -39,9 +39,9 @@ import           Language.Fixpoint.Misc                     as Misc
 import           Language.Fixpoint.Types                    hiding (dcFields, DataDecl, Error, panic)
 import qualified Language.Fixpoint.Types                    as F
 import qualified Language.Haskell.Liquid.Misc               as Misc -- (nubHashOn)
-import qualified Liquid.GHC.Misc           as GM
+import qualified Language.Haskell.Liquid.GHC.Misc           as GM
 import qualified Liquid.GHC.API            as Ghc
-import           Liquid.GHC.Types          (StableName)
+import           Language.Haskell.Liquid.GHC.Types          (StableName)
 import           Language.Haskell.Liquid.Types
 import           Language.Haskell.Liquid.WiredIn
 import qualified Language.Haskell.Liquid.Measure            as Ms

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -24,10 +24,10 @@ import           Language.Fixpoint.Misc
 import qualified Language.Haskell.Liquid.Measure as Ms
 import qualified Language.Fixpoint.Types as F
 import qualified Liquid.GHC.API as Ghc
-import qualified Liquid.GHC.Misc as GM
+import qualified Language.Haskell.Liquid.GHC.Misc as GM
 import           Language.Haskell.Liquid.Types.RefType
 import           Language.Haskell.Liquid.Transforms.CoreToLogic
-import           Liquid.GHC.Misc
+import           Language.Haskell.Liquid.GHC.Misc
 import           Language.Haskell.Liquid.Types
 
 import           Language.Haskell.Liquid.Bare.Resolve as Bare

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -32,8 +32,8 @@ import           Data.Hashable
 import qualified Language.Fixpoint.Misc                    as Misc
 import           Language.Fixpoint.SortCheck               (checkSorted, checkSortedReftFull, checkSortFull)
 import qualified Language.Fixpoint.Types                   as F
-import qualified Liquid.GHC.Misc          as GM
-import           Liquid.GHC.Play          (getNonPositivesTyCon)
+import qualified Language.Haskell.Liquid.GHC.Misc          as GM
+import           Language.Haskell.Liquid.GHC.Play          (getNonPositivesTyCon)
 import           Language.Haskell.Liquid.Misc              (condNull, thd5)
 import           Language.Haskell.Liquid.Types
 import           Language.Haskell.Liquid.WiredIn

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Class.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Class.hs
@@ -24,7 +24,7 @@ import qualified Language.Fixpoint.Types                    as F
 import qualified Language.Fixpoint.Types.Visitor            as F
 
 import           Language.Haskell.Liquid.Types.Dictionaries
-import qualified Liquid.GHC.Misc           as GM
+import qualified Language.Haskell.Liquid.GHC.Misc           as GM
 import qualified Liquid.GHC.API            as Ghc
 import           Language.Haskell.Liquid.Misc
 import           Language.Haskell.Liquid.Types.RefType

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/DataType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/DataType.hs
@@ -28,7 +28,7 @@ import qualified Data.HashSet                           as S
 import qualified Data.Maybe                             as Mb
 
 import qualified Language.Fixpoint.Types                as F
-import qualified Liquid.GHC.Misc       as GM
+import qualified Language.Haskell.Liquid.GHC.Misc       as GM
 import qualified Liquid.GHC.API        as Ghc
 import           Language.Haskell.Liquid.Types.PredType (dataConPSpecType)
 import qualified Language.Haskell.Liquid.Types.RefType  as RT

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Elaborate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Elaborate.hs
@@ -26,7 +26,7 @@ where
 import qualified Language.Fixpoint.Types       as F
 -- import           Control.Arrow
 import           Liquid.GHC.API hiding (panic, varName)
-import qualified Liquid.GHC.Misc
+import qualified Language.Haskell.Liquid.GHC.Misc
                                                as GM
 import           Language.Haskell.Liquid.Types.Types
 import           Language.Haskell.Liquid.Types.RefType

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Expand.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Expand.hs
@@ -40,7 +40,7 @@ import qualified Language.Fixpoint.Types               as F
 -- import qualified Language.Fixpoint.Types.Visitor       as F
 import qualified Language.Fixpoint.Misc                as Misc
 import           Language.Fixpoint.Types (Expr(..)) -- , Symbol, symbol)
-import qualified Liquid.GHC.Misc      as GM
+import qualified Language.Haskell.Liquid.GHC.Misc      as GM
 import qualified Liquid.GHC.API       as Ghc
 import qualified Language.Haskell.Liquid.Types.RefType as RT
 import           Language.Haskell.Liquid.Types         hiding (fresh)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Laws.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Laws.hs
@@ -7,7 +7,7 @@ import           Control.Monad ((<=<))
 
 import qualified Language.Haskell.Liquid.Measure            as Ms
 import qualified Language.Fixpoint.Types                    as F
-import qualified Liquid.GHC.Misc           as GM
+import qualified Language.Haskell.Liquid.GHC.Misc           as GM
 import           Language.Haskell.Liquid.Bare.Types         as Bare
 import           Language.Haskell.Liquid.Bare.Resolve       as Bare
 import           Language.Haskell.Liquid.Bare.Expand        as Bare

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -35,7 +35,7 @@ import qualified Language.Fixpoint.Misc                as Misc
 import qualified Language.Haskell.Liquid.Misc          as Misc
 import           Language.Haskell.Liquid.Misc             ((.||.))
 import qualified Liquid.GHC.API       as Ghc
-import qualified Liquid.GHC.Misc      as GM
+import qualified Language.Haskell.Liquid.GHC.Misc      as GM
 import qualified Language.Haskell.Liquid.Types.RefType as RT
 import           Language.Haskell.Liquid.Types
 -- import           Language.Haskell.Liquid.Types.Bounds

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Misc.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Misc.hs
@@ -24,7 +24,7 @@ import qualified Data.Maybe                            as Mb --(fromMaybe, isNot
 import qualified Text.PrettyPrint.HughesPJ             as PJ
 import qualified Data.List                             as L
 import qualified Language.Fixpoint.Types as F
-import           Liquid.GHC.Misc
+import           Language.Haskell.Liquid.GHC.Misc
 import           Language.Haskell.Liquid.Types.RefType
 import           Language.Haskell.Liquid.Types.Types
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Plugged.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Plugged.hs
@@ -21,9 +21,9 @@ import qualified Data.Maybe                        as Mb
 import qualified Data.List                         as L
 import qualified Language.Fixpoint.Types           as F
 import qualified Language.Fixpoint.Types.Visitor   as F
-import qualified Liquid.GHC.Misc  as GM
+import qualified Language.Haskell.Liquid.GHC.Misc  as GM
 import qualified Liquid.GHC.API   as Ghc
-import           Liquid.GHC.Types (StableName, mkStableName)
+import           Language.Haskell.Liquid.GHC.Types (StableName, mkStableName)
 import           Language.Haskell.Liquid.Types.RefType ()
 import           Language.Haskell.Liquid.Types
 import qualified Language.Haskell.Liquid.Misc       as Misc

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -67,7 +67,7 @@ import qualified Language.Fixpoint.Types               as F
 import qualified Language.Fixpoint.Types.Visitor       as F
 import qualified Language.Fixpoint.Misc                as Misc
 import qualified Liquid.GHC.API       as Ghc
-import qualified Liquid.GHC.Misc      as GM
+import qualified Language.Haskell.Liquid.GHC.Misc      as GM
 import qualified Language.Haskell.Liquid.Misc          as Misc
 import qualified Language.Haskell.Liquid.Types.RefType as RT
 import           Language.Haskell.Liquid.Types.Types

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/ToBare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/ToBare.hs
@@ -14,7 +14,7 @@ import           Data.Bifunctor
 
 import           Language.Fixpoint.Misc (mapSnd)
 import qualified Language.Fixpoint.Types as F
-import           Liquid.GHC.Misc
+import           Language.Haskell.Liquid.GHC.Misc
 import           Liquid.GHC.API
 import           Language.Haskell.Liquid.Types
 -- import           Language.Haskell.Liquid.Measure

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
@@ -22,7 +22,7 @@ import qualified Data.Maybe                    as Mb
 import qualified Language.Fixpoint.Types       as F
 import qualified Language.Fixpoint.Misc        as Misc
 import           Language.Haskell.Liquid.Bare.Elaborate
-import qualified Liquid.GHC.Misc
+import qualified Language.Haskell.Liquid.GHC.Misc
                                                as GM
 import qualified Liquid.GHC.API
                                                as Ghc

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Types.hs
@@ -37,7 +37,7 @@ import qualified Language.Haskell.Liquid.Types.RefType as RT
 import           Language.Haskell.Liquid.Types.Types
 import           Language.Haskell.Liquid.Types.Specs   hiding (BareSpec)
 import           Liquid.GHC.API       as Ghc hiding (Located, Env)
-import           Liquid.GHC.Types     (StableName)
+import           Language.Haskell.Liquid.GHC.Types     (StableName)
 
 
 type ModSpecs = M.HashMap ModName Ms.BareSpec

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Env.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Env.hs
@@ -68,7 +68,7 @@ import           Language.Fixpoint.SortCheck (pruneUnsortedReft)
 
 import           Liquid.GHC.API hiding (panic)
 import           Language.Haskell.Liquid.Types.RefType
-import qualified Liquid.GHC.SpanStack as Sp
+import qualified Language.Haskell.Liquid.GHC.SpanStack as Sp
 import           Language.Haskell.Liquid.Types            hiding (binds, Loc, loc, freeTyVars, Def)
 import           Language.Haskell.Liquid.Constraint.Types
 import           Language.Haskell.Liquid.Constraint.Fresh ()

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Fresh.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Fresh.hs
@@ -37,7 +37,7 @@ import           Language.Haskell.Liquid.Types
 -- import           Language.Haskell.Liquid.Types.RefType
 -- import           Language.Haskell.Liquid.Types.Fresh
 import           Language.Haskell.Liquid.Constraint.Types
-import qualified Liquid.GHC.Misc as GM
+import qualified Language.Haskell.Liquid.GHC.Misc as GM
 import           Liquid.GHC.API as Ghc
 
 --------------------------------------------------------------------------------

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -19,7 +19,6 @@ module Language.Haskell.Liquid.Constraint.Generate ( generateConstraints, genera
 import           Prelude                                       hiding (error)
 import           GHC.Stack ( CallStack )
 import           Liquid.GHC.API               as Ghc hiding ( panic
-                                                            , checkErr
                                                             , (<+>)
                                                             , text
                                                             , vcat

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -23,9 +23,9 @@ import           Liquid.GHC.API               as Ghc hiding ( panic
                                                             , text
                                                             , vcat
                                                             )
-import qualified Liquid.GHC.Resugar           as Rs
-import qualified Liquid.GHC.SpanStack         as Sp
-import qualified Liquid.GHC.Misc              as GM -- ( isInternal, collectArguments, tickSrcSpan, showPpr )
+import qualified Language.Haskell.Liquid.GHC.Resugar           as Rs
+import qualified Language.Haskell.Liquid.GHC.SpanStack         as Sp
+import qualified Language.Haskell.Liquid.GHC.Misc              as GM -- ( isInternal, collectArguments, tickSrcSpan, showPpr )
 import Text.PrettyPrint.HughesPJ ( text )
 import           Control.Monad.State
 import           Data.Maybe                                    (fromMaybe, isJust, mapMaybe)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Init.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Init.hs
@@ -27,8 +27,8 @@ import qualified Language.Haskell.Liquid.UX.CTags              as Tg
 import           Language.Haskell.Liquid.Constraint.Fresh
 import           Language.Haskell.Liquid.Constraint.Env
 import           Language.Haskell.Liquid.WiredIn               (dictionaryVar)
-import qualified Liquid.GHC.SpanStack         as Sp
-import           Liquid.GHC.Misc             ( idDataConM, hasBaseTypeVar, isDataConId) -- dropModuleNames, simplesymbol)
+import qualified Language.Haskell.Liquid.GHC.SpanStack         as Sp
+import           Language.Haskell.Liquid.GHC.Misc             ( idDataConM, hasBaseTypeVar, isDataConId) -- dropModuleNames, simplesymbol)
 import           Liquid.GHC.API               as Ghc
 import           Language.Haskell.Liquid.Misc
 import           Language.Fixpoint.Misc

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Init.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Init.hs
@@ -29,7 +29,7 @@ import           Language.Haskell.Liquid.Constraint.Env
 import           Language.Haskell.Liquid.WiredIn               (dictionaryVar)
 import qualified Liquid.GHC.SpanStack         as Sp
 import           Liquid.GHC.Misc             ( idDataConM, hasBaseTypeVar, isDataConId) -- dropModuleNames, simplesymbol)
-import           Liquid.GHC.API               as Ghc hiding (mapSndM)
+import           Liquid.GHC.API               as Ghc
 import           Language.Haskell.Liquid.Misc
 import           Language.Fixpoint.Misc
 import           Language.Haskell.Liquid.Constraint.Types

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Monad.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Monad.hs
@@ -15,7 +15,7 @@ import           Language.Haskell.Liquid.Types hiding (loc)
 import           Language.Haskell.Liquid.Constraint.Types
 import           Language.Haskell.Liquid.Constraint.Env
 import           Language.Fixpoint.Misc hiding (errorstar)
-import           Liquid.GHC.Misc -- (concatMapM)
+import           Language.Haskell.Liquid.GHC.Misc -- (concatMapM)
 import           Liquid.GHC.API as Ghc hiding (panic, showPpr)
 
 --------------------------------------------------------------------------------

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Qualifier.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Qualifier.hs
@@ -18,7 +18,7 @@ import           Language.Fixpoint.Types                  hiding (panic, mkQual)
 import qualified Language.Fixpoint.Types.Config as FC
 import           Language.Fixpoint.SortCheck
 import           Language.Haskell.Liquid.Types.RefType
-import           Liquid.GHC.Misc         (getSourcePos)
+import           Language.Haskell.Liquid.GHC.Misc         (getSourcePos)
 import           Language.Haskell.Liquid.Misc             (condNull)
 import           Language.Haskell.Liquid.Types.PredType
 import           Liquid.GHC.API hiding (Expr, mkQual, panic)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Relational.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Relational.hs
@@ -35,10 +35,10 @@ import           Liquid.GHC.API                 ( Alt
                                                 , TyVar
                                                 , Var(..))
 import qualified Liquid.GHC.API                as Ghc
-import qualified Liquid.GHC.Misc               as GM
-import           Liquid.GHC.Play               (Subable(sub, subTy))
-import qualified Liquid.GHC.SpanStack          as Sp
-import           Liquid.GHC.TypeRep            ()
+import qualified Language.Haskell.Liquid.GHC.Misc               as GM
+import           Language.Haskell.Liquid.GHC.Play               (Subable(sub, subTy))
+import qualified Language.Haskell.Liquid.GHC.SpanStack          as Sp
+import           Language.Haskell.Liquid.GHC.TypeRep            ()
 import           Language.Haskell.Liquid.Misc
 import           Language.Haskell.Liquid.Types                  hiding (Def,
                                                                  Loc, binds,

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Termination.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Termination.hs
@@ -26,7 +26,7 @@ import           GHC.Types.Var (Var)
 import           GHC.Types.Name (NamedThing, getSrcSpan)
 import           GHC.Core.TyCon (TyCon)
 import           GHC.Core (Bind, CoreExpr, bindersOf)
-import qualified Liquid.GHC.Misc                    as GM
+import qualified Language.Haskell.Liquid.GHC.Misc                    as GM
 import qualified Language.Fixpoint.Types            as F
 import           Language.Fixpoint.Types.PrettyPrint (PPrint)
 import           Language.Haskell.Liquid.Constraint.Types (CG, CGInfo (..), CGEnv, makeRecInvariants)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
@@ -26,7 +26,7 @@ import qualified Data.Maybe as Mb
 -- imports for AxiomEnv
 import qualified Language.Haskell.Liquid.UX.Config as Config
 import           Language.Haskell.Liquid.UX.DiffCheck (coreDefs, coreDeps, dependsOn, Def(..))
-import qualified Liquid.GHC.Misc  as GM -- (simplesymbol)
+import qualified Language.Haskell.Liquid.GHC.Misc  as GM -- (simplesymbol)
 import qualified Data.List                         as L
 import qualified Data.HashMap.Strict               as M
 import qualified Data.HashSet                      as S

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Types.hs
@@ -63,7 +63,7 @@ import           Control.DeepSeq
 import           Data.Maybe               (isJust, mapMaybe)
 import           Control.Monad.State
 
-import           Liquid.GHC.SpanStack
+import           Language.Haskell.Liquid.GHC.SpanStack
 import           Liquid.GHC.API    as Ghc hiding ( (<+>)
                                                                   , vcat
                                                                   , parens

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Interface.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Interface.hs
@@ -14,7 +14,7 @@
 {-# OPTIONS_GHC -Wwarn=deprecations #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
-module Liquid.GHC.Interface (
+module Language.Haskell.Liquid.GHC.Interface (
 
   -- * Printer
     pprintCBs
@@ -76,9 +76,9 @@ import Text.Megaparsec.Error
 import Text.PrettyPrint.HughesPJ        hiding (first, (<>))
 import Language.Fixpoint.Types          hiding (err, panic, Error, Result, Expr)
 import qualified Language.Fixpoint.Misc as Misc
-import Liquid.GHC.Misc
-import Liquid.GHC.Types (MGIModGuts(..))
-import Liquid.GHC.Play
+import Language.Haskell.Liquid.GHC.Misc
+import Language.Haskell.Liquid.GHC.Types (MGIModGuts(..))
+import Language.Haskell.Liquid.GHC.Play
 import Language.Haskell.Liquid.WiredIn (isDerivedInstance)
 import qualified Language.Haskell.Liquid.Measure  as Ms
 import qualified Language.Haskell.Liquid.Misc     as Misc

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Logging.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Logging.hs
@@ -9,7 +9,7 @@
      to pay the price of a pretty-printing \"roundtrip\".
 -}
 
-module Liquid.GHC.Logging (
+module Language.Haskell.Liquid.GHC.Logging (
     fromPJDoc
   , putWarnMsg
   , mkLongErrAt

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -18,7 +18,7 @@
 -- accessing GHC module information. It should NEVER depend on
 -- ANY module inside the Language.Haskell.Liquid.* tree.
 
-module Liquid.GHC.Misc where
+module  Language.Haskell.Liquid.GHC.Misc where
 
 import           Data.String
 import qualified Data.List as L

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Play.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Play.hs
@@ -3,7 +3,7 @@
 
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- TODO(#1918): Only needed for GHC <9.0.1.
 
-module Liquid.GHC.Play where
+module Language.Haskell.Liquid.GHC.Play where
 
 import Prelude hiding (error)
 
@@ -13,7 +13,7 @@ import qualified Data.List           as L
 import qualified Data.Maybe          as Mb
 
 import Liquid.GHC.API as Ghc hiding (substTysWith, panic,showPpr)
-import Liquid.GHC.Misc ()
+import Language.Haskell.Liquid.GHC.Misc ()
 import Language.Haskell.Liquid.Types.Errors
 import Language.Haskell.Liquid.Types.Variance
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -39,6 +39,7 @@ import           GHC.LanguageExtensions
 
 import           Control.Monad
 import qualified Control.Monad.Catch as Ex
+import           Control.Monad.IO.Class (MonadIO)
 
 import           Data.Coerce
 import           Data.Function                            ((&))

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -19,22 +19,22 @@ import qualified Liquid.GHC.API         as O
 import           Liquid.GHC.API         as GHC hiding (Target, Type)
 import qualified Text.PrettyPrint.HughesPJ               as PJ
 import qualified Language.Fixpoint.Types                 as F
-import qualified Liquid.GHC.Misc        as LH
+import qualified  Language.Haskell.Liquid.GHC.Misc        as LH
 import qualified Language.Haskell.Liquid.UX.CmdLine      as LH
-import qualified Liquid.GHC.Interface   as LH
+import qualified Language.Haskell.Liquid.GHC.Interface   as LH
 import qualified Language.Haskell.Liquid.Liquid          as LH
 import qualified Language.Haskell.Liquid.Types.PrettyPrint as LH ( filterReportErrors
                                                                  , filterReportErrorsWith
                                                                  , defaultFilterReporter
                                                                  , reduceFilters )
-import qualified Liquid.GHC.Logging     as LH   (fromPJDoc)
+import qualified Language.Haskell.Liquid.GHC.Logging     as LH   (fromPJDoc)
 
 import           Language.Haskell.Liquid.GHC.Plugin.Types
 import           Language.Haskell.Liquid.GHC.Plugin.Util as Util
 import           Language.Haskell.Liquid.GHC.Plugin.SpecFinder
                                                          as SpecFinder
 
-import           Liquid.GHC.Types       (MGIModGuts(..), miModGuts)
+import           Language.Haskell.Liquid.GHC.Types       (MGIModGuts(..), miModGuts)
 import           GHC.LanguageExtensions
 
 import           Control.Monad

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/Types.hs
@@ -36,8 +36,8 @@ import qualified Data.HashSet        as HS
 
 import           Language.Haskell.Liquid.Types.Specs
 import           Liquid.GHC.API         as GHC
-import qualified Liquid.GHC.Interface   as LH
-import           Liquid.GHC.Misc (realSrcLocSourcePos)
+import qualified Language.Haskell.Liquid.GHC.Interface   as LH
+import           Language.Haskell.Liquid.GHC.Misc (realSrcLocSourcePos)
 import           Language.Fixpoint.Types.Names            ( Symbol )
 import           Language.Fixpoint.Types.Spans            ( SourcePos, dummyPos )
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/Util.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/Util.hs
@@ -52,7 +52,7 @@ deserialiseBinaryObject thisModule eps hpt =
   where
     extractFromHpt :: Maybe a
     extractFromHpt = do
-      modInfo <- lookupUDFM hpt (moduleName thisModule)
+      modInfo <- lookupHpt hpt (moduleName thisModule)
       guard (thisModule == (mi_module . hm_iface $ modInfo))
       xs <- mapM (fromSerialized deserialise . ifAnnotatedValue) (mi_anns . hm_iface $ modInfo)
       listToMaybe xs

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Resugar.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Resugar.hs
@@ -9,7 +9,7 @@
 --   into high-level patterns, that can receive special case handling in
 --   different phases (e.g. ANF, Constraint Generation, etc.)
 
-module Liquid.GHC.Resugar (
+module Language.Haskell.Liquid.GHC.Resugar (
   -- * High-level Source Patterns
     Pattern (..)
 
@@ -22,7 +22,7 @@ module Liquid.GHC.Resugar (
 
 import qualified Data.List as L
 import           Liquid.GHC.API  as Ghc hiding (PatBind)
-import qualified Liquid.GHC.Misc as GM
+import qualified Language.Haskell.Liquid.GHC.Misc as GM
 import qualified Language.Fixpoint.Types          as F 
 import qualified Text.PrettyPrint.HughesPJ        as PJ 
 -- import           Debug.Trace

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/SpanStack.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/SpanStack.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 
-module Liquid.GHC.SpanStack
+module Language.Haskell.Liquid.GHC.SpanStack
    ( -- * Stack of positions
      Span (..)
    , SpanStack
@@ -17,7 +17,7 @@ module Liquid.GHC.SpanStack
 
 import           Prelude                   hiding (error)
 import           Data.Maybe                       (listToMaybe, fromMaybe)
-import           Liquid.GHC.Misc (tickSrcSpan, showPpr)
+import           Language.Haskell.Liquid.GHC.Misc (tickSrcSpan, showPpr)
 import qualified Liquid.GHC.API  as Ghc
 import           Liquid.GHC.API  ( SrcSpan
                                                   , fsLit

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/TypeRep.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/TypeRep.hs
@@ -9,13 +9,13 @@
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-} -- TODO(#1918): Only needed for GHC <9.0.1.
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Liquid.GHC.TypeRep (
+module Language.Haskell.Liquid.GHC.TypeRep (
   mkTyArg, 
 
   showTy
   ) where
 
-import           Liquid.GHC.Misc (showPpr)
+import           Language.Haskell.Liquid.GHC.Misc (showPpr)
 import           Liquid.GHC.API as Ghc hiding (mkTyArg, showPpr, panic)
 import           Language.Fixpoint.Types (symbol)
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Types.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
-module Liquid.GHC.Types where
+module Language.Haskell.Liquid.GHC.Types where
 
 import           Data.HashSet (HashSet, fromList)
 import           Data.Hashable

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
@@ -24,13 +24,13 @@ import           Language.Haskell.Liquid.Types
 import           Language.Haskell.Liquid.UX.Errors
 import           Language.Haskell.Liquid.UX.CmdLine
 import           Language.Haskell.Liquid.UX.Tidy
-import           Liquid.GHC.Misc (showCBs, ignoreCoreBinds) -- howPpr)
+import           Language.Haskell.Liquid.GHC.Misc (showCBs, ignoreCoreBinds) -- howPpr)
 import           Language.Haskell.Liquid.Constraint.Generate
 import           Language.Haskell.Liquid.Constraint.ToFixpoint
 import           Language.Haskell.Liquid.Constraint.Types
 import           Language.Haskell.Liquid.UX.Annotate (mkOutput)
 import qualified Language.Haskell.Liquid.Termination.Structural as ST
-import qualified Liquid.GHC.Misc          as GM 
+import qualified Language.Haskell.Liquid.GHC.Misc          as GM
 import           Liquid.GHC.API as GHC hiding (text, vcat, ($+$), getOpts, (<+>))
 
 --------------------------------------------------------------------------------

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Measure.hs
@@ -34,7 +34,7 @@ import qualified Data.Maybe                             as Mb -- (fromMaybe, isN
 import           Language.Fixpoint.Misc
 import           Language.Fixpoint.Types                hiding (panic, R, DataDecl, SrcSpan, LocSymbol)
 import           Liquid.GHC.API        as Ghc hiding (Expr, showPpr, panic, (<+>))
-import           Liquid.GHC.Misc
+import           Language.Haskell.Liquid.GHC.Misc
 -- import qualified Language.Haskell.Liquid.Misc as Misc
 import           Language.Haskell.Liquid.Types.Types    -- hiding (GhcInfo(..), GhcSpec (..))
 import           Language.Haskell.Liquid.Types.RefType

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -37,7 +37,7 @@ import           GHC                                    (ModuleName, mkModuleNam
 import qualified Text.PrettyPrint.HughesPJ              as PJ
 import           Text.PrettyPrint.HughesPJ.Compat       ((<+>))
 import           Language.Fixpoint.Types                hiding (panic, SVar, DDecl, DataDecl, DataCtor (..), Error, R, Predicate)
-import           Liquid.GHC.Misc       hiding (getSourcePos)
+import           Language.Haskell.Liquid.GHC.Misc       hiding (getSourcePos)
 import           Language.Haskell.Liquid.Types
 -- import           Language.Haskell.Liquid.Types.Errors
 import qualified Language.Fixpoint.Misc                 as Misc

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Termination/Structural.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Termination/Structural.hs
@@ -5,7 +5,7 @@
 module Language.Haskell.Liquid.Termination.Structural (terminationVars) where
 
 import Language.Haskell.Liquid.Types hiding (isDecreasing)
-import Liquid.GHC.Misc (showPpr)
+import Language.Haskell.Liquid.GHC.Misc (showPpr)
 import Liquid.GHC.API  as GHC hiding ( showPpr
                                                       , Env
                                                       , text

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/ANF.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/ANF.hs
@@ -13,7 +13,7 @@ module Language.Haskell.Liquid.Transforms.ANF (anormalize) where
 
 import           Debug.Trace (trace)
 import           Prelude                          hiding (error)
-import           Liquid.GHC.TypeRep
+import           Language.Haskell.Liquid.GHC.TypeRep
 import           Liquid.GHC.API  as Ghc hiding ( mkTyArg
                                                                 , showPpr
                                                                 , DsM
@@ -25,14 +25,14 @@ import qualified Language.Fixpoint.Types    as F
 
 import           Language.Haskell.Liquid.UX.Config  as UX
 import qualified Language.Haskell.Liquid.Misc       as Misc
-import           Liquid.GHC.Misc   as GM
+import           Language.Haskell.Liquid.GHC.Misc   as GM
 import           Language.Haskell.Liquid.Transforms.Rec
 import           Language.Haskell.Liquid.Transforms.InlineAux
 import           Language.Haskell.Liquid.Transforms.Rewrite
 import           Language.Haskell.Liquid.Types.Errors
 
-import qualified Liquid.GHC.SpanStack as Sp
-import qualified Liquid.GHC.Resugar   as Rs
+import qualified Language.Haskell.Liquid.GHC.SpanStack as Sp
+import qualified Language.Haskell.Liquid.GHC.Resugar   as Rs
 import           Data.Maybe                       (fromMaybe)
 import           Data.List                        (sortBy, (\\))
 import qualified Text.Printf as Printf

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -22,7 +22,7 @@ module Language.Haskell.Liquid.Transforms.CoreToLogic
 
 import           Data.ByteString                       (ByteString)
 import           Prelude                               hiding (error)
-import           Liquid.GHC.TypeRep   () -- needed for Eq 'Type'
+import           Language.Haskell.Liquid.GHC.TypeRep   () -- needed for Eq 'Type'
 import           Liquid.GHC.API       hiding (Expr, Located, panic)
 import qualified Liquid.GHC.API       as Ghc
 import qualified Liquid.GHC.API       as C
@@ -40,13 +40,13 @@ import qualified Language.Fixpoint.Misc                as Misc
 import qualified Language.Haskell.Liquid.Misc          as Misc
 import           Language.Fixpoint.Types               hiding (panic, Error, R, simplify)
 import qualified Language.Fixpoint.Types               as F
-import qualified Liquid.GHC.Misc      as GM
+import qualified Language.Haskell.Liquid.GHC.Misc      as GM
 
 
 import           Language.Haskell.Liquid.Bare.Types
 import           Language.Haskell.Liquid.Bare.DataType
 import           Language.Haskell.Liquid.Bare.Misc     (simpleSymbolVar)
-import           Liquid.GHC.Play
+import           Language.Haskell.Liquid.GHC.Play
 import           Language.Haskell.Liquid.Types.Types   --     hiding (GhcInfo(..), GhcSpec (..), LM)
 import           Language.Haskell.Liquid.Types.RefType
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/InlineAux.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/InlineAux.hs
@@ -7,7 +7,7 @@ where
 import qualified Language.Haskell.Liquid.UX.Config  as UX
 import           Liquid.GHC.API
 import           Control.Arrow                  (second)
-import qualified Liquid.GHC.Misc
+import qualified Language.Haskell.Liquid.GHC.Misc
                                                as GM
 import qualified Data.HashMap.Strict           as M
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Rec.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Rec.hs
@@ -14,8 +14,8 @@ import           Control.Monad.State
 import qualified Data.HashMap.Strict                  as M
 import           Data.Hashable
 import           Liquid.GHC.API      as Ghc hiding (panic)
-import           Liquid.GHC.Misc
-import           Liquid.GHC.Play
+import           Language.Haskell.Liquid.GHC.Misc
+import           Language.Haskell.Liquid.GHC.Play
 import           Language.Haskell.Liquid.Misc         (mapSndM)
 import           Language.Fixpoint.Misc               (mapSnd) -- , traceShow)
 import           Language.Haskell.Liquid.Types.Errors

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Rec.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Rec.hs
@@ -13,7 +13,7 @@ import           Control.Arrow                        (second)
 import           Control.Monad.State
 import qualified Data.HashMap.Strict                  as M
 import           Data.Hashable
-import           Liquid.GHC.API      as Ghc hiding (panic, mapSndM)
+import           Liquid.GHC.API      as Ghc hiding (panic)
 import           Liquid.GHC.Misc
 import           Liquid.GHC.Play
 import           Language.Haskell.Liquid.Misc         (mapSndM)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Rewrite.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Rewrite.hs
@@ -25,15 +25,15 @@ module Language.Haskell.Liquid.Transforms.Rewrite
   ) where
 
 import           Liquid.GHC.API as Ghc hiding (showPpr, substExpr)
-import           Liquid.GHC.TypeRep ()
+import           Language.Haskell.Liquid.GHC.TypeRep ()
 import           Data.Maybe     (fromMaybe)
 import           Control.Monad.State hiding (lift)
 import           Language.Fixpoint.Misc       ({- mapFst, -}  mapSnd)
 import qualified          Language.Fixpoint.Types as F
 import           Language.Haskell.Liquid.Misc (safeZipWithError, Nat)
-import           Liquid.GHC.Play (substExpr)
-import           Liquid.GHC.Resugar
-import           Liquid.GHC.Misc (unTickExpr, isTupleId, showPpr, mkAlive) -- , showPpr, tracePpr)
+import           Language.Haskell.Liquid.GHC.Play (substExpr)
+import           Language.Haskell.Liquid.GHC.Resugar
+import           Language.Haskell.Liquid.GHC.Misc (unTickExpr, isTupleId, showPpr, mkAlive) -- , showPpr, tracePpr)
 import           Language.Haskell.Liquid.UX.Config  (Config, noSimplifyCore)
 import qualified Data.List as L
 import qualified Data.HashMap.Strict as M

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Dictionaries.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Dictionaries.hs
@@ -18,7 +18,7 @@ import           Data.Hashable
 import           Prelude                                   hiding (error)
 import qualified Language.Fixpoint.Types as F
 import           Language.Haskell.Liquid.Types.PrettyPrint ()
-import qualified Liquid.GHC.Misc       as GM
+import qualified Language.Haskell.Liquid.GHC.Misc       as GM
 import qualified Liquid.GHC.API        as Ghc
 import           Language.Haskell.Liquid.Types.Types
 -- import           Language.Haskell.Liquid.Types.Visitors (freeVars)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Literals.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Literals.hs
@@ -8,7 +8,7 @@ module Language.Haskell.Liquid.Types.Literals
   ) where
 
 import Prelude hiding (error)
-import Liquid.GHC.TypeRep ()
+import Language.Haskell.Liquid.GHC.TypeRep ()
 import Liquid.GHC.API hiding (panic)
 
 import Language.Haskell.Liquid.Types.Types

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PredType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PredType.hs
@@ -42,7 +42,7 @@ import           Liquid.GHC.API hiding ( panic
                                                         , parens
                                                         , showPpr
                                                         )
-import           Liquid.GHC.TypeRep ()
+import           Language.Haskell.Liquid.GHC.TypeRep ()
 import           Data.Hashable
 import qualified Data.HashMap.Strict             as M
 import qualified Data.Maybe                                 as Mb
@@ -54,7 +54,7 @@ import           Language.Fixpoint.Misc
 -- import           Language.Fixpoint.Types         hiding (Expr, Predicate)
 import qualified Language.Fixpoint.Types                    as F
 import qualified Liquid.GHC.API            as Ghc
-import           Liquid.GHC.Misc
+import           Language.Haskell.Liquid.GHC.Misc
 import           Language.Haskell.Liquid.Misc
 import           Language.Haskell.Liquid.Types.RefType hiding (generalize)
 import           Language.Haskell.Liquid.Types.Types

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
@@ -62,8 +62,8 @@ import           Liquid.GHC.API  as Ghc ( Class
                                                          , srcSpanStartLine
                                                          , srcSpanStartCol
                                                          )
-import           Liquid.GHC.Logging (mkLongErrAt)
-import           Liquid.GHC.Misc
+import           Language.Haskell.Liquid.GHC.Logging (mkLongErrAt)
+import           Language.Haskell.Liquid.GHC.Misc
 import           Language.Haskell.Liquid.Misc
 import           Language.Haskell.Liquid.Types.Types
 import           Prelude                          hiding (error)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -115,8 +115,8 @@ import           Language.Haskell.Liquid.Types.Types hiding (R, DataConP (..))
 import           Language.Haskell.Liquid.Types.Variance
 import           Language.Haskell.Liquid.Misc
 import           Language.Haskell.Liquid.Types.Names
-import qualified Liquid.GHC.Misc as GM
-import           Liquid.GHC.Play (mapType, stringClassArg, isRecursivenewTyCon)
+import qualified Language.Haskell.Liquid.GHC.Misc as GM
+import           Language.Haskell.Liquid.GHC.Play (mapType, stringClassArg, isRecursivenewTyCon)
 import           Liquid.GHC.API        as Ghc hiding ( Expr
                                                                       , Located
                                                                       , tyConName
@@ -132,7 +132,7 @@ import           Liquid.GHC.API        as Ghc hiding ( Expr
                                                                       , panic
                                                                       , text
                                                                       )
-import           Liquid.GHC.TypeRep () -- Eq Type instance
+import           Language.Haskell.Liquid.GHC.TypeRep () -- Eq Type instance
 import Data.List (foldl')
 
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -80,7 +80,7 @@ import           Language.Haskell.Liquid.Types.Generics
 import           Language.Haskell.Liquid.Types.Variance
 import           Language.Haskell.Liquid.Types.Bounds
 import           Liquid.GHC.API hiding (text, (<+>))
-import           Liquid.GHC.Types
+import           Language.Haskell.Liquid.GHC.Types
 import           Text.PrettyPrint.HughesPJ              (text, (<+>))
 import           Text.PrettyPrint.HughesPJ as HughesPJ (($$))
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -263,7 +263,6 @@ import           Liquid.GHC.API as Ghc hiding ( Expr
                                                                , hcat
                                                                , showPpr
                                                                , punctuate
-                                                               , mapSndM
                                                                , ($$)
                                                                , braces
                                                                , angleBrackets

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -295,8 +295,8 @@ import           Language.Fixpoint.Misc
 import qualified Language.Fixpoint.Types as F
 
 import           Language.Haskell.Liquid.Types.Generics
-import           Liquid.GHC.Misc
-import           Liquid.GHC.Logging as GHC
+import           Language.Haskell.Liquid.GHC.Misc
+import           Language.Haskell.Liquid.GHC.Logging as GHC
 import           Language.Haskell.Liquid.Types.Variance
 import           Language.Haskell.Liquid.Types.Errors
 import           Language.Haskell.Liquid.Misc

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Variance.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Variance.hs
@@ -25,7 +25,7 @@ import qualified Data.HashSet            as S
 import qualified Language.Fixpoint.Types as F
 
 import           Language.Haskell.Liquid.Types.Generics
-import qualified Liquid.GHC.Misc as GM
+import qualified Language.Haskell.Liquid.GHC.Misc as GM
 import           Liquid.GHC.API        as Ghc hiding (text)
 
 type VarianceInfo = [Variance]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Visitors.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Visitors.hs
@@ -20,7 +20,7 @@ import qualified Data.HashSet                     as S
 import           Prelude                          hiding (error)
 import           Language.Fixpoint.Misc
 import           Liquid.GHC.API
-import           Liquid.GHC.Misc ()
+import           Language.Haskell.Liquid.GHC.Misc ()
 
 
 ------------------------------------------------------------------------------

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/ACSS.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/ACSS.hs
@@ -25,7 +25,7 @@ import qualified Data.HashMap.Strict as M
 import Data.List   (find, isPrefixOf, findIndex, elemIndices, intercalate, elemIndex)
 import Data.Char   (isSpace)
 import Text.Printf
-import Liquid.GHC.Misc
+import Language.Haskell.Liquid.GHC.Misc
 import Language.Haskell.Liquid.Types.Errors (panic, impossible)
 
 data AnnMap  = Ann

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Annotate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Annotate.hs
@@ -55,7 +55,7 @@ import qualified Language.Haskell.Liquid.UX.ACSS              as ACSS
 import           Language.Haskell.HsColour.Classify
 import           Language.Fixpoint.Utils.Files
 import           Language.Fixpoint.Misc
-import           Liquid.GHC.Misc
+import           Language.Haskell.Liquid.GHC.Misc
 import qualified Liquid.GHC.API              as SrcLoc
 import           Language.Fixpoint.Types                      hiding (panic, Error, Loc, Constant (..), Located (..))
 import           Language.Haskell.Liquid.Misc

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -77,7 +77,7 @@ import Language.Fixpoint.Solver.Stats as Solver
 import Language.Haskell.Liquid.UX.Annotate
 import Language.Haskell.Liquid.UX.Config
 import Language.Haskell.Liquid.UX.SimpleVersion (simpleVersion)
-import Liquid.GHC.Misc
+import Language.Haskell.Liquid.GHC.Misc
 import Language.Haskell.Liquid.Types.PrettyPrint ()
 import Language.Haskell.Liquid.Types       hiding (typ)
 import qualified Language.Haskell.Liquid.UX.ACSS as ACSS

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/DiffCheck.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/DiffCheck.hs
@@ -53,7 +53,7 @@ import           Language.Fixpoint.Types                (atLoc, FixResult (..), 
 import           Language.Fixpoint.Utils.Files
 import           Language.Fixpoint.Solver.Stats ()
 import           Language.Haskell.Liquid.Misc           (mkGraph)
-import           Liquid.GHC.Misc
+import           Language.Haskell.Liquid.GHC.Misc
 import           Liquid.GHC.API        as Ghc hiding ( Located
                                                                       , sourceName
                                                                       , text

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Errors.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Errors.hs
@@ -19,7 +19,7 @@ import           Language.Haskell.Liquid.Types.RefType
 import           Language.Haskell.Liquid.Transforms.Simplify
 import           Language.Haskell.Liquid.UX.Tidy
 import           Language.Haskell.Liquid.Types
-import qualified Liquid.GHC.Misc    as GM
+import qualified Language.Haskell.Liquid.GHC.Misc    as GM
 import qualified Language.Haskell.Liquid.Misc        as Misc
 import qualified Language.Fixpoint.Misc              as Misc
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/QuasiQuoter.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/QuasiQuoter.hs
@@ -26,7 +26,7 @@ import Language.Haskell.TH.Quote
 import Language.Fixpoint.Types hiding (Error, Loc, SrcSpan)
 import qualified Language.Fixpoint.Types as F
 
-import Liquid.GHC.Misc (fSrcSpan)
+import Language.Haskell.Liquid.GHC.Misc (fSrcSpan)
 import Liquid.GHC.API  (SrcSpan)
 import Language.Haskell.Liquid.Parse
 import Language.Haskell.Liquid.Types

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Tidy.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Tidy.hs
@@ -36,7 +36,7 @@ import qualified Data.HashSet                              as S
 import qualified Data.List                                 as L
 import qualified Data.Text                                 as T
 import qualified Control.Exception                         as Ex
-import qualified Liquid.GHC.Misc          as GM
+import qualified Language.Haskell.Liquid.GHC.Misc          as GM
 -- (dropModuleNames, showPpr, stringTyVar)
 import           Language.Fixpoint.Types                   hiding (Result, SrcSpan, Error)
 import           Language.Haskell.Liquid.Types.Types

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/WiredIn.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/WiredIn.hs
@@ -28,7 +28,7 @@ module Language.Haskell.Liquid.WiredIn
 import Prelude                                hiding (error)
 
 -- import Language.Fixpoint.Misc           (mapSnd)
-import Liquid.GHC.Misc
+import Language.Haskell.Liquid.GHC.Misc
 import qualified Liquid.GHC.API as Ghc
 import Liquid.GHC.API (Var, Arity, TyVar, Bind(..), Boxity(..), Expr(..), ArgFlag(..))
 import Language.Haskell.Liquid.Types.Types
@@ -41,7 +41,7 @@ import Language.Haskell.Liquid.Types.Names (selfSymbol)
 import qualified Language.Fixpoint.Types as F
 import qualified Data.HashSet as S
 
-import Liquid.GHC.TypeRep ()
+import Language.Haskell.Liquid.GHC.TypeRep ()
 
 -- | Horrible hack to support hardwired symbols like
 --      `head`, `tail`, `fst`, `snd`


### PR DESCRIPTION
This PR leaves in `Liquid.GHC.*` only the files that depend on boot libraries (including the GHC API).

The other files were moved to `Language.Haskell.Liquid.GHC.*`.

Some commits also make progress with making explicit the import lists in Liquid.GHC.API.

Implements part of #2184 