### PR TITLE
Towards a direct (non plugin-based) API

### DIFF
--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -37,6 +37,7 @@ import           GHC                  as Ghc
     , GhcException(CmdLineError, ProgramError)
     , GhcLink(LinkInMemory)
     , GhcMode(CompManager)
+    , GhcMonad
     , GhcPs
     , GhcRn
     , HsDecl(SigD)
@@ -111,6 +112,7 @@ import           GHC                  as Ghc
     , isRecordSelector
     , isTypeSynonymTyCon
     , isVanillaDataCon
+    , lookupName
     , mkHsApp
     , mkHsDictLet
     , mkHsForAllInvisTele
@@ -414,9 +416,6 @@ import GHC.Driver.Config.Diagnostic as Ghc
     ( initDiagOpts
     , initDsMessageOpts
     , initIfaceMessageOpts
-    )
-import GHC.Driver.Main                as Ghc
-    ( hscTcRcLookupName
     )
 import GHC.Driver.Plugins             as Ghc
     ( ParsedResult(..)

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -23,7 +23,7 @@ import           GHC                  as Ghc
     ( Class
     , DataCon
     , DesugaredModule(DesugaredModule, dm_typechecked_module, dm_core_module)
-    , DynFlags(backend, debugLevel, ghcLink, ghcMode)
+    , DynFlags(backend, debugLevel, ghcLink, ghcMode, warningFlags)
     , FixityDirection(InfixN, InfixR)
     , FixitySig(FixitySig)
     , GenLocated(L)
@@ -81,9 +81,11 @@ import           GHC                  as Ghc
     , TypecheckedModule(tm_checked_module_info, tm_internals_, tm_parsed_module)
     , classMethods
     , classSCTheta
+    , coreModule
     , dataConTyCon
     , dataConFieldLabels
     , dataConWrapperType
+    , desugarModule
     , getLocA
     , getLogger
     , getName
@@ -154,6 +156,7 @@ import           GHC                  as Ghc
     , tyConDataCons
     , tyConKind
     , tyConTyVars
+    , typecheckModule
     , unLoc
     )
 
@@ -413,8 +416,7 @@ import GHC.Driver.Config.Diagnostic as Ghc
     , initIfaceMessageOpts
     )
 import GHC.Driver.Main                as Ghc
-    ( hscDesugar
-    , hscTcRcLookupName
+    ( hscTcRcLookupName
     )
 import GHC.Driver.Plugins             as Ghc
     ( ParsedResult(..)
@@ -428,7 +430,7 @@ import GHC.Driver.Session             as Ghc
     , updOptLevel
     , xopt_set
     )
-import GHC.Driver.Monad               as Ghc (withSession)
+import GHC.Driver.Monad               as Ghc (withSession, reflectGhc, Session(..))
 import GHC.HsToCore.Monad             as Ghc
     ( DsM, initDsTc, initDsWithModGuts, newUnique )
 import GHC.Iface.Syntax               as Ghc
@@ -452,6 +454,7 @@ import GHC.Driver.Backend             as Ghc (interpreterBackend)
 import GHC.Driver.Env                 as Ghc
     ( HscEnv(hsc_mod_graph, hsc_unit_env, hsc_dflags, hsc_plugins)
     , Hsc
+    , hscSetFlags, hscUpdateFlags
     )
 import GHC.Driver.Errors              as Ghc
     ( printMessages )
@@ -499,6 +502,7 @@ import GHC.Tc.Utils.Monad             as Ghc
     ( captureConstraints
     , discardConstraints
     , getEnv
+    , getTopEnv
     , failIfErrsM
     , failM
     , failWithTc
@@ -510,6 +514,7 @@ import GHC.Tc.Utils.Monad             as Ghc
     , reportDiagnostic
     , reportDiagnostics
     , updEnv
+    , updTopEnv
     )
 import GHC.Tc.Utils.TcType            as Ghc (tcSplitDFunTy, tcSplitMethodTy)
 import GHC.Tc.Zonk.Type               as Ghc

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API/Extra.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API/Extra.hs
@@ -10,14 +10,12 @@ module Liquid.GHC.API.Extra (
   , apiComments
   , apiCommentsParsedSource
   , dataConSig
-  , desugarModuleIO
   , fsToUnitId
   , isPatErrorAlt
   , lookupModSummary
   , minus_RDR
   , modInfoLookupNameIO
   , moduleInfoTc
-  , parseModuleIO
   , qualifiedNameFS
   , relevantModules
   , renderWithStyle
@@ -28,7 +26,6 @@ module Liquid.GHC.API.Extra (
   , strictNothing
   , thisPackage
   , tyConRealArity
-  , typecheckModuleIO
   , untick
   ) where
 
@@ -49,7 +46,6 @@ import GHC.Core.Make                  (pAT_ERROR_ID)
 import GHC.Core.Type                  as Ghc hiding (typeKind , isPredTy, extendCvSubst, linear)
 import GHC.Data.Bag                   (bagToList)
 import GHC.Data.FastString            as Ghc
-import qualified GHC.Data.EnumSet as EnumSet
 import GHC.Data.Maybe
 import qualified GHC.Data.Strict
 import GHC.Driver.Env
@@ -145,52 +141,6 @@ relevantModules mg modGuts = used `S.union` dependencies
           UsageHomeModule        { usg_mod_name = modName } -> toModule modName : acc
           UsageMergedRequirement { usg_mod      = modl    } -> modl : acc
           _ -> acc
-
---
--- Parsing, typechecking and desugaring a module
---
-parseModuleIO :: HscEnv -> ModSummary -> IO ParsedModule
-parseModuleIO hscEnv ms = do
-  let hsc_env_tmp = hscEnv { hsc_dflags = ms_hspp_opts ms }
-  hpm <- hscParse hsc_env_tmp ms
-  return (ParsedModule ms (hpm_module hpm) (hpm_src_files hpm))
-
--- | Our own simplified version of 'TypecheckedModule'.
-data TypecheckedModuleLH = TypecheckedModuleLH {
-    tmlh_parsed_module  :: ParsedModule
-  , tmlh_renamed_source :: Maybe RenamedSource
-  , tmlh_mod_summary    :: ModSummary
-  , tmlh_gbl_env        :: TcGblEnv
-  }
-
-typecheckModuleIO :: HscEnv -> ParsedModule -> IO TypecheckedModuleLH
-typecheckModuleIO hscEnv pmod = do
-  -- Suppress all the warnings, so that they won't be printed (which would result in them being
-  -- printed twice, one by GHC and once here).
-  let ms = pm_mod_summary pmod
-  let dynFlags' = ms_hspp_opts ms
-  let hsc_env_tmp = hscEnv { hsc_dflags = dynFlags' { warningFlags = EnumSet.empty } }
-  (tc_gbl_env, rn_info)
-        <- hscTypecheckRename hsc_env_tmp ms $
-                       HsParsedModule { hpm_module = parsedSource pmod,
-                                        hpm_src_files = pm_extra_src_files pmod }
-  return TypecheckedModuleLH {
-      tmlh_parsed_module  = pmod
-    , tmlh_renamed_source = rn_info
-    , tmlh_mod_summary    = ms
-    , tmlh_gbl_env        = tc_gbl_env
-    }
-
--- | Desugar a typechecked module.
-desugarModuleIO :: HscEnv -> ModSummary -> TypecheckedModuleLH -> IO ModGuts
-desugarModuleIO hscEnv originalModSum typechecked = do
-  -- See [NOTE:ghc810] on why we override the dynFlags here before calling 'desugarModule'.
-  let modSum         = originalModSum { ms_hspp_opts = hsc_dflags hscEnv }
-  let parsedMod'     = (tmlh_parsed_module typechecked) { pm_mod_summary = modSum }
-  let typechecked'   = typechecked { tmlh_parsed_module = parsedMod' }
-
-  let hsc_env_tmp = hscEnv { hsc_dflags = ms_hspp_opts (tmlh_mod_summary typechecked') }
-  hscDesugar hsc_env_tmp (tmlh_mod_summary typechecked') (tmlh_gbl_env typechecked')
 
 -- | Abstraction of 'EpaComment'.
 data ApiComment

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -623,16 +623,6 @@ stripParens t = fromMaybe t (strip t)
 stripParensSym :: Symbol -> Symbol
 stripParensSym (symbolText -> t) = symbol (stripParens t)
 
-desugarModule :: TypecheckedModule -> Ghc DesugaredModule
-desugarModule tcm = do
-  let ms = pm_mod_summary $ tm_parsed_module tcm
-  -- let ms = modSummary tcm
-  let (tcg, _) = tm_internals_ tcm
-  hsc_env <- getSession
-  let hsc_env_tmp = hsc_env { hsc_dflags = ms_hspp_opts ms }
-  guts <- liftIO $ hscDesugar{- WithLoc -} hsc_env_tmp ms tcg
-  return DesugaredModule { dm_typechecked_module = tcm, dm_core_module = guts }
-
 --------------------------------------------------------------------------------
 -- | GHC Compatibility Layer ---------------------------------------------------
 --------------------------------------------------------------------------------

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -331,9 +331,10 @@ typecheckHook' cfg0 modSummary0 parsed0 tcGblEnv = do
                   typechecked     <- typecheckModule (LH.ignoreInline parsed2)
                   unoptimisedGuts <- desugarModule typechecked
 
-                  resolvedNames   <- liftIO $ LH.lookupTyThings env2 tcGblEnv
-                  availTyCons     <- liftIO $ LH.availableTyCons env2 tcGblEnv (tcg_exports tcGblEnv)
-                  availVars       <- liftIO $ LH.availableVars env2 tcGblEnv (tcg_exports tcGblEnv)
+                  resolvedNames   <- LH.lookupTyThings tcGblEnv
+                  avails          <- LH.availableTyThings tcGblEnv (tcg_exports tcGblEnv)
+                  let availTyCons = [ tc | ATyCon tc <- avails ]
+                      availVars   = [ var | AnId var <- avails ]
 
                   let tcData = mkTcData (tcg_rn_imports tcGblEnv) resolvedNames availTyCons availVars
                   return $ PipelineData (coreModule unoptimisedGuts) tcData specs


### PR DESCRIPTION
For users that need to do custom steps on the way to a full `TypecheckedModule`, it'd make sense to provide an API that directly consumes the `TypecheckedModule`.