### PR TITLE
Use GHC Name for assumptions

### DIFF
--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -445,7 +445,12 @@ import GHC.Plugins                    as Ghc ( Serialized(Serialized)
                                              , extendIdSubst
                                              , substExpr
                                              )
-import GHC.Core.FVs                   as Ghc (exprFreeVars, exprFreeVarsList, exprSomeFreeVarsList)
+import GHC.Core.FVs                   as Ghc
+    ( exprFreeVars
+    , exprFreeVarsList
+    , exprsOrphNames
+    , exprSomeFreeVarsList
+    )
 import GHC.Core.Opt.OccurAnal         as Ghc
     ( occurAnalysePgm )
 import GHC.Core.TyCo.FVs              as Ghc (tyCoVarsOfCo, tyCoVarsOfType)
@@ -630,6 +635,11 @@ import GHC.Types.Name                 as Ghc
     )
 import GHC.Types.Name.Env             as Ghc
     ( lookupNameEnv )
+import GHC.Types.Name.Set             as Ghc
+    ( NameSet
+    , elemNameSet
+    , nameSetElemsStable
+    )
 import GHC.Types.Name.Cache           as Ghc (NameCache)
 import GHC.Types.Name.Occurrence      as Ghc
     ( NameSpace
@@ -655,6 +665,7 @@ import GHC.Types.Name.Reader          as Ghc
     , globalRdrEnvElts
     , greName
     , lookupGRE
+    , lookupGRE_Name
     , mkQual
     , mkRdrQual
     , mkRdrUnqual

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -639,10 +639,18 @@ import GHC.Types.Name.Occurrence      as Ghc
     , tcName
     )
 import GHC.Types.Name.Reader          as Ghc
-    ( GlobalRdrEnv
+    ( FieldsOrSelectors(WantNormal)
+    , GlobalRdrEnv
+    , GREInfo
     , ImpItemSpec(ImpAll)
     , LookupGRE(LookupRdrName)
-    , WhichGREs(SameNameSpace)
+    , WhichGREs
+        ( SameNameSpace
+        , RelevantGREs
+        , includeFieldSelectors
+        , lookupTyConsAsWell
+        , lookupVariablesForFields
+        )
     , getRdrName
     , globalRdrEnvElts
     , greName

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -548,6 +548,7 @@ import GHC.Types.Annotations          as Ghc
 import GHC.Types.Avail                as Ghc
     ( AvailInfo(Avail, AvailTC)
     , availNames
+    , availsToNameSet
     )
 import GHC.Types.Basic                as Ghc
     ( Arity

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Expand.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Expand.hs
@@ -29,6 +29,7 @@ import Data.Maybe
 
 import           Control.Monad
 import           Control.Monad.State
+import           Data.Bifunctor (second)
 import           Data.Functor ((<&>))
 import qualified Control.Exception         as Ex
 import qualified Data.HashMap.Strict       as M
@@ -385,7 +386,7 @@ instance Expand a => Expand (M.HashMap k a) where
 expandBareSpec :: BareRTEnv -> F.SourcePos -> Ms.BareSpec -> Ms.BareSpec
 expandBareSpec rtEnv l sp = sp
   { measures   = expand rtEnv l (measures   sp)
-  , asmSigs    = expand rtEnv l (asmSigs    sp)
+  , asmSigs    = map (second (expand rtEnv l)) (asmSigs sp)
   , sigs       = expand rtEnv l (sigs       sp)
   , localSigs  = expand rtEnv l (localSigs  sp)
   , reflSigs   = expand rtEnv l (reflSigs   sp)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -28,6 +28,7 @@ module Language.Haskell.Liquid.Bare.Resolve
   , lookupGhcDnTyCon
   , lookupGhcTyCon
   , lookupGhcVar
+  , lookupGhcIdLHName
   , lookupGhcNamedVar
   , matchTyCon
 
@@ -561,6 +562,14 @@ lookupGhcDataConLHName env lname = do
      Ghc.AConLike (Ghc.RealDataCon d) -> Right d
      _ -> panic
            (Just $ GM.fSrcSpan lname) $ "not a data constructor: " ++ show (val lname)
+
+lookupGhcIdLHName :: HasCallStack => Env -> Located LHName -> Lookup Ghc.Id
+lookupGhcIdLHName env lname = do
+   case lookupTyThing env lname of
+     Ghc.AConLike (Ghc.RealDataCon d) -> Right (Ghc.dataConWorkId d)
+     Ghc.AnId x -> Right x
+     _ -> panic
+           (Just $ GM.fSrcSpan lname) $ "not a variable of data constructor: " ++ show (val lname)
 
 -------------------------------------------------------------------------------
 -- | Checking existence of names

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -106,6 +106,7 @@ makeEnv :: Config -> Ghc.Session -> Ghc.TcGblEnv -> GhcSrc -> LogicMap -> [(ModN
 makeEnv cfg session tcg src lmap specs = RE
   { reSession   = session
   , reTcGblEnv  = tcg
+  , reUsedExternals = usedExternals
   , reLMap      = lmap
   , reSyms      = syms
   , _reSubst    = makeVarSubst   src
@@ -121,6 +122,8 @@ makeEnv cfg session tcg src lmap specs = RE
     globalSyms  = concatMap getGlobalSyms specs
     syms        = [ (F.symbol v, v) | v <- vars ]
     vars        = srcVars src
+    usedExternals = Ghc.exprsOrphNames $ map snd $ Ghc.flattenBinds $ _giCbs src
+
 
 getGlobalSyms :: (ModName, BareSpec) -> [F.Symbol]
 getGlobalSyms (_, spec)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Types.hs
@@ -72,6 +72,7 @@ plugSrc _        = Nothing
 data Env = RE 
   { reSession   :: Ghc.Session
   , reTcGblEnv  :: Ghc.TcGblEnv
+  , reUsedExternals :: Ghc.NameSet
   , reLMap      :: LogicMap
   , reSyms      :: [(F.Symbol, Ghc.Var)]    -- ^ see "syms" in old makeGhcSpec'
   , _reSubst    :: F.Subst                  -- ^ see "su"   in old makeGhcSpec'

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
@@ -15,6 +15,7 @@ module Language.Haskell.Liquid.Types.Names
   , getLHNameSymbol
   , makeGHCLHName
   , makeGHCLHNameLocated
+  , makeGHCLHNameLocatedFromId
   , makeLocalLHName
   , makeUnresolvedLHName
   , mapLHNames
@@ -86,6 +87,7 @@ data LHName
 data LHNameSpace
     = LHTcName
     | LHDataConName
+    | LHVarName
   deriving (Data, Eq, Generic, Ord)
 
 instance B.Binary LHNameSpace
@@ -164,6 +166,13 @@ makeLocalLHName s = LHNResolved (LHRLocal s) s
 makeGHCLHNameLocated :: (GHC.NamedThing a, Symbolic a) => a -> Located LHName
 makeGHCLHNameLocated x =
     makeGHCLHName (GHC.getName x) (symbol x) <$ locNamedThing x
+
+makeGHCLHNameLocatedFromId :: GHC.Id -> Located LHName
+makeGHCLHNameLocatedFromId x =
+    case GHC.idDetails x of
+      GHC.DataConWrapId dc -> makeGHCLHNameLocated (GHC.getName dc)
+      GHC.DataConWorkId dc -> makeGHCLHNameLocated (GHC.getName dc)
+      _ -> makeGHCLHNameLocated x
 
 makeUnresolvedLHName :: LHNameSpace -> Symbol -> LHName
 makeUnresolvedLHName = LHNUnresolved

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -398,7 +398,7 @@ data Spec ty bndr  = Spec
   { measures   :: ![Measure ty bndr]                                  -- ^ User-defined properties for ADTs
   , impSigs    :: ![(F.Symbol, F.Sort)]                               -- ^ Imported variables types
   , expSigs    :: ![(F.Symbol, F.Sort)]                               -- ^ Exported variables types
-  , asmSigs    :: ![(F.LocSymbol, ty)]                                -- ^ Assumed (unchecked) types; including reflected signatures
+  , asmSigs    :: ![(F.Located LHName, ty)]                                -- ^ Assumed (unchecked) types; including reflected signatures
   , asmReflectSigs :: ![(F.LocSymbol, F.LocSymbol)]                   -- ^ Assume reflects : left is the actual function and right the pretended one
   , sigs       :: ![(F.LocSymbol, ty)]                                -- ^ Imported functions and types
   , localSigs  :: ![(F.LocSymbol, ty)]                                -- ^ Local type signatures
@@ -588,7 +588,7 @@ data LiftedSpec = LiftedSpec
     -- ^ Imported variables types
   , liftedExpSigs    :: HashSet (F.Symbol, F.Sort)
     -- ^ Exported variables types
-  , liftedAsmSigs    :: HashSet (F.LocSymbol, LocBareType)
+  , liftedAsmSigs    :: HashSet (F.Located LHName, LocBareType)
     -- ^ Assumed (unchecked) types; including reflected signatures
   , liftedAsmReflectSigs    :: HashSet (F.LocSymbol, F.LocSymbol)
     -- ^ Reflected assumed signatures

--- a/src/Data/ByteString/Char8_LHAssumptions.hs
+++ b/src/Data/ByteString/Char8_LHAssumptions.hs
@@ -277,11 +277,11 @@ assume Data.ByteString.Char8.unzip
        , { r : ByteString | bslen r == len i }
        )
 
-assume Data.ByteString.ReadInt.readInt
+assume readInt
     :: i : ByteString
     -> Maybe { p : (Int, { o : ByteString | bslen o < bslen i}) | bslen i /= 0 }
 
-assume Data.ByteString.ReadNat.readInteger
+assume readInteger
     :: i : ByteString
     -> Maybe { p : (Integer, { o : ByteString | bslen o < bslen i}) | bslen i /= 0 }
 @-}

--- a/src/Data/ByteString/Lazy/Char8_LHAssumptions.hs
+++ b/src/Data/ByteString/Lazy/Char8_LHAssumptions.hs
@@ -246,11 +246,11 @@ assume Data.ByteString.Lazy.Char8.unzip
        , { r : ByteString | bllen r == len i }
        )
 
-assume Data.ByteString.Lazy.ReadInt.readInt
+assume readInt
     :: i : ByteString
     -> Maybe { p : (Int, { o : ByteString | bllen o < bllen i}) | bllen i /= 0 }
 
-assume Data.ByteString.Lazy.ReadNat.readInteger
+assume readInteger
     :: i : ByteString
     -> Maybe { p : (Integer, { o : ByteString | bllen o < bllen i}) | bllen i /= 0 }
 

--- a/src/Data/ByteString/Lazy_LHAssumptions.hs
+++ b/src/Data/ByteString/Lazy_LHAssumptions.hs
@@ -16,32 +16,32 @@ invariant { bs : ByteString | 0 <= bllen bs }
 
 invariant { bs : ByteString | bllen bs == stringlen bs }
 
-assume Data.ByteString.Lazy.empty :: { bs : ByteString | bllen bs == 0 }
+assume empty :: { bs : ByteString | bllen bs == 0 }
 
-assume Data.ByteString.Lazy.singleton
+assume singleton
     :: _ -> { bs : ByteString | bllen bs == 1 }
 
-assume Data.ByteString.Lazy.pack
+assume pack
     :: w8s : [_]
     -> { bs : _ | bllen bs == len w8s }
 
-assume Data.ByteString.Lazy.unpack
+assume unpack
     :: bs : ByteString
     -> { w8s : [_] | len w8s == bllen bs }
 
-assume Data.ByteString.Lazy.Internal.fromStrict
+assume fromStrict
     :: i : Data.ByteString.ByteString
     -> { o : ByteString | bllen o == bslen i }
 
-assume Data.ByteString.Lazy.Internal.toStrict
+assume toStrict
     :: i : ByteString
     -> { o : Data.ByteString.ByteString | bslen o == bllen i }
 
-assume Data.ByteString.Lazy.fromChunks
+assume fromChunks
     :: i : [Data.ByteString.ByteString]
     -> { o : ByteString | len i == 0 <=> bllen o == 0 }
 
-assume Data.ByteString.Lazy.toChunks
+assume toChunks
     :: i : ByteString
     -> { os : [{ o : Data.ByteString.ByteString | bslen o <= bllen i}] | len os == 0 <=> bllen i == 0 }
 

--- a/src/Data/ByteString/Short_LHAssumptions.hs
+++ b/src/Data/ByteString/Short_LHAssumptions.hs
@@ -2,7 +2,7 @@
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 module Data.ByteString.Short_LHAssumptions where
 
-import Data.ByteString
+import Data.ByteString (ByteString)
 import Data.ByteString_LHAssumptions()
 import Data.ByteString.Short
 import Data.String_LHAssumptions()
@@ -15,19 +15,19 @@ invariant { bs : ShortByteString  | 0 <= sbslen bs }
 
 invariant { bs : ShortByteString | sbslen bs == stringlen bs }
 
-assume Data.ByteString.Short.Internal.toShort :: i : ByteString -> { o : ShortByteString | sbslen o == bslen i }
+assume toShort :: i : ByteString -> { o : ShortByteString | sbslen o == bslen i }
 
-assume Data.ByteString.Short.Internal.fromShort :: o : ShortByteString -> { i : ByteString | bslen i == sbslen o }
+assume fromShort :: o : ShortByteString -> { i : ByteString | bslen i == sbslen o }
 
-assume Data.ByteString.Short.Internal.pack :: w8s : [Word8] -> { bs : ShortByteString | sbslen bs == len w8s }
+assume pack :: w8s : [Word8] -> { bs : ShortByteString | sbslen bs == len w8s }
 
-assume Data.ByteString.Short.Internal.unpack :: bs : ShortByteString -> { w8s : [Word8] | len w8s == sbslen bs }
+assume unpack :: bs : ShortByteString -> { w8s : [Word8] | len w8s == sbslen bs }
 
-assume Data.ByteString.Short.Internal.empty :: { bs : ShortByteString | sbslen bs == 0 }
+assume empty :: { bs : ShortByteString | sbslen bs == 0 }
 
-assume Data.ByteString.Short.Internal.null :: bs : ShortByteString -> { b : Bool | b <=> sbslen bs == 0 }
+assume Data.ByteString.Short.null :: bs : ShortByteString -> { b : Bool | b <=> sbslen bs == 0 }
 
-assume Data.ByteString.Short.Internal.length :: bs : ShortByteString -> { n : Int | sbslen bs == n }
+assume Data.ByteString.Short.length :: bs : ShortByteString -> { n : Int | sbslen bs == n }
 
-assume Data.ByteString.Short.Internal.index :: bs : ShortByteString -> { n : Int | 0 <= n && n < sbslen bs } -> Word8
+assume index :: bs : ShortByteString -> { n : Int | 0 <= n && n < sbslen bs } -> Word8
 @-}

--- a/src/Data/ByteString_LHAssumptions.hs
+++ b/src/Data/ByteString_LHAssumptions.hs
@@ -13,7 +13,7 @@ invariant { bs : ByteString  | 0 <= bslen bs }
 
 invariant { bs : ByteString | bslen bs == stringlen bs }
 
-assume Data.ByteString.Internal.Type.empty :: { bs : ByteString | bslen bs == 0 }
+assume empty :: { bs : ByteString | bslen bs == 0 }
 
 assume Data.ByteString.singleton :: _ -> { bs : ByteString | bslen bs == 1 }
 

--- a/src/Data/Set_LHAssumptions.hs
+++ b/src/Data/Set_LHAssumptions.hs
@@ -4,6 +4,7 @@ module Data.Set_LHAssumptions where
 
 import Data.Set
 import GHC.Types_LHAssumptions()
+import Prelude hiding (null)
 
 {-@
 
@@ -43,20 +44,20 @@ measure Set_sub  :: (Set a) -> (Set a) -> Bool
 //  ---------------------------------------------------------------------------------------------
 
 assume isSubsetOf    :: (Ord a) => x:(Set a) -> y:(Set a) -> {v:Bool | v <=> Set_sub x y}
-assume Data.Set.Internal.member        :: Ord a => x:a -> xs:(Set a) -> {v:Bool | v <=> Set_mem x xs}
-assume Data.Set.Internal.null          :: Ord a => xs:(Set a) -> {v:Bool | v <=> Set_emp xs}
+assume member        :: Ord a => x:a -> xs:(Set a) -> {v:Bool | v <=> Set_mem x xs}
+assume null          :: Ord a => xs:(Set a) -> {v:Bool | v <=> Set_emp xs}
 
-assume Data.Set.Internal.empty         :: {v:(Set a) | Set_emp v}
-assume Data.Set.Internal.singleton     :: x:a -> {v:(Set a) | v = (Set_sng x)}
-assume Data.Set.Internal.insert        :: Ord a => x:a -> xs:(Set a) -> {v:(Set a) | v = Set_cup xs (Set_sng x)}
-assume Data.Set.Internal.delete        :: (Ord a) => x:a -> xs:(Set a) -> {v:(Set a) | v = Set_dif xs (Set_sng x)}
+assume empty         :: {v:(Set a) | Set_emp v}
+assume singleton     :: x:a -> {v:(Set a) | v = (Set_sng x)}
+assume insert        :: Ord a => x:a -> xs:(Set a) -> {v:(Set a) | v = Set_cup xs (Set_sng x)}
+assume delete        :: (Ord a) => x:a -> xs:(Set a) -> {v:(Set a) | v = Set_dif xs (Set_sng x)}
 
-assume Data.Set.Internal.union         :: Ord a => xs:(Set a) -> ys:(Set a) -> {v:(Set a) | v = Set_cup xs ys}
-assume Data.Set.Internal.intersection  :: Ord a => xs:(Set a) -> ys:(Set a) -> {v:(Set a) | v = Set_cap xs ys}
-assume Data.Set.Internal.difference    :: Ord a => xs:(Set a) -> ys:(Set a) -> {v:(Set a) | v = Set_dif xs ys}
+assume union         :: Ord a => xs:(Set a) -> ys:(Set a) -> {v:(Set a) | v = Set_cup xs ys}
+assume intersection  :: Ord a => xs:(Set a) -> ys:(Set a) -> {v:(Set a) | v = Set_cap xs ys}
+assume difference    :: Ord a => xs:(Set a) -> ys:(Set a) -> {v:(Set a) | v = Set_dif xs ys}
 
-assume Data.Set.Internal.fromList :: Ord a => xs:[a] -> {v:Set a | v = listElts xs}
-assume Data.Set.Internal.toList   :: Ord a => s:Set a -> {xs:[a] | s = listElts xs}
+assume fromList :: Ord a => xs:[a] -> {v:Set a | v = listElts xs}
+assume toList   :: Ord a => s:Set a -> {xs:[a] | s = listElts xs}
 
 //  ---------------------------------------------------------------------------------------------
 //  -- | The set of elements in a list ----------------------------------------------------------

--- a/src/Data/String_LHAssumptions.hs
+++ b/src/Data/String_LHAssumptions.hs
@@ -8,7 +8,7 @@ import GHC.Types_LHAssumptions()
 {-@
 measure stringlen :: a -> Int
 
-assume GHC.Internal.Data.String.fromString
+assume fromString
     ::  forall a. IsString a
     =>  i : [Char]
     ->  { o : a | i ~~ o && len i == stringlen o }

--- a/src/Data/Tuple_LHAssumptions.hs
+++ b/src/Data/Tuple_LHAssumptions.hs
@@ -5,8 +5,8 @@ module Data.Tuple_LHAssumptions where
 import Data.Tuple
 
 {-@
-assume GHC.Internal.Data.Tuple.fst :: {f:(x:(a,b) -> {v:a | v = (fst x)}) | f == fst }
-assume GHC.Internal.Data.Tuple.snd :: {f:(x:(a,b) -> {v:b | v = (snd x)}) | f == snd }
+assume fst :: {f:(x:(a,b) -> {v:a | v = (fst x)}) | f == fst }
+assume snd :: {f:(x:(a,b) -> {v:b | v = (snd x)}) | f == snd }
 
 measure fst :: (a, b) -> a
   fst (a, b) = a

--- a/src/Foreign/Concurrent_LHAssumptions.hs
+++ b/src/Foreign/Concurrent_LHAssumptions.hs
@@ -6,5 +6,5 @@ import Foreign.Concurrent
 import GHC.ForeignPtr_LHAssumptions()
 
 {-@
-assume GHC.Internal.Foreign.Concurrent.newForeignPtr  :: p:(PtrV a) -> IO () -> (IO (ForeignPtrN a (plen p)))
+assume newForeignPtr  :: p:(PtrV a) -> IO () -> (IO (ForeignPtrN a (plen p)))
 @-}

--- a/src/Foreign/ForeignPtr_LHAssumptions.hs
+++ b/src/Foreign/ForeignPtr_LHAssumptions.hs
@@ -3,18 +3,17 @@
 module Foreign.ForeignPtr_LHAssumptions where
 
 import Foreign.Concurrent_LHAssumptions()
-import Foreign.Storable
+import Foreign.ForeignPtr
 import GHC.ForeignPtr
-import GHC.Internal.Foreign.ForeignPtr.Imp
 import GHC.ForeignPtr_LHAssumptions()
 
 {-@
 
-assume GHC.Internal.ForeignPtr.withForeignPtr :: forall a b. fp:(ForeignPtr a)
+assume withForeignPtr :: forall a b. fp:(ForeignPtr a)
   -> ((PtrN a (fplen fp)) -> IO b)
   -> IO b
 
-assume GHC.Internal.Foreign.ForeignPtr.Imp.newForeignPtr ::  _ -> p:(PtrV a) -> (IO (ForeignPtrN a (plen p)))
+assume newForeignPtr ::  _ -> p:(PtrV a) -> (IO (ForeignPtrN a (plen p)))
 
 
 //  this uses `sizeOf (undefined :: a)`, so the ForeignPtr does not necessarily have length `n`

--- a/src/Foreign/Marshal/Alloc_LHAssumptions.hs
+++ b/src/Foreign/Marshal/Alloc_LHAssumptions.hs
@@ -7,5 +7,5 @@ import GHC.Ptr_LHAssumptions()
 import Foreign.Marshal.Alloc
 
 {-@
-assume GHC.Internal.Foreign.Marshal.Alloc.allocaBytes :: n:Nat -> (PtrN a n -> IO b) -> IO b
+assume allocaBytes :: n:Nat -> (PtrN a n -> IO b) -> IO b
 @-}

--- a/src/Foreign/Storable_LHAssumptions.hs
+++ b/src/Foreign/Storable_LHAssumptions.hs
@@ -9,21 +9,21 @@ import GHC.Ptr
 {-@
 predicate PValid P N         = ((0 <= N) && (N < (plen P)))
 
-assume GHC.Internal.Foreign.Storable.poke        :: (Storable a)
+assume poke        :: (Storable a)
                              => {v: (Ptr a) | 0 < (plen v)}
                              -> a
                              -> (IO ())
 
-assume GHC.Internal.Foreign.Storable.peek        :: (Storable a)
+assume peek        :: (Storable a)
                              => p:{v: (Ptr a) | 0 < (plen v)}
                              -> (IO {v:a | v = (deref p)})
 
-assume GHC.Internal.Foreign.Storable.peekByteOff :: (Storable a)
+assume peekByteOff :: (Storable a)
                              => forall b. p:(Ptr b)
                              -> {v:Int | (PValid p v)}
                              -> (IO a)
 
-assume GHC.Internal.Foreign.Storable.pokeByteOff :: (Storable a)
+assume pokeByteOff :: (Storable a)
                              => forall b. p:(Ptr b)
                              -> {v:Int | (PValid p v)}
                              -> a

--- a/src/GHC/Classes_LHAssumptions.hs
+++ b/src/GHC/Classes_LHAssumptions.hs
@@ -2,35 +2,34 @@
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 module GHC.Classes_LHAssumptions where
 
-import GHC.Classes
 import GHC.Types_LHAssumptions()
 
 {-@
 
-assume GHC.Classes.not :: x:Bool -> {v:Bool | ((v) <=> ~(x))}
-assume (GHC.Classes.&&)    :: x:Bool -> y:Bool
+assume not :: x:Bool -> {v:Bool | ((v) <=> ~(x))}
+assume &&    :: x:Bool -> y:Bool
         -> {v:Bool | ((v) <=> ((x) && (y)))}
-assume (GHC.Classes.||)    :: x:Bool -> y:Bool
+assume ||    :: x:Bool -> y:Bool
         -> {v:Bool | ((v) <=> ((x) || (y)))}
-assume (GHC.Classes.==)    :: (Eq  a) => x:a -> y:a
+assume ==    :: (Eq  a) => x:a -> y:a
         -> {v:Bool | ((v) <=> x = y)}
-assume (GHC.Classes./=)    :: (Eq  a) => x:a -> y:a
+assume /=    :: (Eq  a) => x:a -> y:a
         -> {v:Bool | ((v) <=> x != y)}
-assume (GHC.Classes.>)     :: (Ord a) => x:a -> y:a
+assume >     :: (Ord a) => x:a -> y:a
         -> {v:Bool | ((v) <=> x > y)}
-assume (GHC.Classes.>=)    :: (Ord a) => x:a -> y:a
+assume >=    :: (Ord a) => x:a -> y:a
         -> {v:Bool | ((v) <=> x >= y)}
-assume (GHC.Classes.<)     :: (Ord a) => x:a -> y:a
+assume <     :: (Ord a) => x:a -> y:a
         -> {v:Bool | ((v) <=> x < y)}
-assume (GHC.Classes.<=)    :: (Ord a) => x:a -> y:a
+assume <=    :: (Ord a) => x:a -> y:a
         -> {v:Bool | ((v) <=> x <= y)}
 
-assume GHC.Classes.compare :: (Ord a) => x:a -> y:a
+assume compare :: (Ord a) => x:a -> y:a
         -> {v:Ordering | (((v = EQ) <=> (x = y)) &&
                                     ((v = LT) <=> (x < y)) &&
                                     ((v = GT) <=> (x > y))) }
 
-assume GHC.Classes.max :: (Ord a) => x:a -> y:a -> {v:a | v = (if x > y then x else y) }
-assume GHC.Classes.min :: (Ord a) => x:a -> y:a -> {v:a | v = (if x < y then x else y) }
+assume max :: (Ord a) => x:a -> y:a -> {v:a | v = (if x > y then x else y) }
+assume min :: (Ord a) => x:a -> y:a -> {v:a | v = (if x < y then x else y) }
 
 @-}

--- a/src/GHC/ForeignPtr_LHAssumptions.hs
+++ b/src/GHC/ForeignPtr_LHAssumptions.hs
@@ -12,6 +12,6 @@ measure fplen :: ForeignPtr a -> Int
 type ForeignPtrV a   = {v: ForeignPtr a | 0 <= fplen v}
 type ForeignPtrN a N = {v: ForeignPtr a | 0 <= fplen v && fplen v == N }
 
-assume GHC.Internal.ForeignPtr.newForeignPtr_     :: p:(Ptr a) -> (IO (ForeignPtrN a (plen p)))
-assume GHC.Internal.ForeignPtr.mallocPlainForeignPtrBytes :: n:{v:Int  | v >= 0 } -> (IO (ForeignPtrN a n))
+assume newForeignPtr_ :: p:(Ptr a) -> (IO (ForeignPtrN a (plen p)))
+assume mallocPlainForeignPtrBytes :: n:{v:Int  | v >= 0 } -> (IO (ForeignPtrN a n))
 @-}

--- a/src/GHC/IO/Handle_LHAssumptions.hs
+++ b/src/GHC/IO/Handle_LHAssumptions.hs
@@ -7,12 +7,12 @@ import GHC.Ptr
 import GHC.Types_LHAssumptions()
 
 {-@
-assume GHC.Internal.IO.Handle.Text.hGetBuf :: Handle -> Ptr a -> n:Nat
+assume hGetBuf :: Handle -> Ptr a -> n:Nat
         -> (IO {v:Nat | v <= n})
 
-assume GHC.Internal.IO.Handle.Text.hGetBufNonBlocking :: Handle -> Ptr a -> n:Nat
+assume hGetBufNonBlocking :: Handle -> Ptr a -> n:Nat
                    -> (IO {v:Nat | v <= n})
 
-assume GHC.Internal.IO.Handle.hFileSize :: Handle
+assume hFileSize :: Handle
           -> (IO {v:Integer | v >= 0})
 @-}

--- a/src/GHC/Internal/Base_LHAssumptions.hs
+++ b/src/GHC/Internal/Base_LHAssumptions.hs
@@ -2,15 +2,15 @@
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 module GHC.Internal.Base_LHAssumptions where
 
+import GHC.Base (assert)
 import GHC.CString_LHAssumptions()
 import GHC.Exts_LHAssumptions()
 import GHC.Types_LHAssumptions()
-import GHC.Internal.Base
 import Data.Tuple_LHAssumptions()
 
 {-@
 
-assume GHC.Internal.Base.. :: forall <p :: b -> c -> Bool, q :: a -> b -> Bool, r :: a -> c -> Bool>.
+assume . :: forall <p :: b -> c -> Bool, q :: a -> b -> Bool, r :: a -> c -> Bool>.
                    {xcmp::a, wcmp::b<q xcmp> |- c<p wcmp> <: c<r xcmp>}
                    (ycmp:b -> c<p ycmp>)
                 -> (zcmp:a -> b<q zcmp>)
@@ -19,18 +19,18 @@ assume GHC.Internal.Base.. :: forall <p :: b -> c -> Bool, q :: a -> b -> Bool, 
 measure autolen :: forall a. a -> Int
 
 //  Useless as compiled into GHC primitive, which is ignored
-assume GHC.Internal.Base.assert :: {v:Bool | v } -> a -> a
+assume assert :: {v:Bool | v } -> a -> a
 
 instance measure len :: forall a. [a] -> Int
   len []     = 0
   len (y:ys) = 1 + len ys
 
 invariant {v: [a] | len v >= 0 }
-assume GHC.Internal.Base.map       :: (a -> b) -> xs:[a] -> {v: [b] | len v == len xs}
-assume GHC.Internal.Base.++        :: xs:[a] -> ys:[a] -> {v:[a] | len v == len xs + len ys}
+assume map       :: (a -> b) -> xs:[a] -> {v: [b] | len v == len xs}
+assume ++        :: xs:[a] -> ys:[a] -> {v:[a] | len v == len xs + len ys}
 
-assume (GHC.Internal.Base.$)       :: (a -> b) -> a -> b
-assume GHC.Internal.Base.id        :: x:a -> {v:a | v = x}
+assume $         :: (a -> b) -> a -> b
+assume id        :: x:a -> {v:a | v = x}
 
 qualif IsEmp(v:Bool, xs: [a]) : (v <=> (len xs > 0))
 qualif IsEmp(v:Bool, xs: [a]) : (v <=> (len xs = 0))

--- a/src/GHC/Internal/List_LHAssumptions.hs
+++ b/src/GHC/Internal/List_LHAssumptions.hs
@@ -4,67 +4,67 @@ module GHC.Internal.List_LHAssumptions where
 
 import GHC.Internal.List
 import GHC.Types_LHAssumptions()
+import Prelude hiding (foldr1, length, null)
 
 {-@
+assume head         :: xs:{v: [a] | len v > 0} -> {v:a | v = head xs}
+assume tail         :: xs:{v: [a] | len v > 0} -> {v: [a] | len(v) = (len(xs) - 1) && v = tail xs}
 
-assume GHC.Internal.List.head         :: xs:{v: [a] | len v > 0} -> {v:a | v = head xs}
-assume GHC.Internal.List.tail         :: xs:{v: [a] | len v > 0} -> {v: [a] | len(v) = (len(xs) - 1) && v = tail xs}
-
-assume GHC.Internal.List.last         :: xs:{v: [a] | len v > 0} -> a
-assume GHC.Internal.List.init         :: xs:{v: [a] | len v > 0} -> {v: [a] | len(v) = len(xs) - 1}
-assume GHC.Internal.List.null         :: xs:[a] -> {v: Bool | ((v) <=> len(xs) = 0) }
-assume GHC.Internal.List.length       :: xs:[a] -> {v: Int | v = len(xs)}
-assume GHC.Internal.List.filter       :: (a -> Bool) -> xs:[a] -> {v: [a] | len(v) <= len(xs)}
-assume GHC.Internal.List.scanl        :: (a -> b -> a) -> a -> xs:[b] -> {v: [a] | len(v) = 1 + len(xs) }
-assume GHC.Internal.List.scanl1       :: (a -> a -> a) -> xs:{v: [a] | len(v) > 0} -> {v: [a] | len(v) = len(xs) }
-assume GHC.Internal.List.foldr1       :: (a -> a -> a) -> xs:{v: [a] | len(v) > 0} -> a
-assume GHC.Internal.List.scanr        :: (a -> b -> b) -> b -> xs:[a] -> {v: [b] | len(v) = 1 + len(xs) }
-assume GHC.Internal.List.scanr1       :: (a -> a -> a) -> xs:{v: [a] | len(v) > 0} -> {v: [a] | len(v) = len(xs) }
+assume last         :: xs:{v: [a] | len v > 0} -> a
+assume init         :: xs:{v: [a] | len v > 0} -> {v: [a] | len(v) = len(xs) - 1}
+assume null         :: xs:[a] -> {v: Bool | ((v) <=> len(xs) = 0) }
+assume length       :: xs:[a] -> {v: Int | v = len(xs)}
+assume filter       :: (a -> Bool) -> xs:[a] -> {v: [a] | len(v) <= len(xs)}
+assume scanl        :: (a -> b -> a) -> a -> xs:[b] -> {v: [a] | len(v) = 1 + len(xs) }
+assume scanl1       :: (a -> a -> a) -> xs:{v: [a] | len(v) > 0} -> {v: [a] | len(v) = len(xs) }
+assume foldr1       :: (a -> a -> a) -> xs:{v: [a] | len(v) > 0} -> a
+assume scanr        :: (a -> b -> b) -> b -> xs:[a] -> {v: [b] | len(v) = 1 + len(xs) }
+assume scanr1       :: (a -> a -> a) -> xs:{v: [a] | len(v) > 0} -> {v: [a] | len(v) = len(xs) }
 
 lazy GHC.Internal.List.iterate
-assume GHC.Internal.List.iterate :: (a -> a) -> a -> [a]
+assume iterate :: (a -> a) -> a -> [a]
 
-assume GHC.Internal.List.repeat :: a -> [a]
+assume repeat :: a -> [a]
 lazy GHC.Internal.List.repeat
 
-assume GHC.Internal.List.replicate    :: n:Nat -> x:a -> {v: [{v:a | v = x}] | len(v) = n}
+assume replicate    :: n:Nat -> x:a -> {v: [{v:a | v = x}] | len(v) = n}
 
-assume GHC.Internal.List.cycle        :: {v: [a] | len(v) > 0 } -> [a]
+assume cycle        :: {v: [a] | len(v) > 0 } -> [a]
 lazy GHC.Internal.List.cycle
 
-assume GHC.Internal.List.takeWhile    :: (a -> Bool) -> xs:[a] -> {v: [a] | len(v) <= len(xs)}
-assume GHC.Internal.List.dropWhile    :: (a -> Bool) -> xs:[a] -> {v: [a] | len(v) <= len(xs)}
+assume takeWhile    :: (a -> Bool) -> xs:[a] -> {v: [a] | len(v) <= len(xs)}
+assume dropWhile    :: (a -> Bool) -> xs:[a] -> {v: [a] | len(v) <= len(xs)}
 
-assume GHC.Internal.List.take :: n:Int
+assume take :: n:Int
      -> xs:[a]
      -> {v:[a] | if n >= 0 then (len v = (if (len xs) < n then (len xs) else n)) else (len v = 0)}
-assume GHC.Internal.List.drop :: n:Int
+assume drop :: n:Int
      -> xs:[a]
      -> {v:[a] | (if (n >= 0) then (len(v) = (if (len(xs) < n) then 0 else len(xs) - n)) else ((len v) = (len xs)))}
 
-assume GHC.Internal.List.splitAt :: n:_ -> x:[a] -> ({v:[a] | (if (n >= 0) then (if (len x) < n then (len v) = (len x) else (len v) = n) else ((len v) = 0))},[a])<{\x1 x2 -> (len x2) = (len x) - (len x1)}>
-assume GHC.Internal.List.span    :: (a -> Bool)
+assume splitAt :: n:_ -> x:[a] -> ({v:[a] | (if (n >= 0) then (if (len x) < n then (len v) = (len x) else (len v) = n) else ((len v) = 0))},[a])<{\x1 x2 -> (len x2) = (len x) - (len x1)}>
+assume span    :: (a -> Bool)
         -> xs:[a]
         -> ({v:[a]|((len v)<=(len xs))}, {v:[a]|((len v)<=(len xs))})
 
-assume GHC.Internal.List.break :: (a -> Bool) -> xs:[a] -> ([a],[a])<{\x y -> (len xs) = (len x) + (len y)}>
+assume break :: (a -> Bool) -> xs:[a] -> ([a],[a])<{\x y -> (len xs) = (len x) + (len y)}>
 
-assume GHC.Internal.List.reverse      :: xs:[a] -> {v: [a] | len(v) = len(xs)}
+assume reverse      :: xs:[a] -> {v: [a] | len(v) = len(xs)}
 
 //  Copy-pasted from len.hquals
 qualif LenSum(v:[a], xs:[b], ys:[c]): len([v]) = (len([xs]) + len([ys]))
 qualif LenSum(v:[a], xs:[b], ys:[c]): len([v]) = (len([xs]) - len([ys]))
 
-assume GHC.Internal.List.!!         :: xs:[a] -> {v: _ | ((0 <= v) && (v < len(xs)))} -> a
+assume !! :: xs:[a] -> {v: _ | ((0 <= v) && (v < len(xs)))} -> a
 
 
-assume GHC.Internal.List.zip :: xs : [a] -> ys:[b]
+assume zip :: xs : [a] -> ys:[b]
             -> {v : [(a, b)] | ((((len v) <= (len xs)) && ((len v) <= (len ys)))
             && (((len xs) = (len ys)) => ((len v) = (len xs))) )}
 
-assume GHC.Internal.List.zipWith :: (a -> b -> c)
+assume zipWith :: (a -> b -> c)
         -> xs : [a] -> ys:[b]
         -> {v : [c] | (((len v) <= (len xs)) && ((len v) <= (len ys)))}
 
-assume GHC.Internal.List.errorEmptyList :: {v: _ | false} -> a
+assume errorEmptyList :: {v: _ | false} -> a
 @-}

--- a/src/GHC/Real_LHAssumptions.hs
+++ b/src/GHC/Real_LHAssumptions.hs
@@ -9,9 +9,9 @@ import GHC.Internal.Real
 import GHC.Types_LHAssumptions()
 
 {-@
-assume (GHC.Internal.Real.^) :: x:a -> y:{n:b | n >= 0} -> {z:a | (y == 0 => z == 1) && ((x == 0 && y /= 0) <=> z == 0)}
+assume (^) :: x:a -> y:{n:b | n >= 0} -> {z:a | (y == 0 => z == 1) && ((x == 0 && y /= 0) <=> z == 0)}
 
-assume GHC.Internal.Real.fromIntegral    :: x:a -> {v:b|v=x}
+assume fromIntegral    :: x:a -> {v:b|v=x}
 
 class (GHC.Internal.Num.Num a) => GHC.Internal.Real.Fractional a where
   (GHC.Internal.Real./)   :: x:a -> y:{v:a | v /= 0} -> {v:a | v == x / y}

--- a/src/GHC/Types_LHAssumptions.hs
+++ b/src/GHC/Types_LHAssumptions.hs
@@ -29,8 +29,8 @@ embed Addr#    as Str
 
 embed Integer as int
 
-assume GHC.Types.True    :: {v:Bool | v     }
-assume GHC.Types.False   :: {v:Bool | (~ v) }
+assume True    :: {v:Bool | v     }
+assume False   :: {v:Bool | (~ v) }
 assume GHC.Types.isTrue# :: n:_ -> {v:Bool | (n = 1 <=> v)}
 
 assume GHC.Types.D# :: x:Double# -> {v: Double | v = (x :: real) }

--- a/src/Liquid/Prelude/Totality_LHAssumptions.hs
+++ b/src/Liquid/Prelude/Totality_LHAssumptions.hs
@@ -8,13 +8,13 @@ import GHC.Prim
 {-@
 measure totalityError :: a -> Bool
 
-assume GHC.Internal.Control.Exception.Base.patError :: {v:Addr# | totalityError "Pattern match(es) are non-exhaustive"} -> a
+assume patError :: {v:Addr# | totalityError "Pattern match(es) are non-exhaustive"} -> a
 
-assume GHC.Internal.Control.Exception.Base.recSelError :: {v:Addr# | totalityError "Use of partial record field selector"} -> a
+assume recSelError :: {v:Addr# | totalityError "Use of partial record field selector"} -> a
 
-assume GHC.Internal.Control.Exception.Base.nonExhaustiveGuardsError :: {v:Addr# | totalityError "Guards are non-exhaustive"} -> a
+assume nonExhaustiveGuardsError :: {v:Addr# | totalityError "Guards are non-exhaustive"} -> a
 
-assume GHC.Internal.Control.Exception.Base.noMethodBindingError :: {v:Addr# | totalityError "Missing method(s) on instance declaration"} -> a
+assume noMethodBindingError :: {v:Addr# | totalityError "Missing method(s) on instance declaration"} -> a
 
-assume GHC.Internal.Control.Exception.Base.recConError :: {v:Addr# | totalityError "Missing field in record construction"} -> a
+assume recConError :: {v:Addr# | totalityError "Missing field in record construction"} -> a
 @-}

--- a/src/Prelude_LHAssumptions.hs
+++ b/src/Prelude_LHAssumptions.hs
@@ -16,7 +16,7 @@ import Liquid.Prelude.Totality_LHAssumptions()
 
 {-@
 
-assume GHC.Internal.Err.error :: {v:_ | false} -> a
+assume error :: {v:_ | false} -> a
 
 predicate Max V X Y = if X > Y then V = X else V = Y
 predicate Min V X Y = if X < Y then V = X else V = Y

--- a/tests/basic/neg/T2349.hs
+++ b/tests/basic/neg/T2349.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE GADTs #-}
 {-@ LIQUID "--expect-error-containing=is not a subtype of the required type
-      VV : {VV##1465 : [GHC.Types.Int] | len VV##1465 == ?b + 1}" @-}
+      VV : {VV##1461 : [GHC.Types.Int] | len VV##1461 == ?b + 1}" @-}
 {-@ LIQUID "--reflection" @-}
 -- | Test that the refinement types produced for GADTs are
 -- compatible with the Haskell types.

--- a/tests/benchmarks/bytestring-0.9.2.1/Data/ByteString.hs
+++ b/tests/benchmarks/bytestring-0.9.2.1/Data/ByteString.hs
@@ -2146,7 +2146,7 @@ hGetNonBlocking = hGet
 -- As with 'hGet', the string representation in the file is assumed to
 -- be ISO-8859-1.
 
-{-@ assume GHC.Internal.Foreign.Marshal.Alloc.reallocBytes :: p:(Ptr a) -> n:Nat -> (IO (PtrN a n))  @-}
+{-@ assume reallocBytes :: p:(Ptr a) -> n:Nat -> (IO (PtrN a n))  @-}
 hGetContents :: Handle -> IO ByteString
 hGetContents h = do
     let start_size = 1024

--- a/tests/benchmarks/bytestring-0.9.2.1/Data/ByteString/Lazy.hs
+++ b/tests/benchmarks/bytestring-0.9.2.1/Data/ByteString/Lazy.hs
@@ -655,7 +655,7 @@ transpose css = L.map (\ss -> Chunk (S.pack ss) Empty)
 --TODO: make this fast
 
 -- REBARE: somehow with GHC 8.4 importing Data.List actually ends up importing Data.OldList ...
-{-@ assume GHC.Internal.Data.OldList.transpose :: [[a]] -> [{v:[a] | len v > 0}] @-}
+{-@ assume L.transpose :: [[a]] -> [{v:[a] | len v > 0}] @-}
 
 
 -- ---------------------------------------------------------------------

--- a/tests/pos/Comprehension.hs
+++ b/tests/pos/Comprehension.hs
@@ -4,4 +4,4 @@ module Comprehension where
 foo :: Int -> [Int]
 foo n = [0 .. n]
 
-{-@ assume GHC.Internal.Enum.enumFromTo :: (Enum a) => lo:a -> hi:a -> [{v:a | lo <= v && v <= hi}] @-}
+{-@ assume enumFromTo :: (Enum a) => lo:a -> hi:a -> [{v:a | lo <= v && v <= hi}] @-}

--- a/tests/pos/Foo.hs
+++ b/tests/pos/Foo.hs
@@ -2,4 +2,4 @@ module Foo where
 
 bar = 0
 
-{-@ assume (GHC.Internal.Base.++) :: [a] -> [a] -> [a] @-}
+{-@ assume ++ :: [a] -> [a] -> [a] @-}


### PR DESCRIPTION
Another step for #2169. This PR uses GHC Name for assumptions. It is no longer needed to fully qualify assumptions in order to find them in other modules as shown by the updates to LHAssumptions modules in 7cb6f8f.

Also, the retrieval of an Id for an assumption is quite simpler after 5e684c5, where the paths can be compared for LHNames and Symbols in `lookupSymbolOrLHName`.