### PR TITLE
Import specs from all direct imports and only from direct imports

### DIFF
--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -456,7 +456,7 @@ import GHC.Core.Opt.OccurAnal         as Ghc
 import GHC.Core.TyCo.FVs              as Ghc (tyCoVarsOfCo, tyCoVarsOfType)
 import GHC.Driver.Backend             as Ghc (interpreterBackend)
 import GHC.Driver.Env                 as Ghc
-    ( HscEnv(hsc_NC, hsc_mod_graph, hsc_unit_env, hsc_dflags, hsc_plugins)
+    ( HscEnv(hsc_NC, hsc_unit_env, hsc_dflags, hsc_plugins)
     , Hsc
     , hscSetFlags, hscUpdateFlags
     )

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API/Extra.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API/Extra.hs
@@ -10,6 +10,7 @@ module Liquid.GHC.API.Extra (
   , apiComments
   , apiCommentsParsedSource
   , dataConSig
+  , directImports
   , fsToUnitId
   , isPatErrorAlt
   , lookupModSummary
@@ -17,7 +18,6 @@ module Liquid.GHC.API.Extra (
   , modInfoLookupName
   , moduleInfoTc
   , qualifiedNameFS
-  , relevantModules
   , renderWithStyle
   , showPprQualified
   , showPprDebug
@@ -36,7 +36,6 @@ import Data.Data (Data, gmapQr, gmapT)
 import Data.Generics (extQ, extT)
 import Data.Foldable                  (asum)
 import Data.List                      (sortOn)
-import qualified Data.Map as Map
 import qualified Data.Set as S
 import GHC.Builtin.Names ( dollarIdKey, minusName )
 import GHC.Core                       as Ghc
@@ -59,19 +58,11 @@ import GHC.Types.SrcLoc               as Ghc
 import GHC.Types.TypeEnv
 import GHC.Types.Unique               (getUnique, hasKey)
 
-import GHC.Unit.Module.Deps           as Ghc (Dependencies(dep_direct_mods))
-import GHC.Unit.Module.Graph          as Ghc
-  ( NodeKey(NodeKey_Module)
-  , ModNodeKeyWithUid(ModNodeKeyWithUid)
-  , mgTransDeps
-  )
 import GHC.Unit.Module.ModDetails     (md_types)
 import GHC.Unit.Module.ModSummary     (isBootSummary)
 import GHC.Utils.Outputable           as Ghc hiding ((<>))
 
 import GHC.Unit.Module
-import GHC.Unit.Module.ModGuts
-import GHC.Unit.Module.Deps (Usage(..))
 
 -- 'fsToUnitId' is gone in GHC 9, but we can bring code it in terms of 'fsToUnit' and 'toUnitId'.
 fsToUnitId :: FastString -> UnitId
@@ -90,18 +81,6 @@ tyConRealArity tc = go 0 (tyConKind tc)
         Nothing -> acc
         Just ks -> go (acc + 1) ks
 
-getDependenciesModuleNames :: ModuleGraph -> UnitId -> Dependencies -> [ModuleNameWithIsBoot]
-getDependenciesModuleNames mg unitId deps =
-    mapMaybe nodeKeyToModuleName $ S.toList $ S.unions $ catMaybes
-      [ Map.lookup k tdeps
-      | (_, m) <- S.toList $ dep_direct_mods deps
-      , let k = NodeKey_Module $ ModNodeKeyWithUid m unitId
-      ]
-  where
-    tdeps = mgTransDeps mg
-    nodeKeyToModuleName (NodeKey_Module (ModNodeKeyWithUid m _)) = Just m
-    nodeKeyToModuleName _ = Nothing
-
 renderWithStyle :: DynFlags -> SDoc -> PprStyle -> String
 renderWithStyle dynflags sdoc style = Ghc.renderWithContext (Ghc.initSDocContext dynflags style) sdoc
 
@@ -110,35 +89,9 @@ dataConSig :: DataCon -> ([TyCoVar], ThetaType, [Type], Type)
 dataConSig dc
   = (dataConUnivAndExTyCoVars dc, dataConTheta dc, map irrelevantMult $ dataConOrigArgTys dc, dataConOrigResTy dc)
 
--- | The collection of dependencies and usages modules which are relevant for liquidHaskell
-relevantModules :: ModuleGraph -> ModGuts -> S.Set Module
-relevantModules mg modGuts = used `S.union` dependencies
-  where
-    dependencies :: S.Set Module
-    dependencies = S.fromList $ map (toModule . gwib_mod)
-                              . filter ((NotBoot ==) . gwib_isBoot)
-                              . getDependenciesModuleNames mg thisUnitId $ deps
-
-    deps :: Dependencies
-    deps = mg_deps modGuts
-
-    thisModule :: Module
-    thisModule = mg_module modGuts
-
-    thisUnitId = moduleUnitId thisModule
-
-    toModule :: ModuleName -> Module
-    toModule = unStableModule . mkStableModule thisUnitId
-
-    used :: S.Set Module
-    used = S.fromList $ foldl' collectUsage mempty . mg_usages $ modGuts
-      where
-        collectUsage :: [Module] -> Usage -> [Module]
-        collectUsage acc = \case
-          UsagePackageModule     { usg_mod      = modl    } -> modl : acc
-          UsageHomeModule        { usg_mod_name = modName } -> toModule modName : acc
-          UsageMergedRequirement { usg_mod      = modl    } -> modl : acc
-          _ -> acc
+-- | Extracts the direct imports of a module.
+directImports :: TcGblEnv -> S.Set Module
+directImports = S.fromList . moduleEnvKeys . imp_mods . tcg_imports
 
 -- | Abstraction of 'EpaComment'.
 data ApiComment

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API/Extra.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API/Extra.hs
@@ -13,7 +13,6 @@ module Liquid.GHC.API.Extra (
   , directImports
   , fsToUnitId
   , isPatErrorAlt
-  , lookupModSummary
   , minus_RDR
   , modInfoLookupName
   , moduleInfoTc
@@ -59,7 +58,6 @@ import GHC.Types.TypeEnv
 import GHC.Types.Unique               (getUnique, hasKey)
 
 import GHC.Unit.Module.ModDetails     (md_types)
-import GHC.Unit.Module.ModSummary     (isBootSummary)
 import GHC.Utils.Outputable           as Ghc hiding ((<>))
 
 import GHC.Unit.Module
@@ -178,16 +176,6 @@ addNoInlinePragmasToBinds tcg = tcg{ tcg_binds = go (tcg_binds tcg) }
           { abe_poly = markId poly
           , abe_mono = markId mono }
 
-
-lookupModSummary :: HscEnv -> ModuleName -> Maybe ModSummary
-lookupModSummary hscEnv mdl = do
-   let mg = hsc_mod_graph hscEnv
-       mods_by_name = [ ms | ms <- mgModSummaries mg
-                      , ms_mod_name ms == mdl
-                      , NotBoot == isBootSummary ms ]
-   case mods_by_name of
-     [ms] -> Just ms
-     _    -> Nothing
 
 -- | Our own simplified version of 'ModuleInfo' to overcome the fact we cannot construct the \"original\"
 -- one as the constructor is not exported, and 'getHomeModuleInfo' and 'getPackageModuleInfo' are not

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -234,8 +234,8 @@ tyConDataDecl ((tc, dn), NoDecl szF)
 
 tyConDataName :: Ghc.TyCon -> Maybe DataName
 tyConDataName tc
-  | vanillaTc  = Just (DnName ((\x -> makeGHCLHName (Ghc.getName x) (F.symbol x)) <$> GM.locNamedThing tc))
-  | d:_ <- dcs = Just (DnCon  ((\x -> makeGHCLHName (Ghc.getName x) (F.symbol x)) <$> GM.locNamedThing d ))
+  | vanillaTc  = Just $ DnName $ makeGHCLHNameLocated tc
+  | d:_ <- dcs = Just $ DnCon $ makeGHCLHNameLocated d
   | otherwise  = Nothing
   where
     vanillaTc  = Ghc.isVanillaAlgTyCon tc
@@ -247,7 +247,7 @@ dataConDecl d     = {- F.notracepp msg $ -} DataCtor dx (F.symbol <$> as) [] xts
     isGadt        = not (Ghc.isVanillaDataCon d)
     -- msg           = printf "dataConDecl (gadt = %s)" (show isGadt)
     xts           = [(Bare.makeDataConSelector Nothing d i, RT.bareOfType t) | (i, t) <- its ]
-    dx            = (\x -> makeGHCLHName (Ghc.getName x) (F.symbol x)) <$> GM.locNamedThing d
+    dx            = makeGHCLHNameLocated d
     its           = zip [1..] ts
     (as,_ps,ts,ty)  = Ghc.dataConSig d
     outT          = Just (RT.bareOfType ty :: BareType)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -211,10 +211,6 @@ qualifiedDataName :: ModName -> DataName -> DataName
 qualifiedDataName modName (DnName lx) = DnName (updateLHNameSymbol (qualifyModName modName) <$> lx)
 qualifiedDataName modName (DnCon  lx) = DnCon  (updateLHNameSymbol (qualifyModName modName) <$> lx)
 
-updateLHNameSymbol :: (F.Symbol -> F.Symbol) -> LHName -> LHName
-updateLHNameSymbol f (LHNResolved n s) = LHNResolved n (f s)
-updateLHNameSymbol f (LHNUnresolved n s) = LHNUnresolved n (f s)
-
 {-tyConDataDecl :: {tc:TyCon | isAlgTyCon tc} -> Maybe DataDecl @-}
 tyConDataDecl :: ((Ghc.TyCon, DataName), HasDataDecl) -> Maybe DataDecl
 tyConDataDecl (_, HasDecl)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -234,8 +234,8 @@ tyConDataDecl ((tc, dn), NoDecl szF)
 
 tyConDataName :: Ghc.TyCon -> Maybe DataName
 tyConDataName tc
-  | vanillaTc  = Just (DnName ((\x -> lhNameFromGHCName (Ghc.getName x) (F.symbol x)) <$> GM.locNamedThing tc))
-  | d:_ <- dcs = Just (DnCon  ((\x -> lhNameFromGHCName (Ghc.getName x) (F.symbol x)) <$> GM.locNamedThing d ))
+  | vanillaTc  = Just (DnName ((\x -> makeGHCLHName (Ghc.getName x) (F.symbol x)) <$> GM.locNamedThing tc))
+  | d:_ <- dcs = Just (DnCon  ((\x -> makeGHCLHName (Ghc.getName x) (F.symbol x)) <$> GM.locNamedThing d ))
   | otherwise  = Nothing
   where
     vanillaTc  = Ghc.isVanillaAlgTyCon tc
@@ -247,7 +247,7 @@ dataConDecl d     = {- F.notracepp msg $ -} DataCtor dx (F.symbol <$> as) [] xts
     isGadt        = not (Ghc.isVanillaDataCon d)
     -- msg           = printf "dataConDecl (gadt = %s)" (show isGadt)
     xts           = [(Bare.makeDataConSelector Nothing d i, RT.bareOfType t) | (i, t) <- its ]
-    dx            = (\x -> lhNameFromGHCName (Ghc.getName x) (F.symbol x)) <$> GM.locNamedThing d
+    dx            = (\x -> makeGHCLHName (Ghc.getName x) (F.symbol x)) <$> GM.locNamedThing d
     its           = zip [1..] ts
     (as,_ps,ts,ty)  = Ghc.dataConSig d
     outT          = Just (RT.bareOfType ty :: BareType)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
@@ -134,7 +134,7 @@ makeClassDataDecl = fmap (uncurry classDeclToDataDecl)
 -- maybe this should be fixed right after the GHC API refactoring?
 classDeclToDataDecl :: Ghc.Class -> [(Ghc.Id, LocBareType)] -> DataDecl
 classDeclToDataDecl cls refinedIds = DataDecl
-  { tycName   = DnName ((\x -> lhNameFromGHCName (Ghc.getName x) (F.symbol x)) <$> GM.locNamedThing cls)
+  { tycName   = DnName ((\x -> makeGHCLHName (Ghc.getName x) (F.symbol x)) <$> GM.locNamedThing cls)
   , tycTyVars = tyVars
   , tycPVars  = []
   , tycDCons  = Just [dctor]
@@ -145,7 +145,7 @@ classDeclToDataDecl cls refinedIds = DataDecl
   }
  where
   dctor = F.notracepp "classDeclToDataDecl"
-    DataCtor { dcName   = F.dummyLoc $ lhNameFromGHCName (Ghc.getName classDc) (F.symbol classDc)
+    DataCtor { dcName   = F.dummyLoc $ makeGHCLHName (Ghc.getName classDc) (F.symbol classDc)
     -- YL: same as class tyvars??
     -- Ans: it's been working so far so probably yes
                    , dcTyVars = tyVars

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
@@ -134,7 +134,7 @@ makeClassDataDecl = fmap (uncurry classDeclToDataDecl)
 -- maybe this should be fixed right after the GHC API refactoring?
 classDeclToDataDecl :: Ghc.Class -> [(Ghc.Id, LocBareType)] -> DataDecl
 classDeclToDataDecl cls refinedIds = DataDecl
-  { tycName   = DnName ((\x -> makeGHCLHName (Ghc.getName x) (F.symbol x)) <$> GM.locNamedThing cls)
+  { tycName   = DnName $ makeGHCLHNameLocated cls
   , tycTyVars = tyVars
   , tycPVars  = []
   , tycDCons  = Just [dctor]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
@@ -13,7 +13,7 @@ module Language.Haskell.Liquid.Types.Names
   , makeResolvedLHName
   , getLHNameResolved
   , getLHNameSymbol
-  , lhNameFromGHCName
+  , makeGHCLHName
   , makeUnresolvedLHName
   , mapLHNames
   , mapMLocLHNames
@@ -152,8 +152,8 @@ instance PPrint LHName where
 makeResolvedLHName :: LHResolvedName -> Symbol -> LHName
 makeResolvedLHName = LHNResolved
 
-lhNameFromGHCName :: GHC.Name -> Symbol -> LHName
-lhNameFromGHCName n s = makeResolvedLHName (LHRGHC n) s
+makeGHCLHName :: GHC.Name -> Symbol -> LHName
+makeGHCLHName n s = makeResolvedLHName (LHRGHC n) s
 
 makeUnresolvedLHName :: LHNameSpace -> Symbol -> LHName
 makeUnresolvedLHName = LHNUnresolved

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
@@ -19,6 +19,7 @@ module Language.Haskell.Liquid.Types.Names
   , makeUnresolvedLHName
   , mapLHNames
   , mapMLocLHNames
+  , updateLHNameSymbol
   ) where
 
 import Control.DeepSeq
@@ -188,3 +189,7 @@ mapMLocLHNames f = go
   where
     go :: forall b. Data b => b -> m b
     go = gmapM (go `extM` f)
+
+updateLHNameSymbol :: (Symbol -> Symbol) -> LHName -> LHName
+updateLHNameSymbol f (LHNResolved n s) = LHNResolved n (f s)
+updateLHNameSymbol f (LHNUnresolved n s) = LHNUnresolved n (f s)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
@@ -14,6 +14,8 @@ module Language.Haskell.Liquid.Types.Names
   , getLHNameResolved
   , getLHNameSymbol
   , makeGHCLHName
+  , makeGHCLHNameLocated
+  , makeLocalLHName
   , makeUnresolvedLHName
   , mapLHNames
   , mapMLocLHNames
@@ -28,7 +30,7 @@ import Data.String (fromString)
 import GHC.Generics
 import GHC.Stack
 import Language.Fixpoint.Types
-import Language.Haskell.Liquid.GHC.Misc () -- Symbolic GHC.Name
+import Language.Haskell.Liquid.GHC.Misc (locNamedThing) -- Symbolic GHC.Name
 import qualified Liquid.GHC.API as GHC
 import Text.PrettyPrint.HughesPJ.Compat
 
@@ -154,6 +156,13 @@ makeResolvedLHName = LHNResolved
 
 makeGHCLHName :: GHC.Name -> Symbol -> LHName
 makeGHCLHName n s = makeResolvedLHName (LHRGHC n) s
+
+makeLocalLHName :: Symbol -> LHName
+makeLocalLHName s = LHNResolved (LHRLocal s) s
+
+makeGHCLHNameLocated :: (GHC.NamedThing a, Symbolic a) => a -> Located LHName
+makeGHCLHNameLocated x =
+    makeGHCLHName (GHC.getName x) (symbol x) <$ locNamedThing x
 
 makeUnresolvedLHName :: LHNameSpace -> Symbol -> LHName
 makeUnresolvedLHName = LHNUnresolved

--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -37,6 +37,7 @@ library
                       Data.Bits_LHAssumptions
                       Data.Either_LHAssumptions
                       Data.Foldable_LHAssumptions
+                      Data.List_LHAssumptions
                       Data.Maybe_LHAssumptions
                       Data.String_LHAssumptions
                       Data.Tuple_LHAssumptions

--- a/src/Data/List_LHAssumptions.hs
+++ b/src/Data/List_LHAssumptions.hs
@@ -1,0 +1,4 @@
+{-# OPTIONS_GHC -fplugin=LiquidHaskellBoot #-}
+module Data.List_LHAssumptions where
+
+import GHC.Internal.List_LHAssumptions()

--- a/src/GHC/List_LHAssumptions.hs
+++ b/src/GHC/List_LHAssumptions.hs
@@ -1,5 +1,4 @@
 {-# OPTIONS_GHC -fplugin=LiquidHaskellBoot #-}
-{-# OPTIONS_GHC -Wno-unused-imports #-}
 module GHC.List_LHAssumptions where
 
 import GHC.Internal.List_LHAssumptions()

--- a/src/Prelude_LHAssumptions.hs
+++ b/src/Prelude_LHAssumptions.hs
@@ -1,7 +1,10 @@
 {-# OPTIONS_GHC -fplugin=LiquidHaskellBoot #-}
 module Prelude_LHAssumptions where
 
+import Data.Foldable_LHAssumptions()
+import Data.List_LHAssumptions()
 import GHC.Base_LHAssumptions()
+import GHC.Classes_LHAssumptions()
 import GHC.Float_LHAssumptions()
 import GHC.Maybe_LHAssumptions()
 import GHC.Num_LHAssumptions()

--- a/tests/basic/neg/T2349.hs
+++ b/tests/basic/neg/T2349.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE GADTs #-}
 {-@ LIQUID "--expect-error-containing=is not a subtype of the required type
-      VV : {VV##1249 : [GHC.Types.Int] | len VV##1249 == ?b + 1}" @-}
+      VV : {VV##1465 : [GHC.Types.Int] | len VV##1465 == ?b + 1}" @-}
 {-@ LIQUID "--reflection" @-}
 -- | Test that the refinement types produced for GADTs are
 -- compatible with the Haskell types.


### PR DESCRIPTION
The change in behavior is implemented in d3021e7. This makes more predictable when specs will be imported in a module, which in turn makes simpler to resolve names of measures. c29e546 fixes transitive imports between LHAssumptions modules, and 072dd80 adjust the expected output of a negative test after a variable name changed.

All the other commits are small and rather unrelated clean ups.