### PR TITLE
GHC 9.8 backwards compatibility (WIP)

### DIFF
--- a/liquidhaskell-boot/liquidhaskell-boot.cabal
+++ b/liquidhaskell-boot/liquidhaskell-boot.cabal
@@ -60,6 +60,7 @@ library
                       Language.Haskell.Liquid.Constraint.Types
                       Language.Haskell.Liquid.Constraint.Relational
                       Liquid.GHC.API
+                      Liquid.GHC.API.Compat
                       Liquid.GHC.API.Extra
                       Liquid.GHC.API.StableModule
                       Language.Haskell.Liquid.GHC.CoreToLogic

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -18,6 +18,7 @@ module Liquid.GHC.API (
   ) where
 
 import Liquid.GHC.API.Extra as Ghc
+import Liquid.GHC.API.Compat as Ghc
 
 import           GHC                  as Ghc
     ( Class

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -168,14 +168,12 @@ import GHC.Builtin.Names              as Ghc
     , Unique
     , and_RDR
     , bindMName
-    , gHC_INTERNAL_DATA_FOLDABLE
     , eqClassKey
     , eqClassName
     , ge_RDR
     , gt_RDR
     , fractionalClassKey
     , fractionalClassKeys
-    , gHC_INTERNAL_REAL
     , getUnique
     , hasKey
     , isStringClassName

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API/Compat.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API/Compat.hs
@@ -1,0 +1,15 @@
+module Liquid.GHC.API.Compat (
+    UniqueId
+  , toUniqueId
+  ) where
+
+import Data.Word (Word64)
+
+----------------------
+-- Uniques
+----------------------
+
+type UniqueId = Word64
+
+toUniqueId :: Word64 -> UniqueId
+toUniqueId = id

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API/Compat.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API/Compat.hs
@@ -1,9 +1,14 @@
 module Liquid.GHC.API.Compat (
     UniqueId
   , toUniqueId
+
+  , foldableModule
+  , realModule
   ) where
 
 import Data.Word (Word64)
+import qualified GHC.Builtin.Names as Ghc
+import GHC (Module)
 
 ----------------------
 -- Uniques
@@ -13,3 +18,12 @@ type UniqueId = Word64
 
 toUniqueId :: Word64 -> UniqueId
 toUniqueId = id
+
+----------------------
+-- Built-in modules
+----------------------
+
+foldableModule, realModule :: Module
+
+foldableModule = Ghc.gHC_INTERNAL_DATA_FOLDABLE
+realModule = Ghc.gHC_INTERNAL_REAL

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API/Compat.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API/Compat.hs
@@ -1,3 +1,6 @@
+-- | This module contains definitions that change between different versions
+-- of the GHC API. It helps encapsulating differences between branches of LH
+-- that could support different versions of GHC.
 module Liquid.GHC.API.Compat (
     UniqueId
   , toUniqueId

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Elaborate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Elaborate.hs
@@ -604,7 +604,7 @@ fixExprToHsExpr env (F.PAnd (e : es)) = L.foldr f (fixExprToHsExpr env e) es
 --   (nlHsVar (varQual_RDR dATA_FOLDABLE (fsLit "and")))
 --   (nlList $ fixExprToHsExpr env <$> es)
 fixExprToHsExpr env (F.POr es) = mkHsApp
-  (nlHsVar (varQual_RDR gHC_INTERNAL_DATA_FOLDABLE (fsLit "or")))
+  (nlHsVar (varQual_RDR foldableModule (fsLit "or")))
   (nlList $ fixExprToHsExpr env <$> es)
 fixExprToHsExpr env (F.PIff e0 e1) = mkHsApp
   (mkHsApp (nlHsVar (mkVarUnqual (mkFastString "<=>"))) (fixExprToHsExpr env e0)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -993,7 +993,7 @@ withWiredIn m = discardConstraints $ do
     return $ TcWiredIn n Nothing ty
 
 prependGHCRealQual :: FastString -> RdrName
-prependGHCRealQual = varQual_RDR gHC_INTERNAL_REAL
+prependGHCRealQual = varQual_RDR realModule
 
 isFromGHCReal :: NamedThing a => a -> Bool
-isFromGHCReal x = Ghc.nameModule (Ghc.getName x) == gHC_INTERNAL_REAL
+isFromGHCReal x = Ghc.nameModule (Ghc.getName x) == realModule

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -105,11 +105,11 @@ maybeAuxVar s
         name = mkInternalName (mkUnique 'x' uid) occ noSrcSpan
         occ = mkVarOcc (T.unpack (symbolText sym))
 
-stringTyCon :: Char -> Word64 -> String -> TyCon
+stringTyCon :: Char -> UniqueId -> String -> TyCon
 stringTyCon = stringTyConWithKind anyTy
 
 -- FIXME: reusing uniques like this is really dangerous
-stringTyConWithKind :: Kind -> Char -> Word64 -> String -> TyCon
+stringTyConWithKind :: Kind -> Char -> UniqueId -> String -> TyCon
 stringTyConWithKind k c n s = Ghc.mkPrimTyCon name [] k []
   where
     name          = mkInternalName (mkUnique c n) occ noSrcSpan
@@ -508,8 +508,8 @@ takeModuleUnique = mungeNames tailName sepUnique   "takeModuleUnique: "
   where
     tailName msg = symbol . safeLast msg
 
-splitModuleUnique :: Symbol -> (Symbol, Word64)
-splitModuleUnique x = (dropModuleNamesAndUnique x, base62ToW (takeModuleUnique x))
+splitModuleUnique :: Symbol -> (Symbol, UniqueId)
+splitModuleUnique x = (dropModuleNamesAndUnique x, toUniqueId $ base62ToW (takeModuleUnique x))
 
 base62ToW :: Symbol -> Word64
 base62ToW s =  fromMaybe (errorstar "base62ToW Out Of Range") $ go (F.symbolText s)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/ANF.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/ANF.hs
@@ -11,7 +11,6 @@
 
 module Language.Haskell.Liquid.Transforms.ANF (anormalize) where
 
-import           Data.Word (Word64)
 import           Debug.Trace (trace)
 import           Prelude                          hiding (error)
 import           Language.Haskell.Liquid.GHC.TypeRep
@@ -355,7 +354,7 @@ freshNormalVar γ t = do
   let sp = Sp.srcSpan (aeSrcSpan γ)
   return (mkUserLocalOrCoVar (anfOcc i) u Ghc.ManyTy t sp)
 
-anfOcc :: Word64 -> OccName
+anfOcc :: UniqueId -> OccName
 anfOcc = mkVarOccFS . GM.symbolFastString . F.intSymbol F.anfPrefix
 
 data AnfEnv = AnfEnv


### PR DESCRIPTION
- **GHC-9.8 compatibility: `Unique`s contain `Int`s instead of `Word64`s.**
- **GHC-9.8 compatibility: import `foldl'` from `Data.List`**
- **GHC-9.8 compatibility: Different module names for `Foldable` and `Real`**
