### PR TITLE
Avoid useless cabal reconfigurations when testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ commands:
       - run:
           name: Test
           command: |
-            LIQUID_CABAL_PROJECT_FILE=<<parameters.project_file>> cabal v2-run --project-file << parameters.project_file >> test-driver || (<<parameters.allow_test_failures>>)
+            LIQUID_CABAL_PROJECT_FILE=<<parameters.project_file>> scripts/test/test_plugin.sh || (<<parameters.allow_test_failures>>)
             cabal v2-test --project-file << parameters.project_file >> tests:tasty || (<<parameters.allow_test_failures>>)
             (cabal v2-test -j1 --project-file << parameters.project_file >> --enable-test liquidhaskell-boot --flag devel --test-show-details=streaming --test-options="--xml=/tmp/junit/cabal/parser-test-results.xml") || (<<parameters.allow_test_failures>>)
           no_output_timeout: 30m

--- a/scripts/test/test_plugin.sh
+++ b/scripts/test/test_plugin.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
+set -e
 
-TEST_GROUPS="$@"
+CABAL_BUILD_ARGS=$([ -n "$LIQUID_CABAL_PROJECT_FILE" ] && echo --project-file=$LIQUID_CABAL_PROJECT_FILE || true)
 
-cabal v2-run tests:test-driver -- $TEST_GROUPS
+set -x
+# same as "cabal run tests:test-driver -- $@", but runs test-driver in the same
+# environment as cabal, whereas "cabal run" does change the environment which
+# then causes nested cabal calls to reconfigure packages.
+cabal build $CABAL_BUILD_ARGS tests:test-driver
+TEST_DRIVER=$(cabal exec -- bash -c "command -v test-driver")
+"$TEST_DRIVER" $@

--- a/tests/harness/Test/Build.hs
+++ b/tests/harness/Test/Build.hs
@@ -26,23 +26,27 @@ cabalRun :: Options
          -> IO ExitCode
 cabalRun opts names = do
   projectFile <- lookupEnv "LIQUID_CABAL_PROJECT_FILE"
-  runCommand "cabal" $
-    [ "build" ]
-    <> (case projectFile of Nothing -> []; Just projectFile' -> [ "--project-file", T.pack projectFile' ])
-    <> (if measureTimings opts then ["--flags=measure-timings", "-j1"] else ["--keep-going"])
-    <> extraOpts opts
-    <> names
+  let exe = "cabal"
+      args = [ "build" ]
+        <> (case projectFile of Nothing -> []; Just projectFile' -> [ "--project-file", T.pack projectFile' ])
+        <> (if measureTimings opts then ["--flags=measure-timings", "-j1"] else ["--keep-going"])
+        <> extraOpts opts
+        <> names
+  T.putStrLn $ T.unwords $ "running:" : exe : args
+  runCommand exe args
 
 -- | Runs stack on the given test groups
 stackRun :: Options -> [Text] -> IO ExitCode
-stackRun opts names =
-  runCommand "stack" $
-    [ "build", "--flag", "tests:stack" ]
-    <> concat [ ["--flag=tests:measure-timings", "-j1"] | measureTimings opts ]
-    <> testFlags
-    <> extraOpts opts
-    <> [ "--" ]
-    <> testNames
+stackRun opts names = do
+  let exe = "stack"
+      args = [ "build", "--flag", "tests:stack" ]
+        <> concat [ ["--flag=tests:measure-timings", "-j1"] | measureTimings opts ]
+        <> testFlags
+        <> extraOpts opts
+        <> [ "--" ]
+        <> testNames
+  T.putStrLn $ T.unwords $ "running:" : exe : args
+  runCommand exe args
   where
     testNames = fmap ("tests:" <>) names
     -- Enables that particular executable in the cabal file


### PR DESCRIPTION
Before this PR cabal would reconfigure liquid-fixpoint and all following packages in nested calls during tests.

```
scripts/test/test_plugin.sh unit-pos-2
running: cabal v2-run tests:test-driver -- unit-pos-2
Build profile: -w ghc-9.8.2 -O1
In order, the following will be built (use -v for more details):
 - liquid-fixpoint-0.9.6.3 (lib) (configuration changed)
 - liquidhaskell-boot-0.9.8.2 (lib) (configuration changed)
 - liquidhaskell-0.9.8.2 (lib:liquidhaskell) (dependency rebuilt)
 - tests-0.1.0.0 (exe:test-driver) (dependency rebuilt)
Configuring library for liquid-fixpoint-0.9.6.3..
Preprocessing library for liquid-fixpoint-0.9.6.3..
Building library for liquid-fixpoint-0.9.6.3..
Configuring library for liquidhaskell-boot-0.9.8.2..
Preprocessing library for liquidhaskell-boot-0.9.8.2..
Building library for liquidhaskell-boot-0.9.8.2..
Preprocessing library for liquidhaskell-0.9.8.2..
Building library for liquidhaskell-0.9.8.2..
Preprocessing executable 'test-driver' for tests-0.1.0.0..
Building executable 'test-driver' for tests-0.1.0.0..
Running integration tests!
running: cabal build unit-pos-2
Warning: Unknown/unsupported 'ghc' version detected (Cabal 3.10.1.0 supports
'ghc' version < 9.8):
/nix/store/vc4gi3i5n7k3lkp0d3j9smfdjmpi6yyf-ghc-9.8.2/bin/ghc-9.8.2 is version
9.8.2
Build profile: -w ghc-9.8.2 -O1
In order, the following will be built (use -v for more details):
 - liquid-fixpoint-0.9.6.3 (lib) (configuration changed)
 - liquidhaskell-boot-0.9.8.2 (lib) (configuration changed)
 - liquidhaskell-0.9.8.2 (lib:liquidhaskell) (dependency rebuilt)
 - liquid-vector-0.13.1.0.1 (lib:liquid-vector) (dependency rebuilt)
 - liquid-prelude-0.9.2.8.1 (lib:liquid-prelude) (dependency rebuilt)
 - tests-0.1.0.0 (exe:unit-pos-2) (dependency rebuilt)
Configuring library for liquid-fixpoint-0.9.6.3..
Preprocessing library for liquid-fixpoint-0.9.6.3..
Building library for liquid-fixpoint-0.9.6.3..
Configuring library for liquidhaskell-boot-0.9.8.2..
Preprocessing library for liquidhaskell-boot-0.9.8.2..
Building library for liquidhaskell-boot-0.9.8.2..
Preprocessing library for liquidhaskell-0.9.8.2..
Building library for liquidhaskell-0.9.8.2..
Preprocessing library for liquid-vector-0.13.1.0.1..
Building library for liquid-vector-0.13.1.0.1..
Preprocessing library for liquid-prelude-0.9.2.8.1..
Building library for liquid-prelude-0.9.2.8.1..
Preprocessing executable 'unit-pos-2' for tests-0.1.0.0..
Building executable 'unit-pos-2' for tests-0.1.0.0..
...
```