### PR TITLE
Remove strip-ansi-escape-0.1.0.0@rev:2

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -27,8 +27,6 @@ extra-deps:
 - smtlib-backends-process-0.3
 - git: https://github.com/qnikst/ghc-timings-report
   commit: 45ef3498e35897712bde8e002ce18df6d55f8b15
-# for tests
-- strip-ansi-escape-0.1.0.0@sha256:08f2ed93b16086a837ec46eab7ce8d27cf39d47783caaeb818878ea33c2ff75f,1628
 
 resolver: lts-21.20
 


### PR DESCRIPTION
Removes the unused `strip-ansi-escape` dependency from the Stack project. 

This is a follow up from https://github.com/ucsd-progsys/liquidhaskell/commit/e16382c0006f6bd205485576847fba16afa5a304. Within that change the explicit import from this package that was removed was:

```haskell
import Data.String.AnsiEscapeCodes.Strip.Text (stripAnsiEscapeCodes)
```

Found when adding `liquidhaskell` as an [Updo example](https://github.com/up-do).