### PR TITLE
Simplify the liquid-platform:liquidhaskell executable

### DIFF
--- a/liquid-platform/liquid-platform.cabal
+++ b/liquid-platform/liquid-platform.cabal
@@ -33,7 +33,6 @@ executable liquidhaskell
                       , liquidhaskell-boot >= 0.9.2.8
                       , filepath
                       , process           >= 1.6.0.0 && < 1.7
-                      , cmdargs           >= 0.10    && < 0.11
 
   if flag(devel)
     ghc-options: -Werror

--- a/liquid-platform/src/Liquid.hs
+++ b/liquid-platform/src/Liquid.hs
@@ -13,35 +13,20 @@
 import Control.Monad
 
 import System.Environment (lookupEnv, getArgs, unsetEnv)
-import System.FilePath ((</>), takeDirectory, takeExtension)
+import System.FilePath ((</>), takeDirectory)
 import System.Process
 import System.Exit
-import Data.Char (toLower)
 import Data.Maybe
-import Data.Either (partitionEithers)
 import Data.Bifunctor
-import Data.Functor ((<&>))
-import qualified System.Console.CmdArgs.Explicit as CmdArgs
-import Data.List (partition, isPrefixOf, (\\))
+import Data.List (isPrefixOf, (\\))
 
-import Language.Haskell.Liquid.UX.CmdLine (config, printLiquidHaskellBanner, getOpts)
+import Language.Haskell.Liquid.UX.CmdLine (printLiquidHaskellBanner, getOpts)
 
 type GhcArg    = String
 type LiquidArg = String
 
 partitionArgs :: [String] -> ([GhcArg], [LiquidArg])
-partitionArgs args = partitionEithers (map parseArg args)
-  where
-    parseArg :: String -> Either GhcArg LiquidArg
-    parseArg a
-      | forwardToGhc a = Left a
-      | otherwise      = bimap (const a) (const a) (CmdArgs.process config [a])
-
-    -- Unfortunate consequence of the facts things like '-i' needs to be forwarded to GHC
-    -- and not the LH executable.
-    forwardToGhc :: String -> Bool
-    forwardToGhc = isPrefixOf "-i"
-
+partitionArgs = second (drop 1) . break ("--"==)
 
 helpNeeded :: [String] -> Bool
 helpNeeded = elem "--help"
@@ -65,18 +50,23 @@ main = do
   -- If no args are passed, display the help instead of ghc's "no input files." To do so,
   -- due to the fact GHC needs to always have an input file to actually run a source plugin, we
   -- run this with '--interactive'.
-  args <- getArgs <&> \case [] -> ["--interactive", "--help"]
-                            xs -> "--make" : xs
+  args0 <- getArgs
+  when (null args0 || elem "--help" args0) $
+    putStr $ unlines
+      [ "Usage:"
+      , ""
+      , "    liquidhaskell <ghc arguments> [-- <Liquid Haskell arguments>]"
+      , ""
+      ]
+  let args = case args0 of
+               [] -> ["--interactive", "--", "--help"]
+               xs -> "--make" : xs
 
   ghcPath <- fromMaybe "ghc" <$> lookupEnv "LIQUID_GHC_PATH"
 
   packageDbs <- collectPackageDbsFromGHC_ENVIRONMENT
 
-  -- Strip targets out of the arguments, so that we can forward them to GHC before they
-  -- get intercepted by the LH parser.
-  let (targets, cliArgs)    =
-        partition ((`elem` [".o", ".hs", ".lhs"]) . map toLower . takeExtension) args
-  let (ghcArgs, liquidArgs) = partitionArgs cliArgs
+  let (ghcArgs, liquidArgs) = partitionArgs args
 
   let p = proc ghcPath $
                          ["-package-env", "-"]
@@ -90,7 +80,6 @@ main = do
                          ]
                          <> map (mappend "-fplugin-opt=LiquidHaskell:") liquidArgs
                          <> ghcArgs
-                         <> targets
 
   -- Call into 'getOpts' so that things like the json reporter will correctly set the verbosity of the
   -- logging and avoid printing the banner.


### PR DESCRIPTION
Now parameters for liquid haskell are expected after a "--" argument. This should make easier to predict how the command line will be parsed.