### PR TITLE
update GHC version to 9.8.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ jobs:
       image: default
     steps:
       - cabal_build_and_test:
-          ghc_version: "9.8.1"
+          ghc_version: "9.8.2"
 
 workflows:
   version: 2

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-with-compiler: ghc-9.8.1
+with-compiler: ghc-9.8.2
 
 packages: .
           ./liquid-fixpoint

--- a/liquidhaskell-boot/liquidhaskell-boot.cabal
+++ b/liquidhaskell-boot/liquidhaskell-boot.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               liquidhaskell-boot
-version:            0.9.8.1
+version:            0.9.8.2
 synopsis:           Liquid Types for Haskell
 description:        This package provides a plugin to verify Haskell programs.
                     But most likely you should be using the [liquidhaskell package](https://hackage.haskell.org/package/liquidhaskell)
@@ -13,7 +13,7 @@ maintainer:         Ranjit Jhala <jhala@cs.ucsd.edu>
 category:           Language
 homepage:           https://github.com/ucsd-progsys/liquidhaskell
 build-type:         Simple
-tested-with:        GHC == 9.8.1
+tested-with:        GHC == 9.8.2
 
 extra-source-files: tests/specfiles/pos/*.spec
 

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               liquidhaskell
-version:            0.9.8.1
+version:            0.9.8.2
 synopsis:           Liquid Types for Haskell
 description:        Liquid Types for Haskell.
 license:            BSD-3-Clause
@@ -11,7 +11,7 @@ maintainer:         Ranjit Jhala <jhala@cs.ucsd.edu>
 category:           Language
 homepage:           https://github.com/ucsd-progsys/liquidhaskell
 build-type:         Custom
-tested-with:        GHC == 9.6.3
+tested-with:        GHC == 9.8.2
 extra-doc-files: CHANGES.md
                  README.md
 
@@ -78,8 +78,8 @@ library
   hs-source-dirs:     src
 
   build-depends:      base                 >= 4.11.1.0 && < 5,
-                      liquidhaskell-boot   == 0.9.8.1,
-                      bytestring           == 0.12.0.2,
+                      liquidhaskell-boot   == 0.9.8.2,
+                      bytestring           == 0.12.1.0,
                       containers           == 0.6.8,
                       ghc-bignum,
                       ghc-prim

--- a/stack.yaml
+++ b/stack.yaml
@@ -35,7 +35,7 @@ allow-newer-deps:
   - blaze-svg
   - store-core
 
-resolver: nightly-2024-01-26
+resolver: nightly-2024-05-14
 
 nix:
   packages: [cacert, git, hostname, nix, stack, z3]

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -52,7 +52,7 @@ packages:
     git: https://github.com/qnikst/ghc-timings-report
 snapshots:
 - completed:
-    sha256: 876a5c75d90718add42e1ad36d66000bf35050ce1c66748119897a32df613186
-    size: 563963
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2024/1/26.yaml
-  original: nightly-2024-01-26
+    sha256: fa3b5bc91ba72486026c6d9644df505eba3af4180ce072dd026064c62de92876
+    size: 634229
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2024/5/14.yaml
+  original: nightly-2024-05-14


### PR DESCRIPTION
Doesn't add new features, but brings back the HLS support for the devs (9.8.1 is no longer HLS-supported)