### PR TITLE
Implement a Minimal verbosity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,9 @@
 - Add a new flag `--etabeta` to reason with lambdas in PLE [#2356](https://github.com/ucsd-progsys/liquidhaskell/pull/2356)
 - Enabling the LiquidHaskell plugin now enables `-fno-ignore-interface-pragmas` ([#2326](https://github.com/ucsd-progsys/liquidhaskell/pull/2326))
   and `-dkeep-comments` ([#2367](https://github.com/ucsd-progsys/liquidhaskell/pull/2367)).
+- LiquidHaskell earned a new `--minimal` verbosity level as default that prints the banner with the
+  amount of constraints checked ([#2395](https://github.com/ucsd-progsys/liquidhaskell/pull/2395)).
+  This banner is now suppressed when the verbosity is set to `--quiet` ([#2391](https://github.com/ucsd-progsys/liquidhaskell/pull/2391)).
 
 ## 0.9.10.1 (2024-08-21)
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
@@ -11,13 +11,12 @@ import           Prelude hiding (error)
 import           Data.Bifunctor
 import qualified Data.HashSet as S 
 import           Text.PrettyPrint.HughesPJ
-import           System.Console.CmdArgs.Verbosity (whenLoud, whenNormal)
 import           Control.Monad (when)
 import qualified Data.Maybe as Mb
 import qualified Data.List  as L 
 import qualified Language.Haskell.Liquid.UX.DiffCheck as DC
 import           Language.Haskell.Liquid.Misc
-import           Language.Fixpoint.Misc
+import qualified Language.Fixpoint.Misc as F
 import           Language.Fixpoint.Solver
 import qualified Language.Fixpoint.Types as F
 import           Language.Haskell.Liquid.Types.Errors
@@ -52,16 +51,13 @@ checkTargetInfo info = do
         -- donePhase Loud "Only compiling specifications [skipping verification]"
         pure mempty { o_result = F.Safe mempty }
       | otherwise = do
-        whenNormal $ donePhase Loud "Extracted Core using GHC"
-        -- whenLoud  $ do putStrLn $ showpp info
-                     -- putStrLn "*************** Original CoreBinds ***************************"
-                     -- putStrLn $ render $ pprintCBs (cbs info)
-        whenNormal $ donePhase Loud "Transformed Core"
-        whenLoud  $ do donePhase Loud "transformRecExpr-1773-hoho"
-                       putStrLn "*************** Transform Rec Expr CoreBinds *****************"
-                       putStrLn $ showCBs (untidyCore cfg) cbs'
-                       -- putStrLn $ render $ pprintCBs cbs'
-                       -- putStrLn $ showPpr cbs'
+        when (loggingVerbosity cfg == Normal) $ do
+          F.donePhase F.Loud "Extracted Core using GHC"
+          F.donePhase F.Loud "Transformed Core"
+        when (loggingVerbosity cfg == Loud) $ do
+          F.donePhase F.Loud "transformRecExpr-1773-hoho"
+          putStrLn "*************** Transform Rec Expr CoreBinds *****************"
+          putStrLn $ showCBs (untidyCore cfg) cbs'
         edcs <- newPrune cfg cbs' tgt info
         liquidQueries cfg tgt info edcs
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -651,8 +651,8 @@ dummyP ::  Monad m => m (Reft -> b) -> m b
 dummyP fm
   = fm `ap` return dummyReft
 
-symsP :: (IsString tv, Monoid r)
-      => Parser [(Symbol, RType c tv r)]
+symsP :: Monoid r
+      => Parser [(Symbol, RType c BTyVar r)]
 symsP
   = do reservedOp "\\"
        ss <- many symbolP
@@ -661,19 +661,19 @@ symsP
  <|> return []
  <?> "symsP"
 
-dummyRSort :: (IsString tv, Monoid r) => RType c tv r
+dummyRSort :: Monoid r => RType c BTyVar r
 dummyRSort
-  = RVar "dummy" mempty
+  = RVar (BTV "dummy") mempty
 
-predicatesP :: (IsString tv, Monoid r)
-            => Parser [Ref (RType c tv r) BareType]
+predicatesP :: Monoid r
+            => Parser [Ref (RType c BTyVar r) BareType]
 predicatesP
    =  angles (sepBy1 predicate1P comma)
   <|> return []
   <?> "predicatesP"
 
-predicate1P :: (IsString tv, Monoid r)
-            => Parser (Ref (RType c tv r) BareType)
+predicate1P :: Monoid r
+            => Parser (Ref (RType c BTyVar r) BareType)
 predicate1P
    =  try (RProp <$> symsP <*> refP bbaseP)
   <|> (rPropP [] . predUReft <$> monoPredicate1P)
@@ -830,8 +830,8 @@ predUReft p    = MkUReft dummyReft p
 dummyReft :: Monoid a => a
 dummyReft      = mempty
 
-dummyTyId :: IsString a => a
-dummyTyId      = ""
+dummyTyId :: String
+dummyTyId = ""
 
 ------------------------------------------------------------------
 --------------------------- Measures -----------------------------
@@ -1494,12 +1494,10 @@ tupPatP  = mkTupPat  <$> sepBy1 locLowerIdP comma
 conPatP :: Parser (Located Symbol, [Located Symbol])
 conPatP  = (,)       <$> dataConNameP <*> many locLowerIdP
 
-consPatP :: IsString a
-         => Parser (Located a, [Located Symbol])
+consPatP :: Parser (Located Symbol, [Located Symbol])
 consPatP = mkConsPat <$> locLowerIdP  <*> reservedOp ":" <*> locLowerIdP
 
-nilPatP :: IsString a
-        => Parser (Located a, [t])
+nilPatP :: Parser (Located Symbol, [t])
 nilPatP  = mkNilPat  <$> brackets (pure ())
 
 nullaryConPatP :: Parser (Located Symbol, [t])
@@ -1509,10 +1507,10 @@ nullaryConPatP = nilPatP <|> ((,[]) <$> dataConNameP)
 mkTupPat :: Foldable t => t a -> (Located Symbol, t a)
 mkTupPat zs     = (tupDataCon (length zs), zs)
 
-mkNilPat :: IsString a => t -> (Located a, [t1])
+mkNilPat :: t -> (Located Symbol, [t1])
 mkNilPat _      = (dummyLoc "[]", []    )
 
-mkConsPat :: IsString a => t1 -> t -> t1 -> (Located a, [t1])
+mkConsPat :: t1 -> t -> t1 -> (Located Symbol, [t1])
 mkConsPat x _ y = (dummyLoc ":" , [x, y])
 
 tupDataCon :: Int -> Located Symbol

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -78,9 +78,6 @@ module Language.Haskell.Liquid.Types.RType (
   , ppEnv
   , ppEnvShort
 
-  -- , rtyVarUniqueSymbol, tyVarUniqueSymbol
-  , rtyVarType, tyVarVar
-
   -- * Refined Function Info
   , RFInfo(..), defRFInfo, mkRFInfo, classRFInfo
 
@@ -407,13 +404,6 @@ instance F.Symbolic BTyCon where
 instance NFData BTyCon
 
 instance NFData RTyCon
-
-rtyVarType :: RTyVar -> Type
-rtyVarType (RTV v) = TyVarTy v
-
-tyVarVar :: RTVar RTyVar c -> Var
-tyVarVar (RTVar (RTV v) _) = v
-
 
 
 mkBTyCon :: F.LocSymbol -> BTyCon

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -357,9 +357,6 @@ instance Eq BTyVar where
 instance Ord BTyVar where
   compare (BTV x) (BTV y) = compare x y
 
-instance IsString BTyVar where
-  fromString = BTV . fromString
-
 instance B.Binary BTyVar
 instance Hashable BTyVar
 instance NFData   BTyVar

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -765,7 +765,7 @@ reportResult logResultFull cfg targets out = do
          let outputResult = resDocs tidy cr
          -- For now, always print the \"header\" with colours, irrespective to the logger
          -- passed as input.
-         when (loggingVerbosity cfg >= Normal) $
+         when (loggingVerbosity cfg >= Minimal) $
              liftIO $ printHeader (colorResult r) (orHeader outputResult)
          logResultFull outputResult
   where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -38,9 +38,6 @@ module Language.Haskell.Liquid.UX.CmdLine (
    -- * Diff check mode
    , diffcheck
 
-   -- * Show info about this version of LiquidHaskell
-   , printLiquidHaskellBanner
-
 ) where
 
 import Prelude hiding (error)
@@ -58,8 +55,7 @@ import System.Directory
 import System.Exit
 import System.Environment
 import System.Console.CmdArgs.Explicit
-import System.Console.CmdArgs.Implicit     hiding (Loud)
-import qualified System.Console.CmdArgs.Verbosity as CmdArgs
+import System.Console.CmdArgs.Implicit     hiding (Verbosity(..))
 import System.Console.CmdArgs.Text
 import GitHash
 
@@ -69,7 +65,7 @@ import Data.List                           (nub)
 import System.FilePath                     (isAbsolute, takeDirectory, (</>))
 
 import qualified Language.Fixpoint.Types.Config as FC
-import Language.Fixpoint.Misc
+import qualified Language.Fixpoint.Misc as F
 import Language.Fixpoint.Types.Names
 import Language.Fixpoint.Types             hiding (panic, Error, Result, saveQuery)
 import qualified Language.Fixpoint.Types as F
@@ -103,9 +99,10 @@ defaultMaxParams = 2
 config :: Mode (CmdArgs Config)
 config = cmdArgsMode $ Config {
   loggingVerbosity
-    = enum [ Quiet        &= name "quiet"   &= help "Minimal logging verbosity"
+    = enum [ Minimal      &= name "minimal" &= help "Minimal logging verbosity"
+           , Quiet        &= name "quiet"   &= help "Silent logging verbosity"
            , Normal       &= name "normal"  &= help "Normal logging verbosity"
-           , CmdArgs.Loud &= name "verbose" &= help "Verbose logging"
+           , Loud         &= name "verbose" &= help "Verbose logging"
            ]
 
  , files
@@ -503,15 +500,10 @@ getOpts as = do
                                                 }
                                 }
                          as
-  cfg    <- fixConfig cfg1
-  setVerbosity (loggingVerbosity cfg)
-  when (json cfg) $ setVerbosity Quiet
-  withSmtSolver cfg
-
--- | Shows the LiquidHaskell banner, that includes things like the copyright, the
--- git commit and the version.
-printLiquidHaskellBanner :: IO ()
-printLiquidHaskellBanner = whenNormal $ putStrLn copyright
+  cfg2   <- fixConfig cfg1
+  let cfg3 = if json cfg2 then cfg2 {loggingVerbosity = Quiet} else cfg2
+  setVerbosity (cmdargsVerbosity $ loggingVerbosity cfg3)
+  withSmtSolver cfg3
 
 cmdArgsRun' :: Mode (CmdArgs a) -> [String] -> IO a
 cmdArgsRun' md as
@@ -624,7 +616,7 @@ gitMsg gi = concat
 
 mkOpts :: Config -> IO Config
 mkOpts cfg = do
-  let files' = sortNub $ files cfg
+  let files' = F.sortNub $ files cfg
   return     $ cfg { files       = files'
                                    -- See NOTE [searchpath]
                    }
@@ -644,9 +636,9 @@ withPragmas :: MonadIO m => Config -> FilePath -> [Located String] -> (Config ->
 withPragmas cfg fp ps action
   = do cfg' <- liftIO $ (processPragmas cfg ps >>= canonicalizePaths fp) <&> canonConfig
        -- As the verbosity is set /globally/ via the cmdargs lib, re-set it.
-       liftIO $ setVerbosity (loggingVerbosity cfg')
+       liftIO $ setVerbosity (cmdargsVerbosity $ loggingVerbosity cfg')
        res <- action cfg'
-       liftIO $ setVerbosity (loggingVerbosity cfg) -- restore the original verbosity.
+       liftIO $ setVerbosity (cmdargsVerbosity $ loggingVerbosity cfg) -- restore the original verbosity.
        pure res
 
 processPragmas :: Config -> [Located String] -> IO Config
@@ -666,7 +658,7 @@ parsePragma = processPragmas defConfig . (:[])
 
 defConfig :: Config
 defConfig = Config
-  { loggingVerbosity         = Quiet
+  { loggingVerbosity         = Minimal
   , files                    = def
   , idirs                    = def
   , fullcheck                = def
@@ -763,7 +755,7 @@ reportResult :: MonadIO m
              -> m ()
 reportResult logResultFull cfg targets out = do
   annm <- {-# SCC "annotate" #-} liftIO $ annotate cfg targets out
-  liftIO $ whenNormal $ donePhase Loud "annotate"
+  liftIO $ when (loggingVerbosity cfg >= Normal) $ F.donePhase F.Loud "annotate"
   if json cfg then
     liftIO $ reportResultJson annm
    else do
@@ -780,8 +772,8 @@ reportResult logResultFull cfg targets out = do
     tidy :: F.Tidy
     tidy = if shortErrors cfg then F.Lossy else F.Full
 
-    printHeader :: Moods -> Doc -> IO ()
-    printHeader mood d = colorPhaseLn mood "" (render d)
+    printHeader :: F.Moods -> Doc -> IO ()
+    printHeader mood d = F.colorPhaseLn mood "" (render d)
 
 
 reportResultJson :: ACSS.AnnMap -> IO ()
@@ -805,8 +797,8 @@ instance Show (CtxError Doc) where
 
 writeCheckVars :: Symbolic a => Maybe [a] -> IO ()
 writeCheckVars Nothing    = return ()
-writeCheckVars (Just [])   = colorPhaseLn Loud "Checked Binders: None" ""
-writeCheckVars (Just ns)   = colorPhaseLn Loud "Checked Binders:" ""
+writeCheckVars (Just [])   = F.colorPhaseLn F.Loud "Checked Binders: None" ""
+writeCheckVars (Just ns)   = F.colorPhaseLn F.Loud "Checked Binders:" ""
                           >> forM_ ns (putStrLn . symbolString . dropModuleNames . symbol)
 
 type CError = CtxError Doc

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Config.hs
@@ -6,7 +6,9 @@
 module Language.Haskell.Liquid.UX.Config (
      Config (..)
    , HasConfig (..)
+   , Verbosity (..)
    , allowPLE, allowLocalPLE, allowGlobalPLE
+   , cmdargsVerbosity
    , patternFlag
    , higherOrderFlag
    , pruneFlag
@@ -21,11 +23,23 @@ module Language.Haskell.Liquid.UX.Config (
 import Prelude hiding (error)
 import Language.Fixpoint.Types.Config hiding (Config)
 import GHC.Generics
-import System.Console.CmdArgs
+import System.Console.CmdArgs hiding (Verbosity(..))
+import qualified System.Console.CmdArgs as CmdArgs
+
+data Verbosity = Quiet | Minimal | Normal | Loud
+  deriving (Data, Generic, Show, Eq, Ord)
+
+-- | liquid-fixpoint uses CmdArg.Verbosity at least to show the progress bar.
+cmdargsVerbosity :: Verbosity -> CmdArgs.Verbosity
+cmdargsVerbosity Quiet   = CmdArgs.Quiet
+cmdargsVerbosity Minimal = CmdArgs.Quiet
+cmdargsVerbosity Normal  = CmdArgs.Normal
+cmdargsVerbosity Loud    = CmdArgs.Loud
+
 
 -- NOTE: adding strictness annotations breaks the help message
 data Config = Config
-  { loggingVerbosity         :: Verbosity  -- ^ the logging verbosity to use (defaults to 'Quiet')
+  { loggingVerbosity         :: Verbosity  -- ^ the logging verbosity to use (defaults to 'Minimal')
   , files                    :: [FilePath] -- ^ source files to check
   , idirs                    :: [FilePath] -- ^ path to directory for including specs
   , diffcheck                :: Bool       -- ^ check subset of binders modified (+ dependencies) since last check


### PR DESCRIPTION
Follow up to https://github.com/ucsd-progsys/liquidhaskell/pull/2391

This PR implements a new `--minimal` verbosity level as default that prints the banner with the amount of constraints checked. `--normal` prints in addition the progress bars of liquid-fixpoint.

The PR also includes some clean ups to remove code that was not used, and simplifies some types in the Parse module.