### PR TITLE
Strengthen the inlineLoopBreaker transformation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ commands:
             chmod +x ./x86_64-linux-ghcup
             ./x86_64-linux-ghcup install ghc << parameters.ghc_version >>
             ./x86_64-linux-ghcup set ghc << parameters.ghc_version >>
-            ./x86_64-linux-ghcup install cabal 3.10.2.0
+            ./x86_64-linux-ghcup install cabal 3.12.1.0
             export PATH=~/.ghcup/bin:$PATH
             echo 'export PATH=~/.ghcup/bin:$PATH' >> $BASH_ENV
             cabal update

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -548,6 +548,7 @@ import GHC.Types.Basic                as Ghc
     , funPrec
     , InlinePragma(inl_act, inl_inline, inl_rule, inl_sat, inl_src)
     , isDeadOcc
+    , isNoInlinePragma
     , isStrongLoopBreaker
     , noOccInfo
     , topPrec
@@ -574,6 +575,7 @@ import GHC.Types.Id                   as Ghc
     , idInfo
     , idOccInfo
     , isConLikeId
+    , idInlinePragma
     , modifyIdInfo
     , mkExportedLocalId
     , mkUserLocal

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Types.hs
@@ -87,9 +87,10 @@ instance HasConfig Env where
 type LocalVars = M.HashMap F.Symbol [LocalVarDetails]
 
 data LocalVarDetails = LocalVarDetails
-    { lvdLine :: Int
-    , lvdVar :: Ghc.Var
-    }
+  { lvdSourcePos :: F.SourcePos
+  , lvdVar :: Ghc.Var
+  , lvdIsRec :: Bool  -- ^ Is the variable defined in a letrec?
+  } deriving Show
 
 -------------------------------------------------------------------------------
 -- | A @TyThingMap@ is used to resolve symbols into GHC @TyThing@ and, 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Types.hs
@@ -8,6 +8,7 @@ module Language.Haskell.Liquid.Bare.Types
   , TyThingMap 
   , ModSpecs
   , LocalVars 
+  , LocalVarDetails (..)
 
     -- * Tycon and Datacon processing environment
   , TycEnv (..) 
@@ -83,7 +84,12 @@ instance HasConfig Env where
 
 -- | @LocalVars@ is a map from names to lists of pairs of @Ghc.Var@ and 
 --   the lines at which they were defined. 
-type LocalVars = M.HashMap F.Symbol [(Int, Ghc.Var)]
+type LocalVars = M.HashMap F.Symbol [LocalVarDetails]
+
+data LocalVarDetails = LocalVarDetails
+    { lvdLine :: Int
+    , lvdVar :: Ghc.Var
+    }
 
 -------------------------------------------------------------------------------
 -- | A @TyThingMap@ is used to resolve symbols into GHC @TyThing@ and, 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE BangPatterns               #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE ViewPatterns               #-}
 
 module Language.Haskell.Liquid.GHC.Plugin (
 
@@ -46,9 +45,7 @@ import           Control.Monad.IO.Class (MonadIO)
 
 import           Data.Coerce
 import           Data.Function                            ((&))
-import           Data.Kind                                ( Type )
 import qualified Data.List                               as L
-import           Data.IORef
 import qualified Data.Set                                as S
 import           Data.Set                                 ( Set )
 
@@ -56,7 +53,6 @@ import           Data.Set                                 ( Set )
 import qualified Data.HashSet                            as HS
 import qualified Data.HashMap.Strict                     as HM
 
-import           System.IO.Unsafe                         ( unsafePerformIO )
 import           Language.Fixpoint.Types           hiding ( errs
                                                           , panic
                                                           , Error
@@ -82,11 +78,6 @@ newtype LiquidCheckException = ErrorsOccurred [Filter] -- Unmatched expected err
 -- | State and configuration management -----------------------------------------
 ---------------------------------------------------------------------------------
 
--- | A reference to cache the LH's 'Config' and produce it only /once/, during the dynFlags hook.
-cfgRef :: IORef Config
-cfgRef = unsafePerformIO $ newIORef defConfig
-{-# NOINLINE cfgRef #-}
-
 -- | Set to 'True' to enable debug logging.
 debugLogs :: Bool
 debugLogs = False
@@ -94,10 +85,6 @@ debugLogs = False
 ---------------------------------------------------------------------------------
 -- | Useful functions -----------------------------------------------------------
 ---------------------------------------------------------------------------------
-
--- | Reads the 'Config' out of a 'IORef'.
-getConfig :: IO Config
-getConfig = readIORef cfgRef
 
 -- | Combinator which conditionally print on the screen based on the value of 'debugLogs'.
 debugLog :: MonadIO m => String -> m ()
@@ -110,15 +97,15 @@ debugLog msg = when debugLogs $ liftIO (putStrLn msg)
 plugin :: GHC.Plugin
 plugin = GHC.defaultPlugin {
     typeCheckResultAction = liquidPlugin
-  , driverPlugin          = customDynFlags
+  , driverPlugin          = lhDynFlags
   , pluginRecompile       = purePlugin
   }
   where
     liquidPlugin :: [CommandLineOption] -> ModSummary -> TcGblEnv -> TcM TcGblEnv
-    liquidPlugin _ summary gblEnv = do
-      cfg <- liftIO getConfig
+    liquidPlugin opts summary gblEnv = do
+      cfg <- liftIO $ LH.getOpts opts
       if skipModule cfg then return gblEnv
-      else liquidPluginGo summary gblEnv
+      else liquidPluginGo cfg summary gblEnv
 
     -- Unfortunately, we can't make Haddock run the LH plugin, because the former
     -- does mangle the '.hi' files, causing annotations to not be persisted in the
@@ -126,7 +113,7 @@ plugin = GHC.defaultPlugin {
     -- the plugin altogether if the module is being compiled with Haddock.
     -- See also: https://github.com/ucsd-progsys/liquidhaskell/issues/1727
     -- for a post-mortem.
-    liquidPluginGo summary gblEnv = do
+    liquidPluginGo cfg summary gblEnv = do
       logger <- getLogger
       dynFlags <- getDynFlags
       withTiming logger (text "LiquidHaskell" <+> brackets (ppr $ ms_mod_name summary)) (const ()) $ do
@@ -141,7 +128,7 @@ plugin = GHC.defaultPlugin {
             liftIO $ printWarning logger warning
             pure gblEnv
           else do
-            newGblEnv <- typecheckHook summary gblEnv
+            newGblEnv <- typecheckHook cfg summary gblEnv
             case newGblEnv of
               -- Exit with success if all expected errors were found
               Left (ErrorsOccurred []) -> pure gblEnv
@@ -156,34 +143,38 @@ plugin = GHC.defaultPlugin {
 -- | GHC Configuration & Setup -------------------------------------------------
 --------------------------------------------------------------------------------
 
+lhDynFlags :: [CommandLineOption] -> HscEnv -> IO HscEnv
+lhDynFlags _ hscEnv =
+    return hscEnv
+      { hsc_dflags =
+          hsc_dflags hscEnv
+           -- Ignore-interface-pragmas need to be unset to have access to
+           -- the RHS unfoldings in the `Ghc.Var`s which is
+           -- needed as part of the reflection of foreign functions in the logic
+           --
+           -- This needs to be active before the plugin runs, so pragmas are
+           -- read at the time the interface files are loaded.
+           `gopt_unset` Opt_IgnoreInterfacePragmas
+      }
+
 -- | Overrides the default 'DynFlags' options. Specifically, we need the GHC
 -- lexer not to throw away block comments, as this is where the LH spec comments
 -- would live. This is why we set the 'Opt_KeepRawTokenStream' option.
-customDynFlags :: [CommandLineOption] -> HscEnv -> IO HscEnv
-customDynFlags opts hscEnv = do
-  cfg <- liftIO $ LH.getOpts opts
-  writeIORef cfgRef cfg
-  return (hscEnv { hsc_dflags = configureDynFlags (hsc_dflags hscEnv) })
-  where
-    configureDynFlags :: DynFlags -> DynFlags
-    configureDynFlags df =
-      df `gopt_set` Opt_ImplicitImportQualified
-         `gopt_set` Opt_PIC
-         `gopt_set` Opt_DeferTypedHoles
-         `gopt_set` Opt_KeepRawTokenStream
-         -- Opt_InsertBreakpoints is used during desugaring to prevent the
-         -- simple optimizer from inlining local bindings to which we might want
-         -- to attach specifications.
-         --
-         -- https://gitlab.haskell.org/ghc/ghc/-/issues/24386
-         `gopt_set` Opt_InsertBreakpoints
-         -- Ignore-interface-pragmas need to be unset to have access to
-         -- the RHS unfoldings in the `Ghc.Var`s which is
-         -- needed as part of the reflection of foreign functions in the logic
-         `gopt_unset` Opt_IgnoreInterfacePragmas
-         `xopt_set` MagicHash
-         `xopt_set` DeriveGeneric
-         `xopt_set` StandaloneDeriving
+customDynFlags :: DynFlags -> DynFlags
+customDynFlags df =
+    df `gopt_set` Opt_ImplicitImportQualified
+       `gopt_set` Opt_PIC
+       `gopt_set` Opt_DeferTypedHoles
+       `gopt_set` Opt_KeepRawTokenStream
+       -- Opt_InsertBreakpoints is used during desugaring to prevent the
+       -- simple optimizer from inlining local bindings to which we might want
+       -- to attach specifications.
+       --
+       -- https://gitlab.haskell.org/ghc/ghc/-/issues/24386
+       `gopt_set` Opt_InsertBreakpoints
+       `xopt_set` MagicHash
+       `xopt_set` DeriveGeneric
+       `xopt_set` StandaloneDeriving
 
 --------------------------------------------------------------------------------
 -- | \"Unoptimising\" things ----------------------------------------------------
@@ -193,26 +184,13 @@ customDynFlags opts hscEnv = do
 -- user can invoke GHC with /any/ optimisation flag turned out. This is why we grab the core binds by
 -- desugaring the module during /parsing/ (before that's already too late) and we cache the core binds for
 -- the rest of the program execution.
-class Unoptimise a where
-  type UnoptimisedTarget a :: Type
-  unoptimise :: a -> UnoptimisedTarget a
-
-instance Unoptimise DynFlags where
-  type UnoptimisedTarget DynFlags = DynFlags
-  unoptimise df = updOptLevel 0 df
+unoptimiseDynFlags :: DynFlags -> DynFlags
+unoptimiseDynFlags df = updOptLevel 0 df
     { debugLevel   = 1
     , ghcLink      = LinkInMemory
     , backend      = interpreterBackend
     , ghcMode      = CompManager
     }
-
-instance Unoptimise ModSummary where
-  type UnoptimisedTarget ModSummary = ModSummary
-  unoptimise modSummary = modSummary { ms_hspp_opts = unoptimise (ms_hspp_opts modSummary) }
-
-instance Unoptimise (DynFlags, HscEnv) where
-  type UnoptimisedTarget (DynFlags, HscEnv) = HscEnv
-  unoptimise (unoptimise -> df, env) = env { hsc_dflags = df }
 
 --------------------------------------------------------------------------------
 -- | Typechecking phase --------------------------------------------------------
@@ -230,33 +208,49 @@ instance Unoptimise (DynFlags, HscEnv) where
 --    grab from parsing (again) the module by using the GHC API, so we are really
 --    independent from the \"normal\" compilation pipeline.
 --
-typecheckHook :: ModSummary -> TcGblEnv -> TcM (Either LiquidCheckException TcGblEnv)
-typecheckHook (unoptimise -> modSummary) tcGblEnv = do
+typecheckHook :: Config -> ModSummary -> TcGblEnv -> TcM (Either LiquidCheckException TcGblEnv)
+typecheckHook cfg0 modSummary0 tcGblEnv = do
   debugLog $ "We are in module: " <> show (toStableModule thisModule)
+  let modSummary = modSummary0
+        { ms_hspp_opts =
+            customDynFlags $ unoptimiseDynFlags (ms_hspp_opts modSummary0)
+        }
+      thisFile = LH.modSummaryHsFile modSummary
 
-  env             <- env_top <$> getEnv
-  parsed          <- liftIO $ parseModuleIO env (LH.keepRawTokenStream modSummary)
-  let comments    = LH.extractSpecComments parsed
-  -- The LH plugin itself calls the type checker (see following line). This
-  -- would lead to a loop if we didn't remove the plugin when calling the type
-  -- checker.
-  typechecked     <- liftIO $ typecheckModuleIO (dropPlugins env) (LH.ignoreInline parsed)
-  resolvedNames   <- liftIO $ LH.lookupTyThings env tcGblEnv
-  availTyCons     <- liftIO $ LH.availableTyCons env tcGblEnv (tcg_exports tcGblEnv)
-  availVars       <- liftIO $ LH.availableVars env tcGblEnv (tcg_exports tcGblEnv)
+  env0 <- env_top <$> getEnv
+  let env = env0 { hsc_dflags = ms_hspp_opts modSummary }
+  parsed           <- liftIO $ parseModuleIO env (LH.keepRawTokenStream modSummary)
+  let specComments = map mkSpecComment $ LH.extractSpecComments parsed
 
-  unoptimisedGuts <- liftIO $ desugarModuleIO env modSummary typechecked
+  case parseSpecComments (coerce specComments) of
+    Left errors ->
+      LH.filterReportErrors thisFile GHC.failM continue (getFilters cfg0) Full errors
+    Right specs ->
 
-  let tcData = mkTcData (tcg_rn_imports tcGblEnv) resolvedNames availTyCons availVars
-  let pipelineData = PipelineData unoptimisedGuts tcData (map mkSpecComment comments)
+      withPragmas cfg0 thisFile [s | Pragma s <- specs] $ \cfg -> do
 
-  liquidHaskellCheck pipelineData modSummary tcGblEnv
+        -- The LH plugin itself calls the type checker (see following line). This
+        -- would lead to a loop if we didn't remove the plugin when calling the type
+        -- checker.
+        typechecked     <- liftIO $ typecheckModuleIO (dropPlugins env) (LH.ignoreInline parsed)
+        resolvedNames   <- liftIO $ LH.lookupTyThings env tcGblEnv
+        availTyCons     <- liftIO $ LH.availableTyCons env tcGblEnv (tcg_exports tcGblEnv)
+        availVars       <- liftIO $ LH.availableVars env tcGblEnv (tcg_exports tcGblEnv)
+
+        unoptimisedGuts <- liftIO $ desugarModuleIO env modSummary typechecked
+
+        let tcData = mkTcData (tcg_rn_imports tcGblEnv) resolvedNames availTyCons availVars
+        let pipelineData = PipelineData unoptimisedGuts tcData specs
+
+        liquidHaskellCheckWithConfig cfg pipelineData modSummary tcGblEnv
 
   where
     thisModule :: Module
     thisModule = tcg_mod tcGblEnv
 
     dropPlugins hsc_env = hsc_env { hsc_plugins = emptyPlugins }
+
+    continue = pure $ Left (ErrorsOccurred [])
 
 serialiseSpec :: Module -> TcGblEnv -> LiquidLib -> TcM TcGblEnv
 serialiseSpec thisModule tcGblEnv liquidLib = do
@@ -321,21 +315,18 @@ processInputSpec cfg pipelineData modSummary tcGblEnv inputSpec = do
     modGuts :: ModGuts
     modGuts = pdUnoptimisedCore pipelineData
 
-liquidHaskellCheckWithConfig :: Config -> PipelineData -> ModSummary -> TcGblEnv -> TcM (Either LiquidCheckException TcGblEnv)
-liquidHaskellCheckWithConfig globalCfg pipelineData modSummary tcGblEnv = do
+liquidHaskellCheckWithConfig
+  :: Config -> PipelineData -> ModSummary -> TcGblEnv -> TcM (Either LiquidCheckException TcGblEnv)
+liquidHaskellCheckWithConfig cfg pipelineData modSummary tcGblEnv = do
   -- Here, we are calling Liquid Haskell's parser, acting on the unparsed
   -- spec comments stored in the pipeline data.
-  inputSpec' :: Either LiquidCheckException BareSpec <-
-    getLiquidSpec thisFile thisModule (pdSpecComments pipelineData)
+  inputSpec <-
+    getLiquidSpec thisModule (pdSpecComments pipelineData)
 
-  case inputSpec' of
-    Left e -> pure $ Left e
-    Right inputSpec ->
-      withPragmas globalCfg thisFile (Ms.pragmas $ fromBareSpec inputSpec) $ \moduleCfg -> do
-        processInputSpec moduleCfg pipelineData modSummary tcGblEnv inputSpec
-          `Ex.catch` (\(e :: UserError) -> reportErrs moduleCfg [e])
-          `Ex.catch` (\(e :: Error) -> reportErrs moduleCfg [e])
-          `Ex.catch` (\(es :: [Error]) -> reportErrs moduleCfg es)
+  processInputSpec cfg pipelineData modSummary tcGblEnv inputSpec
+    `Ex.catch` (\(e :: UserError) -> reportErrs cfg [e])
+    `Ex.catch` (\(e :: Error) -> reportErrs cfg [e])
+    `Ex.catch` (\(es :: [Error]) -> reportErrs cfg es)
 
   where
     thisFile :: FilePath
@@ -349,12 +340,6 @@ liquidHaskellCheckWithConfig globalCfg pipelineData modSummary tcGblEnv = do
 
     thisModule :: Module
     thisModule = tcg_mod tcGblEnv
-
--- | Partially calls into LiquidHaskell's GHC API.
-liquidHaskellCheck :: PipelineData -> ModSummary -> TcGblEnv -> TcM (Either LiquidCheckException TcGblEnv)
-liquidHaskellCheck pipelineData modSummary tcGblEnv = do
-  cfg <- liftIO getConfig
-  liquidHaskellCheckWithConfig cfg pipelineData modSummary tcGblEnv
 
 checkLiquidHaskellContext :: LiquidHaskellContext -> TcM (Either LiquidCheckException LiquidLib)
 checkLiquidHaskellContext lhContext = do
@@ -456,28 +441,20 @@ data ProcessModuleResult = ProcessModuleResult {
   -- ^ The 'GhcInfo' for the current 'Module' that LiquidHaskell will process.
   }
 
--- | Parse the spec comments from one module, supported by the
--- spec quotes from the imported module. Also looks for
+-- | Process the spec comments from one module. Also looks for
 -- "companion specs" for the current module and merges them in
 -- if it finds one.
-getLiquidSpec :: FilePath -> Module -> [SpecComment] -> TcM (Either LiquidCheckException BareSpec)
-getLiquidSpec thisFile thisModule specComments = do
-  globalCfg <- liftIO getConfig
-  let commSpecE :: Either [Error] (ModName, Spec LocBareType LocSymbol)
-      commSpecE = hsSpecificationP (moduleName thisModule) (coerce specComments)
-  case commSpecE of
-    Left errors ->
-      LH.filterReportErrors thisFile GHC.failM continue (getFilters globalCfg) Full errors
-    Right (toBareSpec . snd -> commSpec) -> do
-      env    <- env_top <$> getEnv
-      res <- liftIO $ SpecFinder.findCompanionSpec env thisModule
-      case res of
-        SpecFound _ _ companionSpec -> do
-          debugLog $ "Companion spec found for " ++ renderModule thisModule
-          pure $ Right $ commSpec <> companionSpec
-        _ -> pure $ Right commSpec
-  where
-    continue = pure $ Left (ErrorsOccurred [])
+getLiquidSpec :: Module -> [BPspec] -> TcM BareSpec
+getLiquidSpec thisModule specComments = do
+  let commSpec = toBareSpec . snd $
+        hsSpecificationP (moduleName thisModule) specComments
+  env    <- env_top <$> getEnv
+  res <- liftIO $ SpecFinder.findCompanionSpec env thisModule
+  case res of
+    SpecFound _ _ companionSpec -> do
+      debugLog $ "Companion spec found for " ++ renderModule thisModule
+      pure $ commSpec <> companionSpec
+    _ -> pure commSpec
 
 processModule :: LiquidHaskellContext -> TcM (Either LiquidCheckException ProcessModuleResult)
 processModule LiquidHaskellContext{..} = do

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/Types.hs
@@ -33,6 +33,7 @@ import           GHC.Generics                      hiding ( moduleName )
 
 import qualified Data.HashSet        as HS
 
+import           Language.Haskell.Liquid.Parse (BPspec)
 import           Language.Haskell.Liquid.Types.Specs
 import           Liquid.GHC.API         as GHC
 import qualified Language.Haskell.Liquid.GHC.Interface   as LH
@@ -93,7 +94,7 @@ mkSpecComment (m, s) = SpecComment (sourcePos m, s)
 data PipelineData = PipelineData {
     pdUnoptimisedCore :: ModGuts
   , pdTcData :: TcData
-  , pdSpecComments :: [SpecComment]
+  , pdSpecComments :: [BPspec]
   }
 
 -- | Data which can be \"safely\" passed to the \"Core\" stage of the pipeline.

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -9,6 +9,7 @@
 
 module Language.Haskell.Liquid.Parse
   ( hsSpecificationP
+  , parseSpecComments
   , specSpecificationP
   , singleSpecP
   , BPspec
@@ -51,14 +52,16 @@ import Control.Monad.State
 
 -- * Top-level parsing API
 
--- | Used to parse .hs and .lhs files (via ApiAnnotations).
-hsSpecificationP :: ModuleName
-                 -> [(SourcePos, String)]
-                 -> Either [Error] (ModName, Measure.BareSpec)
-hsSpecificationP modName specComments =
+hsSpecificationP :: ModuleName -> [BPspec] -> (ModName, Measure.BareSpec)
+hsSpecificationP modName specs =
+    mkSpec (ModName SrcImport modName) specs
+
+-- | Parse comments in .hs and .lhs files
+parseSpecComments :: [(SourcePos, String)] -> Either [Error] [BPspec]
+parseSpecComments specComments =
   case go ([], []) initPStateWithList specComments of
     ([], specs) ->
-      Right $ mkSpec (ModName SrcImport modName) specs
+      Right specs
     (errors, _) ->
       Left errors
   where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -54,12 +54,11 @@ import Control.Monad.State
 -- | Used to parse .hs and .lhs files (via ApiAnnotations).
 hsSpecificationP :: ModuleName
                  -> [(SourcePos, String)]
-                 -> [BPspec]
                  -> Either [Error] (ModName, Measure.BareSpec)
-hsSpecificationP modName specComments specQuotes =
+hsSpecificationP modName specComments =
   case go ([], []) initPStateWithList specComments of
     ([], specs) ->
-      Right $ mkSpec (ModName SrcImport modName) (specs ++ specQuotes)
+      Right $ mkSpec (ModName SrcImport modName) specs
     (errors, _) ->
       Left errors
   where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Rec.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Rec.hs
@@ -7,10 +7,7 @@ module Language.Haskell.Liquid.Transforms.Rec (
      transformRecExpr
      ) where
 
-import qualified Data.HashMap.Strict                  as M
-import           Data.Maybe (mapMaybe)
 import           Liquid.GHC.API      as Ghc hiding (panic)
-import           Language.Haskell.Liquid.GHC.Play
 import           Language.Fixpoint.Misc               (mapSnd) -- , traceShow)
 import           Language.Haskell.Liquid.Types.Errors
 import           Prelude                              hiding (error)
@@ -19,56 +16,7 @@ import qualified Data.List                            as L
 
 
 transformRecExpr :: CoreProgram -> CoreProgram
-transformRecExpr cbs = pg
-  where
-    pg     = inlineFailCases pg0
-    pg0    = map inlineLoopBreaker cbs
-
-
--- | Changes top level bindings of the form
---
--- > v = \x1...xn ->
--- >   letrec v0 = \y0...ym -> e0
--- >       in v0 xj..xn
---
--- to
---
--- > v = \x1...xj y0...ym ->
--- >   e0 [ v0 := v x1...xj y0...ym ]
---
-inlineLoopBreaker :: Bind Id -> Bind Id
-inlineLoopBreaker (NonRec x e)
-    | Just (lbx, lbe, lbargs) <- hasLoopBreaker be =
-       let lbe' = sub (M.singleton lbx ecall) lbe
-           mkLams ex = foldr Lam ex (αs ++ take (length as - length lbargs) as)
-           mkLets ex = foldr Let ex nrbinds
-        in Rec [(x, mkLams (mkLets lbe'))]
-  where
-    (αs, as, e') = collectTyAndValBinders e
-    (nrbinds, be) = collectNonRecLets e'
-
-    ecall = L.foldl' App (L.foldl' App (Var x) (Type . TyVarTy <$> αs)) (Var <$> as)
-
-    hasLoopBreaker :: CoreExpr -> Maybe (Var, CoreExpr, [CoreExpr])
-    hasLoopBreaker (Let (Rec [(x1, e1)]) e2)
-      | (Var x2, args) <- collectArgs e2
-      , isLoopBreaker x1
-      , x1 == x2
-      , all isVar args
-      , L.isSuffixOf (mapMaybe getVar args) as
-      = Just (x1, e1, args)
-    hasLoopBreaker _ = Nothing
-
-    isLoopBreaker =  isStrongLoopBreaker . occInfo . idInfo
-
-    getVar (Var x) = Just x
-    getVar _ = Nothing
-
-    isVar (Var _) = True
-    isVar _ = False
-
-inlineLoopBreaker bs
-  = bs
+transformRecExpr = inlineFailCases
 
 -- | Inlines bindings of the form
 --
@@ -103,15 +51,10 @@ inlineFailCases = (go [] <$>)
 
     goalt su (Alt c xs e)   = Alt c xs (go' su e)
 
-    isFailId x  = isLocalId x && isSystemName (varName x) && L.isPrefixOf "fail" (show x)
+    isFailId x  = isLocalId x && isSystemName (varName x) && L.isPrefixOf "fail" (getOccString x)
     getFailExpr = L.lookup
 
     addFailExpr x (Lam v e) su
       | not (elemVarSet v $ exprFreeVars e)  = (x, e):su
     addFailExpr _ _         _  = impossible Nothing "internal error" -- this cannot happen
 
-
-collectNonRecLets :: Expr t -> ([Bind t], Expr t)
-collectNonRecLets = go []
-  where go bs (Let b@(NonRec _ _) e') = go (b:bs) e'
-        go bs e'                      = (reverse bs, e')

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Rec.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Rec.hs
@@ -4,19 +4,13 @@
 {-# LANGUAGE ScopedTypeVariables       #-}
 
 module Language.Haskell.Liquid.Transforms.Rec (
-     transformRecExpr, isIdTRecBound, setIdTRecBound
+     transformRecExpr
      ) where
 
-import           Control.Arrow                        (second)
-import           Control.Monad.State
 import qualified Data.HashMap.Strict                  as M
-import           Data.Hashable
 import           Data.Maybe (mapMaybe)
-import           Data.Word (Word64)
 import           Liquid.GHC.API      as Ghc hiding (panic)
-import           Language.Haskell.Liquid.GHC.Misc
 import           Language.Haskell.Liquid.GHC.Play
-import           Language.Haskell.Liquid.Misc         (mapSndM)
 import           Language.Fixpoint.Misc               (mapSnd) -- , traceShow)
 import           Language.Haskell.Liquid.Types.Errors
 import           Prelude                              hiding (error)
@@ -26,14 +20,9 @@ import qualified Data.List                            as L
 
 transformRecExpr :: CoreProgram -> CoreProgram
 transformRecExpr cbs = pg
-  -- TODO-REBARE weird GHC crash on Data/Text/Array.hs | isEmptyBag $ filterBag isTypeError e
-  -- TODO-REBARE weird GHC crash on Data/Text/Array.hs = pg
-  -- TODO-REBARE weird GHC crash on Data/Text/Array.hs | otherwise
-  -- TODO-REBARE weird GHC crash on Data/Text/Array.hs = panic Nothing ("Type-check" ++ showSDoc (pprMessageBag e))
   where
     pg     = inlineFailCases pg0
-    pg0    = evalState (transPg (inlineLoopBreaker <$> cbs)) initEnv
-    -- (_, e) = lintCoreBindings [] pg
+    pg0    = map inlineLoopBreaker cbs
 
 
 -- | Changes top level bindings of the form
@@ -75,7 +64,7 @@ inlineLoopBreaker (NonRec x e)
     getVar (Var x) = Just x
     getVar _ = Nothing
 
-    isVar (Var x) = True
+    isVar (Var _) = True
     isVar _ = False
 
 inlineLoopBreaker bs
@@ -122,154 +111,7 @@ inlineFailCases = (go [] <$>)
     addFailExpr _ _         _  = impossible Nothing "internal error" -- this cannot happen
 
 
-type TE = State TrEnv
-
-data TrEnv = Tr { freshIndex  :: !Word64
-                , _loc        :: SrcSpan
-                }
-
-initEnv :: TrEnv
-initEnv = Tr 0 noSrcSpan
-
-transPg :: Traversable t
-        => t (Bind CoreBndr)
-        -> State TrEnv (t (Bind CoreBndr))
-transPg = mapM transBd
-
-transBd :: Bind CoreBndr
-        -> State TrEnv (Bind CoreBndr)
-transBd (NonRec x e) = fmap (NonRec x) (transExpr =<< mapBdM transBd e)
-transBd (Rec xes)    = Rec <$> mapM (mapSndM (mapBdM transBd)) xes
-
-transExpr :: CoreExpr -> TE CoreExpr
-transExpr e
-  | isNonPolyRec e' && not (null tvs)
-  = trans tvs ids bs e'
-  | otherwise
-  = return e
-  where (tvs, ids, e'')       = collectTyAndValBinders e
-        (bs, e')              = collectNonRecLets e''
-
-isNonPolyRec :: Expr CoreBndr -> Bool
-isNonPolyRec (Let (Rec xes) _) = any nonPoly (snd <$> xes)
-isNonPolyRec _                 = False
-
-nonPoly :: CoreExpr -> Bool
-nonPoly = null . fst . splitForAllTyCoVars . exprType
-
 collectNonRecLets :: Expr t -> ([Bind t], Expr t)
 collectNonRecLets = go []
   where go bs (Let b@(NonRec _ _) e') = go (b:bs) e'
         go bs e'                      = (reverse bs, e')
-
-appTysAndIds :: [Var] -> [Id] -> Id -> Expr b
-appTysAndIds tvs ids x = mkApps (mkTyApps (Var x) (map TyVarTy tvs)) (map Var ids)
-
-trans :: Foldable t
-      => [TyVar]
-      -> [Var]
-      -> t (Bind Id)
-      -> Expr Var
-      -> State TrEnv (Expr Id)
-trans vs ids bs (Let (Rec xes) expr)
-  = fmap (mkLam . mkLet') (makeTrans vs liveIds e')
-  where liveIds = mkAlive <$> ids
-        mkLet' e = foldr Let e bs
-        mkLam e = foldr Lam e $ vs ++ liveIds
-        e'      = Let (Rec xes') expr
-        xes'    = second mkLet' <$> xes
-
-trans _ _ _ _ = panic Nothing "TransformRec.trans called with invalid input"
-
-makeTrans :: [TyVar]
-          -> [Var]
-          -> Expr Var
-          -> State TrEnv (Expr Var)
-makeTrans vs ids (Let (Rec xes) e)
- = do fids    <- mapM (mkFreshIds vs ids) xs
-      let (ids', ys) = unzip fids
-      let yes  = appTysAndIds vs ids <$> ys
-      ys'     <- mapM fresh xs
-      let su   = M.fromList $ zip xs (Var <$> ys')
-      let rs   = zip ys' yes
-      let es'  = zipWith (mkE ys) ids' es
-      let xes' = zip ys es'
-      return   $ mkRecBinds rs (Rec xes') (sub su e)
- where
-   (xs, es)       = unzip xes
-   mkSu ys ids'   = mkSubs ids vs ids' (zip xs ys)
-   mkE ys ids' e' = mkCoreLams (vs ++ ids') (sub (mkSu ys ids') e')
-
-makeTrans _ _ _ = panic Nothing "TransformRec.makeTrans called with invalid input"
-
-mkRecBinds :: [(b, Expr b)] -> Bind b -> Expr b -> Expr b
-mkRecBinds xes rs expr = Let rs (L.foldl' f expr xes)
-  where f e (x, xe) = Let (NonRec x xe) e
-
-mkSubs :: (Eq k, Hashable k)
-       => [k] -> [Var] -> [Id] -> [(k, Id)] -> M.HashMap k (Expr b)
-mkSubs ids tvs xs ys = M.fromList $ s1 ++ s2
-  where s1 = second (appTysAndIds tvs xs) <$> ys
-        s2 = zip ids (Var <$> xs)
-
-mkFreshIds :: [TyVar]
-           -> [Var]
-           -> Var
-           -> State TrEnv ([Var], Id)
-mkFreshIds tvs origIds var
-  = do ids'  <- mapM fresh origIds
-       let ids'' = map setIdTRecBound ids'
-       let t  = mkForAllTys ((`Bndr` Required) <$> tvs) $ mkType (reverse ids'') $ varType var
-       let x' = setVarType var t
-       return (ids'', x')
-  where
-    mkType ids ty = foldl (\t x -> FunTy FTF_T_T ManyTy (varType x) t) ty ids -- FIXME(adinapoli): Is 'VisArg' OK here?
-
--- NOTE [Don't choose transform-rec binders as decreasing params]
--- --------------------------------------------------------------
---
--- We don't want to select a binder created by TransformRec as the
--- decreasing parameter, since the user didn't write it. Furthermore,
--- consider T1065. There we have an inner loop that decreases on the
--- sole list parameter. But TransformRec prepends the parameters to the
--- outer `groupByFB` to the inner `groupByFBCore`, and now the first
--- decreasing parameter is the constant `xs0`. Disaster!
---
--- So we need a way to signal to L.H.L.Constraint.Generate that we
--- should ignore these copied Vars. The easiest way to do that is to set
--- a flag on the Var that we know won't be set, and it just so happens
--- GHC has a bunch of optional flags that can be set by various Core
--- analyses that we don't run...
-setIdTRecBound :: Id -> Id
--- This is an ugly hack..
-setIdTRecBound = modifyIdInfo (`setCafInfo` NoCafRefs)
-
-isIdTRecBound :: Id -> Bool
-isIdTRecBound = not . mayHaveCafRefs . cafInfo . idInfo
-
-class Freshable a where
-  fresh :: a -> TE a
-
-instance Freshable Word64 where
-  fresh _ = freshWord64
-
-instance Freshable Unique where
-  fresh _ = freshUnique
-
-instance Freshable Var where
-  fresh v = fmap (setVarUnique v) freshUnique
-
-freshWord64 :: MonadState TrEnv m => m Word64
-freshWord64
-  = do s <- get
-       let n = freshIndex s
-       put s{freshIndex = n+1}
-       return n
-
-freshUnique :: MonadState TrEnv m => m Unique
-freshUnique = fmap (mkUnique 'X') freshWord64
-
--- Do not apply transformations to inner code
-
-mapBdM :: Monad m => t -> a -> m a
-mapBdM _ = return

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Rewrite.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Rewrite.hs
@@ -350,7 +350,8 @@ inlineLoopBreaker (NonRec x e)
 
     hasLoopBreaker :: CoreExpr -> Maybe (Var, CoreExpr, [CoreExpr])
     hasLoopBreaker (Let (Rec [(x1, e1)]) e2)
-      | (Var x2, args) <- collectArgs e2
+      | not (isNoInlinePragma (idInlinePragma x1))
+      , (Var x2, args) <- collectArgs e2
       , isLoopBreaker x1
       , x1 == x2
       , all isVar args

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Rewrite.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Rewrite.hs
@@ -26,11 +26,11 @@ module Language.Haskell.Liquid.Transforms.Rewrite
 
 import           Liquid.GHC.API as Ghc hiding (showPpr, substExpr)
 import           Language.Haskell.Liquid.GHC.TypeRep ()
-import           Data.Maybe     (fromMaybe, isJust)
+import           Data.Maybe     (fromMaybe, isJust, mapMaybe)
 import           Control.Monad.State hiding (lift)
 import           Language.Fixpoint.Misc       ({- mapFst, -}  mapSnd)
 import           Language.Haskell.Liquid.Misc (Nat)
-import           Language.Haskell.Liquid.GHC.Play (substExpr)
+import           Language.Haskell.Liquid.GHC.Play (sub, substExpr)
 import           Language.Haskell.Liquid.GHC.Misc (unTickExpr, isTupleId, mkAlive)
 import           Language.Haskell.Liquid.UX.Config  (Config, noSimplifyCore)
 import qualified Data.List as L
@@ -45,6 +45,8 @@ rewriteBinds cfg
   = fmap (normalizeTuples 
        . rewriteBindWith undollar
        . tidyTuples
+       . rewriteBindWith inlineLoopBreakerTx
+       . inlineLoopBreaker
        . rewriteBindWith strictifyLazyLets)
   | otherwise
   = id
@@ -315,3 +317,59 @@ secondHalf :: [a] -> [a]
 secondHalf xs = drop (n `div` 2) xs
   where
     n         = length xs
+
+
+inlineLoopBreakerTx :: RewriteRule
+inlineLoopBreakerTx (Let b e) = Just $ Let (inlineLoopBreaker b) e
+inlineLoopBreakerTx _ = Nothing
+
+-- | Changes top level bindings of the form
+--
+-- > v = \x1...xn ->
+-- >   letrec v0 = \y0...ym -> e0
+-- >       in v0 xj..xn
+--
+-- to
+--
+-- > v = \x1...xj y0...ym ->
+-- >   e0 [ v0 := v x1...xj y0...ym ]
+--
+inlineLoopBreaker :: Bind Id -> Bind Id
+inlineLoopBreaker (NonRec x e)
+    | Just (lbx, lbe, lbargs) <- hasLoopBreaker be =
+       let asPrefix = take (length as - length lbargs) as
+           lbe' = sub (M.singleton lbx (ecall asPrefix)) lbe
+           mkLams ex = foldr Lam ex (αs ++ asPrefix)
+           mkLets ex = foldr Let ex nrbinds
+        in Rec [(x, mkLams (mkLets lbe'))]
+  where
+    (αs, as, e') = collectTyAndValBinders e
+    (nrbinds, be) = collectNonRecLets e'
+
+    ecall xs = L.foldl' App (L.foldl' App (Var x) (Type . TyVarTy <$> αs)) (Var <$> xs)
+
+    hasLoopBreaker :: CoreExpr -> Maybe (Var, CoreExpr, [CoreExpr])
+    hasLoopBreaker (Let (Rec [(x1, e1)]) e2)
+      | (Var x2, args) <- collectArgs e2
+      , isLoopBreaker x1
+      , x1 == x2
+      , all isVar args
+      , L.isSuffixOf (mapMaybe getVar args) as
+      = Just (x1, e1, args)
+    hasLoopBreaker _ = Nothing
+
+    isLoopBreaker =  isStrongLoopBreaker . occInfo . idInfo
+
+    getVar (Var x) = Just x
+    getVar _ = Nothing
+
+    isVar (Var _) = True
+    isVar _ = False
+
+inlineLoopBreaker bs
+  = bs
+
+collectNonRecLets :: Expr t -> ([Bind t], Expr t)
+collectNonRecLets = go []
+  where go bs (Let b@(NonRec _ _) e') = go (b:bs) e'
+        go bs e'                      = (reverse bs, e')


### PR DESCRIPTION
The `inlineLoopBreaker` transformation eliminates some auxiliary bindings that GHC produces that cause troubles to LH. Roughly,

```Haskell
v = \x1...xn ->                                                                                                                                                                          
  letrec v0 = \y0...ym -> e0                                                                                                                                                             
      in v0 xj..xn                                                                                                                                                                       
```
is converted to
```Haskell
v = \x1...xj y0...ym ->
   e0 [ v0 := v x1...xj y0...ym ]
```

The difficulties for LH are explained in #2325, though I'm not sure that the description is exhaustive yet. This transformation does not always succeed. I've found that disabling `-fbreak-points` when compiling `tests/benchmarks/bytestring-0.9.2.1/Data/ByteString/Fusion/T.hs` produces an auxiliary binding that the current implementation cannot remove.

This PR arranges to call `inlineLoopBreaker` on inner lets, and makes it a bit more general as per the descriptions in the commits. These improvements are driven in turn by the opportunities to make LH more flexible to changes in GHC. One of the achievements is to get rid of an obscure `transPg` transformation on Core.

Another achievement is to make LH work without `-fbreak-points` in almost all tests. Breakpoints are inserted to make the desugarer more conservative on the auxiliary bindings that are introduced. I'm delivering the conclusion of it in another PR, though.

For now, I stop here with `inlineLoopBreaker`. It is possible that we can improve `liquid-fixpoint` so we don't have to be so strict about removing auxiliary bindings. And then we won't need to maintain a more complicated transformation here.