### PR TITLE
Fix up to the pass that adds NOINLINE pragmas

### DIFF
--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API/Extra.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API/Extra.hs
@@ -233,7 +233,7 @@ addNoInlinePragmasToLocalBinds ps =
     ps { pm_parsed_source = go (pm_parsed_source ps) }
   where
     go :: forall a. Data a => a -> a
-    go = gmapT (go `extT` addNoInlinePragmas)
+    go = gmapT ((id `extT` addNoInlinePragmas) . go)
 
     addNoInlinePragmas :: HsValBinds GhcPs -> HsValBinds GhcPs
     addNoInlinePragmas = \case

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -476,7 +476,8 @@ config = cmdArgsMode $ Config {
           &= name "dump-pre-normalized-core"
           &= explicit
   , insertCoreBreakPoints
-    = def &= help "Insert break point when desugaring Haskell (enabled by default)"
+    = False
+          &= help "Insert break point when desugaring Haskell"
           &= name "insert-core-break-points"
           &= explicit
   } &= program "liquid"
@@ -744,7 +745,7 @@ defConfig = Config
   , excludeAutomaticAssumptionsFor = []
   , dumpOpaqueReflections    = False
   , dumpPreNormalizedCore    = False
-  , insertCoreBreakPoints    = True
+  , insertCoreBreakPoints    = False
   }
 
 -- | Write the annotations (i.e. the files in the \".liquid\" hidden folder) and


### PR DESCRIPTION
This fixes the pass introduced in #2340 to add NOINLINE pragmas. It was adding NOINLINE as in
```
let {-# NOINLINE x #-}
    x = e0
 in ... add more NOINLINEs here ...
```
But it was skipping adding NOINLINE pragmas inside `e0`.

With this fix, using breakpoints or NOINLINEs is indistinguishable by tests, so now I have changed the default of `--insert-core-break-points` to `False`.