### PR TITLE
Build the profiling driver with cabal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ commands:
       - run:
           name: Test building the profiling driver
           command: |
-            cabal exec -- ghc scripts/ProfilingDriver.hs
+            cabal build --enable-profiling --flag devel scripts/profiling-driver
 
   stack_build_and_test:
     description: "Build and test the project using Stack"

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ If one wishes to save time or is not interested in top speedups/slowdowns, the b
 
 ## Miscelaneous tasks
 
-* **Profiling** See the instructions in [scripts/ProfilingDriver.hs](scripts/ProfilingDriver.hs).
+* **Profiling** See the instructions in [scripts/profiling-driver/ProfilingDriver.hs](scripts/profiling-driver/ProfilingDriver.hs).
 * **Getting stack traces on exceptions** See `-xc` flag in the [GHC user's guide][ghc-users-guide].
 * **Working with submodules** See `man gitsubmodules` or the [git documentation site][git-documentation].
 

--- a/cabal.project
+++ b/cabal.project
@@ -11,6 +11,7 @@ packages: .
           ./tests/benchmarks/popl18/lib
           ./benchmark-timings
           ./scripts/plot-performance
+          ./scripts/profiling-driver
 
 source-repository-package
     type: git

--- a/liquidhaskell-boot/liquidhaskell-boot.cabal
+++ b/liquidhaskell-boot/liquidhaskell-boot.cabal
@@ -25,11 +25,6 @@ flag devel
   description: Enable more warnings and fail compilation when warnings occur.
                Turn this flag on in CI.
 
-flag deterministic-profiling
-  default:     False
-  description: Support building against GHC with <https://phabricator.haskell.org/D4388>
-               backported
-
 library
   autogen-modules:    Paths_liquidhaskell_boot
   exposed-modules:    Language.Haskell.Liquid.Cabal
@@ -171,9 +166,6 @@ library
 
   if flag(devel)
     ghc-options:      -Wall -Werror
-
-  if flag(deterministic-profiling)
-    cpp-options: -DDETERMINISTIC_PROFILING
 
 test-suite liquidhaskell-parser
   type:             exitcode-stdio-1.0

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -25,11 +25,6 @@ flag devel
   description: Enable more warnings and fail compilation when warnings occur.
                Turn this flag on in CI.
 
-flag deterministic-profiling
-  default:     False
-  description: Support building against GHC with <https://phabricator.haskell.org/D4388>
-               backported
-
 custom-setup
   setup-depends: Cabal<4, base<5, liquidhaskell-boot
 
@@ -91,6 +86,3 @@ library
 
   if flag(devel)
     ghc-options:      -Werror
-
-  if flag(deterministic-profiling)
-    cpp-options: -DDETERMINISTIC_PROFILING

--- a/scripts/profiling-driver/ProfilingDriver.hs
+++ b/scripts/profiling-driver/ProfilingDriver.hs
@@ -7,18 +7,17 @@
 --
 -- Then build this program.
 --
--- > cabal exec --enable-profiling -- ghc -prof scripts/ProfilingDriver.hs
+-- > cabal build --enable-profiling scripts/profiling-driver
 --
 -- Then run the liquidhaskell executable pointing it to this driver with
 -- the LIQUID_GHC_PATH env var.
 --
--- > LIQUID_GHC_PATH=scripts/ProfilingDriver liquidhaskell_datadir=$PWD/liquidhaskell-boot \
+-- > LIQUID_GHC_PATH=path/to/profiling-driver liquidhaskell_datadir=$PWD/liquidhaskell-boot \
 -- >   cabal exec -- liquidhaskell +RTS -p -RTS tests/pos/Bag.hs
 --
 module Main where
 
 import GHC as G
-import GHC.Driver.Session as G
 
 import Control.Monad
 import Control.Monad.IO.Class
@@ -33,7 +32,7 @@ main = do
       df1 <- getSessionDynFlags
       let cmdOpts = ["-fforce-recomp"] ++ filter ("--make" /=) xs
       logger <- liftIO G.initLogger
-      (df2, leftovers, warns) <- G.parseDynamicFlags logger df1 (map G.noLoc cmdOpts)
+      (df2, leftovers, _warns) <- G.parseDynamicFlags logger df1 (map G.noLoc cmdOpts)
       setSessionDynFlags df2
       ts <- mapM (flip G.guessTarget Nothing) $ map unLoc leftovers
       setTargets ts

--- a/scripts/profiling-driver/profiling-driver.cabal
+++ b/scripts/profiling-driver/profiling-driver.cabal
@@ -1,0 +1,38 @@
+cabal-version:      2.4
+name:               profiling-driver
+version:            0.9.2.5.0
+synopsis:           A ghc replacement that can be used to profile plugins
+description:        The usual binary distributions of GHC cannot be used to profile
+                    plugins because GHC is not built with the profiling runtime. This
+                    package provides a GHC replacement that can be built with
+                    profiling enabled and can then load plugins built with profiling
+                    enabled.
+license:            BSD-3-Clause
+copyright:          2010-19 Ranjit Jhala & Niki Vazou & Eric L. Seidel, University of California, San Diego.
+author:             Facundo Domínguez
+maintainer:         Facundo Domínguez <jhala@tweag.io>
+category:           Language
+homepage:           https://github.com/ucsd-progsys/liquidhaskell
+build-type:         Simple
+tested-with:        GHC == 9.2.5
+
+source-repository head
+  type:     git
+  location: https://github.com/ucsd-progsys/liquidhaskell/
+
+flag devel
+  default:     False
+  manual:      True
+  description: Enable more warnings and fail compilation when warnings occur.
+               Turn this flag on in CI.
+
+executable profiling-driver
+  main-is:          ProfilingDriver.hs
+  build-depends:    base            >= 4.8.1.0 && < 5
+                  , ghc             ^>= 9.2
+                  , ghc-paths
+  default-language: Haskell2010
+  ghc-options:      -W
+
+  if flag(devel)
+    ghc-options:    -Wall -Wno-name-shadowing -Werror


### PR DESCRIPTION
Cabal can control better which packages are visible, making the builds more likely to succeed than invoking ghc directly.