### PR TITLE
Add missing assumptions in GHC.Real.div

### DIFF
--- a/src/GHC/Real_LHAssumptions.hs
+++ b/src/GHC/Real_LHAssumptions.hs
@@ -24,8 +24,8 @@ class (GHC.Real.Real a, GHC.Enum.Enum a) => GHC.Real.Integral a where
   GHC.Real.div :: x:a -> y:{v:a | v /= 0} -> {v:a | (v = (x / y)) &&
                                                     ((x >= 0 && y >= 0) => v >= 0) &&
                                                     ((x >= 0 && y >= 1) => v <= x) && 
-                                                    ((1 < y)            => v < x ) && 
-                                                    ((y >= 1)           => v <= x)  
+                                                    ((x > 0 && 1 < y) => v < x ) && 
+                                                    ((x >= 0 && y >= 1) => v <= x)  
                                                     }
   GHC.Real.quotRem :: x:a -> y:{v:a | v /= 0} -> ( {v:a | (v = (x / y)) &&
                                                           ((x >= 0 && y >= 0) => v >= 0) &&


### PR DESCRIPTION
Previously GHC.Real.div had the assumptions `((1 < y)  => v < x )`  and  ` ((y >= 1)  => v <= x)`. These are incorrect as written. If `x = -1` and `y = 2` then `v = -1/2`, which means `v > x` and contradicts both assumptions. The fixed versions are `((x > 0 && 1 < y)  => v < x )`  and  ` ((x >= 0 && y >= 1)  => v <= x)`.