### PR TITLE
Move Reftable class to liquidhaskell-boot

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -818,7 +818,7 @@ strengthenSigs sigs = go <$> Misc.groupList sigs
     go (v, ixs)     = (v,) $ L.foldl1' (flip meetLoc) (F.notracepp ("STRENGTHEN-SIGS: " ++ F.showpp v) (prio ixs))
     prio            = fmap snd . Misc.sortOn fst
     meetLoc         :: LocSpecType -> LocSpecType -> LocSpecType
-    meetLoc t1 t2   = t1 {val = val t1 `F.meet` val t2}
+    meetLoc t1 t2   = t1 {val = val t1 `meet` val t2}
 
 makeMthSigs :: Bare.MeasEnv -> [(Ghc.Var, LocSpecType)]
 makeMthSigs measEnv = [ (v, t) | (_, v, t) <- Bare.meMethods measEnv ]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -366,7 +366,7 @@ strengthenRes st rf = go st
     go (RAllT a t r)   = RAllT a (go t) r
     go (RAllP p t)     = RAllP p $ go t
     go (RFun x i tx t r) = RFun x i tx (go t) r
-    go t               =  t `strengthen` F.ofReft rf
+    go t               =  t `strengthen` ofReft rf
 
 class Subable a where
   subst :: (Ghc.Var, Ghc.CoreExpr) -> a -> a

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -528,7 +528,7 @@ checkTcArity RTyCon{ rtc_tc = tc } givenArity
 
 
 checkAbstractRefs
-  :: (PPrint t, F.Reftable t, SubsTy RTyVar RSort t, F.Reftable (RTProp RTyCon RTyVar (UReft t))) =>
+  :: (PPrint t, Reftable t, SubsTy RTyVar RSort t, Reftable (RTProp RTyCon RTyVar (UReft t))) =>
      RType RTyCon RTyVar (UReft t) -> Maybe Doc
 checkAbstractRefs rt = go rt
   where
@@ -586,7 +586,7 @@ checkAbstractRefs rt = go rt
     pvType' p          = Misc.safeHead (showpp p ++ " not in env of " ++ showpp rt) [pvType q | q <- penv, pname p == pname q]
 
 
-checkReft                    :: (PPrint r, F.Reftable r, SubsTy RTyVar (RType RTyCon RTyVar ()) r, F.Reftable (RTProp RTyCon RTyVar (UReft r)))
+checkReft                    :: (PPrint r, Reftable r, SubsTy RTyVar (RType RTyCon RTyVar ()) r, Reftable (RTProp RTyCon RTyVar (UReft r)))
                              => F.SrcSpan -> F.SEnv F.SortedReft -> F.TCEmb TyCon -> Maybe (RRType (UReft r)) -> UReft r -> Maybe Doc
 checkReft _ _   _   Nothing _   = Nothing -- TODO:RPropP/Ref case, not sure how to check these yet.
 checkReft sp env emb (Just t) _ = (\z -> dr $+$ z) <$> checkSortedReftFull sp env r
@@ -618,7 +618,7 @@ checkMeasure emb γ (M name@(Loc src _ n) sort body _ _)
   where
     txerror = ErrMeas (GM.sourcePosSrcSpan src) (pprint n)
 
-checkMBody :: (PPrint r, F.Reftable r,SubsTy RTyVar RSort r, F.Reftable (RTProp RTyCon RTyVar r))
+checkMBody :: (PPrint r, Reftable r,SubsTy RTyVar RSort r, Reftable (RTProp RTyCon RTyVar r))
            => F.SEnv F.SortedReft
            -> F.TCEmb TyCon
            -> t
@@ -648,7 +648,7 @@ checkMBodyUnify = go
     go t@RApp{} t'@RApp{} = concat $ zipWith go (rt_args t) (rt_args t')
     go _ _                = []
 
-checkMBody' :: (PPrint r, F.Reftable r,SubsTy RTyVar RSort r, F.Reftable (RTProp RTyCon RTyVar r))
+checkMBody' :: (PPrint r, Reftable r,SubsTy RTyVar RSort r, Reftable (RTProp RTyCon RTyVar r))
             => F.TCEmb TyCon
             -> RType RTyCon RTyVar r
             -> F.SEnv F.SortedReft
@@ -706,12 +706,12 @@ getRewriteErrors (rw, t)
           ++ " contains an inner refinement."
 
 
-isRefined :: F.Reftable r => RType c tv r -> Bool
+isRefined :: Reftable r => RType c tv r -> Bool
 isRefined ty
-  | Just r <- stripRTypeBase ty = not $ F.isTauto r
+  | Just r <- stripRTypeBase ty = not $ isTauto r
   | otherwise = False
 
-hasInnerRefinement :: F.Reftable r => RType c tv r -> Bool
+hasInnerRefinement :: Reftable r => RType c tv r -> Bool
 hasInnerRefinement (RFun _ _ rIn rOut _) =
   isRefined rIn || isRefined rOut
 hasInnerRefinement (RAllT _ ty  _) =

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/DataType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/DataType.hs
@@ -372,7 +372,7 @@ meetDataConSpec allowTC emb xts dcs  = M.toList $ snd <$> L.foldl' upd dcm0 xts
     upd dcm (x, t)           = M.insert x (Ghc.getSrcSpan x, tx') dcm
                                 where
                                   tx' = maybe t (meetX x t) (M.lookup x dcm)
-    meetM (l,t) (_,t')       = (l, t `F.meet` t')
+    meetM (l,t) (_,t')       = (l, t `meet` t')
     meetX x t (sp', t')      = F.notracepp (_msg x t t') $ meetVarTypes emb (pprint x) (Ghc.getSrcSpan x, t) (sp', t')
     _msg x t t'              = "MEET-VAR-TYPES: " ++ showpp (x, t, t')
 
@@ -438,7 +438,7 @@ makeSizeCtor :: (F.Symbol, [F.Symbol]) -> DataCtor -> DataCtor
 makeSizeCtor (s,xs) d = d {dcFields = Misc.mapSnd (mapBot go) <$> dcFields d}
   where
     go (RApp c ts rs r) | F.symbol c `elem` xs
-                        = RApp c ts rs (r `F.meet` rsz)
+                        = RApp c ts rs (r `meet` rsz)
     go t                = t
     rsz  = MkUReft (F.Reft (F.vv_, F.PAtom F.Lt
                                       (F.EApp (F.EVar s) (F.EVar F.vv_))
@@ -777,7 +777,7 @@ strengthenClassSel v lt = lt { val = st }
   go (RFun x i tx t r) = do
     x' <- unDummy x <$> reader fst
     r' <- singletonApp s <$> (L.reverse <$> reader snd)
-    RFun x' i tx <$> local (extend x') (go t) <*> pure (F.meet r r')
+    RFun x' i tx <$> local (extend x') (go t) <*> pure (meet r r')
   go t = RT.strengthen t . singletonApp s . L.reverse <$> reader snd
 
 singletonApp :: F.Symbolic a => F.LocSymbol -> [a] -> UReft F.Reft

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -297,7 +297,7 @@ dataConSel permitTC dc n (Proj i) = mkArrow (map (, mempty) as) [] [xt] (mempty 
     err                  = panic Nothing $ "DataCon " ++ show dc ++ "does not have " ++ show i ++ " fields"
 
 -- bkDataCon :: DataCon -> Int -> ([RTVar RTyVar RSort], [SpecType], (Symbol, SpecType, RReft))
-bkDataCon :: (F.Reftable (RTProp RTyCon RTyVar r), PPrint r, F.Reftable r) => Bool -> Ghc.DataCon -> Int -> ([RTVar RTyVar RSort], [RRType r], (F.Symbol, RFInfo, RRType r, r))
+bkDataCon :: (Reftable (RTProp RTyCon RTyVar r), PPrint r, Reftable r) => Bool -> Ghc.DataCon -> Int -> ([RTVar RTyVar RSort], [RRType r], (F.Symbol, RFInfo, RRType r, r))
 bkDataCon permitTC dcn nFlds  = (as, ts, (F.dummySymbol, classRFInfo permitTC, t, mempty))
   where
     ts                = RT.ofType <$> Misc.takeLast nFlds (map Ghc.irrelevantMult _ts)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Misc.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Misc.hs
@@ -53,7 +53,7 @@ makeSymbols f vs xs
 
 {-
 HEAD
-freeSymbols :: (F.Reftable r, F.Reftable r1, F.Reftable r2, TyConable c, TyConable c1, TyConable c2)
+freeSymbols :: (Reftable r, Reftable r1, F.Reftable r2, TyConable c, TyConable c1, TyConable c2)
             => [F.Symbol]
             -> [(a1, Located (RType c2 tv2 r2))]
             -> [(a, Located (RType c1 tv1 r1))]
@@ -69,18 +69,18 @@ freeSymbols xs' xts yts ivs =  [ lx | lx <- Misc.sortNub $ zs ++ zs' ++ zs'' , n
 
 
 -------------------------------------------------------------------------------
-freeSyms :: (F.Reftable r, TyConable c) => Located (RType c tv r) -> [LocSymbol]
+freeSyms :: (Reftable r, TyConable c) => Located (RType c tv r) -> [LocSymbol]
 -------------------------------------------------------------------------------
 freeSyms ty    = [ F.atLoc ty x | x <- tySyms ]
   where
     tySyms     = Misc.sortNub $ concat $ efoldReft (\_ _ -> True) False (\_ _ -> []) (const []) (const ()) f (const id) F.emptySEnv [] (val ty)
-    f γ _ r xs = let F.Reft (v, _) = F.toReft r in
+    f γ _ r xs = let F.Reft (v, _) = toReft r in
                  [ x | x <- F.syms r, x /= v, not (x `F.memberSEnv` γ)] : xs
 
 --- ABOVE IS THE T1773 STUFF
 --- BELOW IS THE develop-classes STUFF
 
--- freeSymbols :: (F.Reftable r, F.Reftable r1, F.Reftable r2, TyConable c, TyConable c1, TyConable c2)
+-- freeSymbols :: (Reftable r, Reftable r1, F.Reftable r2, TyConable c, TyConable c1, TyConable c2)
 --             => [F.Symbol]
 --             -> [(a1, Located (RType c2 tv2 r2))]
 --             -> [(a, Located (RType c1 tv1 r1))]
@@ -95,11 +95,11 @@ freeSyms ty    = [ F.atLoc ty x | x <- tySyms ]
 
 
 
--- freeSyms :: (F.Reftable r, TyConable c) => Located (RType c tv r) -> [LocSymbol]
+-- freeSyms :: (Reftable r, TyConable c) => Located (RType c tv r) -> [LocSymbol]
 -- freeSyms ty    = [ F.atLoc ty x | x <- tySyms ]
 --   where
 --     tySyms     = Misc.sortNub $ concat $ efoldReft (\_ _ -> True) False (\_ _ -> []) (\_ -> []) (const ()) f (const id) F.emptySEnv [] (val ty)
---     f γ _ r xs = let F.Reft (v, _) = F.toReft r in
+--     f γ _ r xs = let F.Reft (v, _) = toReft r in
 --                  [ x | x <- F.syms r, x /= v, not (x `F.memberSEnv` γ)] : xs
 
 -}

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -879,9 +879,9 @@ rtypePredBinds = map RT.uPVar . ty_preds . toRTypeRep
 
 --------------------------------------------------------------------------------
 type Expandable r = ( PPrint r
-                    , F.Reftable r
+                    , Reftable r
                     , SubsTy RTyVar (RType RTyCon RTyVar ()) r
-                    , F.Reftable (RTProp RTyCon RTyVar r))
+                    , Reftable (RTProp RTyCon RTyVar r))
 
 ofBRType :: (Expandable r) => Env -> ModName -> ([F.Symbol] -> r -> r) -> F.SourcePos -> BRType r
          -> Lookup (RRType r)
@@ -972,9 +972,9 @@ bareTCApp r (Loc _ _ c) rs ts
   = RT.rApp c ts rs r
 
 
-tyApp :: F.Reftable r => RType c tv r -> [RType c tv r] -> [RTProp c tv r] -> r
+tyApp :: Reftable r => RType c tv r -> [RType c tv r] -> [RTProp c tv r] -> r
       -> RType c tv r
-tyApp (RApp c ts rs r) ts' rs' r' = RApp c (ts ++ ts') (rs ++ rs') (r `F.meet` r')
+tyApp (RApp c ts rs r) ts' rs' r' = RApp c (ts ++ ts') (rs ++ rs') (r `meet` r')
 tyApp t                []  []  r  = t `RT.strengthen` r
 tyApp _                 _  _   _  = panic Nothing "Bare.Type.tyApp on invalid inputs"
 
@@ -1012,8 +1012,8 @@ addSymSort sp tce tyi (RApp rc@RTyCon{} ts rs rr)
     -- pvs             = rTyConPVs rc'
     (rargs, rrest)     = splitAt (length pvs) rs
     r2                 = L.foldl' go rr rrest
-    go r (RProp _ (RHole r')) = r' `F.meet` r
-    go r (RProp  _ t' )       = let r' = Mb.fromMaybe mempty (stripRTypeBase t') in r `F.meet` r'
+    go r (RProp _ (RHole r')) = r' `meet` r
+    go r (RProp  _ t' )       = let r' = Mb.fromMaybe mempty (stripRTypeBase t') in r `meet` r'
 
 addSymSort _ _ _ t
   = t

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Env.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Env.hs
@@ -168,7 +168,7 @@ addCGEnv tx γ (eMsg, sym, RAllE yy tyy tyx)
   = addCGEnv tx γ (eMsg, sym, t)
   where
     xs            = localBindsOfType tyy (renv γ)
-    t             = L.foldl' F.meet ttrue [ tyx' `F.subst1` (yy, F.EVar x) | x <- xs]
+    t             = L.foldl' meet ttrue [ tyx' `F.subst1` (yy, F.EVar x) | x <- xs]
     (tyx', ttrue) = splitXRelatedRefs yy tyx
 
 addCGEnv tx γ (_, x, t') = do
@@ -181,7 +181,7 @@ addCGEnv tx γ (_, x, t') = do
   is    <- (:) <$> addBind l x (rTypeSortedReft' γ' tem t) <*> addClassBind γ' l t
   return $ γ' { fenv = insertsFEnv (fenv γ) is }
 
-rTypeSortedReft' :: (PPrint r, F.Reftable r, SubsTy RTyVar RSort r, F.Reftable (RTProp RTyCon RTyVar r))
+rTypeSortedReft' :: (PPrint r, Reftable r, SubsTy RTyVar RSort r, Reftable (RTProp RTyCon RTyVar r))
     => CGEnv -> F.Templates -> RRType r -> F.SortedReft
 rTypeSortedReft' γ t
   = pruneUnsortedReft (feEnv $ fenv γ) t . f

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Relational.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Relational.hs
@@ -321,7 +321,7 @@ unapply γ y yt (z : zs) (RFun x _ s t _) e suffix = do
     e' = subVarAndTy z z' e
 unapply _ _ _ (_ : _) t _ _ = F.panic $ "can't unapply type " ++ F.showpp t
 unapply γ y yt [] t e _ = do
-  let yt' = t `F.meet` yt
+  let yt' = t `meet` yt
   γ' <- γ += ("unapply res", y, yt')
   return $ traceWhenLoud ("SCRUTINEE " ++ F.showpp (y, yt')) (γ', e)
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Split.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Split.hs
@@ -118,7 +118,7 @@ bsplitW γ t =
      isHO  <- gets allowHO
      return $ bsplitW' γ t temp isHO
 
-bsplitW' :: (PPrint r, F.Reftable r, SubsTy RTyVar RSort r, F.Reftable (RTProp RTyCon RTyVar r))
+bsplitW' :: (PPrint r, Reftable r, SubsTy RTyVar RSort r, Reftable (RTProp RTyCon RTyVar r))
          => CGEnv -> RRType r -> F.Templates -> Bool -> [F.WfC Cinfo]
 bsplitW' γ t temp isHO
   | isHO || F.isNonTrivial r'
@@ -267,7 +267,7 @@ splitC _ (SubR γ o r)
     vv  = "vvRec"
     ci  = Ci src err (cgVar γ)
     err = Just $ ErrAssType src o (text $ show o ++ "type error") g (rHole rr)
-    rr  = F.toReft r
+    rr  = toReft r
     tag = getTag γ
     src = getLocation γ
     g   = reLocal $ renv γ

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
@@ -161,7 +161,7 @@ refinementEQs :: LocSpecType -> [(F.Expr, F.Expr)]
 refinementEQs t =
   case stripRTypeBase tres of
     Just r ->
-      [ (lhs, rhs) | (F.EEq lhs rhs) <- F.splitPAnd $ F.reftPred (F.toReft r) ]
+      [ (lhs, rhs) | (F.EEq lhs rhs) <- F.splitPAnd $ F.reftPred (toReft r) ]
     Nothing ->
       []
   where
@@ -182,7 +182,7 @@ makeRewriteOne tce (_, t)
 
     xs = do
       (sym, arg) <- zip (ty_binds tRep) (ty_args tRep)
-      let e = maybe F.PTrue (F.reftPred . F.toReft) (stripRTypeBase arg)
+      let e = maybe F.PTrue (F.reftPred . toReft) (stripRTypeBase arg)
       return $ F.RR (rTypeSort tce arg) (F.Reft (sym, e))
 
     tRep = toRTypeRep $ val t
@@ -289,17 +289,17 @@ specTypeToLogic allowTC es expr st
   where
     res       = specTypeToResultRef expr st
     args      = zipWith mkExpr (mkReft <$> ts) es
-    mkReft t  =  F.toReft $ Mb.fromMaybe mempty (stripRTypeBase t)
+    mkReft t  =  toReft $ Mb.fromMaybe mempty (stripRTypeBase t)
     mkExpr (F.Reft (v, ev)) e = F.subst1 ev (v, e)
 
 
     ok      = okLen && okClass && okArgs
     okLen   = length xs == length xs
-    okClass = all (F.isTauto . snd) cls
+    okClass = all (isTauto . snd) cls
     okArgs  = all okArg ts
 
     okArg (RVar _ _) = True
-    okArg t@RApp{}   = F.isTauto (t{rt_reft = mempty})
+    okArg t@RApp{}   = isTauto (t{rt_reft = mempty})
     okArg _          = False
 
 
@@ -313,7 +313,7 @@ specTypeToLogic allowTC es expr st
 
 specTypeToResultRef :: F.Expr -> SpecType -> F.Expr
 specTypeToResultRef e t
-  = mkExpr $ F.toReft $ Mb.fromMaybe mempty (stripRTypeBase $ ty_res trep)
+  = mkExpr $ toReft $ Mb.fromMaybe mempty (stripRTypeBase $ ty_res trep)
   where
     mkExpr (F.Reft (v, ev)) = F.subst1 ev (v, e)
     trep                   = toRTypeRep t

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Types.hs
@@ -351,13 +351,13 @@ conjoinInvariantShift t1 t2
 conjoinInvariant :: SpecType -> SpecType -> SpecType
 conjoinInvariant (RApp c ts rs r) (RApp ic its _ ir)
   | c == ic && length ts == length its
-  = RApp c (zipWith conjoinInvariantShift ts its) rs (r `F.meet` ir)
+  = RApp c (zipWith conjoinInvariantShift ts its) rs (r `meet` ir)
 
 conjoinInvariant t@(RApp _ _ _ r) (RVar _ ir)
-  = t { rt_reft = r `F.meet` ir }
+  = t { rt_reft = r `meet` ir }
 
 conjoinInvariant t@(RVar _ r) (RVar _ ir)
-  = t { rt_reft = r `F.meet` ir }
+  = t { rt_reft = r `meet` ir }
 
 conjoinInvariant t _
   = t
@@ -386,7 +386,7 @@ makeRecInvariants γ [x] = γ {invs = M.unionWith (++) (invs γ) is}
 
     guard' (RApp c ts rs r)
       | Just f <- szFun <$> sizeFunction (rtc_info c)
-      = RApp c ts rs (MkUReft (ref f $ F.toReft r) mempty)
+      = RApp c ts rs (MkUReft (ref f $ toReft r) mempty)
       | otherwise
       = RApp c ts rs mempty
     guard' t

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Bounds.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Bounds.hs
@@ -162,4 +162,4 @@ makeRef penv v rr
   where
     r                    = Pr [toUsedPVar penv rr]
 
-makeRef _    v p         = F.ofReft (F.Reft (val v, p))
+makeRef _    v p         = ofReft (F.Reft (val v, p))

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Meet.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Meet.hs
@@ -11,7 +11,7 @@ import           Language.Haskell.Liquid.Types.RefType ()
 import           Liquid.GHC.API as Ghc
 
 meetVarTypes :: F.TCEmb TyCon -> Doc -> (SrcSpan, SpecType) -> (SrcSpan, SpecType) -> SpecType
-meetVarTypes _emb _v hs lq = {- meetError emb err -} F.meet hsT lqT
+meetVarTypes _emb _v hs lq = {- meetError emb err -} meet hsT lqT
   where
     (_hsSp, hsT)      = hs
     (_lqSp, lqT)      = lq
@@ -23,7 +23,7 @@ meetVarTypes _emb _v hs lq = {- meetError emb err -} F.meet hsT lqT
 _meetError :: F.TCEmb TyCon -> Error -> SpecType -> SpecType -> SpecType
 _meetError _emb _e t t'
   -- // | meetable emb t t'
-  | True              = t `F.meet` t'
+  | True              = t `meet` t'
   -- // | otherwise         = panicError e
 
 _meetable :: F.TCEmb TyCon -> SpecType -> SpecType -> Bool

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
@@ -217,24 +217,24 @@ type Prec = PprPrec
 pprRtype :: (OkRT c tv r) => PPEnv -> Prec -> RType c tv r -> Doc
 --------------------------------------------------------------------------------
 pprRtype bb p t@(RAllT _ _ r)
-  = F.ppTy r $ pprForall bb p t
+  = ppTy r $ pprForall bb p t
 pprRtype bb p t@(RAllP _ _)
   = pprForall bb p t
 pprRtype _ _ (RVar a r)
-  = F.ppTy r $ pprint a
+  = ppTy r $ pprint a
 pprRtype bb p t@RFun{}
   = maybeParen p funPrec (pprRtyFun bb empty t)
 pprRtype bb p (RApp c [t] rs r)
   | isList c
-  = F.ppTy r $ brackets (pprRtype bb p t) <-> ppReftPs bb p rs
+  = ppTy r $ brackets (pprRtype bb p t) <-> ppReftPs bb p rs
 pprRtype bb p (RApp c ts rs r)
   | isTuple c
-  = F.ppTy r $ parens (intersperse comma (pprRtype bb p <$> ts)) <-> ppReftPs bb p rs
+  = ppTy r $ parens (intersperse comma (pprRtype bb p <$> ts)) <-> ppReftPs bb p rs
 pprRtype bb p (RApp c ts rs r)
   | isEmpty rsDoc && isEmpty tsDoc
-  = F.ppTy r $ ppT c
+  = ppTy r $ ppT c
   | otherwise
-  = F.ppTy r $ parens $ ppT c <+> rsDoc <+> tsDoc
+  = ppTy r $ parens $ ppT c <+> rsDoc <+> tsDoc
   where
     rsDoc            = ppReftPs bb p rs
     tsDoc            = hsep (pprRtype bb p <$> ts)
@@ -247,7 +247,7 @@ pprRtype bb p t@RAllE{}
 pprRtype _ _ (RExprArg e)
   = braces $ pprint e
 pprRtype bb p (RAppTy t t' r)
-  = F.ppTy r $ pprRtype bb p t <+> pprRtype bb p t'
+  = ppTy r $ pprRtype bb p t <+> pprRtype bb p t'
 pprRtype bb p (RRTy e _ OCons t)
   = sep [braces (pprRsubtype bb p e) <+> "=>", pprRtype bb p t]
 pprRtype bb p (RRTy e r o rt)
@@ -257,7 +257,7 @@ pprRtype bb p (RRTy e r o rt)
     ppp  doc    = text "<<" <+> doc <+> text ">>"
     ppxt (x, t) = pprint x <+> ":" <+> pprRtype bb p t
 pprRtype _ _ (RHole r)
-  = F.ppTy r $ text "_"
+  = ppTy r $ text "_"
 
 ppTyConB :: TyConable c => PPEnv -> c -> Doc
 ppTyConB bb
@@ -288,8 +288,8 @@ maybeParen ctxt_prec inner_prec pretty
 
 ppExists
   :: (OkRT c tv r, PPrint c, PPrint tv, PPrint (RType c tv r),
-      PPrint (RType c tv ()), F.Reftable (RTProp c tv r),
-      F.Reftable (RTProp c tv ()))
+      PPrint (RType c tv ()), Reftable (RTProp c tv r),
+      Reftable (RTProp c tv ()))
   => PPEnv -> Prec -> RType c tv r -> Doc
 ppExists bb p rt
   = text "exists" <+> brackets (intersperse comma [pprDbind bb topPrec x t | (x, t) <- ws]) <-> dot <-> pprRtype bb p rt'
@@ -309,10 +309,10 @@ ppAllExpr bb p rt
 
 ppReftPs
   :: (OkRT c tv r, PPrint (RType c tv r), PPrint (RType c tv ()),
-      F.Reftable (Ref (RType c tv ()) (RType c tv r)))
+      Reftable (Ref (RType c tv ()) (RType c tv r)))
   => t -> t1 -> [Ref (RType c tv ()) (RType c tv r)] -> Doc
 ppReftPs _ _ rs
-  | all F.isTauto rs   = empty
+  | all isTauto rs   = empty
   | not (ppPs ppEnv) = empty
   | otherwise        = angleBrackets $ hsep $ punctuate comma $ pprRef <$> rs
 
@@ -432,10 +432,10 @@ ppRefSym s  = pprint s
 dot :: Doc
 dot                = char '.'
 
-instance (PPrint r, F.Reftable r) => PPrint (UReft r) where
+instance (PPrint r, Reftable r) => PPrint (UReft r) where
   pprintTidy k (MkUReft r p)
-    | F.isTauto r  = pprintTidy k p
-    | F.isTauto p  = pprintTidy k r
+    | isTauto r  = pprintTidy k p
+    | isTauto p  = pprintTidy k r
     | otherwise  = pprintTidy k p <-> text " & " <-> pprintTidy k r
 
 --------------------------------------------------------------------------------

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -285,7 +285,6 @@ instance Reftable (RTProp RTyCon RTyVar (UReft Reft)) where
   ppTy (RProp _ (RHole r)) d  = ppTy r d
   ppTy (RProp _ _) _          = panic Nothing "RefType: Reftable ppTy in RProp"
   toReft                      = panic Nothing "RefType: Reftable toReft"
-  params                      = panic Nothing "RefType: Reftable params for Ref"
   bot                         = panic Nothing "RefType: Reftable bot    for Ref"
   ofReft                      = panic Nothing "RefType: Reftable ofReft for Ref"
 
@@ -297,7 +296,6 @@ instance Reftable (RTProp RTyCon RTyVar ()) where
   ppTy (RProp _ (RHole r)) d  = ppTy r d
   ppTy (RProp _ _) _          = panic Nothing "RefType: Reftable ppTy in RProp"
   toReft                      = panic Nothing "RefType: Reftable toReft"
-  params                      = panic Nothing "RefType: Reftable params for Ref"
   bot                         = panic Nothing "RefType: Reftable bot    for Ref"
   ofReft                      = panic Nothing "RefType: Reftable ofReft for Ref"
 
@@ -309,7 +307,6 @@ instance Reftable (RTProp BTyCon BTyVar (UReft Reft)) where
   ppTy (RProp _ (RHole r)) d  = ppTy r d
   ppTy (RProp _ _) _          = panic Nothing "RefType: Reftable ppTy in RProp"
   toReft                      = panic Nothing "RefType: Reftable toReft"
-  params                      = panic Nothing "RefType: Reftable params for Ref"
   bot                         = panic Nothing "RefType: Reftable bot    for Ref"
   ofReft                      = panic Nothing "RefType: Reftable ofReft for Ref"
 
@@ -321,7 +318,6 @@ instance Reftable (RTProp BTyCon BTyVar ())  where
   ppTy (RProp _ (RHole r)) d  = ppTy r d
   ppTy (RProp _ _) _          = panic Nothing "RefType: Reftable ppTy in RProp"
   toReft                      = panic Nothing "RefType: Reftable toReft"
-  params                      = panic Nothing "RefType: Reftable params for Ref"
   bot                         = panic Nothing "RefType: Reftable bot    for Ref"
   ofReft                      = panic Nothing "RefType: Reftable ofReft for Ref"
 
@@ -333,7 +329,6 @@ instance Reftable (RTProp RTyCon RTyVar Reft) where
   ppTy (RProp _ (RHole r)) d  = ppTy r d
   ppTy (RProp _ _) _          = panic Nothing "RefType: Reftable ppTy in RProp"
   toReft                      = panic Nothing "RefType: Reftable toReft"
-  params                      = panic Nothing "RefType: Reftable params for Ref"
   bot                         = panic Nothing "RefType: Reftable bot    for Ref"
   ofReft                      = panic Nothing "RefType: Reftable ofReft for Ref"
 
@@ -366,7 +361,6 @@ instance (PPrint r, Reftable r, SubsTy RTyVar (RType RTyCon RTyVar ()) r, Reftab
   isTauto     = isTrivial
   ppTy        = panic Nothing "ppTy RProp Reftable"
   toReft      = panic Nothing "toReft on RType"
-  params      = panic Nothing "params on RType"
   bot         = panic Nothing "bot on RType"
   ofReft      = panic Nothing "ofReft on RType"
 
@@ -376,7 +370,6 @@ instance Reftable (RType BTyCon BTyVar (UReft Reft)) where
   top t       = mapReft top t
   ppTy        = panic Nothing "ppTy RProp Reftable"
   toReft      = panic Nothing "toReft on RType"
-  params      = panic Nothing "params on RType"
   bot         = panic Nothing "bot on RType"
   ofReft      = panic Nothing "ofReft on RType"
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -285,7 +285,6 @@ instance Reftable (RTProp RTyCon RTyVar (UReft Reft)) where
   ppTy (RProp _ (RHole r)) d  = ppTy r d
   ppTy (RProp _ _) _          = panic Nothing "RefType: Reftable ppTy in RProp"
   toReft                      = panic Nothing "RefType: Reftable toReft"
-  bot                         = panic Nothing "RefType: Reftable bot    for Ref"
   ofReft                      = panic Nothing "RefType: Reftable ofReft for Ref"
 
 instance Reftable (RTProp RTyCon RTyVar ()) where
@@ -296,7 +295,6 @@ instance Reftable (RTProp RTyCon RTyVar ()) where
   ppTy (RProp _ (RHole r)) d  = ppTy r d
   ppTy (RProp _ _) _          = panic Nothing "RefType: Reftable ppTy in RProp"
   toReft                      = panic Nothing "RefType: Reftable toReft"
-  bot                         = panic Nothing "RefType: Reftable bot    for Ref"
   ofReft                      = panic Nothing "RefType: Reftable ofReft for Ref"
 
 instance Reftable (RTProp BTyCon BTyVar (UReft Reft)) where
@@ -307,7 +305,6 @@ instance Reftable (RTProp BTyCon BTyVar (UReft Reft)) where
   ppTy (RProp _ (RHole r)) d  = ppTy r d
   ppTy (RProp _ _) _          = panic Nothing "RefType: Reftable ppTy in RProp"
   toReft                      = panic Nothing "RefType: Reftable toReft"
-  bot                         = panic Nothing "RefType: Reftable bot    for Ref"
   ofReft                      = panic Nothing "RefType: Reftable ofReft for Ref"
 
 instance Reftable (RTProp BTyCon BTyVar ())  where
@@ -318,7 +315,6 @@ instance Reftable (RTProp BTyCon BTyVar ())  where
   ppTy (RProp _ (RHole r)) d  = ppTy r d
   ppTy (RProp _ _) _          = panic Nothing "RefType: Reftable ppTy in RProp"
   toReft                      = panic Nothing "RefType: Reftable toReft"
-  bot                         = panic Nothing "RefType: Reftable bot    for Ref"
   ofReft                      = panic Nothing "RefType: Reftable ofReft for Ref"
 
 instance Reftable (RTProp RTyCon RTyVar Reft) where
@@ -329,7 +325,6 @@ instance Reftable (RTProp RTyCon RTyVar Reft) where
   ppTy (RProp _ (RHole r)) d  = ppTy r d
   ppTy (RProp _ _) _          = panic Nothing "RefType: Reftable ppTy in RProp"
   toReft                      = panic Nothing "RefType: Reftable toReft"
-  bot                         = panic Nothing "RefType: Reftable bot    for Ref"
   ofReft                      = panic Nothing "RefType: Reftable ofReft for Ref"
 
 ----------------------------------------------------------------------------
@@ -361,7 +356,6 @@ instance (PPrint r, Reftable r, SubsTy RTyVar (RType RTyCon RTyVar ()) r, Reftab
   isTauto     = isTrivial
   ppTy        = panic Nothing "ppTy RProp Reftable"
   toReft      = panic Nothing "toReft on RType"
-  bot         = panic Nothing "bot on RType"
   ofReft      = panic Nothing "ofReft on RType"
 
 
@@ -370,7 +364,6 @@ instance Reftable (RType BTyCon BTyVar (UReft Reft)) where
   top t       = mapReft top t
   ppTy        = panic Nothing "ppTy RProp Reftable"
   toReft      = panic Nothing "toReft on RType"
-  bot         = panic Nothing "bot on RType"
   ofReft      = panic Nothing "ofReft on RType"
 
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -695,7 +695,7 @@ strengthenRefType_ _ (RVar v1 r1)  (RVar v2 r2) | v1 == v2
 strengthenRefType_ f t1 t2
   = f t1 t2
 
-meets :: (F.Reftable r) => [r] -> [r] -> [r]
+meets :: (Reftable r) => [r] -> [r] -> [r]
 meets [] rs                 = rs
 meets rs []                 = rs
 meets rs rs'
@@ -703,11 +703,11 @@ meets rs rs'
   | otherwise               = panic Nothing "meets: unbalanced rs"
 
 strengthen :: Reftable r => RType c tv r -> r -> RType c tv r
-strengthen (RApp c ts rs r)   r' = RApp c ts rs   (r `F.meet` r')
-strengthen (RVar a r)         r' = RVar a         (r `F.meet` r')
-strengthen (RFun b i t1 t2 r) r' = RFun b i t1 t2 (r `F.meet` r')
-strengthen (RAppTy t1 t2 r)   r' = RAppTy t1 t2   (r `F.meet` r')
-strengthen (RAllT a t r)      r' = RAllT a t      (r `F.meet` r')
+strengthen (RApp c ts rs r)   r' = RApp c ts rs   (r `meet` r')
+strengthen (RVar a r)         r' = RVar a         (r `meet` r')
+strengthen (RFun b i t1 t2 r) r' = RFun b i t1 t2 (r `meet` r')
+strengthen (RAppTy t1 t2 r)   r' = RAppTy t1 t2   (r `meet` r')
+strengthen (RAllT a t r)      r' = RAllT a t      (r `meet` r')
 strengthen t                  _  = t
 
 quantifyRTy :: (Monoid r, Eq tv) => [RTVar tv (RType c tv ())] -> RType c tv r -> RType c tv r
@@ -1551,7 +1551,7 @@ appSolRefa s p = mapKVars f p
 
 --------------------------------------------------------------------------------
 -- shiftVV :: Int -- SpecType -> Symbol -> SpecType
-shiftVV :: (TyConable c, F.Reftable (f Reft), Functor f)
+shiftVV :: (TyConable c, Reftable (f Reft), Functor f)
         => RType c tv (f Reft) -> Symbol -> RType c tv (f Reft)
 --------------------------------------------------------------------------------
 shiftVV t@(RApp _ ts rs r) vv'

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -1484,7 +1484,6 @@ instance (F.PPrint r, F.Reftable r) => F.Reftable (UReft r) where
   isTauto               = isTautoUreft
   ppTy                  = ppTyUreft
   toReft (MkUReft r ps) = F.toReft r `F.meet` F.toReft ps
-  bot (MkUReft r _)     = MkUReft (F.bot r) (Pr [])
   top (MkUReft r p)     = MkUReft (F.top r) (F.top p)
   ofReft r              = MkUReft (F.ofReft r) mempty
 
@@ -1538,7 +1537,6 @@ instance (F.Subable r, F.Reftable r, TyConable c) => F.Subable (RType c tv r) wh
 instance F.Reftable Predicate where
   isTauto (Pr ps)      = null ps
 
-  bot (Pr _)           = panic Nothing "No BOT instance for Predicate"
   ppTy r d | F.isTauto r      = d
            | not (ppPs ppEnv) = d
            | otherwise        = d <-> angleBrackets (F.pprint r)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -1484,7 +1484,6 @@ instance (F.PPrint r, F.Reftable r) => F.Reftable (UReft r) where
   isTauto               = isTautoUreft
   ppTy                  = ppTyUreft
   toReft (MkUReft r ps) = F.toReft r `F.meet` F.toReft ps
-  params (MkUReft r _)  = F.params r
   bot (MkUReft r _)     = MkUReft (F.bot r) (Pr [])
   top (MkUReft r p)     = MkUReft (F.top r) (F.top p)
   ofReft r              = MkUReft (F.ofReft r) mempty
@@ -1546,7 +1545,6 @@ instance F.Reftable Predicate where
 
   toReft (Pr ps@(p:_))        = F.Reft (parg p, F.pAnd $ pToRef <$> ps)
   toReft _                    = mempty
-  params                      = todo Nothing "TODO: instance of params for Predicate"
 
   ofReft = todo Nothing "TODO: Predicate.ofReft"
 


### PR DESCRIPTION
Reftable only seems to be needed by LH and coupled to the RType to represent refinement types. Moving it here makes LF less dependent on the LH implementation.

This PR depends on https://github.com/ucsd-progsys/liquid-fixpoint/pull/709