### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ cabal.project.local
 tests/synthesis/logs/*
 !tests/synthesis/logs/.gitkeep
 /tests/logs/
-/.stack-work/
+.stack-work
 /.vagrant/
 TAGS
 tags*


### PR DESCRIPTION
Updated `.gitignore` to ignore nested `.stack-work` folders (e.g. the ones in liquidhaskell-boot)