### PR TITLE
Use GHC Name after resolving asserted specs

### DIFF
--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -634,8 +634,6 @@ import GHC.Types.Name                 as Ghc
     , occNameString
     , stableNameCmp
     )
-import GHC.Types.Name.Env             as Ghc
-    ( NameEnv, lookupNameEnv, mkNameEnv )
 import GHC.Types.Name.Set             as Ghc
     ( NameSet
     , elemNameSet
@@ -701,6 +699,12 @@ import GHC.Types.SrcLoc               as Ghc
     , srcSpanToRealSrcSpan
     )
 import GHC.Types.Tickish              as Ghc (CoreTickish, GenTickish(..))
+import GHC.Types.TypeEnv              as Ghc
+    ( TypeEnv
+    , lookupTypeEnv
+    , mkTypeEnv
+    , plusTypeEnv
+    )
 import GHC.Types.Unique               as Ghc
     ( getKey, mkUnique )
 import GHC.Types.Unique.Set           as Ghc (mkUniqSet)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -936,7 +936,7 @@ myAsmSig v sigs = Mb.fromMaybe errImp (mbHome `mplus` mbImp)
 makeTExpr :: Bare.Env -> ModName -> [(Ghc.Var, LocBareType)] -> BareRTEnv -> Ms.BareSpec
           -> Bare.Lookup [(Ghc.Var, LocBareType, Maybe [Located F.Expr])]
 makeTExpr env name tySigs rtEnv spec = do
-  vExprs       <- M.fromList <$> makeVarTExprs env name spec
+  vExprs       <- M.fromList <$> makeVarTExprs env spec
   let vSigExprs = Misc.hashMapMapWithKey (\v t -> (t, M.lookup v vExprs)) vSigs
   return [ (v, t, qual t <$> es) | (v, (t, es)) <- M.toList vSigExprs ]
   where
@@ -952,10 +952,10 @@ qualifyTermExpr env name rtEnv t le
     e   = F.val le
     bs  = ty_binds . toRTypeRep . val $ t
 
-makeVarTExprs :: Bare.Env -> ModName -> Ms.BareSpec -> Bare.Lookup [(Ghc.Var, [Located F.Expr])]
-makeVarTExprs env name spec =
+makeVarTExprs :: Bare.Env -> Ms.BareSpec -> Bare.Lookup [(Ghc.Var, [Located F.Expr])]
+makeVarTExprs env spec =
   forM (Ms.termexprs spec) $ \(x, es) -> do
-    vx <- Bare.lookupGhcVar env name "Var" (getLHNameSymbol <$> x)
+    vx <- Bare.lookupGhcIdLHName env x
     return (vx, es)
 
 ----------------------------------------------------------------------------------------

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -885,7 +885,7 @@ makeFromSet msg f env specs = concat [ mk n xs | (n, s) <- specs, let xs = S.toL
 makeTySigs :: Bare.Env -> Bare.SigEnv -> ModName -> Ms.BareSpec
            -> Bare.Lookup [(Ghc.Var, LocSpecType, Maybe [Located F.Expr])]
 makeTySigs env sigEnv name spec = do
-  bareSigs   <- bareTySigs env name                spec
+  bareSigs   <- bareTySigs env                     spec
   expSigs    <- makeTExpr  env name bareSigs rtEnv spec
   let rawSigs = Bare.resolveLocalBinds env expSigs
   return [ (x, cook x bt, z) | (x, bt, z) <- rawSigs ]
@@ -893,11 +893,11 @@ makeTySigs env sigEnv name spec = do
     rtEnv     = Bare.sigRTEnv sigEnv
     cook x bt = Bare.cookSpecType env sigEnv name (Bare.HsTV x) bt
 
-bareTySigs :: Bare.Env -> ModName -> Ms.BareSpec -> Bare.Lookup [(Ghc.Var, LocBareType)]
-bareTySigs env name spec = checkDuplicateSigs <$> vts
+bareTySigs :: Bare.Env -> Ms.BareSpec -> Bare.Lookup [(Ghc.Var, LocBareType)]
+bareTySigs env spec = checkDuplicateSigs <$> vts
   where
     vts = forM ( Ms.sigs spec ) $ \ (x, t) -> do
-            v <- F.notracepp "LOOKUP-GHC-VAR" $ Bare.lookupGhcVar env name "rawTySigs" (getLHNameSymbol <$> x)
+            v <- F.notracepp "LOOKUP-GHC-VAR" $ Bare.lookupGhcIdLHName env x
             return (v, t)
 
 -- checkDuplicateSigs :: [(Ghc.Var, LocSpecType)] -> [(Ghc.Var, LocSpecType)]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -1077,10 +1077,10 @@ getAsmSigs myName name spec
   | otherwise      =
       [ (False, x, t)
       | (x, t) <- map (first SOLLHName) (Ms.asmSigs spec)
-                  ++ map (first (SOLSymbol . qSym . fmap getLHNameSymbol)) (Ms.sigs spec)
+                  ++ map (first (SOLLHName . fmap (updateLHNameSymbol qSym))) (Ms.sigs spec)
       ]
   where
-    qSym           = fmap (GM.qualifySymbol ns)
+    qSym           = GM.qualifySymbol ns
     ns             = F.symbol name
 
 -- TODO-REBARE: grepClassAssumes

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Expand.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Expand.hs
@@ -387,7 +387,7 @@ expandBareSpec :: BareRTEnv -> F.SourcePos -> Ms.BareSpec -> Ms.BareSpec
 expandBareSpec rtEnv l sp = sp
   { measures   = expand rtEnv l (measures   sp)
   , asmSigs    = map (second (expand rtEnv l)) (asmSigs sp)
-  , sigs       = expand rtEnv l (sigs       sp)
+  , sigs       = map (second (expand rtEnv l)) (sigs sp)
   , reflSigs   = expand rtEnv l (reflSigs   sp)
   , ialiases   = [ (f x, f y) | (x, y) <- ialiases sp ]
   , dataDecls  = expand rtEnv l (dataDecls  sp)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -581,7 +581,7 @@ lookupGhcIdLHName env lname = do
      Just (Ghc.AConLike (Ghc.RealDataCon d)) -> Right (Ghc.dataConWorkId d)
      Just (Ghc.AnId x) -> Right x
      _ -> panic
-           (Just $ GM.fSrcSpan lname) $ "not a variable of data constructor: " ++ show (val lname)
+           (Just $ GM.fSrcSpan lname) $ "not a variable or data constructor: " ++ show (val lname)
 
 -------------------------------------------------------------------------------
 -- | Checking existence of names

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
@@ -81,7 +81,7 @@ compileClasses src env (name, spec) rest =
     Just (cls, sig) -> (M.alter (merge sig) cls refs, sigs')
    where
     clsOp = do
-      var <- Bare.maybeResolveSym env name "grabClassSig" $ getLHNameSymbol <$> lsym
+      var <- either (const Nothing) Just $ Bare.lookupGhcIdLHName env lsym
       cls <- Ghc.isClassOpId_maybe var
       pure (cls, (var, ref))
     merge sig v = case v of

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
@@ -73,15 +73,15 @@ compileClasses src env (name, spec) rest =
       -- class methods
   (refinedMethods, sigsNew) = foldr grabClassSig (mempty, mempty) (sigs spec)
   grabClassSig
-    :: (F.LocSymbol, ty)
-    -> (M.HashMap Ghc.Class [(Ghc.Id, ty)], [(F.LocSymbol, ty)])
-    -> (M.HashMap Ghc.Class [(Ghc.Id, ty)], [(F.LocSymbol, ty)])
+    :: (F.Located LHName, ty)
+    -> (M.HashMap Ghc.Class [(Ghc.Id, ty)], [(F.Located LHName, ty)])
+    -> (M.HashMap Ghc.Class [(Ghc.Id, ty)], [(F.Located LHName, ty)])
   grabClassSig sigPair@(lsym, ref) (refs, sigs') = case clsOp of
     Nothing         -> (refs, sigPair : sigs')
     Just (cls, sig) -> (M.alter (merge sig) cls refs, sigs')
    where
     clsOp = do
-      var <- Bare.maybeResolveSym env name "grabClassSig" lsym
+      var <- Bare.maybeResolveSym env name "grabClassSig" $ getLHNameSymbol <$> lsym
       cls <- Ghc.isClassOpId_maybe var
       pure (cls, (var, ref))
     merge sig v = case v of

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Types.hs
@@ -72,7 +72,7 @@ plugSrc _        = Nothing
 data Env = RE 
   { reSession   :: Ghc.Session
   , reTcGblEnv  :: Ghc.TcGblEnv
-  , reLocalVarsEnv :: Ghc.NameEnv Ghc.Var   -- ^ an environment of local variables
+  , reTypeEnv   :: Ghc.TypeEnv
   , reUsedExternals :: Ghc.NameSet
   , reLMap      :: LogicMap
   , reSyms      :: [(F.Symbol, Ghc.Var)]    -- ^ see "syms" in old makeGhcSpec'

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -400,7 +400,7 @@ data Spec ty bndr  = Spec
   , expSigs    :: ![(F.Symbol, F.Sort)]                               -- ^ Exported variables types
   , asmSigs    :: ![(F.Located LHName, ty)]                                -- ^ Assumed (unchecked) types; including reflected signatures
   , asmReflectSigs :: ![(F.LocSymbol, F.LocSymbol)]                   -- ^ Assume reflects : left is the actual function and right the pretended one
-  , sigs       :: ![(F.LocSymbol, ty)]                                -- ^ Imported functions and types
+  , sigs       :: ![(F.Located LHName, ty)]                           -- ^ Imported functions and types
   , reflSigs   :: ![(F.LocSymbol, ty)]                                -- ^ Reflected type signatures
   , invariants :: ![(Maybe F.LocSymbol, ty)]                          -- ^ Data type invariants; the Maybe is the generating measure
   , ialiases   :: ![(ty, ty)]                                         -- ^ Data type invariants to be checked
@@ -435,7 +435,7 @@ data Spec ty bndr  = Spec
   , claws      :: ![RClass ty]                                        -- ^ Refined Type-Classe Laws
   , relational :: ![(LocSymbol, LocSymbol, ty, ty, RelExpr, RelExpr)] -- ^ Relational types
   , asmRel     :: ![(LocSymbol, LocSymbol, ty, ty, RelExpr, RelExpr)] -- ^ Assumed relational types
-  , termexprs  :: ![(F.LocSymbol, [F.Located F.Expr])]                -- ^ Terminating Conditions for functions
+  , termexprs  :: ![(F.Located LHName, [F.Located F.Expr])]                -- ^ Terminating Conditions for functions
   , rinstance  :: ![RInstance ty]
   , ilaws      :: ![RILaws ty]
   , dvariance  :: ![(F.Located LHName, [Variance])]                   -- ^ TODO ? Where do these come from ?!
@@ -589,7 +589,7 @@ data LiftedSpec = LiftedSpec
     -- ^ Assumed (unchecked) types; including reflected signatures
   , liftedAsmReflectSigs    :: HashSet (F.LocSymbol, F.LocSymbol)
     -- ^ Reflected assumed signatures
-  , liftedSigs       :: HashSet (F.LocSymbol, LocBareType)
+  , liftedSigs       :: HashSet (F.Located LHName, LocBareType)
     -- ^ Imported functions and types
   , liftedInvariants :: HashSet (Maybe F.LocSymbol, LocBareType)
     -- ^ Data type invariants; the Maybe is the generating measure

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/QuasiQuoter.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/QuasiQuoter.hs
@@ -83,13 +83,13 @@ throwErrorInQ uerr =
 
 mkSpecDecs :: BPspec -> Either UserError [Dec]
 mkSpecDecs (Asrt (name, ty)) =
-  return . SigD (symbolName name)
+  return . SigD (lhNameToName name)
     <$> simplifyBareType name (quantifyFreeRTy $ val ty)
 mkSpecDecs (LAsrt (name, ty)) =
   return . SigD (symbolName name)
     <$> simplifyBareType name (quantifyFreeRTy $ val ty)
 mkSpecDecs (Asrts (names, (ty, _))) =
-  (\t -> (`SigD` t) . symbolName <$> names)
+  (\t -> (`SigD` t) . lhNameToName <$> names)
     <$> simplifyBareType (head names) (quantifyFreeRTy $ val ty)
 mkSpecDecs (Alias rta) =
   return . TySynD name tvs <$> simplifyBareType lsym (rtBody (val rta))
@@ -135,7 +135,7 @@ lhNameToName lname = case val lname of
 
 -- BareType to TH Type ---------------------------------------------------------
 
-simplifyBareType :: LocSymbol -> BareType -> Either UserError Type
+simplifyBareType :: PPrint a => Located a -> BareType -> Either UserError Type
 simplifyBareType s t = case simplifyBareType' t of
   Simplified t' ->
     Right t'


### PR DESCRIPTION
This is another step for #2169.

The first two commits are small refactorings. The one about putting the types from the core program in the type environment (072cb95) is important to mimic the current behavior: when types are different in core and in the typing environment, prefer the type in core. The types should be always alpha equivalent. It also puts the types of non-top-level variables in the typing environment, so we can simplify lookups a bit.

The general structure of introducing LHNames follow. First 2074e96 introduces LHName at the places of the AST where asserted specs are kept. And the follow up commits remove the conversions from LHName to symbol that helped preserving the old behavior.

Near the end, we get a nice commit (1d33cce) that removes a bit of redundant renaming code in LH (redundant with respect to the name resolution that we can do more directly with the GHC API).