### PR TITLE
Add more explicit import lists to Liquid.GHC.API

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Types.hs
@@ -68,7 +68,6 @@ import           Liquid.GHC.API    as Ghc hiding ( (<+>)
                                                                   , vcat
                                                                   , parens
                                                                   , ($+$)
-                                                                  , LC
                                                                   )
 import           Language.Haskell.Liquid.Misc           (thrd3)
 import           Language.Haskell.Liquid.WiredIn        (wiredSortedSyms)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Interface.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Interface.hs
@@ -53,7 +53,6 @@ import           Liquid.GHC.API as Ghc hiding ( text
                                                                , vcat
                                                                , showPpr
                                                                , mkStableModule
-                                                               , Target
                                                                , Located
                                                                )
 import qualified Liquid.GHC.API as Ghc

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -731,9 +731,6 @@ gHC_VERSION = show (__GLASGOW_HASKELL__ :: Int)
 symbolFastString :: Symbol -> FastString
 symbolFastString = mkFastStringByteString . T.encodeUtf8 . symbolText
 
-lintCoreBindings :: [Var] -> CoreProgram -> (Bag SDoc, Bag SDoc)
-lintCoreBindings = Ghc.lintCoreBindings (defaultDynFlags undefined (undefined ("LlvmTargets" :: String))) CoreDoNothing
-
 synTyConRhs_maybe :: TyCon -> Maybe Type
 synTyConRhs_maybe = Ghc.synTyConRhs_maybe
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Play.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Play.hs
@@ -12,7 +12,7 @@ import qualified Data.HashMap.Strict as M
 import qualified Data.List           as L
 import qualified Data.Maybe          as Mb
 
-import Liquid.GHC.API as Ghc hiding (substTysWith, panic,showPpr)
+import Liquid.GHC.API as Ghc hiding (panic, showPpr)
 import Language.Haskell.Liquid.GHC.Misc ()
 import Language.Haskell.Liquid.Types.Errors
 import Language.Haskell.Liquid.Types.Variance

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -16,7 +16,7 @@ module Language.Haskell.Liquid.GHC.Plugin (
   ) where
 
 import qualified Liquid.GHC.API         as O
-import           Liquid.GHC.API         as GHC hiding (Target, Type)
+import           Liquid.GHC.API         as GHC hiding (Type)
 import qualified Text.PrettyPrint.HughesPJ               as PJ
 import qualified Language.Fixpoint.Types                 as F
 import qualified  Language.Haskell.Liquid.GHC.Misc        as LH
@@ -404,7 +404,7 @@ loadDependencies currentModuleConfig thisModule mods = do
   hscEnv    <- env_top <$> getEnv
   results   <- SpecFinder.findRelevantSpecs
                  (excludeAutomaticAssumptionsFor currentModuleConfig) hscEnv mods
-  deps      <- foldlM processResult mempty (reverse results)
+  deps      <- foldM processResult mempty (reverse results)
   redundant <- liftIO $ configToRedundantDependencies hscEnv currentModuleConfig
 
   debugLog $ "Redundant dependencies ==> " ++ show redundant

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/SpecFinder.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/SpecFinder.hs
@@ -28,6 +28,7 @@ import           Data.IORef
 import           Data.Maybe
 
 import           Control.Exception
+import           Control.Monad                            ( foldM )
 import           Control.Monad.Trans                      ( lift )
 import           Control.Monad.Trans.Maybe
 
@@ -64,7 +65,7 @@ findRelevantSpecs :: [String] -- ^ Package to exclude for loading LHAssumptions
                   -> TcM [SpecFinderResult]
 findRelevantSpecs lhAssmPkgExcludes hscEnv mods = do
     eps <- liftIO $ readIORef (hsc_EPS hscEnv)
-    foldlM (loadRelevantSpec eps) mempty mods
+    foldM (loadRelevantSpec eps) mempty mods
   where
 
     loadRelevantSpec :: ExternalPackageState -> [SpecFinderResult] -> Module -> TcM [SpecFinderResult]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Resugar.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Resugar.hs
@@ -21,7 +21,7 @@ module Language.Haskell.Liquid.GHC.Resugar (
   ) where
 
 import qualified Data.List as L
-import           Liquid.GHC.API  as Ghc hiding (PatBind)
+import           Liquid.GHC.API  as Ghc
 import qualified Language.Haskell.Liquid.GHC.Misc as GM
 import qualified Language.Fixpoint.Types          as F 
 import qualified Text.PrettyPrint.HughesPJ        as PJ 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
@@ -31,7 +31,7 @@ import           Language.Haskell.Liquid.Constraint.Types
 import           Language.Haskell.Liquid.UX.Annotate (mkOutput)
 import qualified Language.Haskell.Liquid.Termination.Structural as ST
 import qualified Language.Haskell.Liquid.GHC.Misc          as GM
-import           Liquid.GHC.API as GHC hiding (text, vcat, ($+$), getOpts, (<+>))
+import           Liquid.GHC.API as GHC hiding (text, vcat, ($+$), (<+>))
 
 --------------------------------------------------------------------------------
 checkTargetInfo :: TargetInfo -> IO (Output Doc)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Errors.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Errors.hs
@@ -85,7 +85,6 @@ import           Liquid.GHC.API as Ghc hiding ( Expr
                                                                , panic
                                                                , int
                                                                , hcat
-                                                               , spans
                                                                )
 import           Language.Fixpoint.Types      (pprint, showpp, Tidy (..), PPrint (..), Symbol, Expr, SubcId)
 import qualified Language.Fixpoint.Misc       as Misc

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -244,7 +244,6 @@ module Language.Haskell.Liquid.Types.Types (
   where
 
 import           Liquid.GHC.API as Ghc hiding ( Expr
-                                                               , Target
                                                                , isFunTy
                                                                , ($+$)
                                                                , nest


### PR DESCRIPTION
All import lists are explicit in Liquid.GHC.API now.

Implements part of #2184