### PR TITLE
Make --exact-data-cons the default

### DIFF
--- a/docs/blog/2016-10-06-structural-induction.lhs
+++ b/docs/blog/2016-10-06-structural-induction.lhs
@@ -105,13 +105,8 @@ check whether the `length xs` is decreasing.
 Reflecting Lists into the Logic
 -------------------------------
 
-To talk about lists in the logic, we use the annotation
-
-\begin{code}
-{-@ LIQUID "--exact-data-cons" @-}
-\end{code}
-
-which **automatically** derives measures for
+To talk about data types in the logic, LH will automatically derive
+measures for
 
 * *testing* if a value has a given data constructor, and
 * *extracting* the corresponding field's value.

--- a/docs/blog/2016-12-25-isomorphisms.lhs
+++ b/docs/blog/2016-12-25-isomorphisms.lhs
@@ -49,7 +49,6 @@ are provably **isomorphic**.
 \begin{code}
 {-@ LIQUID "--higherorder" @-}
 {-@ LIQUID "--totalhaskell" @-}
-{-@ LIQUID "--exactdc" @-}
 {-@ LIQUID "--diffcheck" @-}
 {-@ LIQUID "--eliminate=some" @-}
 

--- a/docs/blog/2017-01-06-reductions.lhs
+++ b/docs/blog/2017-01-06-reductions.lhs
@@ -45,7 +45,6 @@ This proof reduction is possible since Peano numbers are homomorphic to Natural 
 \begin{code}
 {-@ LIQUID "--higherorder"    @-}
 {-@ LIQUID "--totalhaskell"   @-}
-{-@ LIQUID "--exactdc"        @-}
 {-@ LIQUID "--diffcheck"      @-}
 {-@ LIQUID "--pruneunsorted"  @-}
 {-@ LIQUID "--eliminate=some" @-}

--- a/docs/blog/todo/Iso.lhs
+++ b/docs/blog/todo/Iso.lhs
@@ -14,7 +14,6 @@ demo: Iso.hs
 \begin{code}
 {-@ LIQUID "--higherorder" @-}
 {-@ LIQUID "--totalhaskell" @-}
-{-@ LIQUID "--exactdc" @-}
 {-@ LIQUID "--diffcheck" @-}
 
 module Iso where

--- a/liquid-prelude/src/Language/Haskell/Liquid/ProofCombinators.hs
+++ b/liquid-prelude/src/Language/Haskell/Liquid/ProofCombinators.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE IncoherentInstances   #-}
 
+{-@ LIQUID "--no-exact-data-cons"     @-}
 module Language.Haskell.Liquid.ProofCombinators (
 
   -- ATTENTION! `Admit` and `(==!)` are UNSAFE: they should not belong the final proof term

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -273,9 +273,9 @@ config = cmdArgsMode $ Config {
           &= name "port"
           &= help "Port at which lhi should listen"
 
- , exactDC
-    = def &= help "Exact Type for Data Constructors"
-          &= name "exact-data-cons"
+ , noExactDC
+    = False &= help "Do not generate exact Type for Data Constructors"
+            &= name "no-exact-data-cons"
 
  , noADT
     = def &= help "Do not generate ADT representations in refinement logic"
@@ -679,7 +679,7 @@ defConfig = Config
   , notruetypes              = def
   , nototality               = False
   , pruneUnsorted            = def
-  , exactDC                  = def
+  , noExactDC                = def
   , noADT                    = def
   , expectErrorContaining    = def
   , expectAnyError           = False

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Config.hs
@@ -12,6 +12,7 @@ module Language.Haskell.Liquid.UX.Config (
    , pruneFlag
    , maxCaseExpand
    , exactDCFlag
+   , exactDC
    , hasOpt
    , totalityCheck
    , terminationCheck
@@ -68,7 +69,7 @@ data Config = Config
   , cFiles                   :: [String]   -- ^ .c files to compile and link against (for GHC)
   , eliminate                :: Eliminate  -- ^ eliminate (i.e. don't use qualifs for) for "none", "cuts" or "all" kvars
   , port                     :: Int        -- ^ port at which lhi should listen
-  , exactDC                  :: Bool       -- ^ Automatically generate singleton types for data constructors
+  , noExactDC                :: Bool       -- ^ Do not automatically generate singleton types for data constructors
   , noADT                    :: Bool       -- ^ Disable ADTs (only used with exactDC)
   , expectErrorContaining    :: [String]   -- ^ expect failure from Liquid with at least one of the following messages
   , expectAnyError           :: Bool       -- ^ expect failure from Liquid with any message
@@ -109,6 +110,9 @@ data Config = Config
   , pandocHtml               :: Bool       -- ^ Use pandoc to generate html
   , excludeAutomaticAssumptionsFor :: [String]
   } deriving (Generic, Data, Typeable, Show, Eq)
+
+exactDC :: Config -> Bool
+exactDC = not . noExactDC
 
 allowPLE :: Config -> Bool
 allowPLE cfg

--- a/src/Data/Bits_LHAssumptions.hs
+++ b/src/Data/Bits_LHAssumptions.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fplugin=LiquidHaskellBoot #-}
+{-@ LIQUID "--no-exact-data-cons" @-}
 module Data.Bits_LHAssumptions where
 
 {-@

--- a/src/Data/Int_LHAssumptions.hs
+++ b/src/Data/Int_LHAssumptions.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fplugin=LiquidHaskellBoot #-}
+{-@ LIQUID "--no-exact-data-cons" @-}
 module Data.Int_LHAssumptions where
 
 {-@

--- a/src/Data/Tuple_LHAssumptions.hs
+++ b/src/Data/Tuple_LHAssumptions.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_GHC -fplugin=LiquidHaskellBoot #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
+{-@ LIQUID "--no-exact-data-cons" @-}
 module Data.Tuple_LHAssumptions where
 
 import Data.Tuple

--- a/src/Data/Word_LHAssumptions.hs
+++ b/src/Data/Word_LHAssumptions.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fplugin=LiquidHaskellBoot #-}
+{-@ LIQUID "--no-exact-data-cons" @-}
 module Data.Word_LHAssumptions where
 
 {-@

--- a/src/Foreign/C/Types_LHAssumptions.hs
+++ b/src/Foreign/C/Types_LHAssumptions.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fplugin=LiquidHaskellBoot #-}
+{-@ LIQUID "--no-exact-data-cons" @-}
 module Foreign.C.Types_LHAssumptions where
 
 import GHC.Int_LHAssumptions()

--- a/src/Foreign/Ptr_LHAssumptions.hs
+++ b/src/Foreign/Ptr_LHAssumptions.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fplugin=LiquidHaskellBoot #-}
+{-@ LIQUID "--no-exact-data-cons" @-}
 module Foreign.Ptr_LHAssumptions where
 
 

--- a/src/GHC/Float_LHAssumptions.hs
+++ b/src/GHC/Float_LHAssumptions.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fplugin=LiquidHaskellBoot #-}
+{-@ LIQUID "--no-exact-data-cons" @-}
 module GHC.Float_LHAssumptions(Floating(..)) where
 
 {-@

--- a/src/GHC/Int_LHAssumptions.hs
+++ b/src/GHC/Int_LHAssumptions.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_GHC -fplugin=LiquidHaskellBoot #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
+{-@ LIQUID "--no-exact-data-cons" @-}
 module GHC.Int_LHAssumptions where
 
 import GHC.Int

--- a/src/GHC/Maybe_LHAssumptions.hs
+++ b/src/GHC/Maybe_LHAssumptions.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fplugin=LiquidHaskellBoot #-}
+{-@ LIQUID "--no-exact-data-cons" @-}
 module GHC.Maybe_LHAssumptions where
 
 {-@

--- a/src/GHC/Num_LHAssumptions.hs
+++ b/src/GHC/Num_LHAssumptions.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fplugin=LiquidHaskellBoot #-}
+{-@ LIQUID "--no-exact-data-cons" @-}
 module GHC.Num_LHAssumptions where
 
 {-@

--- a/src/GHC/Word_LHAssumptions.hs
+++ b/src/GHC/Word_LHAssumptions.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fplugin=LiquidHaskellBoot #-}
+{-@ LIQUID "--no-exact-data-cons" @-}
 module GHC.Word_LHAssumptions where
 
 {-@

--- a/src/Liquid/Prelude/Real_LHAssumptions.hs
+++ b/src/Liquid/Prelude/Real_LHAssumptions.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fplugin=LiquidHaskellBoot #-}
+{-@ LIQUID "--no-exact-data-cons" @-}
 module Liquid.Prelude.Real_LHAssumptions where
 
 import GHC.Num()

--- a/src/Liquid/Prelude/Totality_LHAssumptions.hs
+++ b/src/Liquid/Prelude/Totality_LHAssumptions.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_GHC -fplugin=LiquidHaskellBoot #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
+{-@ LIQUID "--no-exact-data-cons" @-}
 module Liquid.Prelude.Totality_LHAssumptions where
 
 import Control.Exception.Base

--- a/tests/DependentHaskell/todo/LF326.hs
+++ b/tests/DependentHaskell/todo/LF326.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-cons"   @-}
 {-@ LIQUID "--ple" @-}
 module Foo where
 import Prelude hiding (Maybe (..))

--- a/tests/benchmarks/cse230/src/Week10/Imp.hs
+++ b/tests/benchmarks/cse230/src/Week10/Imp.hs
@@ -1,7 +1,6 @@
 {-@ LIQUID "--reflection"  @-}
 {-@ LIQUID "--ple"         @-}
 {-@ LIQUID "--short-names" @-}
-{-@ LIQUID "--exact-data-cons" @-}
 
 {-@ infixr ++  @-}  -- TODO: Silly to have to rewrite this annotation!
 {-@ infixr <~  @-}  -- TODO: Silly to have to rewrite this annotation!

--- a/tests/benchmarks/haskell16/pos/tmp/MonoidPeano.hs
+++ b/tests/benchmarks/haskell16/pos/tmp/MonoidPeano.hs
@@ -1,6 +1,5 @@
 {-#LH LIQUID "--higherorder"     @-}
 {-#LH LIQUID "--totality"        @-}
-{-#LH LIQUID "--exact-data-cons" @-}
 {-#LH LIQUID "--higherorderqs" @-}
 
 module Peano where

--- a/tests/benchmarks/popl18/nople/neg/BasicLambdas.hs
+++ b/tests/benchmarks/popl18/nople/neg/BasicLambdas.hs
@@ -2,7 +2,6 @@
 
 {-@ LIQUID "--higherorder"      @-}
 {- LIQUID "--autoproofs"      @-}
-{-@ LIQUID "--exact-data-cons" @-}
 module BasicLambdas where
 
 import Proves 

--- a/tests/benchmarks/popl18/nople/neg/MonadReader.hs
+++ b/tests/benchmarks/popl18/nople/neg/MonadReader.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--expect-any-error" @-}
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--extensionality"  @-}
 
 

--- a/tests/benchmarks/popl18/nople/pos/ApplicativeReader.hs
+++ b/tests/benchmarks/popl18/nople/pos/ApplicativeReader.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--alphaequivalence" @-}
 {-@ LIQUID "--betaequivalence" @-}
 

--- a/tests/benchmarks/popl18/nople/pos/Euclide.hs
+++ b/tests/benchmarks/popl18/nople/pos/Euclide.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"      @-}
-{-@ LIQUID "--exact-data-cons" @-}
 
 module Euclide where
 

--- a/tests/benchmarks/popl18/nople/pos/FunctorReader.hs
+++ b/tests/benchmarks/popl18/nople/pos/FunctorReader.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--alphaequivalence" @-}
 {-@ LIQUID "--betaequivalence"  @-}
 

--- a/tests/benchmarks/popl18/nople/pos/FunctorReader_NoExtensionality.hs
+++ b/tests/benchmarks/popl18/nople/pos/FunctorReader_NoExtensionality.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--betaequivalence"  @-}
 
 

--- a/tests/benchmarks/popl18/nople/pos/MonadReader.hs
+++ b/tests/benchmarks/popl18/nople/pos/MonadReader.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"       @-}
-{-@ LIQUID "--exact-data-cons"   @-}
 
 -- NOPROP probably breaks some fixpoint flag 
 

--- a/tests/benchmarks/popl18/nople/pos/NatInduction.hs
+++ b/tests/benchmarks/popl18/nople/pos/NatInduction.hs
@@ -5,7 +5,6 @@ import Language.Haskell.Liquid.ProofCombinators
 import Prelude hiding (sum, range)
 
 {-@ LIQUID "--higherorder" @-}
-{-@ LIQUID "--exactdc" @-}
 
 {-@ natinduction :: p:(Nat-> Bool) -> PAnd {v:Proof | p 0} (n:Nat -> {v:Proof | p (n-1)} -> {v:Proof | p n})
                  -> n:Nat -> {v:Proof | p n}  @-}

--- a/tests/benchmarks/popl18/nople/pos/NaturalDeduction.hs
+++ b/tests/benchmarks/popl18/nople/pos/NaturalDeduction.hs
@@ -6,7 +6,6 @@
 module NaturalDeduction where
 
 {-@ LIQUID "--higherorder" @-}
-{-@ LIQUID "--exact-data-cons" @-}
 
 import Language.Haskell.Liquid.ProofCombinators
 

--- a/tests/benchmarks/popl18/nople/pos/OverviewListInfix.hs
+++ b/tests/benchmarks/popl18/nople/pos/OverviewListInfix.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--eliminate" @-}
 {-@ LIQUID "--maxparams=10"  @-}
 {-@ LIQUID "--higherorderqs" @-}

--- a/tests/benchmarks/popl18/nople/pos/Peano.hs
+++ b/tests/benchmarks/popl18/nople/pos/Peano.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--higherorderqs" @-}
 
 module Peano where

--- a/tests/benchmarks/popl18/nople/pos/Solver.hs
+++ b/tests/benchmarks/popl18/nople/pos/Solver.hs
@@ -6,7 +6,6 @@
 -- | Also, &&, not and rest logical operators are not in scope in the axioms
 
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--pruneunsorted"   @-}
 
 -- TAG: absref

--- a/tests/benchmarks/popl18/nople/pos/Unification.hs
+++ b/tests/benchmarks/popl18/nople/pos/Unification.hs
@@ -6,7 +6,6 @@
 -- where? switch off non-lin-cuts in higher-order mode?
 
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--eliminate=all"   @-}
 
 module Unification where

--- a/tests/benchmarks/popl18/nople/todo/Soundness.hs
+++ b/tests/benchmarks/popl18/nople/todo/Soundness.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--higherorder"     @-}
 {-@ LIQUID "--totality"        @-}
-{-@ LIQUID "--exact-data-cons" @-}
 
 module Soundness where
 

--- a/tests/benchmarks/popl18/ple/pos/NatInduction.hs
+++ b/tests/benchmarks/popl18/ple/pos/NatInduction.hs
@@ -5,7 +5,6 @@ import Language.Haskell.Liquid.ProofCombinators
 import Prelude hiding (sum, range)
 
 {-@ LIQUID "--higherorder" @-}
-{-@ LIQUID "--exactdc" @-}
 
 {-@ natinduction :: p:(Nat-> Bool) -> PAnd {v:Proof | p 0} (n:Nat -> {v:Proof | p (n-1)} -> {v:Proof | p n})
                  -> n:Nat -> {v:Proof | p n}  @-}

--- a/tests/benchmarks/popl18/ple/pos/NaturalDeduction.hs
+++ b/tests/benchmarks/popl18/ple/pos/NaturalDeduction.hs
@@ -6,7 +6,6 @@
 module NaturalDeduction where
 
 {-@ LIQUID "--higherorder" @-}
-{-@ LIQUID "--exact-data-cons" @-}
 
 import Language.Haskell.Liquid.ProofCombinators
 

--- a/tests/benchmarks/sf/Induction.hs
+++ b/tests/benchmarks/sf/Induction.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--ple" @-}
 

--- a/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Check.hs
+++ b/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Check.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
-{-@ LIQUID "--exact-data-cons" @-}
 -- ple is necessary to reason about the evaluation of checkBindings
 {-@ LIQUID "--ple" @-}
 

--- a/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Data/List.hs
+++ b/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Data/List.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--ple" @-}
 
 -----------------------------------------------------------------------------

--- a/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Eval.hs
+++ b/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Eval.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE EmptyCase #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--ple" @-}
 {-@ LIQUID "--no-positivity-check" @-}
 

--- a/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Repl.hs
+++ b/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Repl.hs
@@ -1,8 +1,6 @@
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 {-# LANGUAGE FlexibleInstances, UndecidableInstances, ViewPatterns,
              NondecreasingIndentation #-}
--- XXX: Why do we need --exact-data-cons here?
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--ple" @-}
 
 -----------------------------------------------------------------------------

--- a/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Step.hs
+++ b/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Step.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE EmptyCase #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--ple" @-}
 
 -----------------------------------------------------------------------------

--- a/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Unchecked.hs
+++ b/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Unchecked.hs
@@ -11,7 +11,6 @@
 ----------------------------------------------------------------------------
 
 {-# LANGUAGE LambdaCase #-}
-{- LIQUID "--exact-data-cons" @-}
 
 module Language.Stitch.LH.Unchecked where
 

--- a/tests/benchmarks/stitch-lh/tests/Tests/Check.hs
+++ b/tests/benchmarks/stitch-lh/tests/Tests/Check.hs
@@ -1,5 +1,4 @@
 {-# OPTIONS_GHC -fplugin=LiquidHaskell #-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--ple" @-}
 module Tests.Check where
 

--- a/tests/classes/pos/TypeEquality00.hs
+++ b/tests/classes/pos/TypeEquality00.hs
@@ -18,7 +18,6 @@
 
 module TypeEquality00 where
 
-{-@ LIQUID "--exact-data-con" @-}
 
 {-@ data EntityFieldPerson typ where                                                                                     
       PersonNums :: EntityFieldPerson {v:_ | len v > 0}                                                               

--- a/tests/classes/pos/TypeEquality01.hs
+++ b/tests/classes/pos/TypeEquality01.hs
@@ -13,7 +13,6 @@
 {-# LANGUAGE TypeFamilies               #-}
 
 {-@ LIQUID "--no-adt"         @-}
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
 {-@ LIQUID "--no-termination" @-}
 

--- a/tests/datacon/pos/T1476.hs
+++ b/tests/datacon/pos/T1476.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE GADTs, TypeFamilies, GeneralizedNewtypeDeriving, OverloadedStrings, TemplateHaskell, QuasiQuotes, MultiParamTypeClasses #-}
 
 {-@ LIQUID "--no-adt"                   @-}
-{-@ LIQUID "--exact-data-cons"           @-}
 {-@ LIQUID "--higherorder"              @-}
 {-@ LIQUID "--no-termination" @-}
 -- | Description of database records.

--- a/tests/errors/BadData1.hs
+++ b/tests/errors/BadData1.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--expect-error-containing=Data constructors in refinement do not match original datatype for `EntityField`" @-}
 {-@ LIQUID "--no-adt"         @-}
-{-@ LIQUID "--exact-data-con" @-}
 
 {-# LANGUAGE ExistentialQuantification, KindSignatures, TypeFamilies, GADTs #-}
 

--- a/tests/errors/BadData2.hs
+++ b/tests/errors/BadData2.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--expect-error-containing=Data constructors in refinement do not match original datatype for `Hog`" @-}
-{-@ LIQUID "--exact-data-cons" @-}
 
 module BadData2 where
 

--- a/tests/errors/BadSig1.hs
+++ b/tests/errors/BadSig1.hs
@@ -1,7 +1,6 @@
 {-@ LIQUID "--expect-error-containing=Illegal type specification for `BadSig1.EZ`" @-}
 {-# LANGUAGE GADTs #-}
 
-{-@ LIQUID "--exact-data-con" @-}
 
 module BadSig1 where
 

--- a/tests/errors/ExportReflect0.hs
+++ b/tests/errors/ExportReflect0.hs
@@ -1,6 +1,5 @@
 -- LH issue #1023
 
-{-@ LIQUID "--exactdc"     @-}
 {-@ LIQUID "--higherorder" @-}
 
 module ExportReflect0 (foo, zogbert) where

--- a/tests/errors/ShadowFieldInline.hs
+++ b/tests/errors/ShadowFieldInline.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--expect-error-containing=Multiple specifications for `pig`" @-}
-{-@ LIQUID "--exactdc" @-}
 
 module ShadowFieldInline where
 

--- a/tests/errors/ShadowFieldReflect.hs
+++ b/tests/errors/ShadowFieldReflect.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--expect-error-containing=Multiple specifications for `pig`" @-}
-{-@ LIQUID "--exactdc" @-}
 
 module ShadowFieldReflect where
 

--- a/tests/errors/TODOVarInTypeAlias.hs
+++ b/tests/errors/TODOVarInTypeAlias.hs
@@ -1,7 +1,6 @@
 -- VS.hs
 {-@ LIQUID "--higherorder"    @-}
 {-@ LIQUID "--totality"       @-}
-{-@ LIQUID "--exactdc"        @-}
 
 module TODOVarInTypeAlias where
 

--- a/tests/import/client/RC1015.hs
+++ b/tests/import/client/RC1015.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exactdc" @-}
 {-@ LIQUID "--higherorder" @-}
 
 module RC1015 where

--- a/tests/import/client/T1180.hs
+++ b/tests/import/client/T1180.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE GADTs #-}
 
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--noadt" @-}
 
 module T1180 where

--- a/tests/import/lib/PeanoLib.hs
+++ b/tests/import/lib/PeanoLib.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE GADTs #-}
 
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
 {-@ LIQUID "--ple"            @-}
 {-@ LIQUID "--noadt"          @-}

--- a/tests/import/lib/RL1015Lib.hs
+++ b/tests/import/lib/RL1015Lib.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exactdc" @-}
 {-@ LIQUID "--higherorder" @-}
 
 module RL1015Lib where

--- a/tests/import/lib/ReflectLib7.hs
+++ b/tests/import/lib/ReflectLib7.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"    @-}
-{-@ LIQUID "--exactdc"        @-}
 
 module ReflectLib7 where
 

--- a/tests/import/lib/T1102_LibX.hs
+++ b/tests/import/lib/T1102_LibX.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
 
 module T1102_LibX where
 

--- a/tests/import/lib/T1102_LibY.hs
+++ b/tests/import/lib/T1102_LibY.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
 
 module T1102_LibY where 
 

--- a/tests/import/lib/T1102_LibZ.hs
+++ b/tests/import/lib/T1102_LibZ.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
 
 module T1102_LibZ where
 

--- a/tests/import/lib/T1112.hs
+++ b/tests/import/lib/T1112.hs
@@ -1,6 +1,5 @@
 
 {-@ LIQUID "--higherorder"    @-}
-{-@ LIQUID "--exact-data-con" @-}
 
 module T1112 where
 

--- a/tests/import/lib/T1117Lib.hs
+++ b/tests/import/lib/T1117Lib.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"        @-}
-{-@ LIQUID "--exactdc"            @-}
 
 module T1117Lib where
 

--- a/tests/import/lib/T1118Lib1.hs
+++ b/tests/import/lib/T1118Lib1.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"        @-}
-{-@ LIQUID "--exactdc"            @-}
 module T1118Lib1 where
 
 import T1118Lib2 

--- a/tests/neg/AdtPeano0.hs
+++ b/tests/neg/AdtPeano0.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--expect-any-error" @-}
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
 
 module AdtPeano0 where

--- a/tests/neg/AdtPeano1.hs
+++ b/tests/neg/AdtPeano1.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--expect-any-error" @-}
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 
 module AdtPeano1 where

--- a/tests/neg/ExactADT6.hs
+++ b/tests/neg/ExactADT6.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--expect-any-error" @-}
 {-@ LIQUID "--no-adt"         @-}
-{-@ LIQUID "--exact-data-con" @-}
 
 {-# LANGUAGE ExistentialQuantification, KindSignatures, TypeFamilies, GADTs #-}
 

--- a/tests/neg/ExactGADT6.hs
+++ b/tests/neg/ExactGADT6.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--expect-any-error" @-}
 {-@ LIQUID "--no-adt"         @-}
-{-@ LIQUID "--exact-data-con" @-}
 
 {-# LANGUAGE ExistentialQuantification, KindSignatures, TypeFamilies, GADTs #-}
 

--- a/tests/neg/ExactGADT7.hs
+++ b/tests/neg/ExactGADT7.hs
@@ -4,7 +4,6 @@
 
 {-@ LIQUID "--prune-unsorted" @-}
 {-@ LIQUID "--no-adt"         @-}
-{-@ LIQUID "--exact-data-con" @-}
 
 module ExactGADT7 where
 

--- a/tests/parser/pos/NestedTuples.hs
+++ b/tests/parser/pos/NestedTuples.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-cons" @-}
 
 module NestedTuples where
 

--- a/tests/parser/pos/ReflectedInfix.hs
+++ b/tests/parser/pos/ReflectedInfix.hs
@@ -1,6 +1,5 @@
 module ReflectedInfix where
 {-@ LIQUID "--higherorder"    @-}
-{-@ LIQUID "--exact-data-con" @-}
 
 import Language.Haskell.Liquid.ProofCombinators 
 import Prelude hiding ((++))

--- a/tests/parser/pos/Tuples.hs
+++ b/tests/parser/pos/Tuples.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-cons" @-}
 
 module Tuples where
 

--- a/tests/ple/neg/BinahQuery.hs
+++ b/tests/ple/neg/BinahQuery.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--expect-any-error" @-}
 {-@ LIQUID "--no-adt" 	                           @-}
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--no-termination"                      @-}
 {-@ LIQUID "--ple" @-} 

--- a/tests/ple/neg/BinahUpdate.hs
+++ b/tests/ple/neg/BinahUpdate.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--expect-any-error" @-}
 {-@ LIQUID "--no-adt" 	                           @-}
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--no-termination"                      @-}
 {-@ LIQUID "--ple" @-} 

--- a/tests/ple/neg/BinahUpdateClient.hs
+++ b/tests/ple/neg/BinahUpdateClient.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--no-adt" 	                           @-}
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--no-termination"                      @-}
 {-@ LIQUID "--ple" @-} 

--- a/tests/ple/neg/BinahUpdateLib.hs
+++ b/tests/ple/neg/BinahUpdateLib.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--expect-any-error" @-}
 {-@ LIQUID "--no-adt" 	                           @-}
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--no-termination"                      @-}
 {-@ LIQUID "--ple" @-}

--- a/tests/ple/neg/BinahUpdateLib1.hs
+++ b/tests/ple/neg/BinahUpdateLib1.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--expect-any-error" @-}
 {-@ LIQUID "--no-adt" 	                           @-}
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--no-termination"                      @-}
 {-@ LIQUID "--ple" @-}

--- a/tests/ple/neg/ExactGADT5.hs
+++ b/tests/ple/neg/ExactGADT5.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--expect-any-error" @-}
 {-@ LIQUID "--no-adt" 	                           @-}
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--no-termination"                      @-}
 {-@ LIQUID "--ple" @-}

--- a/tests/ple/neg/T1173.hs
+++ b/tests/ple/neg/T1173.hs
@@ -2,7 +2,6 @@
 module T1173 where
 
 {-@ LIQUID "--no-adt" 	      @-}
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
 {-@ LIQUID "--ple"            @-}
 

--- a/tests/ple/pos/BinahQuery.hs
+++ b/tests/ple/pos/BinahQuery.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--no-adt" 	                           @-}
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--no-termination"                      @-}
 {-@ LIQUID "--ple" @-} 

--- a/tests/ple/pos/BinahUpdate.hs
+++ b/tests/ple/pos/BinahUpdate.hs
@@ -3,7 +3,6 @@
 module BinahUpdate where
 
 {-@ LIQUID "--no-adt" 	                           @-}
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--no-termination"                      @-}
 {-@ LIQUID "--ple" @-} 

--- a/tests/ple/pos/Compiler.hs
+++ b/tests/ple/pos/Compiler.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
 {-@ LIQUID "--ple"            @-} 
 {-@ LIQUID "--no-totality"    @-} 

--- a/tests/ple/pos/ExactGADT5.hs
+++ b/tests/ple/pos/ExactGADT5.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--no-adt"         @-}
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
 {-@ LIQUID "--no-termination" @-}
 {-@ LIQUID "--ple"            @-}

--- a/tests/ple/pos/ExactGADT7.hs
+++ b/tests/ple/pos/ExactGADT7.hs
@@ -3,7 +3,6 @@
 
 {-@ LIQUID "--prune-unsorted" @-}
 {-@ LIQUID "--no-adt"         @-}
-{-@ LIQUID "--exact-data-con" @-}
 {- LIQUID "--ple" @-}
 
 module ExactGADT7 where

--- a/tests/ple/pos/FilterPLE.hs
+++ b/tests/ple/pos/FilterPLE.hs
@@ -1,7 +1,6 @@
 {-@ LIQUID "--no-termination" @-}
 {-@ LIQUID "--short-names"    @-}
 {-@ LIQUID "--higherorder"    @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--ple"            @-}
 
 module FilterPLE where

--- a/tests/ple/pos/IndPerm.hs
+++ b/tests/ple/pos/IndPerm.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE GADTs            #-}
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
 {-@ LIQUID "--ple"            @-}
 

--- a/tests/ple/pos/PleORM.hs
+++ b/tests/ple/pos/PleORM.hs
@@ -1,6 +1,5 @@
 module PleORM where
 
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
 {-@ LIQUID "--ple"            @-}
 

--- a/tests/ple/pos/T1173.hs
+++ b/tests/ple/pos/T1173.hs
@@ -1,7 +1,6 @@
 module T1173 where
 
 {-@ LIQUID "--no-adt" 	      @-}
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
 {-@ LIQUID "--ple"            @-}
 

--- a/tests/ple/pos/T1302b.hs
+++ b/tests/ple/pos/T1302b.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE EmptyDataDecls, GADTs, ExistentialQuantification #-}
 
 {-@ LIQUID "--no-adt" 	      @-}
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
 {-@ LIQUID "--no-termination" @-}
 {-@ LIQUID "--no-totality"    @-}

--- a/tests/pos/AdtList0.hs
+++ b/tests/pos/AdtList0.hs
@@ -1,5 +1,4 @@
 
-{-@ LIQUID "--exact-data-cons" @-}
 
 module AdtList0 where
 

--- a/tests/pos/AdtList1.hs
+++ b/tests/pos/AdtList1.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-cons" @-}
 
 module AdtList1 where
 

--- a/tests/pos/AdtList3.hs
+++ b/tests/pos/AdtList3.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-cons" @-}
 
 module AdtList3 where
 

--- a/tests/pos/AdtList4.hs
+++ b/tests/pos/AdtList4.hs
@@ -2,7 +2,6 @@
 --   we instantiate the output of `app` with quals like `v < xs` `v > xs` etc.
 --   where v, xs are of the ADT sort `List a`.
 
-{-@ LIQUID "--exact-data-cons" @-}
 
 module AdtList4 where
 

--- a/tests/pos/AdtList5.hs
+++ b/tests/pos/AdtList5.hs
@@ -2,7 +2,6 @@
 --   are "holes" in the data-decl specification, presumably because the lifting
 --   happens BEFORE the holes are resolved.
 
-{-@ LIQUID "--exact-data-cons" @-}
 
 module AdtList5 where
 

--- a/tests/pos/AdtPeano0.hs
+++ b/tests/pos/AdtPeano0.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
 
 module AdtPeano0 where

--- a/tests/pos/AdtPeano1.hs
+++ b/tests/pos/AdtPeano1.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 
 module AdtPeano1 where

--- a/tests/pos/CasesToLogic.hs
+++ b/tests/pos/CasesToLogic.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-cons"     @-}
 {-@ LIQUID "--higherorder"        @-}
 
 module CasesToLogic where

--- a/tests/pos/ExactADT6.hs
+++ b/tests/pos/ExactADT6.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
 
 {-# LANGUAGE ExistentialQuantification, KindSignatures, TypeFamilies, GADTs #-}
 

--- a/tests/pos/ExactGADT0.hs
+++ b/tests/pos/ExactGADT0.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE GADTs #-}
 
-{-@ LIQUID "--exact-data-con" @-}
 
 
 module ExactGADT0 where

--- a/tests/pos/ExactGADT1.hs
+++ b/tests/pos/ExactGADT1.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
 
 {-# LANGUAGE  GADTs #-}
 

--- a/tests/pos/ExactGADT2.hs
+++ b/tests/pos/ExactGADT2.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
 
 {-# LANGUAGE  GADTs #-}
 

--- a/tests/pos/ExactGADT6.hs
+++ b/tests/pos/ExactGADT6.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
 
 {-# LANGUAGE ExistentialQuantification, KindSignatures, TypeFamilies, GADTs #-}
 

--- a/tests/pos/ListISort_perm.hs
+++ b/tests/pos/ListISort_perm.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE GADTs            #-}
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
 
 module ListISort_perm where

--- a/tests/pos/MutuallyDependentADT.hs
+++ b/tests/pos/MutuallyDependentADT.hs
@@ -1,6 +1,5 @@
 module MutuallyDependentADT where
 
-{-@ LIQUID "--exactdc"  @-}
 
 data Pred l 
   = PTerm (Term l)

--- a/tests/pos/ORM.hs
+++ b/tests/pos/ORM.hs
@@ -1,6 +1,5 @@
 module ORM where
 
-{-@ LIQUID "--exactdc"  @-}
 {-@ LIQUID "--higherorder" @-}
 
 

--- a/tests/pos/OrdList.hs
+++ b/tests/pos/OrdList.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-exact-data-cons" @-}
 {-@ LIQUID "--pruneunsorted" @-}
 
 module OrdList (

--- a/tests/pos/Pair.hs
+++ b/tests/pos/Pair.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-exact-data-cons" @-}
 module Pair () where
 
 import Language.Haskell.Liquid.Prelude 

--- a/tests/pos/RecSelector.hs
+++ b/tests/pos/RecSelector.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-exact-data-cons" @-}
 module RecSelector where
 
 data F a = F {fx :: a, fy :: a, fzz :: a} | G {fx :: a}

--- a/tests/pos/Record0.hs
+++ b/tests/pos/Record0.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-cons" @-}
 
 module Record0 () where
 

--- a/tests/pos/RecordSelectorError.hs
+++ b/tests/pos/RecordSelectorError.hs
@@ -1,3 +1,4 @@
+{-@ LIQUID "--no-exact-data-cons" @-}
 module RecordSelectorError where
 
 data F a b = F {fx :: a, fy :: b} | G {fx :: a}

--- a/tests/pos/ReflectBooleanFunctions.hs
+++ b/tests/pos/ReflectBooleanFunctions.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exactdc"      @-}
 {-@ LIQUID "--higherorder"  @-}
 module ReflectBooleanFunctions where
 

--- a/tests/pos/ReflectMutual.hs
+++ b/tests/pos/ReflectMutual.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exactdc" @-}
 
 module ReflectMutual where
 

--- a/tests/pos/Rest.hs
+++ b/tests/pos/Rest.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--ple" @-}
 
 module Rest where

--- a/tests/pos/T1024.hs
+++ b/tests/pos/T1024.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exactdc"     @-}
 {-@ LIQUID "--higherorder" @-}
 
 module T1024 where

--- a/tests/pos/T1025a.hs
+++ b/tests/pos/T1025a.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exactdc"     @-}                                                            
 {-@ LIQUID "--higherorder" @-}                                                            
 
 module T1025a where

--- a/tests/pos/T1060.hs
+++ b/tests/pos/T1060.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--ple" @-}
 

--- a/tests/pos/T1085.hs
+++ b/tests/pos/T1085.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-cons"   @-}
 
 module T1085 where
 

--- a/tests/pos/T1092.hs
+++ b/tests/pos/T1092.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"        @-}
-{-@ LIQUID "--exactdc"            @-}
 module T1092 where
 
 import Language.Haskell.Liquid.ProofCombinators

--- a/tests/pos/T1100.hs
+++ b/tests/pos/T1100.hs
@@ -2,7 +2,6 @@
 
 module T1100 where
 
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--no-termination"                      @-}
 

--- a/tests/pos/T1220.hs
+++ b/tests/pos/T1220.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exactdc" @-}
 
 module T1220 where
 

--- a/tests/pos/T1223.hs
+++ b/tests/pos/T1223.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exactdc" @-}
 {-@ LIQUID "--higherorder" @-}
 {-@ LIQUID "--ple-local" @-}
 {-@ infix   ++ @-}

--- a/tests/pos/T1267.hs
+++ b/tests/pos/T1267.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--max-case-expand=0" @-}
-{-@ LIQUID "--exactdc" @-}
 
 module T1267 where
 

--- a/tests/pos/T1278_2.hs
+++ b/tests/pos/T1278_2.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-cons" @-}
 
 module T1278_2 where
 

--- a/tests/pos/T1302.hs
+++ b/tests/pos/T1302.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE EmptyDataDecls, GADTs, ExistentialQuantification #-}
 
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
 
 module T1302 where

--- a/tests/pos/T1363.hs
+++ b/tests/pos/T1363.hs
@@ -2,7 +2,6 @@
 
 module T1363 where
 
-{-@ LIQUID "--exact-data-cons" @-}
 
 {-@ mySum :: Integer -> xs:[Integer] -> Integer / [len xs] @-}
 mySum :: Integer -> [Integer] -> Integer

--- a/tests/pos/T1874.hs
+++ b/tests/pos/T1874.hs
@@ -1,6 +1,5 @@
 module T1874 where
 
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--reflection"      @-}
 {-@ LIQUID "--ple"             @-}
 

--- a/tests/pos/T820.hs
+++ b/tests/pos/T820.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exactdc"      @-}
 {-@ LIQUID "--higherorder"  @-}
 
 module T820 where

--- a/tests/pos/WhyLH.hs
+++ b/tests/pos/WhyLH.hs
@@ -1,7 +1,6 @@
 module WhyLH where
 
 {-@ LIQUID "--ple" @-}
-{-@ LIQUID "--exact-data-cons" @-}
 
 -- This test contains the examples of the blogpost at
 -- https://www.tweag.io/blog/2022-01-19-why-liquid-haskell/

--- a/tests/pos/WrapUnWrap.hs
+++ b/tests/pos/WrapUnWrap.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"  @-}
-{-@ LIQUID "--exactdc"      @-}
 module WrapUnWrap where
 
 

--- a/tests/strings/pos/DivideAndQunquer.hs
+++ b/tests/strings/pos/DivideAndQunquer.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--higherorder"         @-}
 {-@ LIQUID "--totality"            @-}
-{-@ LIQUID "--exactdc"             @-}
 
 
 module DivideAndQunquer where 

--- a/tests/strings/pos/StringIndexing.hs
+++ b/tests/strings/pos/StringIndexing.hs
@@ -9,7 +9,6 @@
 {-@ LIQUID "--cores=10"            @-}
 {-@ LIQUID "--higherorder"         @-}
 {-@ LIQUID "--totality"            @-}
-{-@ LIQUID "--exactdc"             @-}
 
 module Main where
 

--- a/tests/strings/pos/StringIndexingStep3.hs
+++ b/tests/strings/pos/StringIndexingStep3.hs
@@ -17,7 +17,6 @@ NV TODO
 
 {-@ LIQUID "--higherorder"         @-}
 {-@ LIQUID "--totality"            @-}
-{-@ LIQUID "--exactdc"             @-}
 
 module Main where
 

--- a/tests/strings/pos/StringLib.hs
+++ b/tests/strings/pos/StringLib.hs
@@ -2,7 +2,6 @@
 
 {-@ LIQUID "--higherorder"         @-}
 {-@ LIQUID "--totality"            @-}
-{-@ LIQUID "--exactdc"             @-}
 
 module StringLib where
 

--- a/tests/strings/todo/Boyer_Moore.hs
+++ b/tests/strings/todo/Boyer_Moore.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--higherorder"       @-}
 {-@ LIQUID "--totality"          @-}
-{-@ LIQUID "--exactdc"           @-}
 
 module BoyerMoore where
 

--- a/tests/terminate/neg/T1404_3.hs
+++ b/tests/terminate/neg/T1404_3.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--expect-any-error" @-}
-{-@ LIQUID "--exactdc" @-}
 module T1404_3 where
 
 data Peano = Z | S Peano

--- a/tests/terminate/pos/Ackermann.hs
+++ b/tests/terminate/pos/Ackermann.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exactdc" @-}
 module Ackermann where
 
 data Peano = Z | S Peano

--- a/tests/todo/AALib.hs
+++ b/tests/todo/AALib.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exactdc" @-}
 
 module AALib where 
 

--- a/tests/todo/Adt0.hs
+++ b/tests/todo/Adt0.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--totality"                            @-}
 {-@ LIQUID "--ple" @-}

--- a/tests/todo/ApplicativeMaybe0.hs
+++ b/tests/todo/ApplicativeMaybe0.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--higherorder"     @-}
 {- LIQUID "--totality"        @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--ple" @-}
 {-@ LIQUID "--fuel=10" @-}
 

--- a/tests/todo/ApplicativeMaybe1.hs
+++ b/tests/todo/ApplicativeMaybe1.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--higherorder"     @-}
 {- LIQUID "--totality"        @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--ple" @-}
 {-@ LIQUID "--fuel=10" @-}
 

--- a/tests/todo/ExactGADT3.hs
+++ b/tests/todo/ExactGADT3.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
 
 {-# LANGUAGE  GADTs #-}
 

--- a/tests/todo/ExactGADT6.hs
+++ b/tests/todo/ExactGADT6.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
 
 {-# LANGUAGE  GADTs #-}
 

--- a/tests/todo/MaybeReflect0Lib.hs
+++ b/tests/todo/MaybeReflect0Lib.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--higherorder"     @-}
 {-@ LIQUID "--totality"        @-}
-{-@ LIQUID "--exact-data-cons" @-}
 
 
 {-# LANGUAGE IncoherentInstances   #-}

--- a/tests/todo/MaybeReflect1Lib.hs
+++ b/tests/todo/MaybeReflect1Lib.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--higherorder"     @-}
 {-@ LIQUID "--totality"        @-}
-{-@ LIQUID "--exact-data-cons" @-}
 
 
 {-# LANGUAGE IncoherentInstances   #-}

--- a/tests/todo/MeasureImport.hs
+++ b/tests/todo/MeasureImport.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exactdc" @-}
 
 import AALib
 

--- a/tests/todo/ReflImp.hs
+++ b/tests/todo/ReflImp.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--higherorder"     @-}
 {-@ LIQUID "--totality"        @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--higherorderqs"   @-}
 
 module Peano where

--- a/tests/todo/SearchTree.hs
+++ b/tests/todo/SearchTree.hs
@@ -2,7 +2,6 @@
 -- This file takes nearly a MINUTE when automatic-instances is off,
 -- and FOREVER when automatic-instances is on.
 
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--totality"                            @-}
 

--- a/tests/todo/T1037A.hs
+++ b/tests/todo/T1037A.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"        @-}
-{-@ LIQUID "--exactdc"            @-}
 
 module T1037A where
 

--- a/tests/todo/T1037B.hs
+++ b/tests/todo/T1037B.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder"        @-}
-{-@ LIQUID "--exactdc"            @-}
 
 module T1037B where
 

--- a/tests/todo/T1089.hs
+++ b/tests/todo/T1089.hs
@@ -1,5 +1,4 @@
 
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--no-termination"                      @-}
 {-@ LIQUID "--ple" @-}

--- a/tests/todo/T1094_Lib.hs
+++ b/tests/todo/T1094_Lib.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--higherorder" @-}
-{-@ LIQUID "--exactdc"     @-}
 
 module T1094_Lib where
 

--- a/tests/todo/T1189.hs
+++ b/tests/todo/T1189.hs
@@ -2,7 +2,6 @@
 
 {-# LANGUAGE GADTs #-}
 
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--higherorder"    @-}
 {-@ LIQUID "--ple"            @-}
 

--- a/tests/todo/T1278.1.hs
+++ b/tests/todo/T1278.1.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-cons" @-}
 module Term where
 
 {-@ data Tree [sz] @-}

--- a/tests/todo/T995.hs
+++ b/tests/todo/T995.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con" @-}
 {-@ LIQUID "--ple" @-}
 
 module Basics

--- a/tests/todo/T996.hs
+++ b/tests/todo/T996.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con"                      @-}
 
 module Induction where
 

--- a/tests/todo/T997.hs
+++ b/tests/todo/T997.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--totality"                            @-}
 {-@ LIQUID "--ple" @-}

--- a/tests/todo/T997a.hs
+++ b/tests/todo/T997a.hs
@@ -1,4 +1,3 @@
-{-@ LIQUID "--exact-data-con"                      @-}
 {-@ LIQUID "--higherorder"                         @-}
 {-@ LIQUID "--totality"                            @-}
 {-@ LIQUID "--ple" @-}

--- a/tests/todo/TypeError.hs
+++ b/tests/todo/TypeError.hs
@@ -4,7 +4,6 @@
 
 {-@ LIQUID "--autoproofs"      @-}
 {-@ LIQUID "--totality"        @-}
-{-@ LIQUID "--exact-data-cons" @-}
 module Append where
 
 import AxiomatizeLib

--- a/tests/todo/mapreduce.hs
+++ b/tests/todo/mapreduce.hs
@@ -1,6 +1,5 @@
 {-@ LIQUID "--higherorder"         @-}
 {-@ LIQUID "--totality"            @-}
-{-@ LIQUID "--exactdc"             @-}
 {-@ LIQUID "--no-measure-fields"   @-}
 
 


### PR DESCRIPTION
`--exact-data-cons` is a source of confusion for users that try to reflect functions every now and then.

In this PR I'm enabling it by default.

Note that I'm also removing the flag `--exact-data-cons` and adding a flag  `--no-exact-data-cons`, which might not be your preference if you care about backward compatibility of the command line.