### PR TITLE
Handle assume on local names when resolving to LHName

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -36,3 +36,7 @@ package liquidhaskell
 package liquidhaskell-boot
   ghc-options: -j
   flags: +devel
+
+constraints:
+  -- vector-0.13.2.0 breaks store-0.7.18
+  vector <= 0.13.1.0

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -635,7 +635,7 @@ import GHC.Types.Name                 as Ghc
     , stableNameCmp
     )
 import GHC.Types.Name.Env             as Ghc
-    ( lookupNameEnv )
+    ( NameEnv, lookupNameEnv, mkNameEnv )
 import GHC.Types.Name.Set             as Ghc
     ( NameSet
     , elemNameSet

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -891,7 +891,7 @@ makeTySigs env sigEnv name spec = do
 bareTySigs :: Bare.Env -> ModName -> Ms.BareSpec -> Bare.Lookup [(Ghc.Var, LocBareType)]
 bareTySigs env name spec = checkDuplicateSigs <$> vts
   where
-    vts = forM ( Ms.sigs spec ++ Ms.localSigs spec ) $ \ (x, t) -> do
+    vts = forM ( Ms.sigs spec ) $ \ (x, t) -> do
             v <- F.notracepp "LOOKUP-GHC-VAR" $ Bare.lookupGhcVar env name "rawTySigs" x
             return (v, t)
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Expand.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Expand.hs
@@ -388,7 +388,6 @@ expandBareSpec rtEnv l sp = sp
   { measures   = expand rtEnv l (measures   sp)
   , asmSigs    = map (second (expand rtEnv l)) (asmSigs sp)
   , sigs       = expand rtEnv l (sigs       sp)
-  , localSigs  = expand rtEnv l (localSigs  sp)
   , reflSigs   = expand rtEnv l (reflSigs   sp)
   , ialiases   = [ (f x, f y) | (x, y) <- ialiases sp ]
   , dataDecls  = expand rtEnv l (dataDecls  sp)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -14,6 +14,7 @@
 module Language.Haskell.Liquid.Bare.Resolve
   ( -- * Creating the Environment
     makeEnv
+  , makeLocalVars
 
     -- * Resolving symbols
   , ResolveSym (..)
@@ -30,6 +31,7 @@ module Language.Haskell.Liquid.Bare.Resolve
   , lookupGhcVar
   , lookupGhcIdLHName
   , lookupGhcNamedVar
+  , lookupLocalVar
   , matchTyCon
 
   -- * Checking if names exist
@@ -102,10 +104,11 @@ type Lookup a = Either [Error] a
 -------------------------------------------------------------------------------
 -- | Creating an environment
 -------------------------------------------------------------------------------
-makeEnv :: Config -> Ghc.Session -> Ghc.TcGblEnv -> GhcSrc -> LogicMap -> [(ModName, BareSpec)] -> Env
-makeEnv cfg session tcg src lmap specs = RE
+makeEnv :: Config -> Ghc.Session -> Ghc.TcGblEnv -> LocalVars -> GhcSrc -> LogicMap -> [(ModName, BareSpec)] -> Env
+makeEnv cfg session tcg localVars src lmap specs = RE
   { reSession   = session
   , reTcGblEnv  = tcg
+  , reLocalVarsEnv = makeLocalVarsEnv localVars
   , reUsedExternals = usedExternals
   , reLMap      = lmap
   , reSyms      = syms
@@ -113,7 +116,7 @@ makeEnv cfg session tcg src lmap specs = RE
   , _reTyThings = makeTyThingMap src
   , reQualImps  = _gsQualImps     src
   , reAllImps   = _gsAllImps      src
-  , reLocalVars = makeLocalVars  src
+  , reLocalVars = localVars
   , reSrc       = src
   , reGlobSyms  = S.fromList     globalSyms
   , reCfg       = cfg
@@ -135,8 +138,12 @@ getGlobalSyms (_, spec)
   where
     mbName = F.val . msName
 
-makeLocalVars :: GhcSrc -> LocalVars
-makeLocalVars = localVarMap . localBinds . _giCbs
+makeLocalVars :: [Ghc.CoreBind] -> LocalVars
+makeLocalVars = localVarMap . localBinds
+
+makeLocalVarsEnv :: LocalVars -> Ghc.NameEnv Ghc.Var
+makeLocalVarsEnv m =
+    Ghc.mkNameEnv [ (Ghc.getName (lvdVar d), lvdVar d) | d <- concat (M.elems m) ]
 
 -- TODO: rewrite using CoreVisitor
 localBinds :: [Ghc.CoreBind] -> [LocalVarDetails]
@@ -566,9 +573,13 @@ lookupGhcDataConLHName env lname = do
 
 lookupGhcIdLHName :: HasCallStack => Env -> Located LHName -> Lookup Ghc.Id
 lookupGhcIdLHName env lname = do
-   case lookupTyThing env lname of
-     Ghc.AConLike (Ghc.RealDataCon d) -> Right (Ghc.dataConWorkId d)
-     Ghc.AnId x -> Right x
+   case lookupTyThingMaybe env lname of
+     Nothing
+       | LHNResolved (LHRGHC n) _ <- val lname
+       , Just x <- Ghc.lookupNameEnv (reLocalVarsEnv env) n ->
+         Right x
+     Just (Ghc.AConLike (Ghc.RealDataCon d)) -> Right (Ghc.dataConWorkId d)
+     Just (Ghc.AnId x) -> Right x
      _ -> panic
            (Just $ GM.fSrcSpan lname) $ "not a variable of data constructor: " ++ show (val lname)
 
@@ -953,19 +964,21 @@ matchTyCon env lc = do
 -- This should be benign because the result doesn't depend of when exactly this is
 -- called. Since this code is intended to be used inside a GHC plugin, there is no
 -- danger that GHC is finalized before the result is evaluated.
-lookupTyThing :: Env -> Located LHName -> Ghc.TyThing
-lookupTyThing env lc@(Loc _ _ c0) = unsafePerformIO $ do
+lookupTyThingMaybe :: Env -> Located LHName -> Maybe Ghc.TyThing
+lookupTyThingMaybe env lc@(Loc _ _ c0) = unsafePerformIO $ do
     case c0 of
       LHNUnresolved _ _ -> panic (Just $ GM.fSrcSpan lc) $ "unresolved name: " ++ show c0
       LHNResolved rn _ -> case rn of
         LHRLocal _ -> panic (Just $ GM.fSrcSpan lc) $ "cannot resolve a local name: " ++ show c0
         LHRIndex i -> panic (Just $ GM.fSrcSpan lc) $ "cannot resolve a LHRIndex " ++ show i
         LHRLogic (LogicName s _) -> panic (Just $ GM.fSrcSpan lc) $ "lookupTyThing: cannot resolve a LHRLogic name " ++ show s
-        LHRGHC n -> do
-          m <- Ghc.reflectGhc (Interface.lookupTyThing (reTcGblEnv env) n) (reSession env)
-          case m of
-            Just tt -> return tt
-            Nothing -> panic (Just $ GM.fSrcSpan lc) $ "not found: " ++ show c0
+        LHRGHC n ->
+          Ghc.reflectGhc (Interface.lookupTyThing (reTcGblEnv env) n) (reSession env)
+
+lookupTyThing :: Env -> Located LHName -> Ghc.TyThing
+lookupTyThing env lc =
+    Mb.fromMaybe (panic (Just $ GM.fSrcSpan lc) $ "not found: " ++ show (val lc)) $
+      lookupTyThingMaybe env lc
 
 bareTCApp :: (Expandable r)
           => r

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -447,7 +447,6 @@ qualifyBareSpec env name l bs sp = sp
   { measures   = qualify env name l bs (measures   sp)
   , asmSigs    = qualify env name l bs (asmSigs    sp)
   , sigs       = qualify env name l bs (sigs       sp)
-  , localSigs  = qualify env name l bs (localSigs  sp)
   , reflSigs   = qualify env name l bs (reflSigs   sp)
   , dataDecls  = qualify env name l bs (dataDecls  sp)
   , newtyDecls = qualify env name l bs (newtyDecls sp)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Types.hs
@@ -72,6 +72,7 @@ plugSrc _        = Nothing
 data Env = RE 
   { reSession   :: Ghc.Session
   , reTcGblEnv  :: Ghc.TcGblEnv
+  , reLocalVarsEnv :: Ghc.NameEnv Ghc.Var   -- ^ an environment of local variables
   , reUsedExternals :: Ghc.NameSet
   , reLMap      :: LogicMap
   , reSyms      :: [(F.Symbol, Ghc.Var)]    -- ^ see "syms" in old makeGhcSpec'

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -315,6 +315,9 @@ locNamedThing x = F.Loc l lE x
 instance F.Loc Var where
   srcSpan v = SS (getSourcePos v) (getSourcePosE v)
 
+instance F.Loc Name where
+  srcSpan v = SS (getSourcePos v) (getSourcePosE v)
+
 namedLocSymbol :: (F.Symbolic a, NamedThing a) => a -> F.Located F.Symbol
 namedLocSymbol d = F.symbol <$> locNamedThing d
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -120,12 +120,7 @@ resolveLHNames taliases globalRdrEnv =
       let m = LH.takeModuleNames s
           n = LH.dropModuleNames s
           nString = symbolString n
-          -- TODO: Maybe change the parser so dataConNameP doesn't include the
-          -- parentheses around infix operators.
-          maybeUnpar = case nString of
-            '(':rest -> init rest
-            _ -> nString
-          oname = GHC.mkOccName (mkGHCNameSpace ns) maybeUnpar
+          oname = GHC.mkOccName (mkGHCNameSpace ns) nString
           rdrn =
             if m == "" then
               GHC.mkRdrUnqual oname

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -26,10 +26,13 @@ import           Data.Generics (extT)
 
 import qualified Data.HashSet                            as HS
 import qualified Data.HashMap.Strict                     as HM
+import           Data.Maybe (fromMaybe, listToMaybe)
 import qualified Data.Text                               as Text
 import qualified GHC.Types.Name.Occurrence
 
 import           Language.Fixpoint.Types hiding (Error, panic)
+import           Language.Haskell.Liquid.Bare.Resolve (lookupLocalVar)
+import           Language.Haskell.Liquid.Bare.Types (LocalVars)
 import           Language.Haskell.Liquid.Types.Errors (TError(ErrDupNames, ErrResolve), panic)
 import           Language.Haskell.Liquid.Types.Specs
 import           Language.Haskell.Liquid.Types.Types
@@ -61,11 +64,12 @@ collectTypeAliases m bs deps =
 -- | Converts occurrences of LHNUnresolved to LHNResolved using the provided
 -- type aliases and GlobalRdrEnv.
 resolveLHNames
-  :: HM.HashMap Symbol (Module, RTAlias Symbol BareType)
+  :: LocalVars
+  -> HM.HashMap Symbol (Module, RTAlias Symbol BareType)
   -> GlobalRdrEnv
   -> BareSpec
   -> Either [Error] BareSpec
-resolveLHNames taliases globalRdrEnv =
+resolveLHNames localVars taliases globalRdrEnv =
     (\(bs, es) -> if null es then Right bs else Left es) .
     runWriter .
     mapMLocLHNames (\l -> (<$ l) <$> resolveLHName l) .
@@ -82,30 +86,43 @@ resolveLHNames taliases globalRdrEnv =
         | otherwise ->
           case HM.lookup s taliases of
             Just (m, _) -> pure $ LHNResolved (LHRLogic $ LogicName s m) s
-            Nothing -> lookupGRELHName LHTcName lname s
+            Nothing -> lookupGRELHName LHTcName lname s listToMaybe
       LHNUnresolved LHVarName s
-        | isDataCon s -> lookupGRELHName LHDataConName lname s
-        | otherwise -> lookupGRELHName LHVarName lname s
-      LHNUnresolved ns s -> lookupGRELHName ns lname s
+        | isDataCon s -> lookupGRELHName LHDataConName lname s listToMaybe
+        | otherwise ->
+            lookupGRELHName LHVarName lname s
+              (fmap (either id GHC.getName) . lookupLocalVar localVars (atLoc lname s))
+      LHNUnresolved ns s -> lookupGRELHName ns lname s listToMaybe
       n@(LHNResolved (LHRLocal _) _) -> pure n
       n ->
         let sp = Just $ LH.sourcePosSrcSpan $ loc lname
          in panic sp $ "resolveLHNames: Unexpected resolved name: " ++ show n
 
-    lookupGRELHName ns lname s =
+    lookupGRELHName ns lname s localNameLookup =
       case GHC.lookupGRE globalRdrEnv (mkLookupGRE ns s) of
-        [e] ->
-          pure $ LHNResolved (LHRGHC $ GHC.greName e) s
+        [e] -> do
+          let n = GHC.greName e
+              n' = fromMaybe n $ localNameLookup [n]
+          pure $ LHNResolved (LHRGHC n') s
         es@(_:_) -> do
-          tell [ErrDupNames
-                  (LH.fSrcSpan lname)
-                  (pprint s)
-                  (map (PJ.text . showPprUnsafe) es)
-               ]
-          pure $ val lname
-        [] -> do
-          tell [errResolve (nameSpaceKind ns) "Cannot resolve name" (s <$ lname)]
-          pure $ val lname
+          let topLevelNames = map GHC.greName es
+          case localNameLookup topLevelNames of
+            Just n | notElem n topLevelNames ->
+              pure $ LHNResolved (LHRGHC n) s
+            _ -> do
+              tell [ErrDupNames
+                      (LH.fSrcSpan lname)
+                      (pprint s)
+                      (map (PJ.text . showPprUnsafe) es)
+                   ]
+              pure $ val lname
+        [] ->
+          case localNameLookup [] of
+            Just n' ->
+              pure $ LHNResolved (LHRGHC n') s
+            Nothing -> do
+              tell [errResolve (nameSpaceKind ns) "Cannot resolve name" (s <$ lname)]
+              pure $ val lname
 
     errResolve :: PJ.Doc -> String -> LocSymbol -> Error
     errResolve k msg lx = ErrResolve (LH.fSrcSpan lx) k (pprint (val lx)) (PJ.text msg)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -1069,7 +1069,6 @@ mkSpec name xs         = (name,) $ qualifySpec (symbol name) Measure.Spec
   , Measure.asmReflectSigs = [(l, r) | AssmReflect (l, r) <- xs]
   , Measure.sigs       = [a | Asrt   a <- xs]
                       ++ [(y, t) | Asrts (ys, (t, _)) <- xs, y <- ys]
-  , Measure.localSigs  = []
   , Measure.reflSigs   = []
   , Measure.impSigs    = []
   , Measure.expSigs    = []

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -1108,7 +1108,7 @@ specP :: Parser BPspec
 specP
   = fallbackSpecP "assume" ((reserved "reflect" >> fmap AssmReflect assmReflectBindP)
         <|> (reserved "relational" >>  fmap AssmRel relationalP)
-        <|>                            fmap Assm   assumptionP  )
+        <|>                            fmap Assm   tyBindLHNameP  )
     <|> fallbackSpecP "assert"      (fmap Asrt    tyBindP  )
     <|> fallbackSpecP "autosize"    (fmap ASize   asizeP   )
     <|> (reserved "local"         >> fmap LAsrt   tyBindP  )
@@ -1252,8 +1252,12 @@ tyBindP :: Parser (LocSymbol, Located BareType)
 tyBindP =
   (,) <$> locBinderP <* reservedOp "::" <*> located genBareTypeP
 
-assumptionP :: Parser (Located LHName, Located BareType)
-assumptionP = do
+tyBindMethodP :: Parser (LocSymbol, Located BareType)
+tyBindMethodP =
+  (,) <$> located binderInfixParensP <* reservedOp "::" <*> located genBareTypeP
+
+tyBindLHNameP :: Parser (Located LHName, Located BareType)
+tyBindLHNameP = do
     x <- locBinderP
     _ <- reservedOp "::"
     t <- located genBareTypeP

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -1418,7 +1418,7 @@ riMethodSigP
   = try (do reserved "assume"
             (x, t) <- tyBindP
             return (x, RIAssumed t) )
- <|> do (x, t) <- tyBindP
+ <|> do (x, t) <- tyBindMethodP
         return (x, RISig t)
  <?> "riMethodSigP"
 
@@ -1479,6 +1479,16 @@ binderP =
   <|> binderIdP
   -- Note: It is important that we do *not* use the LH/fixpoint reserved words here,
   -- because, for example, we must be able to use "assert" as an identifier.
+
+-- | Like binderP, but surrounds infix operators with parenthesis.
+--
+-- This is only needed by `tests/parser/pos/T892.hs` and needs to be
+-- investigated why.
+binderInfixParensP :: Parser Symbol
+binderInfixParensP =
+      symbol . (\ x -> "(" <> x <> ")") . symbolText <$> parens infixBinderIdP
+  <|> binderIdP
+
 
 measureDefP :: Parser Body -> Parser (Def (Located BareType) LocSymbol)
 measureDefP bodyP
@@ -1581,7 +1591,7 @@ dataConNameP
   where
      idP p  = takeWhile1P Nothing (not . p)
      bad c  = isSpace c || c `elem` ("(,)" :: String)
-     pwr s  = symbol $ "(" <> s <> ")"
+     pwr s  = symbol s
 
 dataSizeP :: Parser (Maybe SizeFun)
 dataSizeP

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -401,7 +401,6 @@ data Spec ty bndr  = Spec
   , asmSigs    :: ![(F.Located LHName, ty)]                                -- ^ Assumed (unchecked) types; including reflected signatures
   , asmReflectSigs :: ![(F.LocSymbol, F.LocSymbol)]                   -- ^ Assume reflects : left is the actual function and right the pretended one
   , sigs       :: ![(F.LocSymbol, ty)]                                -- ^ Imported functions and types
-  , localSigs  :: ![(F.LocSymbol, ty)]                                -- ^ Local type signatures
   , reflSigs   :: ![(F.LocSymbol, ty)]                                -- ^ Reflected type signatures
   , invariants :: ![(Maybe F.LocSymbol, ty)]                          -- ^ Data type invariants; the Maybe is the generating measure
   , ialiases   :: ![(ty, ty)]                                         -- ^ Data type invariants to be checked
@@ -464,7 +463,6 @@ instance Semigroup (Spec ty bndr) where
            , asmSigs    =           asmSigs    s1 ++ asmSigs    s2
            , asmReflectSigs    =    asmReflectSigs s1 ++ asmReflectSigs s2
            , sigs       =           sigs       s1 ++ sigs       s2
-           , localSigs  =           localSigs  s1 ++ localSigs  s2
            , reflSigs   =           reflSigs   s1 ++ reflSigs   s2
            , invariants =           invariants s1 ++ invariants s2
            , ialiases   =           ialiases   s1 ++ ialiases   s2
@@ -515,7 +513,6 @@ instance Monoid (Spec ty bndr) where
            , asmSigs    = []
            , asmReflectSigs = []
            , sigs       = []
-           , localSigs  = []
            , reflSigs   = []
            , invariants = []
            , ialiases   = []
@@ -864,7 +861,6 @@ unsafeFromLiftedSpec a = Spec
   , asmSigs    = S.toList . liftedAsmSigs $ a
   , asmReflectSigs = S.toList . liftedAsmReflectSigs $ a
   , sigs       = S.toList . liftedSigs $ a
-  , localSigs  = mempty
   , reflSigs   = mempty
   , relational = mempty
   , asmRel     = mempty

--- a/tests/names/pos/LocalAssume.hs
+++ b/tests/names/pos/LocalAssume.hs
@@ -1,0 +1,13 @@
+-- | Tests that local assumptions are taken into consideration
+module LocalAssume where
+
+import Prelude (Int)
+
+{-@ f :: {v: Int | v > 0} @-}
+f :: Int
+f = g
+  where
+    {-@ assume g :: {v:Int | v > 0} @-}
+    g :: Int
+    g = 0
+

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -792,6 +792,7 @@ executable names-pos
                     , Local01
                     , Local02
                     , Local03
+                    , LocalAssume
                     , LocalSpec
                     , Ord
                     , Set00


### PR DESCRIPTION
Fixes #2419.

As the issue proposes, 319f716 uses the logic to resolve local names in LHNameResolution.hs.
The rest of the commits are small refactorings.
