### PR TITLE
Use GHC names for instance methods and dictionaries

### DIFF
--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -305,8 +305,10 @@ import GHC.Core.FamInstEnv            as Ghc
 import GHC.Core.InstEnv               as Ghc
     ( ClsInst(is_cls, is_dfun, is_dfun_name, is_tys)
     , DFunId
+    , InstEnvs
     , instEnvElts
     , instanceSig
+    , lookupUniqueInstEnv
     )
 import GHC.Core.Make                  as Ghc
     ( mkCoreApps
@@ -514,6 +516,8 @@ import GHC.Tc.Types                   as Ghc
 import GHC.Tc.Types.Evidence          as Ghc
     ( TcEvBinds(EvBinds) )
 import GHC.Tc.Types.Origin            as Ghc (lexprCtOrigin)
+import GHC.Tc.Utils.Env               as Ghc
+    ( tcGetInstEnvs )
 import GHC.Tc.Utils.Monad             as Ghc
     ( captureConstraints
     , discardConstraints

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -308,7 +308,7 @@ import GHC.Core.InstEnv               as Ghc
     , InstEnvs
     , instEnvElts
     , instanceSig
-    , lookupUniqueInstEnv
+    , lookupInstEnv
     )
 import GHC.Core.Make                  as Ghc
     ( mkCoreApps

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -403,7 +403,7 @@ makeTyConEmbeds :: Bare.Env -> Ms.BareSpec -> F.TCEmb Ghc.TyCon
 makeTyConEmbeds env spec
   = F.tceFromList [ (tc, t) | (c,t) <- F.tceToList (Ms.embeds spec), tc <- symTc c ]
     where
-      symTc = Mb.maybeToList . either (const Nothing) Just . Bare.matchTyCon env
+      symTc = Mb.maybeToList . either (const Nothing) Just . Bare.lookupGhcTyConLHName env
 
 --------------------------------------------------------------------------------
 -- | [NOTE]: REFLECT-IMPORTS

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -1039,14 +1039,6 @@ getAsmSigs myName name spec
     qSym           = GM.qualifySymbol ns
     ns             = F.symbol name
 
--- TODO-REBARE: grepClassAssumes
-_grepClassAssumes :: [RInstance t] -> [(Located F.Symbol, t)]
-_grepClassAssumes  = concatMap go
-  where
-    go    xts              = Mb.mapMaybe goOne (risigs xts)
-    goOne (x, RIAssumed t) = Just (fmap (F.symbol . (".$c" ++ ) . F.symbolString) x, t)
-    goOne (_, RISig _)     = Nothing
-
 makeSigEnv :: F.TCEmb Ghc.TyCon -> Bare.TyConMap -> S.HashSet StableName -> BareRTEnv -> Bare.SigEnv
 makeSigEnv embs tyi exports rtEnv = Bare.SigEnv
   { sigEmbs     = embs

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -275,7 +275,7 @@ makeGhcSpec0 cfg session tcg instEnvs localVars src lmap targetSpec dependencySp
   -- NB: we first compute a measure environment w/o the opaque reflections, so that we can bootstrap
   -- the signature `sig`. Then we'll add the opaque reflections before we compute `sData` and al.
   let (dg1, measEnv0) = withDiagnostics $ makeMeasEnv      env tycEnv sigEnv       specs
-  let (dg2, sig) = withDiagnostics $ makeSpecSig cfg name specs env sigEnv   tycEnv measEnv0 (_giCbs src)
+  let (dg2, sig) = withDiagnostics $ makeSpecSig cfg name mySpec iSpecs2 env sigEnv tycEnv measEnv0 (_giCbs src)
   elaboratedSig <-
     if allowTC then Bare.makeClassAuxTypes (elaborateSpecType coreToLg simplifier) datacons instMethods
                               >>= elaborateSig sig
@@ -800,12 +800,12 @@ makeAutoInst env name spec = S.fromList <$> kvs
 
 
 ----------------------------------------------------------------------------------------
-makeSpecSig :: Config -> ModName -> Bare.ModSpecs -> Bare.Env -> Bare.SigEnv -> Bare.TycEnv -> Bare.MeasEnv -> [Ghc.CoreBind]
-            -> Bare.Lookup GhcSpecSig
+makeSpecSig :: Config -> ModName -> Ms.BareSpec -> Bare.ModSpecs -> Bare.Env -> Bare.SigEnv -> Bare.TycEnv -> Bare.MeasEnv -> [Ghc.CoreBind]
+            -> Bare.Lookup (GhcSpecSig)
 ----------------------------------------------------------------------------------------
-makeSpecSig cfg name specs env sigEnv tycEnv measEnv cbs = do
+makeSpecSig cfg name mySpec specs env sigEnv tycEnv measEnv cbs = do
   mySigs     <- makeTySigs  env sigEnv name mySpec
-  aSigs      <- F.notracepp ("makeSpecSig aSigs " ++ F.showpp name) $ makeAsmSigs env sigEnv name specs
+  aSigs      <- F.notracepp ("makeSpecSig aSigs " ++ F.showpp name) $ makeAsmSigs env sigEnv name allSpecs
   let asmSigs =  Bare.tcSelVars tycEnv
               ++ aSigs
               ++ [ (x,t) | (_, x, t) <- concatMap snd (Bare.meCLaws measEnv) ]
@@ -821,7 +821,7 @@ makeSpecSig cfg name specs env sigEnv tycEnv measEnv cbs = do
   return SpSig
     { gsTySigs   = tySigs
     , gsAsmSigs  = asmSigs
-    , gsAsmReflects = bimap getVar getVar <$> concatMap (asmReflectSigs . snd) (M.toList specs)
+    , gsAsmReflects = bimap getVar getVar <$> concatMap (asmReflectSigs . snd) allSpecs
     , gsRefSigs  = []
     , gsDicts    = dicts
     -- , gsMethods  = if noclasscheck cfg then [] else Bare.makeMethodTypes dicts (Bare.meClasses  measEnv) cbs
@@ -833,9 +833,8 @@ makeSpecSig cfg name specs env sigEnv tycEnv measEnv cbs = do
     , gsAsmRel   = asmRel
   }
   where
-    dicts      = Bare.makeSpecDictionaries env sigEnv specs
-    mySpec     = M.lookupDefault mempty name specs
-    allSpecs   = M.toList specs
+    dicts = Bare.makeSpecDictionaries env sigEnv (name, mySpec) (M.toList specs)
+    allSpecs   = (name, mySpec) : M.toList specs
     rtEnv      = Bare.sigRTEnv sigEnv
     getVar sym = case Bare.lookupGhcVar env name "assume-reflection specs" sym of
       Right x -> x
@@ -908,12 +907,12 @@ checkDuplicateSigs xts = case Misc.uniqueByKey symXs  of
     symXs = [ (F.symbol x, F.loc t) | (x, t) <- xts ]
 
 
-makeAsmSigs :: Bare.Env -> Bare.SigEnv -> ModName -> Bare.ModSpecs -> Bare.Lookup [(Ghc.Var, LocSpecType)]
+makeAsmSigs :: Bare.Env -> Bare.SigEnv -> ModName -> [(ModName, Ms.BareSpec)] -> Bare.Lookup [(Ghc.Var, LocSpecType)]
 makeAsmSigs env sigEnv myName specs = do
   raSigs <- rawAsmSigs env myName specs
   return [ (x, t) | (name, x, bt) <- raSigs, let t = Bare.cookSpecType env sigEnv name (Bare.LqTV x) bt ]
 
-rawAsmSigs :: Bare.Env -> ModName -> Bare.ModSpecs -> Bare.Lookup [(ModName, Ghc.Var, LocBareType)]
+rawAsmSigs :: Bare.Env -> ModName -> [(ModName, Ms.BareSpec)] -> Bare.Lookup [(ModName, Ghc.Var, LocBareType)]
 rawAsmSigs env myName specs = do
   aSigs <- allAsmSigs env myName specs
   return [ (m, v, t) | (v, sigs) <- aSigs, let (m, t) = myAsmSig v sigs ]
@@ -987,10 +986,10 @@ takeBiggest :: (Ord b) => (a -> b) -> [a] -> Maybe a
 takeBiggest _ []  = Nothing
 takeBiggest f xs  = Just $ L.maximumBy (compare `on` f) xs
 
-allAsmSigs :: Bare.Env -> ModName -> Bare.ModSpecs ->
+allAsmSigs :: Bare.Env -> ModName -> [(ModName, Ms.BareSpec)] ->
               Bare.Lookup [(Ghc.Var, [(Bool, ModName, LocBareType)])]
 allAsmSigs env myName specs = do
-  let aSigs = [ (name, locallyDefined, x, t) | (name, spec) <- M.toList specs
+  let aSigs = [ (name, locallyDefined, x, t) | (name, spec) <- specs
                                    , (locallyDefined, x, t) <- getAsmSigs myName name spec ]
   vSigs    <- forM aSigs $ \(name, locallyDefined, x, t) -> do
                 v <- Bare.lookupGhcIdLHName env x

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Class.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Class.hs
@@ -150,7 +150,7 @@ makeCLaws env sigEnv myName specs = do
   return (Mb.catMaybes zMbs)
   where
     err tc   = error ("Not a type class: " ++ F.showpp tc)
-    classTc  = either (const Nothing) Just . Bare.matchTyCon env . btc_tc . rcName
+    classTc  = either (const Nothing) Just . Bare.lookupGhcTyConLHName env . btc_tc . rcName
     classTcs = [ (name, cls, tc) | (name, spec) <- M.toList specs
                                  , cls          <- Ms.claws spec
                                  , tc           <- Mb.maybeToList (classTc cls)
@@ -168,7 +168,7 @@ makeClasses env sigEnv myName specs = do
     classTcs = [ (name, cls, tc) | (name, spec) <- M.toList specs
                                  , cls          <- Ms.classes spec
                                  , tc           <- Mb.maybeToList (classTc cls) ]
-    classTc = either (const Nothing) Just . Bare.matchTyCon env . btc_tc . rcName
+    classTc = either (const Nothing) Just . Bare.lookupGhcTyConLHName env . btc_tc . rcName
 
 mkClass :: Bare.Env -> Bare.SigEnv -> ModName -> ModName -> RClass LocBareType -> Ghc.TyCon
         -> Bare.Lookup (Maybe (DataConP, [(ModName, Ghc.Var, LocSpecType)]))

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/DataType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/DataType.hs
@@ -610,7 +610,7 @@ ofBDataDecl env name (Just dd@(DataDecl tc as ps cts pos sfun pt _)) maybe_invar
     err            = ErrBadData (GM.fSrcSpan tc) (pprint tc) "Mismatch in number of type variables"
 
 ofBDataDecl env name Nothing (Just (tc, is)) =
-  case Bare.matchTyCon env tc of
+  case Bare.lookupGhcTyConLHName env tc of
     Left e    -> Left e
     Right tc' -> Right ((name, TyConP srcpos tc' [] [] tcov tcontr Nothing, Nothing), [])
   where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Laws.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Laws.hs
@@ -42,7 +42,7 @@ makeInstanceLaw env sigEnv sigs name rilaw = LawInstance
     errmsg = error ("Not a type class: " ++ F.showpp tc)
 
     classTc = tyConClass_maybe <=<
-              either (const Nothing) Just . Bare.matchTyCon env . btc_tc
+              either (const Nothing) Just . Bare.lookupGhcTyConLHName env . btc_tc
 
     mkTy :: LocBareType -> LocSpecType
     mkTy = Bare.cookSpecType env sigEnv name Bare.GenTV

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -104,8 +104,8 @@ type Lookup a = Either [Error] a
 -------------------------------------------------------------------------------
 -- | Creating an environment
 -------------------------------------------------------------------------------
-makeEnv :: Config -> Ghc.Session -> Ghc.TcGblEnv -> LocalVars -> GhcSrc -> LogicMap -> [(ModName, BareSpec)] -> Env
-makeEnv cfg session tcg localVars src lmap specs = RE
+makeEnv :: Config -> Ghc.Session -> Ghc.TcGblEnv -> Ghc.InstEnvs -> LocalVars -> GhcSrc -> LogicMap -> [(ModName, BareSpec)] -> Env
+makeEnv cfg session tcg instEnv localVars src lmap specs = RE
   { reSession   = session
   , reTcGblEnv  = tcg
   , reTypeEnv   =
@@ -114,6 +114,7 @@ makeEnv cfg session tcg localVars src lmap specs = RE
       -- also include the types of local variables.
       let varsEnv = Ghc.mkTypeEnv $ map Ghc.AnId $ letVars $ _giCbs src
        in Ghc.tcg_type_env tcg `Ghc.plusTypeEnv` varsEnv
+  , reInstEnvs = instEnv
   , reUsedExternals = usedExternals
   , reLMap      = lmap
   , reSyms      = syms

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -32,7 +32,7 @@ module Language.Haskell.Liquid.Bare.Resolve
   , lookupGhcIdLHName
   , lookupGhcNamedVar
   , lookupLocalVar
-  , matchTyCon
+  , lookupGhcTyConLHName
 
   -- * Checking if names exist
   , knownGhcVar
@@ -943,11 +943,11 @@ ofBRType env name f l = go []
     goSyms (x, t)                 = (x,) <$> ofBSortE env name l t
     goRApp bs tc ts rs r          = bareTCApp <$> goReft bs r <*> lc' <*> mapM (goRef bs) rs <*> mapM (go bs) ts
       where
-        lc'                    = F.atLoc lc <$> matchTyCon env lc
+        lc'                    = F.atLoc lc <$> lookupGhcTyConLHName env lc
         lc                     = btc_tc tc
 
-matchTyCon :: Env -> Located LHName -> Lookup Ghc.TyCon
-matchTyCon env lc = do
+lookupGhcTyConLHName :: Env -> Located LHName -> Lookup Ghc.TyCon
+lookupGhcTyConLHName env lc = do
     case lookupTyThing env lc of
       Ghc.ATyCon tc -> Right tc
       Ghc.AConLike (Ghc.RealDataCon dc) -> Right $ Ghc.promoteDataCon dc

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
@@ -121,7 +121,7 @@ compileClasses src env (name, spec) rest =
       ++ concatMap (Mb.mapMaybe resolveClassMaybe . dataDecls . snd) rest
   resolveClassMaybe :: DataDecl -> Maybe Ghc.Class
   resolveClassMaybe d =
-    either (const Nothing) Just (Bare.matchTyCon env $ dataNameSymbol $ tycName d)
+    either (const Nothing) Just (Bare.lookupGhcTyConLHName env $ dataNameSymbol $ tycName d)
       >>= Ghc.tyConClass_maybe
 
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Types.hs
@@ -73,6 +73,7 @@ data Env = RE
   { reSession   :: Ghc.Session
   , reTcGblEnv  :: Ghc.TcGblEnv
   , reTypeEnv   :: Ghc.TypeEnv
+  , reInstEnvs  :: Ghc.InstEnvs
   , reUsedExternals :: Ghc.NameSet
   , reLMap      :: LogicMap
   , reSyms      :: [(F.Symbol, Ghc.Var)]    -- ^ see "syms" in old makeGhcSpec'

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -1364,7 +1364,7 @@ instanceP
        c    <- classBTyConP
        tvs  <- try oneClassArg <|> manyTill iargsP (try $ reserved "where")
        ms   <- block riMethodSigP
-       return $ RI c tvs ms
+       return $ RI c Nothing tvs ms
   where
     supersP  = try ((parens (superP `sepBy1` comma) <|> fmap pure superP)
                        <* reservedOp "=>")

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -1229,16 +1229,12 @@ tyBindP :: Parser (LocSymbol, Located BareType)
 tyBindP =
   (,) <$> locBinderP <* reservedOp "::" <*> located genBareTypeP
 
-tyBindMethodP :: Parser (LocSymbol, Located BareType)
-tyBindMethodP =
-  (,) <$> located binderInfixParensP <* reservedOp "::" <*> located genBareTypeP
-
 tyBindLHNameP :: Parser (Located LHName, Located BareType)
 tyBindLHNameP = do
-    x <- locBinderP
+    x <- locBinderLHNameP
     _ <- reservedOp "::"
     t <- located genBareTypeP
-    return (makeUnresolvedLHName LHVarName <$> x, t)
+    return (x, t)
 
 -- | Parses a loc symbol.
 assmReflectBindP :: Parser (LocSymbol, LocSymbol)
@@ -1381,12 +1377,12 @@ instanceP
     mkVar v  = dummyLoc $ RVar v mempty
 
 
-riMethodSigP :: Parser (LocSymbol, RISig (Located BareType))
+riMethodSigP :: Parser (Located LHName, RISig (Located BareType))
 riMethodSigP
   = try (do reserved "assume"
-            (x, t) <- tyBindP
+            (x, t) <- tyBindLHNameP
             return (x, RIAssumed t) )
- <|> do (x, t) <- tyBindMethodP
+ <|> do (x, t) <- tyBindLHNameP
         return (x, RISig t)
  <?> "riMethodSigP"
 
@@ -1451,16 +1447,6 @@ binderP =
   <|> binderIdP
   -- Note: It is important that we do *not* use the LH/fixpoint reserved words here,
   -- because, for example, we must be able to use "assert" as an identifier.
-
--- | Like binderP, but surrounds infix operators with parenthesis.
---
--- This is only needed by `tests/parser/pos/T892.hs` and needs to be
--- investigated why.
-binderInfixParensP :: Parser Symbol
-binderInfixParensP =
-      symbol . (\ x -> "(" <> x <> ")") . symbolText <$> parens infixBinderIdP
-  <|> binderIdP
-
 
 measureDefP :: Parser Body -> Parser (Def (Located BareType) LocSymbol)
 measureDefP bodyP

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Dictionaries.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Dictionaries.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE FlexibleContexts     #-}
 module Language.Haskell.Liquid.Types.Dictionaries (
-    makeDictionary
-  , dfromList
+    dfromList
   , dmapty
   , dmap
   , dinsert
@@ -11,7 +10,6 @@ module Language.Haskell.Liquid.Types.Dictionaries (
   , fromRISig
   ) where
 
-import           Data.Bifunctor (first)
 import           Data.Hashable
 
 import           Prelude                                   hiding (error)
@@ -19,39 +17,11 @@ import qualified Language.Fixpoint.Types as F
 import           Language.Haskell.Liquid.Types.PrettyPrint ()
 import qualified Language.Haskell.Liquid.GHC.Misc       as GM
 import qualified Liquid.GHC.API        as Ghc
-import           Language.Haskell.Liquid.Types.Errors
-import           Language.Haskell.Liquid.Types.Names
-import           Language.Haskell.Liquid.Types.RType
-import           Language.Haskell.Liquid.Types.RTypeOp
 -- import           Language.Haskell.Liquid.Types.Visitors (freeVars)
 import           Language.Haskell.Liquid.Types.RefType ()
 import           Language.Haskell.Liquid.Types.Types
 import qualified Data.HashMap.Strict                       as M
 
-
-makeDictionary :: RInstance LocSpecType -> (F.Symbol, M.HashMap F.Symbol (RISig LocSpecType))
-makeDictionary (RI c ts xts) = (makeDictionaryName (getLHNameSymbol <$> btc_tc c) ts, M.fromList (first (getLHNameSymbol . val) <$> xts))
-
-makeDictionaryName :: LocSymbol -> [LocSpecType] -> F.Symbol
-makeDictionaryName t ts
-  = F.notracepp _msg $ F.symbol ("$f" ++ F.symbolString (val t) ++ concatMap mkName ts)
-  where
-    mkName = makeDicTypeName sp . dropUniv . val
-    sp     = GM.fSrcSpan t
-    _msg   = "MAKE-DICTIONARY " ++ F.showpp (val t, ts)
-
--- | @makeDicTypeName@ DOES NOT use show/symbol in the @RVar@ case 
---   as those functions add the unique-suffix which then breaks the 
---   class resolution.
-
-makeDicTypeName :: Ghc.SrcSpan -> SpecType -> String
-makeDicTypeName _ RFun{}           = "(->)"
-makeDicTypeName _ (RApp c _ _ _)   = F.symbolString . GM.dropModuleNamesCorrect . F.symbol . rtc_tc $ c
-makeDicTypeName _ (RVar (RTV a) _) = show (Ghc.getName a)
-makeDicTypeName sp t               = panic (Just sp) ("makeDicTypeName: called with invalid type " ++ show t)
-
-dropUniv :: SpecType -> SpecType
-dropUniv t = t' where (_,_,t') = bkUniv t
 
 --------------------------------------------------------------------------------
 -- | Dictionary Environment ----------------------------------------------------

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Dictionaries.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Dictionaries.hs
@@ -30,7 +30,7 @@ import qualified Data.HashMap.Strict                       as M
 
 
 makeDictionary :: RInstance LocSpecType -> (F.Symbol, M.HashMap F.Symbol (RISig LocSpecType))
-makeDictionary (RI c ts xts) = (makeDictionaryName (getLHNameSymbol <$> btc_tc c) ts, M.fromList (first val <$> xts))
+makeDictionary (RI c ts xts) = (makeDictionaryName (getLHNameSymbol <$> btc_tc c) ts, M.fromList (first (getLHNameSymbol . val) <$> xts))
 
 makeDictionaryName :: LocSymbol -> [LocSpecType] -> F.Symbol
 makeDictionaryName t ts

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -284,7 +284,7 @@ isApp _                              = False
 data RInstance t = RI
   { riclass :: BTyCon
   , ritype  :: [t]
-  , risigs  :: [(F.LocSymbol, RISig t)]
+  , risigs  :: [(F.Located LHName, RISig t)]
   } deriving (Eq, Generic, Functor, Data, Typeable, Show)
     deriving Hashable via Generically (RInstance t)
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -283,6 +283,9 @@ isApp _                              = False
 
 data RInstance t = RI
   { riclass :: BTyCon
+    -- | The name of the dictionary
+    -- Provided when resolving names
+  , riDictName :: Maybe (F.Located LHName)
   , ritype  :: [t]
   , risigs  :: [(F.Located LHName, RISig t)]
   } deriving (Eq, Generic, Functor, Data, Typeable, Show)
@@ -309,7 +312,7 @@ ppRISig k x (RIAssumed t) = "assume" <+> F.pprintTidy k x <+> "::" <+> F.pprintT
 ppRISig k x (RISig t)     =              F.pprintTidy k x <+> "::" <+> F.pprintTidy k t
 
 instance F.PPrint t => F.PPrint (RInstance t) where
-  pprintTidy k (RI n ts mts) = ppMethods k "instance" n ts mts
+  pprintTidy k (RI n _ ts mts) = ppMethods k "instance" n ts mts
 
 
 instance (B.Binary t) => B.Binary (RInstance t)

--- a/tests/parser/pos/T892.hs
+++ b/tests/parser/pos/T892.hs
@@ -8,6 +8,8 @@ class CheckedNum a where
   (+) :: a -> a -> a
   (-) :: a -> a -> a
 
+{-@ predicate BoundInt X = 0 < X + 10000 && X < 10000 @-}
+
 instance CheckedNum Int where
 {-@ instance CheckedNum Int where
       (-) :: x:Int -> y:{v:Int | BoundInt (x - v)} -> {v: Int | v == x - y}

--- a/tests/pos/T385.hs
+++ b/tests/pos/T385.hs
@@ -1,7 +1,7 @@
 {-@ LIQUID "--noclasscheck"    @-}
 module T385 where
 
-import Prelude hiding (Functor, Monad)
+import Prelude hiding (Functor, Monad, (>>))
 
 data ST s a = ST {runState :: s -> (a,s)}
 


### PR DESCRIPTION
Another step for #2169.

The most interesting commits are d6f5159 and c57ab44. For some reason, the specifications of class instances were ignored if they could not be linked to a dictionary. With the changes here, an error is produced instead that the user can then fix. Most likely it will be due to a mismatch of type parameters.

Another flaw fixed here is that dictionaries were looked multiple times:
 * once when compiling the module that contains the instance specification, and
 * once whenever such module was imported in another module.

These two resolutions didn't always yield the same result because the dictionaries were not always in scope when trying to resolve them. With this PR, the resolution of the spec is serialized and reused in all modules that import an instance spec.

Another improvement in this PR is that we use the GHC API to find the dictionaries via `InstEnvs` instead of trying to find a variable in our typing environment with a particular name.

