### PR TITLE
Remove dependency on recursion-schemes

### DIFF
--- a/liquidhaskell-boot/liquidhaskell-boot.cabal
+++ b/liquidhaskell-boot/liquidhaskell-boot.cabal
@@ -158,7 +158,6 @@ library
                     , unordered-containers >= 0.2.11
                     , vector               >= 0.10
                     , free
-                    , data-fix
                     , extra
   default-language:   Haskell98
   default-extensions: PatternGuards, RecordWildCards, DoAndIfThenElse

--- a/liquidhaskell-boot/liquidhaskell-boot.cabal
+++ b/liquidhaskell-boot/liquidhaskell-boot.cabal
@@ -159,7 +159,6 @@ library
                     , unordered-containers >= 0.2.11
                     , vector               >= 0.10
                     , free
-                    , recursion-schemes    >= 5.2 && < 5.3
                     , data-fix
                     , extra
   default-language:   Haskell98

--- a/liquidhaskell-boot/liquidhaskell-boot.cabal
+++ b/liquidhaskell-boot/liquidhaskell-boot.cabal
@@ -159,7 +159,7 @@ library
                     , unordered-containers >= 0.2.11
                     , vector               >= 0.10
                     , free
-                    , recursion-schemes    < 5.3
+                    , recursion-schemes    >= 5.2 && < 5.3
                     , data-fix
                     , extra
   default-language:   Haskell98

--- a/liquidhaskell-boot/liquidhaskell-boot.cabal
+++ b/liquidhaskell-boot/liquidhaskell-boot.cabal
@@ -130,7 +130,6 @@ library
                     , cereal
                     , cmdargs              >= 0.10
                     , containers           >= 0.5
-                    , data-default         >= 0.5
                     , deepseq              >= 1.3
                     , directory            >= 1.2
                     , filepath             >= 1.3

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Elaborate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Elaborate.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE TypeApplications          #-}
 {-# LANGUAGE LambdaCase                #-}
 {-# LANGUAGE OverloadedStrings         #-}
-{-# LANGUAGE CPP                       #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -32,12 +31,20 @@ import qualified Data.List                     as L
 import qualified Data.HashMap.Strict           as M
 import qualified Data.HashSet                  as S
 import           Control.Monad.Free
-#if MIN_VERSION_recursion_schemes(5,2,0)
-import           Data.Fix                      hiding (hylo)
-#endif
+import           Data.Fix (Fix (Fix))
 
 import           Data.Char                      ( isUpper )
 import           Data.Functor.Foldable
+                   ( Base
+                   , Corecursive (embed)
+                   , Recursive (project)
+                   , distAna
+                   , distPara
+                   , ghylo
+                   , hylo
+                   , para
+                   , refix
+                   )
 import           GHC.Types.Name.Occurrence
 import qualified Liquid.GHC.API as Ghc
                                                 (noExtField)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Elaborate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Elaborate.hs
@@ -35,7 +35,6 @@ import           Data.Char                      ( isUpper )
 import           GHC.Types.Name.Occurrence
 import qualified Liquid.GHC.API as Ghc
                                                 (noExtField)
-import           Data.Default                   ( def )
 import qualified Data.Maybe                    as Mb
 
 -- TODO: make elaboration monadic so typeclass names are unified to something
@@ -449,7 +448,7 @@ elaborateSpecType' partialTp coreToLogic simplify t =
     RHole    _ -> impossible Nothing "RHole should not appear here"
     RRTy{}     -> todo Nothing ("Not sure how to elaborate RRTy" ++ F.showpp t)
  where
-  boolType = RApp (RTyCon boolTyCon [] def) [] [] mempty :: SpecType
+  boolType = RApp (RTyCon boolTyCon [] defaultTyConInfo) [] [] mempty :: SpecType
   elaborateReft
     :: (F.PPrint a)
     => (F.Reft, SpecType)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Elaborate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Elaborate.hs
@@ -31,15 +31,14 @@ import qualified Data.List                     as L
 import qualified Data.HashMap.Strict           as M
 import qualified Data.HashSet                  as S
 import           Control.Monad.Free
-import           Data.Fix (Fix (Fix))
 
 import           Data.Char                      ( isUpper )
 import           Data.Functor.Foldable
                    ( Base
                    , Corecursive (embed)
                    , Recursive (project)
-                   , hylo
-                   , refix
+                   , ana
+                   , cata
                    )
 import           GHC.Types.Name.Occurrence
 import qualified Liquid.GHC.API as Ghc
@@ -237,13 +236,12 @@ instance Corecursive (RType c tv r) where
 
 -- A one-way function. Kind of like injecting something into Maybe
 specTypeToPartial :: forall a . SpecType -> SpecTypeF (Free SpecTypeF a)
-specTypeToPartial = hylo (fmap wrap) project
+specTypeToPartial = cata (fmap wrap)
 
--- probably should return spectype instead..
 plugType :: SpecType -> PartialSpecType -> SpecType
-plugType t = refix . f
+plugType t = f
  where
-  f = hylo Fix $ \case
+  f = ana $ \case
     Pure _   -> specTypeToPartial t
     Free res -> res
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Elaborate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Elaborate.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE ExplicitForAll            #-}
 {-# LANGUAGE TypeFamilies              #-}
 {-# LANGUAGE DeriveFunctor             #-}
-{-# LANGUAGE TypeApplications          #-}
 {-# LANGUAGE LambdaCase                #-}
 {-# LANGUAGE OverloadedStrings         #-}
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -22,7 +22,6 @@ module Language.Haskell.Liquid.Bare.Measure
   , varLocSym
   ) where
 
-import Data.Default
 import qualified Control.Exception as Ex
 import Prelude hiding (mapM, error)
 import Data.Bifunctor
@@ -316,7 +315,7 @@ bkDataCon permitTC dcn nFlds  = (as, ts, (F.dummySymbol, classRFInfo permitTC, t
 data DataConSel = Check | Proj Int
 
 bareBool :: SpecType
-bareBool = RApp (RTyCon Ghc.boolTyCon [] def) [] [] mempty
+bareBool = RApp (RTyCon Ghc.boolTyCon [] defaultTyConInfo) [] [] mempty
 
 
 {- | NOTE:Use DataconWorkId

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PredType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PredType.hs
@@ -58,7 +58,6 @@ import           Language.Haskell.Liquid.GHC.Misc
 import           Language.Haskell.Liquid.Misc
 import           Language.Haskell.Liquid.Types.RefType hiding (generalize)
 import           Language.Haskell.Liquid.Types.Types
-import           Data.Default
 
 makeTyConInfo :: F.TCEmb Ghc.TyCon -> [Ghc.TyCon] -> [TyConP] -> TyConMap
 makeTyConInfo tce fiTcs tcps = TyConMap
@@ -291,7 +290,7 @@ wpredRTyCon   :: RTyCon
 wpredRTyCon   = symbolRTyCon wpredName
 
 symbolRTyCon   :: F.Symbol -> RTyCon
-symbolRTyCon n = RTyCon (stringTyCon 'x' 42 $ F.symbolString n) [] def
+symbolRTyCon n = RTyCon (stringTyCon 'x' 42 $ F.symbolString n) [] defaultTyConInfo
 
 -------------------------------------------------------------------------------------
 -- | Instantiate `PVar` with `RTProp` -----------------------------------------------

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -299,7 +299,6 @@ import           Language.Haskell.Liquid.Types.Variance
 import           Language.Haskell.Liquid.Types.Errors
 import           Language.Haskell.Liquid.Misc
 import           Language.Haskell.Liquid.UX.Config
-import           Data.Default
 
 
 -----------------------------------------------------------------------------
@@ -711,9 +710,6 @@ isProp _          = False
 
 defaultTyConInfo :: TyConInfo
 defaultTyConInfo = TyConInfo [] [] Nothing
-
-instance Default TyConInfo where
-  def = defaultTyConInfo
 
 
 -----------------------------------------------------------------------


### PR DESCRIPTION
Elaborate.hs was using `recursion-schemes`. It makes sense in this module because it has a functor to represent holes in `RType`. However, the recursions were only readable to someone familiar with functors and hylomorphisms with no particular benefit in return.

This PR is removing the dependency on `recursion-schemes` while keeping one trivial use of catas and anamorphisms. I had set initially to remove the `SpecTypeF` functor entirely, until I stumbled upon `PartialSpecType`, which does need the functor and which purpose I don't understand sufficiently to replace it yet.