### PR TITLE
update to latest liquid-fixpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ commands:
       - checkout
       - add_ssh_keys
       - run: git submodule sync
-      - run: git submodule update --init --remote
+      - run: git submodule update --init
 
   cabal_build_and_test:
     description: "Build the project and run the tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ commands:
       - checkout
       - add_ssh_keys
       - run: git submodule sync
-      - run: git submodule update --init
+      - run: git submodule update --init --remote
 
   cabal_build_and_test:
     description: "Build the project and run the tests"
@@ -150,14 +150,14 @@ jobs:
 
   stack_900:
     machine:
-      image: ubuntu-2004:202107-02
+      image: default
     steps:
         - stack_build_and_test:
             stack_yaml_file: "stack.yaml"
             extra_build_flags: "--flag liquidhaskell-boot:devel"
   cabal_900:
     machine:
-      image: ubuntu-2004:202107-02
+      image: default
     steps:
       - cabal_build_and_test:
           ghc_version: "9.8.1"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "liquid-fixpoint"]
 	path = liquid-fixpoint
-	url = https://github.com/clayrat/liquid-fixpoint.git
-	branch = elab-set
+	url = https://github.com/ucsd-progsys/liquid-fixpoint.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "liquid-fixpoint"]
 	path = liquid-fixpoint
 	url = https://github.com/clayrat/liquid-fixpoint.git
-    branch = elab-set
+	branch = elab-set

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "liquid-fixpoint"]
 	path = liquid-fixpoint
-	url = https://github.com/ucsd-progsys/liquid-fixpoint.git
+	url = https://github.com/clayrat/liquid-fixpoint.git
+    branch = elab-set

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -252,11 +252,11 @@ btP = do
     PcExplicit b -> parseFun c b
   <?> "btP"
   where
-    parseFun c@(PC sb t1) sym  =
+    parseFun c@(PC sb t1) sy  =
       (do
             reservedOp "->"
             PC _ t2 <- btP
-            return (PC sb (rFun sym t1 t2)))
+            return (PC sb (rFun sy t1 t2)))
         <|>
          (do
             reservedOp "=>"
@@ -408,8 +408,8 @@ refDefP :: Symbol
         -> Parser Expr
         -> Parser (Reft -> BareType)
         -> Parser BareType
-refDefP sym rp kindP' = braces $ do
-  x       <- optBindP sym
+refDefP sy rp kindP' = braces $ do
+  x       <- optBindP sy
   -- NOSUBST i       <- freshIntP
   t       <- try (kindP' <* reservedOp "|") <|> return (RHole . uTop) <?> "refDefP"
   ra      <- rp
@@ -1174,10 +1174,10 @@ fallbackSpecP kw p = do
 
 -- | Same as tyBindsP, except the single initial symbol has already been matched
 tyBindsRemP :: LocSymbol -> Parser ([LocSymbol], (Located BareType, Maybe [Located Expr]))
-tyBindsRemP sym = do
+tyBindsRemP sy = do
   reservedOp "::"
   tb <- termBareTypeP
-  return ([sym],tb)
+  return ([sy],tb)
 
 pragmaP :: Parser (Located String)
 pragmaP = locStringLiteral

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -1633,20 +1633,6 @@ dataPropTyP :: Parser (Maybe BareType)
 dataPropTyP = Just <$> between (reservedOp "::") (reserved "where") bareTypeP
 
 ---------------------------------------------------------------------
--- | Parsing Qualifiers ---------------------------------------------
----------------------------------------------------------------------
-
-fTyConP :: Parser FTycon
-fTyConP
-  =   (reserved "int"     >> return intFTyCon)
-  <|> (reserved "Integer" >> return intFTyCon)
-  <|> (reserved "Int"     >> return intFTyCon)
-  <|> (reserved "real"    >> return realFTyCon)
-  <|> (reserved "bool"    >> return boolFTyCon)
-  <|> (symbolFTycon      <$> locUpperIdP)
-  <?> "fTyConP"
-
----------------------------------------------------------------------
 -- Identifiers ------------------------------------------------------
 ---------------------------------------------------------------------
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -39,7 +39,7 @@ import           Control.Monad.Except
 import           Control.Monad.Identity
 import qualified Language.Fixpoint.Misc                as Misc
 import qualified Language.Haskell.Liquid.Misc          as Misc
-import           Language.Fixpoint.Types               hiding (panic, Error, R, simplify)
+import           Language.Fixpoint.Types               hiding (panic, Error, R, simplify, isBool)
 import qualified Language.Fixpoint.Types               as F
 import qualified Language.Haskell.Liquid.GHC.Misc      as GM
 
@@ -111,9 +111,9 @@ measureSpecType allowTC v = go mkT [] [(1::Int)..] st
     hasRApps _                = False
 
 
--- | 'weakenResult foo t' drops the singleton constraint `v = foo x y` 
---   that is added, e.g. for measures in /strengthenResult'. 
---   This should only be used _when_ checking the body of 'foo' 
+-- | 'weakenResult foo t' drops the singleton constraint `v = foo x y`
+--   that is added, e.g. for measures in /strengthenResult'.
+--   This should only be used _when_ checking the body of 'foo'
 --   where the output, is, by definition, equal to the singleton.
 weakenResult :: Bool -> Var -> SpecType -> SpecType
 weakenResult allowTC v t = F.notracepp msg t'
@@ -621,7 +621,7 @@ instance Simplify C.CoreExpr where
     = C.Let (simplify allowTC xes) (simplify allowTC e)
   simplify allowTC (C.Case e x _t alts@[Alt _ _ ee,_,_]) | isBangInteger alts
   -- XXX(matt): seems to be for debugging?
-    = -- Misc.traceShow ("To simplify allowTC case") $ 
+    = -- Misc.traceShow ("To simplify allowTC case") $
        sub (M.singleton x (simplify allowTC e)) (simplify allowTC ee)
   simplify allowTC (C.Case e x t alts)
     = C.Case (simplify allowTC e) x t (filter (not . isPatErrorAlt) (simplify allowTC <$> alts))

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/DiffCheck.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/DiffCheck.hs
@@ -48,7 +48,7 @@ import qualified Data.HashSet                           as S
 import qualified Data.HashMap.Strict                    as M
 import qualified Data.List                              as L
 import           System.Directory                       (copyFile, doesFileExist)
-import           Language.Fixpoint.Types                (atLoc, FixResult (..), SourcePos(..), safeSourcePos, unPos)
+import           Language.Fixpoint.Types                (atLoc, FixResult (..), SourcePos(..), unPos)
 -- import qualified Language.Fixpoint.Misc                 as Misc
 import           Language.Fixpoint.Utils.Files
 import           Language.Fixpoint.Solver.Stats ()
@@ -567,22 +567,6 @@ checkedItv chDefs = foldr (`IM.insert` ()) IM.empty is
 --------------------------------------------------------------------------------
 -- | Aeson instances -----------------------------------------------------------
 --------------------------------------------------------------------------------
-
-instance ToJSON SourcePos where
-  toJSON p = object [   "sourceName"   .= f
-                      , "sourceLine"   .= unPos l
-                      , "sourceColumn" .= unPos c
-                      ]
-             where
-               f    = sourceName   p
-               l    = sourceLine   p
-               c    = sourceColumn p
-
-instance FromJSON SourcePos where
-  parseJSON (Object v) = safeSourcePos <$> v .: "sourceName"
-                                <*> v .: "sourceLine"
-                                <*> v .: "sourceColumn"
-  parseJSON _          = mempty
 
 instance FromJSON ErrorResult
 

--- a/tests/pos/PolySet.hs
+++ b/tests/pos/PolySet.hs
@@ -1,0 +1,19 @@
+{-@ LIQUID "--reflection"     @-}
+
+-- Tests elaboration of set operations on polymorphic types
+-- see https://github.com/ucsd-progsys/liquidhaskell/issues/2272
+
+module PolySet where
+
+import Data.Set
+
+data Lst a = Emp | Cons a (Lst a)
+
+{-@ measure lstHd @-}
+lstHd :: Ord a => Lst a -> Set a
+lstHd  Emp       = empty
+lstHd (Cons x _) = singleton x
+
+lcons ::  Lst l -> Lst (Lst l)
+{-@ lcons :: p: Lst l -> {v:Lst (Lst l) | v = Cons p Emp } @-}
+lcons p = Cons p Emp


### PR DESCRIPTION
Don't merge yet (before https://github.com/ucsd-progsys/liquid-fixpoint/pull/688), the LF submodule currently points to a branch.

Fixes #2272

@ranjitjhala I had to remove two things to make LH work with the `develop` version of LF: 

1. `fTyConP` as a parser with the same name was made public at https://github.com/ucsd-progsys/liquid-fixpoint/pull/683
2. conflicting JSON instances for `SourcePos` which were added at https://github.com/ucsd-progsys/liquid-fixpoint/pull/680

The tests pass without those, but I'm unsure if we should remove them in favor of liquid-fixpoint implementations (as done currently), or if we need to de-duplicate somehow.