### PR TITLE
Use type substitution from GHC in TypeRep.hs

### DIFF
--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -270,11 +270,7 @@ import GHC.Core.Coercion              as Ghc
     , mkRepReflCo
     )
 import GHC.Core.Coercion.Axiom        as Ghc
-    ( Branched
-    , CoAxiom
-    , CoAxiomRule(CoAxiomRule)
-    , coAxiomTyCon
-    )
+    ( coAxiomTyCon )
 import GHC.Core.ConLike               as Ghc
     ( ConLike(RealDataCon) )
 import GHC.Core.DataCon               as Ghc
@@ -325,26 +321,7 @@ import GHC.Core.Subst                 as Ghc (emptySubst, extendCvSubst)
 import GHC.Core.TyCo.Rep              as Ghc
     ( FunTyFlag(FTF_T_T, FTF_C_T)
     , ForAllTyFlag(Required)
-    , Coercion
-        ( AppCo
-        , AxiomRuleCo
-        , AxiomInstCo
-        , CoVarCo
-        , ForAllCo
-        , FunCo
-        , HoleCo
-        , InstCo
-        , KindCo
-        , LRCo
-        , Refl
-        , GRefl
-        , SelCo
-        , SubCo
-        , SymCo
-        , TransCo
-        , TyConAppCo
-        , UnivCo
-        )
+    , Coercion (AxiomInstCo, SymCo)
     , TyLit(CharTyLit, NumTyLit, StrTyLit)
     , Type
         ( AppTy
@@ -366,6 +343,7 @@ import GHC.Core.TyCo.Rep              as Ghc
     , mkTyVarTys
     )
 import GHC.Core.TyCo.Compare          as Ghc (eqType, nonDetCmpType)
+import GHC.Core.TyCo.Subst            as Ghc (extendSubstInScopeSet, substCo, zipTvSubst)
 import GHC.Core.TyCon                 as Ghc
     ( TyConBinder
     , TyConBndrVis(AnonTCB)
@@ -467,6 +445,7 @@ import GHC.Plugins                    as Ghc ( deserializeWithData
 import GHC.Core.FVs                   as Ghc (exprFreeVars, exprFreeVarsList, exprSomeFreeVarsList)
 import GHC.Core.Opt.OccurAnal         as Ghc
     ( occurAnalysePgm )
+import GHC.Core.TyCo.FVs              as Ghc (tyCoVarsOfCo, tyCoVarsOfType)
 import GHC.Driver.Backend             as Ghc (interpreterBackend)
 import GHC.Driver.Env                 as Ghc
     ( HscEnv(hsc_mod_graph, hsc_unit_env, hsc_dflags, hsc_plugins) )

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Play.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Play.hs
@@ -174,14 +174,10 @@ instance Subable CoreExpr where
   subTy s (Lam b e)      = Lam (subTy s b) (subTy s e)
   subTy s (Let b e)      = Let (subTy s b) (subTy s e)
   subTy s (Case e b t a) = Case (subTy s e) (subTy s b) (subTy s t) (map (subTy s) a)
-  subTy s (Cast e c)     = Cast (subTy s e) (subTy s c)
+  subTy s (Cast e _c)    = Cast (subTy s e) $ panic Nothing "subTy Coercion"
   subTy s (Tick t e)     = Tick t (subTy s e)
   subTy s (Type t)       = Type (subTy s t)
-  subTy s (Coercion c)   = Coercion (subTy s c)
-
-instance Subable Coercion where
-  sub _ c                = c
-  subTy _ _              = panic Nothing "subTy Coercion"
+  subTy _s (Coercion _c) = Coercion $ panic Nothing "subTy Coercion"
 
 instance Subable (Alt Var) where
  sub s (Alt a b e)   = Alt a (map (sub s) b)   (sub s e)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/TypeRep.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/TypeRep.hs
@@ -30,14 +30,12 @@ instance Eq Type where
 eqType' :: Type -> Type -> Bool 
 eqType' (LitTy l1) (LitTy l2) 
   = l1 == l2  
-eqType' (CoercionTy c1) (CoercionTy c2) 
-  = c1 == c2  
-eqType'(CastTy t1 c1) (CastTy t2 c2) 
-  = eqType' t1 t2 && c1 == c2 
+eqType' (CoercionTy _c1) (CoercionTy _c2) = True
+eqType'(CastTy t1 _c1) (CastTy t2 _c2) = eqType' t1 t2
 eqType' (FunTy a1 m1 t11 t12) (FunTy a2 m2 t21 t22)
   = a1 == a2 && m1 == m2 && eqType' t11 t21 && eqType' t12 t22  
 eqType' (ForAllTy (Bndr v1 _) t1) (ForAllTy (Bndr v2 _) t2) 
-  = eqType' t1 (subst v2 (TyVarTy v1) t2) 
+  = eqType' t1 (substType v2 (TyVarTy v1) t2)
 eqType' (TyVarTy v1) (TyVarTy v2) 
   = v1 == v2 
 eqType' (AppTy t11 t12) (AppTy t21 t22) 
@@ -49,10 +47,6 @@ eqType' _ _
 
 
 deriving instance (Eq tyvar, Eq argf) => Eq (VarBndr tyvar argf)
-
-instance Eq Coercion where
-  _ == _ = True 
-
 
 showTy :: Type -> String 
 showTy (TyConApp c ts) = "(RApp   " ++ showPpr c ++ " " ++ sep' ", " (showTy <$> ts) ++ ")"
@@ -75,96 +69,29 @@ sep' s (x:xs) = x ++ s ++ sep' s xs
 -- | GHC Type Substitutions ---------------------------------------------------
 -------------------------------------------------------------------------------
 
-class SubstTy a where
-  subst :: TyVar -> Type -> a -> a
-  subst _ _ = id  
-
-instance SubstTy Type where
-  subst = substType
-
 substType :: TyVar -> Type -> Type -> Type
 substType x tx (TyConApp c ts) 
-  = TyConApp c (subst x tx <$> ts)
+  = TyConApp c (substType x tx <$> ts)
 substType x tx (AppTy t1 t2)   
-  = AppTy (subst x tx t1) (subst x tx t2) 
+  = AppTy (substType x tx t1) (substType x tx t2)
 substType x tx (TyVarTy y)   
   | symbol x == symbol y
   = tx 
   | otherwise
   = TyVarTy y 
 substType x tx (FunTy aaf m t1 t2)
-  = FunTy aaf m (subst x tx t1) (subst x tx t2)
+  = FunTy aaf m (substType x tx t1) (substType x tx t2)
 substType x tx f@(ForAllTy b@(Bndr y _) t)  
   | symbol x == symbol y 
   = f
   | otherwise 
-  = ForAllTy b (subst x tx t)
+  = ForAllTy b (substType x tx t)
 substType x tx (CastTy t c)    
-  = CastTy (subst x tx t) (subst x tx c)
+  = let ss = extendSubstInScopeSet (zipTvSubst [x] [tx]) (tyCoVarsOfCo c)
+     in CastTy (substType x tx t) (substCo ss c)
 substType x tx (CoercionTy c)  
-  = CoercionTy $ subst x tx c 
+  = let ss = extendSubstInScopeSet (zipTvSubst [x] [tx]) (tyCoVarsOfCo c)
+     in CoercionTy $ substCo ss c
 substType _ _  (LitTy l)
   = LitTy l  
 
-
-instance SubstTy Coercion where
-  subst = substCoercion
-
-substCoercion :: TyVar -> Type -> Coercion -> Coercion
-substCoercion x tx (TyConAppCo r c cs)
-  = TyConAppCo (subst x tx r) c (subst x tx <$> cs)
-substCoercion x tx (AppCo c1 c2)
-  = AppCo (subst x tx c1) (subst x tx c2)
-substCoercion x tx (FunCo r afl afr cN c1 c2)
-  = FunCo r afl afr cN (subst x tx c1) (subst x tx c2) -- TODO(adinapoli) Is this the correct substitution?
-substCoercion x tx (ForAllCo y f1 f2 c1 c2)
-  | symbol x == symbol y 
-  = ForAllCo y f1 f2 c1 c2
-  | otherwise 
-  = ForAllCo y f1 f2 (subst x tx c1) (subst x tx c2)
-substCoercion _ _ (CoVarCo y)
-  = CoVarCo y 
-substCoercion x tx (AxiomInstCo co bi cs)
-  = AxiomInstCo (subst x tx co) bi (subst x tx <$> cs)  
-substCoercion x tx (UnivCo y r t1 t2)
-  = UnivCo (subst x tx y) (subst x tx r) (subst x tx t1) (subst x tx t2)
-substCoercion x tx (SymCo c)
-  = SymCo (subst x tx c)
-substCoercion x tx (TransCo c1 c2)
-  = TransCo (subst x tx c1) (subst x tx c2)
-substCoercion x tx (AxiomRuleCo ca cs)
-  = AxiomRuleCo (subst x tx ca)  (subst x tx <$> cs)  
-substCoercion x tx (SelCo i c)
-  = SelCo i (subst x tx c)
-substCoercion x tx (LRCo i c)
-  = LRCo i (subst x tx c)
-substCoercion x tx (InstCo c1 c2)
-  = InstCo (subst x tx c1) (subst x tx c2)
-substCoercion x tx (KindCo c)
-  = KindCo (subst x tx c)
-substCoercion x tx (SubCo c)
-  = SubCo (subst x tx c)
-substCoercion _x _tx (Refl t)
-  = Refl t
-substCoercion _x _tx (GRefl r t c)
-  = GRefl r t c
-substCoercion _x _tx (HoleCo c)
-  = HoleCo c
-
-instance SubstTy Role where
-instance SubstTy (CoAxiom Branched) where
-
-instance SubstTy UnivCoProvenance where
-  subst x tx (PhantomProv c)
-    = PhantomProv $ subst x tx c 
-  subst x tx (ProofIrrelProv c)
-    = ProofIrrelProv $ subst x tx c 
-  subst _ _ ch 
-    = ch 
-
-instance SubstTy CoAxiomRule where
-  subst x tx (CoAxiomRule n rs r ps) 
-    = CoAxiomRule n (subst x tx <$> rs) (subst x tx r) (\eq -> subst x tx (ps (subst x tx eq)))
-
-instance (SubstTy a, Functor m) => SubstTy (m a) where
-  subst x tx xs = subst x tx <$> xs


### PR DESCRIPTION
This PR uses the GHC API for substitutions in coercions.