### PR TITLE
WIP update to latest liquid-fixpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ commands:
       - checkout
       - add_ssh_keys
       - run: git submodule sync
-      - run: git submodule update --init
+      - run: git submodule update --init --remote
 
   cabal_build_and_test:
     description: "Build the project and run the tests"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "liquid-fixpoint"]
 	path = liquid-fixpoint
-	url = https://github.com/ucsd-progsys/liquid-fixpoint.git
+	url = https://github.com/clayrat/liquid-fixpoint.git
+	branch = ple-theories

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Support for GHC 9.8.2.
+- Fixed the polymorphism-related crash in liquid-fixpoint caused by a restrictive theory encoding [#2272](https://github.com/ucsd-progsys/liquidhaskell/issues/2272).
+
 ## 0.9.8.1 (2024-02-05)
 
 - Set support for GHC 9.8.1 [#2248](https://github.com/ucsd-progsys/liquidhaskell/pull/2248)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -633,7 +633,7 @@ checkMBody senv emb _ sort (Def m c _ bs body) = checkMBody' emb sort γ' sp bod
     keep | allowTC = not . isEmbeddedClass
          | otherwise = not . isClassType
     -- YL: extract permitTC information from sort
-    allowTC = or $ fmap (fromMaybe False . permitTC) (ty_info $ toRTypeRep sort)
+    allowTC = any (fromMaybe False . permitTC) (ty_info $ toRTypeRep sort)
     trep  = toRTypeRep ct
     su    = checkMBodyUnify (ty_res trep) (last txs)
     txs   = thd5 $ bkArrowDeep sort

--- a/tests/ple/pos/ListPolySet.hs
+++ b/tests/ple/pos/ListPolySet.hs
@@ -1,0 +1,46 @@
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
+
+module ListPolySet where
+
+import Prelude hiding (all)
+import Data.Set hiding (all)
+import Language.Haskell.Liquid.ProofCombinators
+
+{-@ reflect assert @-}
+{-@ assert :: b:{Bool | b } -> x:a -> {v:a | v == x && b} @-}
+assert :: Bool -> a -> a
+assert _ x = x
+
+{-@ reflect ?? @-}
+x ?? y = y
+
+{-@ reflect all @-}
+all :: (a -> Bool) -> [a] -> Bool
+all _ []       = True
+all p (x : xs) = p x && all p xs
+
+{-@ all_to_elem :: (Ord a, Eq a) => f:(a -> Bool)
+                -> ls:{[a] | all f ls}
+                -> e:{a | (member e (fromList ls))}
+                -> { f e } @-}
+all_to_elem :: (Ord a, Eq a) => (a -> Bool) -> [a] -> a -> ()
+all_to_elem _ []       _ = ()
+all_to_elem f (x : xs) e | x == e
+  = assert (all f (x : xs)) ()
+                         | otherwise
+  = assert (all f (x : xs)) ()
+    ? assert (all f xs) ()
+    ? member e (fromList xs)
+    ? all_to_elem f xs e
+
+{-@ all_subset :: f:(a -> Bool)
+               -> ls1:{[a] | all (f) ls1 }
+               -> ls2:{[a] | isSubsetOf (fromList ls2) (fromList ls1) }
+               -> { all f ls2 } @-}
+all_subset :: Ord a => (a -> Bool) -> [a] -> [a] -> ()
+all_subset f ls1 (x : ls2) =
+  assert (member x (fromList ls1)) ()
+    ?? all_to_elem f ls1 x
+    ?? all_subset f ls1 ls2
+all_subset f _ _ = ()

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -1446,6 +1446,7 @@ executable unit-pos-1
                     , Poly3a
                     , Poly3
                     , Poly4
+                    , PolySet
                     , Polyfun
                     , Polyqual
                     , PositivityCheck

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2336,6 +2336,7 @@ executable ple-pos
                     , Isort_erase
                     , ListAnd
                     , Lists
+                    , ListPolySet
                     , MergeSort
                     , MJFix
                     , MossakaBug


### PR DESCRIPTION
Fixes #2288 

Don't merge yet (before https://github.com/ucsd-progsys/liquid-fixpoint/pull/696), the LF submodule currently points to a branch of a fork.

This updates LF to the version with compacted sort coercions for Sets, which fixes crashes for PLE-heavy code resulting from missing coercions.