### PR TITLE
Fully qualify names in CoreToLogic

### DIFF
--- a/liquid-prelude/src/Language/Haskell/Liquid/Prelude.hs
+++ b/liquid-prelude/src/Language/Haskell/Liquid/Prelude.hs
@@ -134,10 +134,18 @@ safeZipWith f (a:as) (b:bs) = f a b : safeZipWith f as bs
 safeZipWith _ []     []     = []
 safeZipWith _ _ _ = error "safeZipWith: cannot happen!"
 
-{-@ (==>) :: p:Bool -> q:Bool -> {v:Bool | v <=> (p =>  q)} @-}
+{-@ (==>) :: p:Bool -> q:Bool -> {v:Bool | v <=> (p => q)} @-}
 infixr 8 ==>
 (==>) :: Bool -> Bool -> Bool
 False ==> False = True
 False ==> True  = True
 True  ==> True  = True
 True  ==> False = False
+
+{-@ (<=>) :: p:Bool -> q:Bool -> {v:Bool | v <=> (p <=> q)} @-}
+infixr 8 <=>
+(<=>) :: Bool -> Bool -> Bool
+False <=> False = True
+False <=> True  = False
+True  <=> True  = True
+True  <=> False = False

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -377,28 +377,28 @@ coreToIte allowTC e (efalse, etrue)
 toPredApp :: Bool -> C.CoreExpr -> LogicM Expr
 toPredApp allowTC p = go . Misc.mapFst opSym . splitArgs allowTC $ p
   where
-    opSym = fmap GM.dropModuleNamesAndUnique . tomaybesymbol
+    opSym = tomaybesymbol
     go (Just f, [e1, e2])
       | Just rel <- M.lookup f brels
       = PAtom rel <$> coreToLg allowTC e1 <*> coreToLg allowTC e2
     go (Just f, [e])
-      | f == symbol ("not" :: String)
+      | f == symbol ("GHC.Classes.not" :: String)
       = PNot <$>  coreToLg allowTC e
-      | f == symbol ("len" :: String)
-      = EApp (EVar "len") <$> coreToLg allowTC e
     go (Just f, [e1, e2])
-      | f == symbol ("||" :: String)
+      | f == symbol ("GHC.Classes.||" :: String)
       = POr <$> mapM (coreToLg allowTC) [e1, e2]
-      | f == symbol ("&&" :: String)
+      | f == symbol ("GHC.Classes.&&" :: String)
       = PAnd <$> mapM (coreToLg allowTC) [e1, e2]
-      | f == symbol ("==>" :: String)
+      | f == symbol ("Language.Haskell.Liquid.Prelude.==>" :: String)
       = PImp <$> coreToLg allowTC e1 <*> coreToLg allowTC e2
-      | f == symbol ("<=>" :: String)
+      | f == symbol ("Language.Haskell.Liquid.Prelude.<=>" :: String)
       = PIff <$> coreToLg allowTC e1 <*> coreToLg allowTC e2
+      | f == symbol ("GHC.Base.const" :: String)
+      = coreToLg allowTC e1
     go (Just f, [es])
-      | f == symbol ("or" :: String)
+      | f == symbol ("GHC.Internal.Data.Foldable.or" :: String)
       = POr  . deList <$> coreToLg allowTC es
-      | f == symbol ("and" :: String)
+      | f == symbol ("GHC.Internal.Data.Foldable.and" :: String)
       = PAnd . deList <$> coreToLg allowTC es
     go (_, _)
       = toLogicApp allowTC p
@@ -475,12 +475,12 @@ isCst _              = True
 
 
 brels :: M.HashMap Symbol Brel
-brels = M.fromList [ (symbol ("==" :: String), Eq)
-                   , (symbol ("/=" :: String), Ne)
-                   , (symbol (">=" :: String), Ge)
-                   , (symbol (">" :: String) , Gt)
-                   , (symbol ("<=" :: String), Le)
-                   , (symbol ("<" :: String) , Lt)
+brels = M.fromList [ (symbol ("GHC.Classes.==" :: String), Eq)
+                   , (symbol ("GHC.Classes./=" :: String), Ne)
+                   , (symbol ("GHC.Classes.>=" :: String), Ge)
+                   , (symbol ("GHC.Classes.>" :: String) , Gt)
+                   , (symbol ("GHC.Classes.<=" :: String), Le)
+                   , (symbol ("GHC.Classes.<" :: String) , Lt)
                    ]
 
 bops :: M.HashMap Symbol Bop

--- a/tests/basic/neg/ShadowLogicSymbols.hs
+++ b/tests/basic/neg/ShadowLogicSymbols.hs
@@ -1,0 +1,18 @@
+-- | LH should not confuse functions with the same name as symbols in
+-- | the logic with the corresponding measures
+{-@ LIQUID "--expect-error-containing=Liquid Type Mismatch" @-}
+{-@ LIQUID "--ple"    	@-}
+
+module ShadowLogicSymbols where
+
+import Prelude hiding (not)
+
+not :: Bool -> Bool
+not a = a
+
+{-@ reflect shouldBeId @-}
+shouldBeId :: Bool -> Bool
+shouldBeId x = not x
+
+{-@ lemma :: {shouldBeId False} @-}
+lemma = ()

--- a/tests/basic/pos/ShadowLogicSymbols.hs
+++ b/tests/basic/pos/ShadowLogicSymbols.hs
@@ -1,0 +1,16 @@
+-- | You can't shadow names from the logic. You need to fully qualify them to use the symbols you
+-- | defined in your specs if they already have a counterpart in the logic.
+
+{-@ LIQUID "--ple"    	@-}
+{-@ LIQUID "--reflection"    	@-}
+
+module ShadowLogicSymbols where
+
+import Prelude hiding (not)
+
+{-@ reflect not @-}
+not :: Bool -> Bool
+not a = a
+
+{-@ lemma :: {ShadowLogicSymbols.not True} @-}
+lemma = ()

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2159,6 +2159,7 @@ executable basic-neg
                     , Inc04Lib
                     , List00
                     , Poly00
+                    , ShadowLogicSymbols
                     , T1459
 
     ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
@@ -2216,6 +2217,7 @@ executable basic-pos
                     , OpaqueRefl05
                     , OpaqueRefl06
                     , Poly00
+                    , ShadowLogicSymbols
                     , SkipDerived00
 
     ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0


### PR DESCRIPTION
Related to issue #2319, in this PR we fully qualify symbols when transforming CoreExpr into Expr of the logic so we don't mistake builtin symbols with functions defined by the user (see example in the issue).

Worth mentioning, it means that this does not pass verification:

```
{-@ LIQUID "--ple"    	@-}
{-@ LIQUID "--reflection"    	@-}

module Inc00 where

import Prelude hiding (not)

{-@ reflect not @-}
not :: Bool -> Bool
not a = a

{-@ lemma :: {not True} @-}
lemma = ()
```

If you want to refer to your reflected functions that clash with builtin symbols of the logic, you have to fully qualify them:

```
{-@ LIQUID "--ple"    	@-}
{-@ LIQUID "--reflection"    	@-}

module Inc00 where

import Prelude hiding (not)

{-@ reflect not @-}
not :: Bool -> Bool
not a = a

{-@ lemma :: {Inc00.not True} @-}
lemma = ()
```

So that there's no ambiguity. Without qualification, we assume `not` (or the like) to refer to the builtin symbols from the logic.

Any comments welcome!