### PR TITLE
Update tuple names to match what GHC uses

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Interface.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Interface.hs
@@ -36,7 +36,6 @@ module Language.Haskell.Liquid.GHC.Interface (
   , makeFamInstEnv
   , clearSpec
   , checkFilePragmas
-  , keepRawTokenStream
   , lookupTyThings
   , availableTyThings
   , updLiftedSpec
@@ -144,17 +143,6 @@ updLiftedSpec s1 (Just s2) = clearSpec s1 `mappend` s2
 
 clearSpec :: Ms.BareSpec -> Ms.BareSpec
 clearSpec s = s { sigs = [], asmSigs = [], aliases = [], ealiases = [], qualifiers = [], dataDecls = [] }
-
-keepRawTokenStream :: ModSummary -> ModSummary
-keepRawTokenStream modSummary = modSummary
-  { ms_hspp_opts = ms_hspp_opts modSummary `gopt_set` Opt_KeepRawTokenStream }
-
-_impThings :: [Var] -> [TyThing] -> [TyThing]
-_impThings vars  = filter ok
-  where
-    vs          = S.fromList vars
-    ok (AnId x) = S.member x vs
-    ok _        = True
 
 allImports :: [LImportDecl GhcRn] -> S.HashSet Symbol
 allImports imps = S.fromList (symbol . unLoc . ideclName . unLoc <$> imps)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -22,6 +22,7 @@
 
 module  Language.Haskell.Liquid.GHC.Misc where
 
+import           Data.Char (isDigit)
 import           Data.String
 import qualified Data.List as L
 import           Data.Word (Word64)
@@ -568,8 +569,15 @@ sepUnique = "#"
 mungeNames :: (String -> [T.Text] -> Symbol) -> T.Text -> String -> Symbol -> Symbol
 mungeNames _ _ _ ""  = ""
 mungeNames f d msg s'@(symbolText -> s)
-  | s' == tupConName = tupConName
+  | isTupleSymbol s' = s'
   | otherwise        = f (msg ++ T.unpack s) $ T.splitOn d $ stripParens s
+
+isTupleSymbol :: Symbol -> Bool
+isTupleSymbol s =
+    let t = F.symbolText s
+     in T.isPrefixOf "Tuple" t &&
+        T.all isDigit (T.drop 5 t) &&
+        T.length t > 5
 
 qualifySymbol :: Symbol -> Symbol -> Symbol
 qualifySymbol (symbolText -> m) x'@(symbolText -> x)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -22,7 +22,6 @@
 
 module  Language.Haskell.Liquid.GHC.Misc where
 
-import           Data.Char (isDigit)
 import           Data.String
 import qualified Data.List as L
 import           Data.Word (Word64)
@@ -34,7 +33,7 @@ import           Liquid.GHC.API            as Ghc hiding
 import qualified Liquid.GHC.API            as Ghc (GenLocated (L))
 
 
-import           Data.Char                                  (isLower, isSpace, isUpper)
+import           Data.Char                                  (isDigit, isLower, isSpace, isUpper)
 import           Data.Maybe                                 (isJust, fromMaybe, fromJust, maybeToList)
 import           Data.Hashable
 import qualified Data.HashSet                               as S

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/SpecFinder.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/SpecFinder.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE RankNTypes   #-}
 
 module Language.Haskell.Liquid.GHC.Plugin.SpecFinder

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -771,9 +771,13 @@ bTup [(_,t)] _ r
   | otherwise  = t `strengthen` reftUReft r
 bTup ts rs r
   | all Mb.isNothing (fst <$> ts) || length ts < 2
-  = RApp (mkBTyCon $ dummyLoc tupConName) (snd <$> ts) rs (reftUReft r)
+  = RApp
+      (mkBTyCon $ dummyLoc $ fromString $ "Tuple" ++ show (length ts))
+      (snd <$> ts) rs (reftUReft r)
   | otherwise
-  = RApp (mkBTyCon $ dummyLoc tupConName) (top . snd <$> ts) rs' (reftUReft r)
+  = RApp
+      (mkBTyCon $ dummyLoc $ fromString $ "Tuple" ++ show (length ts))
+      (top . snd <$> ts) rs' (reftUReft r)
   where
     args       = [(Mb.fromMaybe dummySymbol x, mapReft mempty t) | (x,t) <- ts]
     makeProp i = RProp (take i args) ((snd <$> ts)!!i)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -514,7 +514,7 @@ isClassOrSubClass p cls
 instance TyConable Symbol where
   isFun   s = F.funConName == s
   isList  s = F.listConName == s
-  isTuple s = F.tupConName == s
+  isTuple = isTupleSymbol
   ppTycon   = text . F.symbolString
 
 instance TyConable F.LocSymbol where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -1639,7 +1639,7 @@ typeSortForAll tce τ  = F.notracepp ("typeSortForall " ++ showpp τ) $ genSort 
 tyConName :: TyCon -> Symbol
 tyConName c
   | listTyCon == c    = listConName
-  | Ghc.isTupleTyCon c = tupConName
+  | Ghc.isTupleTyCon c = symbol $ "Tuple" ++ show (tyConArity c)
   | otherwise         = symbol c
 
 typeSortFun :: TCEmb TyCon -> Type -> Sort


### PR DESCRIPTION
While tuples used to be handled with a single `Tuple` type, now they are represented with types `Tuple0`,...,`Tuple64`.

This PR updates the names and liquid-fixpoint after merging https://github.com/ucsd-progsys/liquid-fixpoint/pull/714.

Some smaller refactorings are added as well in ceb7500 and 22c1132.