### PR TITLE
Update ProofCombinators.hs

### DIFF
--- a/liquid-prelude/src/Language/Haskell/Liquid/ProofCombinators.hs
+++ b/liquid-prelude/src/Language/Haskell/Liquid/ProofCombinators.hs
@@ -153,8 +153,6 @@ infixl 3 ==!
 
 infixl 3 ==.
 
-{-# DEPRECATED (==.) "Use (===) instead" #-}
-
 {-# INLINE (==.) #-} 
 (==.) :: a -> a -> a 
 _ ==. x = x 

--- a/liquid-prelude/src/Language/Haskell/Liquid/ProofCombinators.hs
+++ b/liquid-prelude/src/Language/Haskell/Liquid/ProofCombinators.hs
@@ -149,7 +149,7 @@ infixl 3 ==!
 -- | The above operators check each intermediate proof step.
 --   The operator `==.` below accepts an optional proof term
 --   argument, but does not check intermediate steps.
---   TODO: What is it USEFUL FOR?
+--   So, using `==.` the proofs are faster, but the error messages worse. 
 
 infixl 3 ==.
 


### PR DESCRIPTION
`==.` is faster than `===` because it is not checking intermediate steps!