### PR TITLE
Add missing assumptions in GHC.Internal.Real.div and its tests. Use div instead of / in the spec

### DIFF
--- a/src/GHC/Real_LHAssumptions.hs
+++ b/src/GHC/Real_LHAssumptions.hs
@@ -26,7 +26,7 @@ class (GHC.Internal.Real.Real a, GHC.Internal.Enum.Enum a) => GHC.Internal.Real.
                                                     ((x >= 0 && y >= 1) => v <= x) &&
                                                     ((1 < y && x >= 0)  => v < x) &&
                                                     ((1 < y && x < 0)   => v > x) &&
-                                                    ((y >= 1 && x > 0)  => v <= x) &&
+                                                    ((y >= 1 && x >= 0)  => v <= x) &&
                                                     ((x < 0 && y > 0)   => v <= 0) &&
                                                     ((x > 0 && y < 0)   => v <= 0) &&
                                                     ((x < 0 && y < 0)   => v >= 0)

--- a/src/GHC/Real_LHAssumptions.hs
+++ b/src/GHC/Real_LHAssumptions.hs
@@ -26,7 +26,7 @@ class (GHC.Internal.Real.Real a, GHC.Internal.Enum.Enum a) => GHC.Internal.Real.
                                                     ((x >= 0 && y >= 1) => v <= x) &&
                                                     ((1 < y && x >= 0)  => v < x) &&
                                                     ((1 < y && x < 0)   => v > x) &&
-                                                    ((y >= 1)           => v <= x) &&
+                                                    ((y >= 1 && x > 0)  => v <= x) &&
                                                     ((x < 0 && y > 0)   => v <= 0) &&
                                                     ((x > 0 && y < 0)   => v <= 0) &&
                                                     ((x < 0 && y < 0)   => v >= 0)

--- a/src/GHC/Real_LHAssumptions.hs
+++ b/src/GHC/Real_LHAssumptions.hs
@@ -21,11 +21,15 @@ class (GHC.Internal.Real.Real a, GHC.Internal.Enum.Enum a) => GHC.Internal.Real.
   GHC.Internal.Real.rem :: x:a -> y:{v:a | v /= 0} -> {v:a | ((v >= 0) && (v < y))}
   GHC.Internal.Real.mod :: x:a -> y:{v:a | v /= 0} -> {v:a | v = x mod y && ((0 <= x && 0 < y) => (0 <= v && v < y))}
 
-  GHC.Internal.Real.div :: x:a -> y:{v:a | v /= 0} -> {v:a | (v = (x / y)) &&
+  GHC.Internal.Real.div :: x:a -> y:{v:a | v /= 0} -> {v:a | (v = div x y) &&
                                                     ((x >= 0 && y >= 0) => v >= 0) &&
-                                                    ((x >= 0 && y >= 1) => v <= x) && 
-                                                    ((1 < y)            => v < x ) && 
-                                                    ((y >= 1)           => v <= x)  
+                                                    ((x >= 0 && y >= 1) => v <= x) &&
+                                                    ((1 < y && x >= 0)  => v < x) &&
+                                                    ((1 < y && x < 0)   => v > x) &&
+                                                    ((y >= 1)           => v <= x) &&
+                                                    ((x < 0 && y > 0)   => v <= 0) &&
+                                                    ((x > 0 && y < 0)   => v <= 0) &&
+                                                    ((x < 0 && y < 0)   => v >= 0)
                                                     }
   GHC.Internal.Real.quotRem :: x:a -> y:{v:a | v /= 0} -> ( {v:a | (v = (x / y)) &&
                                                           ((x >= 0 && y >= 0) => v >= 0) &&

--- a/tests/terminate/neg/Div.hs
+++ b/tests/terminate/neg/Div.hs
@@ -1,4 +1,6 @@
 {-@ LIQUID "--expect-error-containing=Liquid Type Mismatch" @-}
+-- Tests that non-termination is detected when div is used in the
+-- argument of a recursive call.
 module Div where
 
 iterateTo0 :: Int -> Int

--- a/tests/terminate/neg/Div.hs
+++ b/tests/terminate/neg/Div.hs
@@ -1,0 +1,18 @@
+{-@ LIQUID "--expect-error-containing=Liquid Type Mismatch" @-}
+module Div where
+
+iterateTo0 :: Int -> Int
+iterateTo0 0 = 0
+iterateTo0 n = iterateTo0 (div n 2)
+
+{-@ test :: {v:Int | v == 0} @-}
+test = iterateTo0 (-1)
+
+{-@ test2 :: {v:Int | v == 0} @-}
+test2 = iterateTo0 1024
+
+{-@ test3 :: {v:Int | v == 0} @-}
+test3 = iterateTo0 9
+
+{-@ test4 :: {v:Int | v == 0} @-}
+test4 = iterateTo0 0

--- a/tests/terminate/pos/Div.hs
+++ b/tests/terminate/pos/Div.hs
@@ -1,0 +1,19 @@
+module Div where
+
+{-@ iterateTo0 :: n:Int -> {v:Int | v == 0} @-}
+iterateTo0 :: Int -> Int
+iterateTo0 n
+  | n <= 0    = 0
+  | otherwise = iterateTo0 (div n 2)
+
+{-@ test :: {v:Int | v == 0} @-}
+test = iterateTo0 (-1)
+
+{-@ test2 :: {v:Int | v == 0} @-}
+test2 = iterateTo0 1024
+
+{-@ test3 :: {v:Int | v == 0} @-}
+test3 = iterateTo0 9
+
+{-@ test4 :: {v:Int | v == 0} @-}
+test4 = iterateTo0 0

--- a/tests/terminate/pos/Div.hs
+++ b/tests/terminate/pos/Div.hs
@@ -1,3 +1,5 @@
+-- Tests that termination is detected when using div in the argument
+-- of the recursive call.
 module Div where
 
 {-@ iterateTo0 :: n:Int -> {v:Int | v == 0} @-}

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2586,6 +2586,7 @@ executable terminate-neg
 
     other-modules:
                       AutoTerm
+                    , Div
                     , Even
                     , Qsloop
                     , Rename

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2543,6 +2543,7 @@ executable terminate-pos
     other-modules:
                       Ackermann
                     , AutoTerm
+                    , Div
                     , Lexicographic
                     , List00
                     , List00_local


### PR DESCRIPTION
This PR is a continuation of https://github.com/ucsd-progsys/liquidhaskell/pull/2311.

Co-authors are:

- @facundominguez (for the `iterateTo0` definition from https://github.com/ucsd-progsys/liquidhaskell/issues/2285)
- @mbazzani (for the assumptions in `GHC.Internal.Real.div` in https://github.com/ucsd-progsys/liquidhaskell/pull/2311)
- and myself.

I would also be interested in adding `quickcheck` tests for the specs, as suggested by @ranjitjhala in https://github.com/ucsd-progsys/liquidhaskell/issues/2285#issuecomment-2122794785, but I think it would be better to do that in a separate PR.

Tested locally.