### PR TITLE
Remove some  ByteString Assumptions

### DIFF
--- a/src/Data/ByteString_LHAssumptions.hs
+++ b/src/Data/ByteString_LHAssumptions.hs
@@ -12,8 +12,6 @@ invariant { bs : Data.ByteString.ByteString  | 0 <= bslen bs }
 
 invariant { bs : Data.ByteString.ByteString | bslen bs == stringlen bs }
 
-assume Data.ByteString.Internal.empty :: { bs : Data.ByteString.ByteString | bslen bs == 0 }
-
 assume Data.ByteString.singleton :: _ -> { bs : Data.ByteString.ByteString | bslen bs == 1 }
 
 assume Data.ByteString.pack :: w8s : [_]


### PR DESCRIPTION
Trying to fix the build error: 

```
/private/var/folders/2f/kzm4yd19613d13hyqzgtrd7h0000gp/T/stack-e0a2d75deeabe009/liquidhaskell-0.9.2.5.0/src/Data/ByteString_LHAssumptions.hs:15:8: error:
liquidhaskell>     • Unknown variable `Data.ByteString.Internal.empty`
liquidhaskell>     Var
liquidhaskell>     •
liquidhaskell>    |
liquidhaskell> 15 | assume Data.ByteString.Internal.empty :: { bs : Data.ByteString.ByteString | bslen bs == 0 }
```