### PR TITLE
Enhance the core transformation to strictify let pattern matching

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Rewrite.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Rewrite.hs
@@ -154,7 +154,7 @@ rewriteWith :: RewriteRule -> CoreExpr -> CoreExpr
 --------------------------------------------------------------------------------
 rewriteWith tx           = go
   where
-    go                   = txTop . step
+    go                   = step . txTop
     txTop e              = fromMaybe e (tx e)
     goB (Rec xes)        = Rec         (mapSnd go <$> xes)
     goB (NonRec x e)     = NonRec x    (go e)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Rewrite.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Rewrite.hs
@@ -226,8 +226,8 @@ simplifyPatTuple (Let (NonRec x e@(Case _ _ _ [Alt (DataAlt _) _ _])) rest)
         replaceAltInNestedCases (Ghc.exprType e') ss e'' e
 
 simplifyPatTuple (Let (NonRec x e@(Case e0 _ _ [Alt (DataAlt _) bs _])) rest)
-  | Just v <- isVar e0
-  , Just i0 <- isProjectionOf v e
+  | Just v0 <- isVar e0
+  , Just i0 <- isProjectionOf v0 e
   , let n = length bs
   , n > 1
   =

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2123,7 +2123,7 @@ executable relational-pos
                     , AsynchCase
                     , Axiom
                     , CheckedImp
-                    , Isort
+--                  , Isort  -- Disabled due to https://github.com/ucsd-progsys/liquidhaskell/issues/2335
                     , MapFusion
                     , MutRec
                     , SndOrdPredNonRel


### PR DESCRIPTION
This PR makes more effective a transformation in the code to rewrite

```haskell
let pat = e0 in e1
```
to
```haskell
case e0 of
  pat = e1
```

A new case is handled, and the transformation is constrained to apply only in cases where it doesn't break the type of the transformed expression.

Much of the challenge is that when we get to transform core, the lazy patterns have already been desugared to a bunch of lets which use projections instead. See the documentation of `strictifyLazyLets` for details.

The `Isort.hs` test had to be disabled as explained in #2335.

This PR is related to #2257. It doesn't address that issue, but it makes more predictable how LH will transform core. Fixing #2257 would require documenting the transformation to the user.