### PR TITLE
Use GHC Name to resolve names of reflect annotations and similar

### DIFF
--- a/docs/mkDocs/docs/options.md
+++ b/docs/mkDocs/docs/options.md
@@ -243,6 +243,18 @@ Opaque reflections:
 - GHC.Internal.Real.even
 ```
 
+If not reflecting `keepEvens`, the other functions can still be opaquely-reflected with the `opaque-reflect`
+annotation.
+
+```Haskell
+{-@ LIQUID "--reflection"      @-}
+{-@ LIQUID "--dump-opaque-reflections"      @-}
+
+module OpaqueRefl06 where
+
+{-@ opaque-reflect even @-}
+{-@ opaque-reflect filter @-}
+```
 
 Note: you can also reflect functions *away* from their definition, using interface files. For instance, you may do:
 

--- a/docs/mkDocs/docs/options.md
+++ b/docs/mkDocs/docs/options.md
@@ -267,10 +267,10 @@ not all functions can be reflected, for the same reasons as some of your own fun
  for instance).
 
 If the reflection of these happen to need the reflection of private variables inside those modules, you can also request their reflection
-with another `reflect` annotation with the _fully-qualified_ name of the private variable to reflect, i.e. something like:
+with a `private-reflect` annotation with the _fully-qualified_ name of the private variable to reflect, i.e. something like:
 
 ```
-{-@ reflect MyMod.privFn @-}
+{-@ private-reflect MyMod.privFn @-}
 ```
 
 Note: reflection of private variables only work if these variables occur in the definition of other variables that could already be reflected.

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -236,6 +236,7 @@ import GHC.Core                       as Ghc
     , Expr(App, Case, Cast, Coercion, Lam, Let, Lit, Tick, Type, Var)
     , Unfolding(CoreUnfolding, DFunUnfolding, uf_tmpl)
     , bindersOf
+    , bindersOfBinds
     , cmpAlt
     , collectArgs
     , collectBinders

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -488,7 +488,9 @@ reflectedVars spec cbs = fst <$> xDefs
   where
     xDefs              = Mb.mapMaybe (`GM.findVarDef` cbs) reflSyms
     reflSyms =
-      val <$> S.toList (Ms.reflects spec) ++ S.toList (Ms.privateReflects spec)
+      val <$>
+        map (fmap getLHNameSymbol) (S.toList (Ms.reflects spec)) ++
+        S.toList (Ms.privateReflects spec)
 
 measureVars :: Ms.BareSpec -> [Ghc.CoreBind] -> [Ghc.Var]
 measureVars spec cbs = fst <$> xDefs
@@ -723,7 +725,8 @@ makeSpecRefl cfg src specs env name sig tycEnv = do
     rflSyms      = S.map val rflLocSyms
     lmap         = Bare.reLMap env
     notInReflOnes (_, a) = not $
-      a `S.member` Ms.reflects mySpec || a `S.member` Ms.privateReflects mySpec
+      a `S.member` (S.map (fmap getLHNameSymbol) (Ms.reflects mySpec)) ||
+      a `S.member` Ms.privateReflects mySpec
     anyNonReflFn = L.find notInReflOnes (Ms.asmReflectSigs mySpec)
 
 isReflectVar :: S.HashSet F.Symbol -> Ghc.Var -> Bool

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -487,7 +487,8 @@ reflectedVars :: Ms.BareSpec -> [Ghc.CoreBind] -> [Ghc.Var]
 reflectedVars spec cbs = fst <$> xDefs
   where
     xDefs              = Mb.mapMaybe (`GM.findVarDef` cbs) reflSyms
-    reflSyms           = val <$> S.toList (Ms.reflects spec)
+    reflSyms =
+      val <$> S.toList (Ms.reflects spec) ++ S.toList (Ms.privateReflects spec)
 
 measureVars :: Ms.BareSpec -> [Ghc.CoreBind] -> [Ghc.Var]
 measureVars spec cbs = fst <$> xDefs
@@ -721,7 +722,8 @@ makeSpecRefl cfg src specs env name sig tycEnv = do
     rflLocSyms   = Bare.getLocReflects (Just env) specs
     rflSyms      = S.map val rflLocSyms
     lmap         = Bare.reLMap env
-    notInReflOnes (_, a) = not $ a `S.member` Ms.reflects mySpec
+    notInReflOnes (_, a) = not $
+      a `S.member` Ms.reflects mySpec || a `S.member` Ms.privateReflects mySpec
     anyNonReflFn = L.find notInReflOnes (Ms.asmReflectSigs mySpec)
 
 isReflectVar :: S.HashSet F.Symbol -> Ghc.Var -> Bool

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -484,19 +484,22 @@ specTypeCons         = foldRType tc []
     tc acc _         = acc
 
 reflectedVars :: Ms.BareSpec -> [Ghc.CoreBind] -> [Ghc.Var]
-reflectedVars spec cbs = fst <$> xDefs
+reflectedVars spec cbs =
+    filter
+      (isReflSym . makeGHCLHNameLocatedFromId)
+      (Ghc.bindersOfBinds cbs)
   where
-    xDefs              = Mb.mapMaybe (`GM.findVarDef` cbs) reflSyms
-    reflSyms =
-      val <$>
-        map (fmap getLHNameSymbol) (S.toList (Ms.reflects spec)) ++
-        S.toList (Ms.privateReflects spec)
+    isReflSym x =
+      S.member x (Ms.reflects spec) ||
+      S.member (fmap getLHNameSymbol x) (Ms.privateReflects spec)
 
 measureVars :: Ms.BareSpec -> [Ghc.CoreBind] -> [Ghc.Var]
-measureVars spec cbs = fst <$> xDefs
+measureVars spec cbs =
+    filter
+      ((`S.member` measureSyms) . makeGHCLHNameLocatedFromId)
+      (Ghc.bindersOfBinds cbs)
   where
-    xDefs              = Mb.mapMaybe (`GM.findVarDef` cbs) measureSyms
-    measureSyms        = val <$> S.toList (Ms.hmeas spec)
+    measureSyms = Ms.hmeas spec
 
 ------------------------------------------------------------------------------------------
 makeSpecVars :: Config -> GhcSrc -> Ms.BareSpec -> Bare.Env -> Bare.MeasEnv
@@ -848,7 +851,12 @@ makeInlSigs env rtEnv
 makeMsrSigs :: Bare.Env -> BareRTEnv -> [(ModName, Ms.BareSpec)] -> [(Ghc.Var, LocSpecType)]
 makeMsrSigs env rtEnv
   = makeLiftedSigs rtEnv (CoreToLogic.inlineSpecType (typeclass (getConfig env)))
-  . makeFromSet "hmeas" Ms.hmeas env
+  . concatMap (map (lookupFunctionId env) . S.toList . Ms.hmeas . snd)
+
+lookupFunctionId :: Bare.Env -> Located LHName -> Ghc.Id
+lookupFunctionId env x =
+    either (panic (Just $ GM.fSrcSpan x) "function not found") id $
+    Bare.lookupGhcIdLHName env x
 
 makeLiftedSigs :: BareRTEnv -> (Ghc.Var -> SpecType) -> [Ghc.Var] -> [(Ghc.Var, LocSpecType)]
 makeLiftedSigs rtEnv f xs
@@ -1119,18 +1127,12 @@ makeMeasureInvariants :: Bare.Env -> ModName -> GhcSpecSig -> Ms.BareSpec
 makeMeasureInvariants env name sig mySpec
   = Mb.catMaybes <$>
     unzip (measureTypeToInv env name <$> [(x, (y, ty)) | x <- xs, (y, ty) <- sigs
-                                         , isSymbolOfVar (val x) y ])
+                                         , x == makeGHCLHNameLocatedFromId y ])
   where
     sigs = gsTySigs sig
     xs   = S.toList (Ms.hmeas  mySpec)
 
-isSymbolOfVar :: Symbol -> Ghc.Var -> Bool
-isSymbolOfVar x v = x == symbol' v
-  where
-    symbol' :: Ghc.Var -> Symbol
-    symbol' = GM.dropModuleNames . symbol . Ghc.getName
-
-measureTypeToInv :: Bare.Env -> ModName -> (LocSymbol, (Ghc.Var, LocSpecType)) -> ((Maybe Ghc.Var, LocSpecType), Maybe UnSortedExpr)
+measureTypeToInv :: Bare.Env -> ModName -> (Located LHName, (Ghc.Var, LocSpecType)) -> ((Maybe Ghc.Var, LocSpecType), Maybe UnSortedExpr)
 measureTypeToInv env name (x, (v, t))
   = notracepp "measureTypeToInv" ((Just v, t {val = Bare.qualifyTop env name (F.loc x) mtype}), usorted)
   where
@@ -1140,7 +1142,11 @@ measureTypeToInv env name (x, (v, t))
     res  = ty_res   trep
     z    = last args
     tz   = last rts
-    usorted = if isSimpleADT tz then Nothing else first (:[]) <$> mkReft (dummyLoc $ F.symbol v) z tz res
+    usorted =
+      if isSimpleADT tz then
+        Nothing
+      else
+        first (:[]) <$> mkReft (dummyLoc $ val $ makeGHCLHNameLocatedFromId v) z tz res
     mtype
       | null rts
       = uError $ ErrHMeas (GM.sourcePosSrcSpan $ loc t) (pprint x) "Measure has no arguments!"
@@ -1149,18 +1155,18 @@ measureTypeToInv env name (x, (v, t))
     isSimpleADT (RApp _ ts _ _) = all isRVar ts
     isSimpleADT _               = False
 
-mkInvariant :: LocSymbol -> Symbol -> SpecType -> SpecType -> SpecType
+mkInvariant :: Located LHName -> Symbol -> SpecType -> SpecType -> SpecType
 mkInvariant x z t tr = strengthen (top <$> t) (MkUReft reft' mempty)
       where
         reft' = Mb.maybe mempty Reft mreft
         mreft = mkReft x z t tr
 
 
-mkReft :: LocSymbol -> Symbol -> SpecType -> SpecType -> Maybe (Symbol, Expr)
+mkReft :: Located LHName -> Symbol -> SpecType -> SpecType -> Maybe (Symbol, Expr)
 mkReft x z _t tr
   | Just q <- stripRTypeBase tr
   = let Reft (v, p) = toReft q
-        su          = mkSubst [(v, mkEApp x [EVar v]), (z,EVar v)]
+        su          = mkSubst [(v, mkEApp (fmap getLHNameSymbol x) [EVar v]), (z,EVar v)]
         -- p'          = pAnd $ filter (\e -> z `notElem` syms e) $ conjuncts p
     in  Just (v, subst su p)
 mkReft _ _ _ _

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -848,7 +848,7 @@ makeMthSigs measEnv = [ (v, t) | (_, v, t) <- Bare.meMethods measEnv ]
 makeInlSigs :: Bare.Env -> BareRTEnv -> [(ModName, Ms.BareSpec)] -> [(Ghc.Var, LocSpecType)]
 makeInlSigs env rtEnv
   = makeLiftedSigs rtEnv (CoreToLogic.inlineSpecType (typeclass (getConfig env)))
-  . makeFromSet "hinlines" Ms.inlines env
+  . concatMap (map (lookupFunctionId env) . S.toList . Ms.inlines . snd)
 
 makeMsrSigs :: Bare.Env -> BareRTEnv -> [(ModName, Ms.BareSpec)] -> [(Ghc.Var, LocSpecType)]
 makeMsrSigs env rtEnv

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -869,12 +869,6 @@ makeLiftedSigs rtEnv f xs
   where
     expand   = Bare.specExpandType rtEnv
 
-makeFromSet :: String -> (Ms.BareSpec -> S.HashSet LocSymbol) -> Bare.Env -> [(ModName, Ms.BareSpec)]
-            -> [Ghc.Var]
-makeFromSet msg f env specs = concat [ mk n xs | (n, s) <- specs, let xs = S.toList (f s)]
-  where
-    mk name                 = Mb.mapMaybe (Bare.maybeResolveSym env name msg)
-
 makeTySigs :: Bare.Env -> Bare.SigEnv -> ModName -> Ms.BareSpec
            -> Bare.Lookup [(Ghc.Var, LocSpecType, Maybe [Located F.Expr])]
 makeTySigs env sigEnv name spec = do

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -22,7 +22,6 @@ module Language.Haskell.Liquid.Bare (
   , saveLiftedSpec
   ) where
 
-import           Prelude                                    hiding (error)
 import           Control.Monad                              (forM, mplus, when)
 import qualified Control.Exception                          as Ex
 import qualified Data.Binary                                as B
@@ -707,9 +706,12 @@ makeSpecRefl cfg src specs env name sig tycEnv = do
   case anyNonReflFn of
     Just (actSym , preSym) ->
       let preSym' = show (val preSym) in
-      let errorMsg = preSym' ++ " must be reflected first using {-@ reflect " ++ preSym' ++ " @-}" in
-      let error = ErrHMeas (GM.sourcePosSrcSpan $ loc actSym) (pprint $ val actSym) (text errorMsg) :: Error
-      in Ex.throw error
+      let errorMsg = preSym' ++ " must be reflected first using {-@ reflect " ++ preSym' ++ " @-}"
+      in Ex.throw
+           (ErrHMeas
+             (GM.sourcePosSrcSpan $ loc actSym)
+             (pprint $ val actSym)
+             (text errorMsg) :: Error)
     Nothing -> return SpRefl
       { gsLogicMap   = lmap
       , gsAutoInst   = autoInst

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -179,7 +179,8 @@ getReflectDefs src sig spec env modName =
   searchInTransitiveClosure symsToResolve initialDefinedMap []
   where
     sigs                    = gsTySigs sig
-    symsToResolve           = S.toList (Ms.reflects spec)
+    symsToResolve =
+      S.toList (Ms.reflects spec) ++ S.toList (Ms.privateReflects spec)
     cbs                     = _giCbs src
     initialDefinedMap          = M.empty
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -265,7 +265,7 @@ findVarDefType :: [(Ghc.Id, Ghc.CoreExpr)] -> [(Ghc.Var, LocSpecType)] -> Bare.E
                -> M.HashMap LocSymbol Ghc.Var -> ToReflectName
                -> Maybe (LocSymbol, Maybe SpecType, Ghc.Var, Ghc.CoreExpr)
 findVarDefType cbs sigs env _defs (Left x) =
-  case L.find ((x ==) . makeGHCLHNameLocated . fst) cbs of
+  case L.find ((val x ==) . makeGHCLHNameFromId . fst) cbs of
   -- YL: probably ok even without checking typeclass flag since user cannot
   -- manually reflect internal names
   Just (v, e) ->

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -283,7 +283,6 @@ findVarDefType cbs sigs env _defs (Left x) =
           [ "Symbol exists but is not defined in the current file,"
           , "and no unfolding is available in the interface files"
           ]
-  where
 
 findVarDefType _cbs sigs _env defs (Right x) = do
     var <- M.lookup x defs

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -180,7 +180,7 @@ getReflectDefs src sig spec env modName =
   where
     sigs                    = gsTySigs sig
     symsToResolve =
-      S.toList (Ms.reflects spec) ++ S.toList (Ms.privateReflects spec)
+      map (fmap getLHNameSymbol) (S.toList (Ms.reflects spec)) ++ S.toList (Ms.privateReflects spec)
     cbs                     = _giCbs src
     initialDefinedMap          = M.empty
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -93,7 +93,7 @@ checkBareSpec sp
                                                      , S.fromList fields
                                                      ]
                         ]
-    inlines   = Ms.inlines    sp
+    inlines   = S.map (fmap getLHNameSymbol) (Ms.inlines sp)
     hmeasures = S.map (fmap getLHNameSymbol) (Ms.hmeas sp)
     reflects  = S.map (fmap getLHNameSymbol) (Ms.reflects sp)
     measures  = msName    <$> Ms.measures sp

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -39,6 +39,7 @@ import           Language.Haskell.Liquid.GHC.Play          (getNonPositivesTyCon
 import           Language.Haskell.Liquid.Misc              (condNull, thd5)
 import           Language.Haskell.Liquid.Types.DataDecl
 import           Language.Haskell.Liquid.Types.Errors
+import           Language.Haskell.Liquid.Types.Names
 import           Language.Haskell.Liquid.Types.PredType
 import           Language.Haskell.Liquid.Types.PrettyPrint
 import           Language.Haskell.Liquid.Types.RType
@@ -94,7 +95,7 @@ checkBareSpec sp
                         ]
     inlines   = Ms.inlines    sp
     hmeasures = Ms.hmeas      sp
-    reflects  = Ms.reflects   sp
+    reflects  = S.map (fmap getLHNameSymbol) (Ms.reflects sp)
     measures  = msName    <$> Ms.measures sp
     fields    = concatMap dataDeclFields (Ms.dataDecls sp)
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -94,7 +94,7 @@ checkBareSpec sp
                                                      ]
                         ]
     inlines   = Ms.inlines    sp
-    hmeasures = Ms.hmeas      sp
+    hmeasures = S.map (fmap getLHNameSymbol) (Ms.hmeas sp)
     reflects  = S.map (fmap getLHNameSymbol) (Ms.reflects sp)
     measures  = msName    <$> Ms.measures sp
     fields    = concatMap dataDeclFields (Ms.dataDecls sp)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -379,6 +379,7 @@ getLocReflects mbEnv = S.unions . fmap (uncurry $ names mbEnv) . M.toList
     names Nothing _ modSpec = unqualified modSpec
     unqualified modSpec = S.unions
       [ Ms.reflects modSpec
+      , Ms.privateReflects modSpec
       , S.fromList (snd <$> Ms.asmReflectSigs modSpec)
       , S.fromList (fst <$> Ms.asmReflectSigs modSpec)
       , Ms.inlines modSpec, Ms.hmeas modSpec

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -380,8 +380,8 @@ getLocReflects mbEnv = S.unions . fmap (uncurry $ names mbEnv) . M.toList
     unqualified modSpec = S.unions
       [ S.map (fmap getLHNameSymbol) (Ms.reflects modSpec)
       , Ms.privateReflects modSpec
-      , S.fromList (snd <$> Ms.asmReflectSigs modSpec)
-      , S.fromList (fst <$> Ms.asmReflectSigs modSpec)
+      , S.fromList (fmap getLHNameSymbol . snd <$> Ms.asmReflectSigs modSpec)
+      , S.fromList (fmap getLHNameSymbol . fst <$> Ms.asmReflectSigs modSpec)
       , Ms.inlines modSpec, Ms.hmeas modSpec
       ]
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -378,7 +378,7 @@ getLocReflects mbEnv = S.unions . fmap (uncurry $ names mbEnv) . M.toList
     names (Just env) modName modSpec = Bare.qualifyLocSymbolTop env modName `S.map` unqualified modSpec
     names Nothing _ modSpec = unqualified modSpec
     unqualified modSpec = S.unions
-      [ Ms.reflects modSpec
+      [ S.map (fmap getLHNameSymbol) (Ms.reflects modSpec)
       , Ms.privateReflects modSpec
       , S.fromList (snd <$> Ms.asmReflectSigs modSpec)
       , S.fromList (fst <$> Ms.asmReflectSigs modSpec)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
@@ -60,8 +60,8 @@ compileClasses src env (name, spec) rest =
     { dataDecls = clsDecls
     , reflects  = F.notracepp "reflects " $ S.fromList
                     (  fmap
-                        ( fmap GM.dropModuleNames
-                        . GM.namedLocSymbol
+                        ( fmap (updateLHNameSymbol GM.dropModuleNames)
+                        . makeGHCLHNameLocatedFromId
                         . Ghc.instanceDFunId
                         . fst
                         )
@@ -87,7 +87,7 @@ compileClasses src env (name, spec) rest =
     merge sig v = case v of
       Nothing -> Just [sig]
       Just vs -> Just (sig : vs)
-  methods = [ GM.namedLocSymbol x | (_, xs) <- instmethods, x <- xs ]
+  methods = [ makeGHCLHNameLocatedFromId x | (_, xs) <- instmethods, x <- xs ]
       -- instance methods
 
   mkSymbol x

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -657,17 +657,6 @@ ignoreCoreBinds vs cbs
     go (Rec xes)      = [Rec (filter ((`notElem` vs) . fst) xes)]
 
 
-findVarDef :: Symbol -> [CoreBind] -> Maybe (Var, CoreExpr)
-findVarDef sym cbs = case xCbs of
-                     (NonRec v def   : _ ) -> Just (v, def)
-                     (Rec [(v, def)] : _ ) -> Just (v, def)
-                     _                     -> Nothing
-  where
-    xCbs            = [ cb | cb <- concatMap unRec cbs, sym `elem` coreBindSymbols cb ]
-    unRec (Rec xes) = [NonRec x es | (x,es) <- xes]
-    unRec nonRec    = [nonRec]
-
-
 findVarDefMethod :: Symbol -> [CoreBind] -> Maybe (Var, CoreExpr)
 findVarDefMethod sym cbs =
   case rcbs  of

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -863,7 +863,7 @@ data Pspec ty ctor
   | Reflect (Located LHName)                              -- ^ 'reflect' annotation; reflect Haskell binder as function in logic
   | PrivateReflect LocSymbol                              -- ^ 'private-reflect' annotation
   | OpaqueReflect (Located LHName)                        -- ^ 'opaque-reflect' annotation
-  | Inline  LocSymbol                                     -- ^ 'inline' annotation;  inline (non-recursive) binder as an alias
+  | Inline  (Located LHName)                              -- ^ 'inline' annotation;  inline (non-recursive) binder as an alias
   | Ignore  (Located LHName)                              -- ^ 'ignore' annotation; skip all checks inside this binder
   | ASize   (Located LHName)                              -- ^ 'autosize' annotation; automatically generate size metric for this type
   | HBound  LocSymbol                                     -- ^ 'bound' annotation; lift Haskell binder as an abstract-refinement "bound"
@@ -1117,7 +1117,7 @@ specP
     <|> (reserved "infixl"        >> fmap BFix    infixlP  )
     <|> (reserved "infixr"        >> fmap BFix    infixrP  )
     <|> (reserved "infix"         >> fmap BFix    infixP   )
-    <|> fallbackSpecP "inline"      (fmap Inline  inlineP  )
+    <|> fallbackSpecP "inline"      (fmap Inline locBinderLHNameP)
     <|> fallbackSpecP "ignore"      (fmap Ignore  locBinderLHNameP)
 
     <|> fallbackSpecP "bound"       (fmap PBound  boundP
@@ -1184,9 +1184,6 @@ axiomP = locBinderP
 
 hboundP :: Parser LocSymbol
 hboundP = locBinderP
-
-inlineP :: Parser LocSymbol
-inlineP = locBinderP
 
 datavarianceP :: Parser (Located LHName, [Variance])
 datavarianceP = liftM2 (,) (locUpperIdLHNameP LHTcName) (many varianceP)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -866,7 +866,6 @@ data Pspec ty ctor
   | Inline  (Located LHName)                              -- ^ 'inline' annotation;  inline (non-recursive) binder as an alias
   | Ignore  (Located LHName)                              -- ^ 'ignore' annotation; skip all checks inside this binder
   | ASize   (Located LHName)                              -- ^ 'autosize' annotation; automatically generate size metric for this type
-  | HBound  LocSymbol                                     -- ^ 'bound' annotation; lift Haskell binder as an abstract-refinement "bound"
   | PBound  (Bound ty Expr)                               -- ^ 'bound' definition
   | Pragma  (Located String)                              -- ^ 'LIQUID' pragma, used to save configuration options in source files
   | CMeas   (Measure ty ())                               -- ^ 'class measure' definition
@@ -957,8 +956,6 @@ ppPspec k (Inline  lx)
   = "inline" <+> pprintTidy k (val lx)
 ppPspec k (Ignore  lx)
   = "ignore" <+> pprintTidy k (val lx)
-ppPspec k (HBound  lx)
-  = "bound" <+> pprintTidy k (val lx)
 ppPspec k (ASize   lx)
   = "autosize" <+> pprintTidy k (val lx)
 ppPspec k (PBound  bnd)
@@ -1015,7 +1012,6 @@ ppPspec k (AssmRel (lxl, lxr, tl, tr, q, p))
   -- show (Axiom  _) = "Axiom"
   show (Reflect _) = "Reflect"
   show (HMeas  _) = "HMeas"
-  show (HBound _) = "HBound"
   show (Inline _) = "Inline"
   show (Pragma _) = "Pragma"
   show (CMeas  _) = "CMeas"
@@ -1092,7 +1088,6 @@ mkSpec name xs         = (name,) $ qualifySpec (symbol name) Measure.Spec
   , Measure.inlines    = S.fromList [s | Inline s <- xs]
   , Measure.ignores    = S.fromList [s | Ignore s <- xs]
   , Measure.autosize   = S.fromList [s | ASize  s <- xs]
-  , Measure.hbounds    = S.fromList [s | HBound s <- xs]
   , Measure.axeqs      = []
   }
 
@@ -1120,8 +1115,7 @@ specP
     <|> fallbackSpecP "inline"      (fmap Inline locBinderLHNameP)
     <|> fallbackSpecP "ignore"      (fmap Ignore  locBinderLHNameP)
 
-    <|> fallbackSpecP "bound"       (fmap PBound  boundP
-                                 <|> fmap HBound  hboundP  )
+    <|> fallbackSpecP "bound"       (fmap PBound  boundP)
     <|> (reserved "class"
          >> ((reserved "measure"  >> fmap CMeas  cMeasureP )
          <|> fmap Class  classP                            ))
@@ -1181,9 +1175,6 @@ rewriteWithP = (,) <$> locBinderLHNameP <*> brackets (sepBy1 locBinderLHNameP co
 
 axiomP :: Parser LocSymbol
 axiomP = locBinderP
-
-hboundP :: Parser LocSymbol
-hboundP = locBinderP
 
 datavarianceP :: Parser (Located LHName, [Variance])
 datavarianceP = liftM2 (,) (locUpperIdLHNameP LHTcName) (many varianceP)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -837,7 +837,7 @@ type BPspec = Pspec LocBareType LocSymbol
 data Pspec ty ctor
   = Meas    (Measure ty ctor)                             -- ^ 'measure' definition
   | Assm    (Located LHName, ty)                          -- ^ 'assume' signature (unchecked)
-  | AssmReflect (LocSymbol, LocSymbol)                    -- ^ 'assume reflects' signature (unchecked)
+  | AssmReflect (Located LHName, Located LHName)          -- ^ 'assume reflects' signature (unchecked)
   | Asrt    (Located LHName, ty)                          -- ^ 'assert' signature (checked)
   | LAsrt   (LocSymbol, ty)                               -- ^ 'local' assertion -- TODO RJ: what is this
   | Asrts   ([Located LHName], (ty, Maybe [Located Expr]))     -- ^ sym0, ..., symn :: ty / [m0,..., mn]
@@ -1222,9 +1222,9 @@ tyBindLHNameP = do
     return (x, t)
 
 -- | Parses a loc symbol.
-assmReflectBindP :: Parser (LocSymbol, LocSymbol)
+assmReflectBindP :: Parser (Located LHName, Located LHName)
 assmReflectBindP =
-  (,) <$> locBinderP <* reservedOp "as" <*> locBinderP
+  (,) <$> locBinderLHNameP <* reservedOp "as" <*> locBinderLHNameP
 
 termBareTypeP :: Parser (Located BareType, Maybe [Located Expr])
 termBareTypeP = do

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -860,7 +860,7 @@ data Pspec ty ctor
   | Rewritewith (Located LHName, [Located LHName])        -- ^ 'rewritewith' annotation, the first binder is using the rewrite rules of the second list,
   | Insts   (Located LHName)                              -- ^ 'auto-inst' or 'ple' annotation; use ple locally on binder
   | HMeas   LocSymbol                                     -- ^ 'measure' annotation; lift Haskell binder as measure
-  | Reflect LocSymbol                                     -- ^ 'reflect' annotation; reflect Haskell binder as function in logic
+  | Reflect (Located LHName)                              -- ^ 'reflect' annotation; reflect Haskell binder as function in logic
   | PrivateReflect LocSymbol                              -- ^ 'private-reflect' annotation
   | OpaqueReflect LocSymbol                               -- ^ 'opaque-reflect' annotation
   | Inline  LocSymbol                                     -- ^ 'inline' annotation;  inline (non-recursive) binder as an alias
@@ -1107,8 +1107,8 @@ specP
     <|> (reserved "local"         >> fmap LAsrt   tyBindP  )
 
     -- TODO: These next two are synonyms, kill one
-    <|> fallbackSpecP "axiomatize"  (fmap Reflect axiomP   )
-    <|> fallbackSpecP "reflect"     (fmap Reflect axiomP   )
+    <|> fallbackSpecP "axiomatize"  (fmap Reflect locBinderLHNameP)
+    <|> fallbackSpecP "reflect"     (fmap Reflect locBinderLHNameP)
     <|> (reserved "private-reflect" >> fmap PrivateReflect axiomP  )
     <|> (reserved "opaque-reflect" >> fmap OpaqueReflect axiomP  )
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -861,6 +861,7 @@ data Pspec ty ctor
   | Insts   (Located LHName)                              -- ^ 'auto-inst' or 'ple' annotation; use ple locally on binder
   | HMeas   LocSymbol                                     -- ^ 'measure' annotation; lift Haskell binder as measure
   | Reflect LocSymbol                                     -- ^ 'reflect' annotation; reflect Haskell binder as function in logic
+  | PrivateReflect LocSymbol                              -- ^ 'private-reflect' annotation
   | OpaqueReflect LocSymbol                               -- ^ 'opaque-reflect' annotation
   | Inline  LocSymbol                                     -- ^ 'inline' annotation;  inline (non-recursive) binder as an alias
   | Ignore  (Located LHName)                              -- ^ 'ignore' annotation; skip all checks inside this binder
@@ -948,6 +949,8 @@ ppPspec k (HMeas   lx)
   = "measure" <+> pprintTidy k (val lx)
 ppPspec k (Reflect lx)
   = "reflect" <+> pprintTidy k (val lx)
+ppPspec k (PrivateReflect lx)
+  = "private-reflect" <+> pprintTidy k (val lx)
 ppPspec k (OpaqueReflect lx)
   = "opaque-reflect" <+> pprintTidy k (val lx)
 ppPspec k (Inline  lx)
@@ -1083,6 +1086,7 @@ mkSpec name xs         = (name,) $ qualifySpec (symbol name) Measure.Spec
   , Measure.rewriteWith = M.fromList [s | Rewritewith s <- xs]
   , Measure.bounds     = M.fromList [(bname i, i) | PBound i <- xs]
   , Measure.reflects   = S.fromList [s | Reflect s <- xs]
+  , Measure.privateReflects = S.fromList [s | PrivateReflect s <- xs]
   , Measure.opaqueReflects = S.fromList [s | OpaqueReflect s <- xs]
   , Measure.hmeas      = S.fromList [s | HMeas  s <- xs]
   , Measure.inlines    = S.fromList [s | Inline s <- xs]
@@ -1105,6 +1109,7 @@ specP
     -- TODO: These next two are synonyms, kill one
     <|> fallbackSpecP "axiomatize"  (fmap Reflect axiomP   )
     <|> fallbackSpecP "reflect"     (fmap Reflect axiomP   )
+    <|> (reserved "private-reflect" >> fmap PrivateReflect axiomP  )
     <|> (reserved "opaque-reflect" >> fmap OpaqueReflect axiomP  )
 
     <|> fallbackSpecP "measure"    hmeasureP

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -1274,14 +1274,14 @@ rtAliasP f bodyP
 hmeasureP :: Parser BPspec
 hmeasureP = do
   setLayout
-  (do b <- try (locBinderP <* reservedOp "::")
-      ty <- located genBareTypeP
-      popLayout >> popLayout
-      eqns <- block $ try $ measureDefP (rawBodyP <|> tyBodyP ty)
-      return (Meas $ Measure.mkM b ty eqns MsMeasure mempty)
+  do b <- try (locBinderP <* reservedOp "::")
+     ty <- located genBareTypeP
+     popLayout >> popLayout
+     eqns <- block $ try $ measureDefP (rawBodyP <|> tyBodyP ty)
+     return (Meas $ Measure.mkM b ty eqns MsMeasure mempty)
     <|>
    do b <- locBinderLHNameP
-      popLayout >> popLayout >> return (HMeas b))
+      popLayout >> popLayout >> return (HMeas b)
 
 measureP :: Parser (Measure (Located BareType) LocSymbol)
 measureP = do

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -862,7 +862,7 @@ data Pspec ty ctor
   | HMeas   LocSymbol                                     -- ^ 'measure' annotation; lift Haskell binder as measure
   | Reflect (Located LHName)                              -- ^ 'reflect' annotation; reflect Haskell binder as function in logic
   | PrivateReflect LocSymbol                              -- ^ 'private-reflect' annotation
-  | OpaqueReflect LocSymbol                               -- ^ 'opaque-reflect' annotation
+  | OpaqueReflect (Located LHName)                        -- ^ 'opaque-reflect' annotation
   | Inline  LocSymbol                                     -- ^ 'inline' annotation;  inline (non-recursive) binder as an alias
   | Ignore  (Located LHName)                              -- ^ 'ignore' annotation; skip all checks inside this binder
   | ASize   (Located LHName)                              -- ^ 'autosize' annotation; automatically generate size metric for this type
@@ -1110,7 +1110,7 @@ specP
     <|> fallbackSpecP "axiomatize"  (fmap Reflect locBinderLHNameP)
     <|> fallbackSpecP "reflect"     (fmap Reflect locBinderLHNameP)
     <|> (reserved "private-reflect" >> fmap PrivateReflect axiomP  )
-    <|> (reserved "opaque-reflect" >> fmap OpaqueReflect axiomP  )
+    <|> (reserved "opaque-reflect" >> fmap OpaqueReflect locBinderLHNameP  )
 
     <|> fallbackSpecP "measure"    hmeasureP
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
@@ -14,6 +14,7 @@ module Language.Haskell.Liquid.Types.Names
   , getLHNameResolved
   , getLHNameSymbol
   , makeGHCLHName
+  , makeGHCLHNameFromId
   , makeGHCLHNameLocated
   , makeGHCLHNameLocatedFromId
   , makeLocalLHName
@@ -177,6 +178,14 @@ makeResolvedLHName = LHNResolved
 
 makeGHCLHName :: GHC.Name -> Symbol -> LHName
 makeGHCLHName n s = makeResolvedLHName (LHRGHC n) s
+
+makeGHCLHNameFromId :: GHC.Id -> LHName
+makeGHCLHNameFromId x =
+    let n = case GHC.idDetails x of
+              GHC.DataConWrapId dc -> GHC.getName dc
+              GHC.DataConWorkId dc -> GHC.getName dc
+              _ -> GHC.getName x
+     in makeGHCLHName n (symbol n)
 
 makeLocalLHName :: Symbol -> LHName
 makeLocalLHName s = LHNResolved (LHRLocal s) s

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
@@ -82,7 +82,26 @@ data LHName
       -- unresolved names.
       LHNResolved !LHResolvedName !Symbol
     | LHNUnresolved !LHNameSpace !Symbol
-  deriving (Data, Eq, Generic, Ord)
+  deriving (Data, Generic)
+
+-- | An Eq instance that ignores the Symbol in resolved names
+instance Eq LHName where
+  LHNResolved n0 _ == LHNResolved n1 _ = n0 == n1
+  LHNUnresolved ns0 s0 == LHNUnresolved ns1 s1 = ns0 == ns1 && s0 == s1
+  _ == _ = False
+
+-- | An Ord instance that ignores the Symbol in resolved names
+instance Ord LHName where
+  compare (LHNResolved n0 _) (LHNResolved n1 _) = compare n0 n1
+  compare (LHNUnresolved ns0 s0) (LHNUnresolved ns1 s1) =
+    compare (ns0, s0) (ns1, s1)
+  compare LHNResolved{} _ = LT
+  compare LHNUnresolved{} _ = GT
+
+-- | A Hashable instance that ignores the Symbol in resolved names
+instance Hashable LHName where
+  hashWithSalt s (LHNResolved n _) = hashWithSalt s n
+  hashWithSalt s (LHNUnresolved ns sym) = s `hashWithSalt` ns `hashWithSalt` sym
 
 data LHNameSpace
     = LHTcName
@@ -115,7 +134,6 @@ instance Hashable LHResolvedName where
   hashWithSalt s (LHRLocal n) = s `hashWithSalt` (2::Int) `hashWithSalt` n
   hashWithSalt s (LHRIndex w) = s `hashWithSalt` (3::Int) `hashWithSalt` w
 
-instance Hashable LHName
 instance Hashable LogicName where
   hashWithSalt s (LogicName sym m) =
         s `hashWithSalt` sym

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -397,7 +397,7 @@ data Spec ty bndr  = Spec
   , fails      :: !(S.HashSet (F.Located LHName))                     -- ^ These Functions should be unsafe
   , reflects   :: !(S.HashSet (F.Located LHName))                     -- ^ Binders to reflect
   , privateReflects :: !(S.HashSet F.LocSymbol)                       -- ^ Private binders to reflect
-  , opaqueReflects :: !(S.HashSet F.LocSymbol)                        -- ^ Binders to opaque-reflect
+  , opaqueReflects :: !(S.HashSet (F.Located LHName))                 -- ^ Binders to opaque-reflect
   , autois     :: !(S.HashSet (F.Located LHName))                     -- ^ Automatically instantiate axioms in these Functions
   , hmeas      :: !(S.HashSet F.LocSymbol)                            -- ^ Binders to turn into measures using haskell definitions
   , hbounds    :: !(S.HashSet F.LocSymbol)                            -- ^ Binders to turn into bounds using haskell definitions

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -399,7 +399,7 @@ data Spec ty bndr  = Spec
   , privateReflects :: !(S.HashSet F.LocSymbol)                       -- ^ Private binders to reflect
   , opaqueReflects :: !(S.HashSet (F.Located LHName))                 -- ^ Binders to opaque-reflect
   , autois     :: !(S.HashSet (F.Located LHName))                     -- ^ Automatically instantiate axioms in these Functions
-  , hmeas      :: !(S.HashSet F.LocSymbol)                            -- ^ Binders to turn into measures using haskell definitions
+  , hmeas      :: !(S.HashSet (F.Located LHName))                     -- ^ Binders to turn into measures using haskell definitions
   , hbounds    :: !(S.HashSet F.LocSymbol)                            -- ^ Binders to turn into bounds using haskell definitions
   , inlines    :: !(S.HashSet F.LocSymbol)                            -- ^ Binders to turn into logic inline using haskell definitions
   , ignores    :: !(S.HashSet (F.Located LHName))                            -- ^ Binders to ignore during checking; that is DON't check the corebind.

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -396,6 +396,7 @@ data Spec ty bndr  = Spec
   , rewriteWith :: !(M.HashMap (F.Located LHName) [F.Located LHName]) -- ^ Definitions using rewrite rules
   , fails      :: !(S.HashSet (F.Located LHName))                     -- ^ These Functions should be unsafe
   , reflects   :: !(S.HashSet F.LocSymbol)                            -- ^ Binders to reflect
+  , privateReflects :: !(S.HashSet F.LocSymbol)                       -- ^ Private binders to reflect
   , opaqueReflects :: !(S.HashSet F.LocSymbol)                        -- ^ Binders to opaque-reflect
   , autois     :: !(S.HashSet (F.Located LHName))                     -- ^ Automatically instantiate axioms in these Functions
   , hmeas      :: !(S.HashSet F.LocSymbol)                            -- ^ Binders to turn into measures using haskell definitions
@@ -464,6 +465,7 @@ instance Semigroup (Spec ty bndr) where
            , rewriteWith = M.union  (rewriteWith s1)  (rewriteWith s2)
            , fails      = S.union   (fails    s1)  (fails    s2)
            , reflects   = S.union   (reflects s1)  (reflects s2)
+           , privateReflects = S.union (privateReflects s1) (privateReflects s2)
            , opaqueReflects   = S.union   (opaqueReflects s1)  (opaqueReflects s2)
            , hmeas      = S.union   (hmeas    s1)  (hmeas    s2)
            , hbounds    = S.union   (hbounds  s1)  (hbounds  s2)
@@ -498,6 +500,7 @@ instance Monoid (Spec ty bndr) where
            , autois     = S.empty
            , hmeas      = S.empty
            , reflects   = S.empty
+           , privateReflects = S.empty
            , opaqueReflects = S.empty
            , hbounds    = S.empty
            , inlines    = S.empty
@@ -821,6 +824,7 @@ unsafeFromLiftedSpec a = Spec
   , rewrites   = mempty
   , rewriteWith = mempty
   , reflects   = mempty
+  , privateReflects = mempty
   , opaqueReflects   = mempty
   , autois     = liftedAutois a
   , hmeas      = mempty

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -395,7 +395,7 @@ data Spec ty bndr  = Spec
   , rewrites    :: !(S.HashSet (F.Located LHName))                    -- ^ Theorems turned into rewrite rules
   , rewriteWith :: !(M.HashMap (F.Located LHName) [F.Located LHName]) -- ^ Definitions using rewrite rules
   , fails      :: !(S.HashSet (F.Located LHName))                     -- ^ These Functions should be unsafe
-  , reflects   :: !(S.HashSet F.LocSymbol)                            -- ^ Binders to reflect
+  , reflects   :: !(S.HashSet (F.Located LHName))                     -- ^ Binders to reflect
   , privateReflects :: !(S.HashSet F.LocSymbol)                       -- ^ Private binders to reflect
   , opaqueReflects :: !(S.HashSet F.LocSymbol)                        -- ^ Binders to opaque-reflect
   , autois     :: !(S.HashSet (F.Located LHName))                     -- ^ Automatically instantiate axioms in these Functions

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -380,7 +380,7 @@ data Spec ty bndr  = Spec
   { measures   :: ![Measure ty bndr]                                  -- ^ User-defined properties for ADTs
   , expSigs    :: ![(F.Symbol, F.Sort)]                               -- ^ Exported logic symbols
   , asmSigs    :: ![(F.Located LHName, ty)]                           -- ^ Assumed (unchecked) types; including reflected signatures
-  , asmReflectSigs :: ![(F.LocSymbol, F.LocSymbol)]                   -- ^ Assume reflects : left is the actual function and right the pretended one
+  , asmReflectSigs :: ![(F.Located LHName, F.Located LHName)]         -- ^ Assume reflects : left is the actual function and right the pretended one
   , sigs       :: ![(F.Located LHName, ty)]                           -- ^ Asserted spec signatures
   , invariants :: ![(Maybe F.LocSymbol, ty)]                          -- ^ Data type invariants; the Maybe is the generating measure
   , ialiases   :: ![(ty, ty)]                                         -- ^ Data type invariants to be checked

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -401,8 +401,8 @@ data Spec ty bndr  = Spec
   , autois     :: !(S.HashSet (F.Located LHName))                     -- ^ Automatically instantiate axioms in these Functions
   , hmeas      :: !(S.HashSet (F.Located LHName))                     -- ^ Binders to turn into measures using haskell definitions
   , hbounds    :: !(S.HashSet F.LocSymbol)                            -- ^ Binders to turn into bounds using haskell definitions
-  , inlines    :: !(S.HashSet F.LocSymbol)                            -- ^ Binders to turn into logic inline using haskell definitions
-  , ignores    :: !(S.HashSet (F.Located LHName))                            -- ^ Binders to ignore during checking; that is DON't check the corebind.
+  , inlines    :: !(S.HashSet (F.Located LHName))                     -- ^ Binders to turn into logic inline using haskell definitions
+  , ignores    :: !(S.HashSet (F.Located LHName))                     -- ^ Binders to ignore during checking; that is DON't check the corebind.
   , autosize   :: !(S.HashSet (F.Located LHName))                     -- ^ Type Constructors that get automatically sizing info
   , pragmas    :: ![F.Located String]                                 -- ^ Command-line configurations passed in through source
   , cmeasures  :: ![Measure ty ()]                                    -- ^ Measures attached to a type-class

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -400,7 +400,6 @@ data Spec ty bndr  = Spec
   , opaqueReflects :: !(S.HashSet (F.Located LHName))                 -- ^ Binders to opaque-reflect
   , autois     :: !(S.HashSet (F.Located LHName))                     -- ^ Automatically instantiate axioms in these Functions
   , hmeas      :: !(S.HashSet (F.Located LHName))                     -- ^ Binders to turn into measures using haskell definitions
-  , hbounds    :: !(S.HashSet F.LocSymbol)                            -- ^ Binders to turn into bounds using haskell definitions
   , inlines    :: !(S.HashSet (F.Located LHName))                     -- ^ Binders to turn into logic inline using haskell definitions
   , ignores    :: !(S.HashSet (F.Located LHName))                     -- ^ Binders to ignore during checking; that is DON't check the corebind.
   , autosize   :: !(S.HashSet (F.Located LHName))                     -- ^ Type Constructors that get automatically sizing info
@@ -468,7 +467,6 @@ instance Semigroup (Spec ty bndr) where
            , privateReflects = S.union (privateReflects s1) (privateReflects s2)
            , opaqueReflects   = S.union   (opaqueReflects s1)  (opaqueReflects s2)
            , hmeas      = S.union   (hmeas    s1)  (hmeas    s2)
-           , hbounds    = S.union   (hbounds  s1)  (hbounds  s2)
            , inlines    = S.union   (inlines  s1)  (inlines  s2)
            , ignores    = S.union   (ignores  s1)  (ignores  s2)
            , autosize   = S.union   (autosize s1)  (autosize s2)
@@ -502,7 +500,6 @@ instance Monoid (Spec ty bndr) where
            , reflects   = S.empty
            , privateReflects = S.empty
            , opaqueReflects = S.empty
-           , hbounds    = S.empty
            , inlines    = S.empty
            , ignores    = S.empty
            , autosize   = S.empty
@@ -535,7 +532,6 @@ instance Monoid (Spec ty bndr) where
 -- * The 'lazy', we don't do termination checking in lifted specs;
 -- * The 'reflects', the reflection has already happened at this point;
 -- * The 'hmeas', we have /already/ turned these into measures at this point;
--- * The 'hbounds', ditto as 'hmeas';
 -- * The 'inlines', ditto as 'hmeas';
 -- * The 'ignores', ditto as 'hmeas';
 -- * The 'pragmas', we can't make any use of this information for lifted specs;
@@ -824,7 +820,6 @@ unsafeFromLiftedSpec a = Spec
   , opaqueReflects   = mempty
   , autois     = liftedAutois a
   , hmeas      = mempty
-  , hbounds    = mempty
   , inlines    = mempty
   , ignores    = mempty
   , autosize   = liftedAutosize a

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -550,8 +550,6 @@ data LiftedSpec = LiftedSpec
     -- ^ Exported logic symbols
   , liftedAsmSigs    :: HashSet (F.Located LHName, LocBareType)
     -- ^ Assumed (unchecked) types; including reflected signatures
-  , liftedAsmReflectSigs    :: HashSet (F.LocSymbol, F.LocSymbol)
-    -- ^ Reflected assumed signatures
   , liftedSigs       :: HashSet (F.Located LHName, LocBareType)
     -- ^ Asserted spec signatures
   , liftedInvariants :: HashSet (Maybe F.LocSymbol, LocBareType)
@@ -602,7 +600,6 @@ emptyLiftedSpec = LiftedSpec
   { liftedMeasures = mempty
   , liftedExpSigs  = mempty
   , liftedAsmSigs  = mempty
-  , liftedAsmReflectSigs  = mempty
   , liftedSigs     = mempty
   , liftedInvariants = mempty
   , liftedIaliases   = mempty
@@ -775,7 +772,6 @@ toLiftedSpec a = LiftedSpec
   { liftedMeasures   = S.fromList . measures $ a
   , liftedExpSigs    = S.fromList . expSigs  $ a
   , liftedAsmSigs    = S.fromList . asmSigs  $ a
-  , liftedAsmReflectSigs = S.fromList . asmReflectSigs  $ a
   , liftedSigs       = S.fromList . sigs     $ a
   , liftedInvariants = S.fromList . invariants $ a
   , liftedIaliases   = S.fromList . ialiases $ a
@@ -806,7 +802,7 @@ unsafeFromLiftedSpec a = Spec
   { measures   = S.toList . liftedMeasures $ a
   , expSigs    = S.toList . liftedExpSigs $ a
   , asmSigs    = S.toList . liftedAsmSigs $ a
-  , asmReflectSigs = S.toList . liftedAsmReflectSigs $ a
+  , asmReflectSigs = mempty
   , sigs       = S.toList . liftedSigs $ a
   , relational = mempty
   , asmRel     = mempty

--- a/liquidhaskell-boot/tests/Parser.hs
+++ b/liquidhaskell-boot/tests/Parser.hs
@@ -103,10 +103,6 @@ testSpecP =
        parseSingleSpec "bound Foo = true" @?==
           "bound Foo forall [] . [] =  true"
 
-    , testCase "bound HBound" $
-       parseSingleSpec "bound step" @?==
-            "bound step"
-
     , testCase "class measure" $
        parseSingleSpec "class measure sz :: forall a. a -> Int" @?==
             "class measure sz :: forall a . lq_tmp$db##0:a -> Int"

--- a/tests/basic/neg/AssmRefl01.hs
+++ b/tests/basic/neg/AssmRefl01.hs
@@ -1,5 +1,5 @@
 -- | Testing when the pretended function is not reflected into the logic
-{-@ LIQUID "--expect-error-containing=\"myfoobar\" must be reflected first using {-@ reflect \"myfoobar\" @-}" @-}
+{-@ LIQUID "--expect-error-containing=myfoobar must be reflected first using {-@ reflect myfoobar @-}" @-}
 {-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--ple"        @-}
 

--- a/tests/basic/neg/AssmRefl02.hs
+++ b/tests/basic/neg/AssmRefl02.hs
@@ -1,5 +1,5 @@
 -- | Duplicate reflection
-{-@ LIQUID "--expect-error-containing=Duplicate reflection of \"foobar\"" @-}
+{-@ LIQUID "--expect-error-containing=Duplicate reflection of foobar" @-}
 {-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--ple"        @-}
 

--- a/tests/basic/neg/AssmRefl04.hs
+++ b/tests/basic/neg/AssmRefl04.hs
@@ -1,5 +1,5 @@
 -- | Duplicate assume reflects
-{-@ LIQUID "--expect-error-containing=Duplicate reflection of \"alwaysFalse\"" @-}
+{-@ LIQUID "--expect-error-containing=Duplicate reflection of alwaysFalse" @-}
 {-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--ple"        @-}
 

--- a/tests/basic/pos/ReflExt02A.hs
+++ b/tests/basic/pos/ReflExt02A.hs
@@ -11,7 +11,7 @@ import ReflExt02B
 
 {-@ reflect ReflExt02B.myAdd @-}
 
-{-@ reflect myAdd @-}
+{-@ reflect ReflExt02A.myAdd @-}
 myAdd :: Int
 myAdd = 12
 

--- a/tests/basic/pos/ReflExt03A.hs
+++ b/tests/basic/pos/ReflExt03A.hs
@@ -8,7 +8,7 @@ module ReflExt03A where
 import ReflExt03B
 
 {-@ reflect f @-}
-{-@ reflect ReflExt03B.myAdd @-}
+{-@ private-reflect ReflExt03B.myAdd @-}
 
 -- 3 * 2 + 2 = 8
 {-@ lemma :: {f 3 2 = 8} @-}

--- a/tests/benchmarks/cse230/src/Week10/State.hs
+++ b/tests/benchmarks/cse230/src/Week10/State.hs
@@ -3,7 +3,7 @@
 
 module State where
 
-import Prelude hiding ((++), const, max)
+import Prelude hiding ((++), const, max, init)
 import ProofCombinators
 
 data GState k v = Init v | Bind k v (GState k v)

--- a/tests/benchmarks/icfp15/pos/Dropwhile.hs
+++ b/tests/benchmarks/icfp15/pos/Dropwhile.hs
@@ -46,7 +46,7 @@ dropWhile f Emp  = Emp
 
 -- | This `witness` bound relates the predicate used in dropWhile
 
-{-@ bound witness @-}
+{- bound witness @-}
 witness :: Eq a => (a -> Bool) -> (a -> Bool -> Bool) -> a -> Bool -> a -> Bool
 witness p w = \ y b v -> (not b) ==> w y b ==> (v == y) ==> p v
 

--- a/tests/benchmarks/sf/Lists.hs
+++ b/tests/benchmarks/sf/Lists.hs
@@ -4,7 +4,7 @@
 
 module Lists where
 
-import Prelude hiding (reverse, length, filter)
+import Prelude hiding (reverse, length, filter, pred, sum)
 -- import           Prelude (Char, Int, Bool (..))
 import           Language.Haskell.Liquid.ProofCombinators
 

--- a/tests/errors/AmbiguousInline.hs
+++ b/tests/errors/AmbiguousInline.hs
@@ -19,8 +19,7 @@ import Debug.Trace
 import GHC.TypeLits
 
 import Language.Haskell.Liquid.Prelude (liquidAssert)
--- FIX import Prelude hiding (min, max)
-import Prelude hiding (max)
+import Prelude hiding (min, max)
 
 junk = BS.head
 

--- a/tests/errors/AmbiguousReflect.hs
+++ b/tests/errors/AmbiguousReflect.hs
@@ -1,12 +1,7 @@
+{-@ LIQUID "--expect-error-containing=Ambiguous specification symbol `mappend`"  @-}
 {-@ LIQUID "--reflection"  @-}
 
 module AmbiguousReflect where
-
--- ISSUE: Uncomment the below to make this test pass
---
---    import Prelude hiding (mappend)
--- 
--- LH should give an error message indicating the above.
 
 data D = D Int Int 
 

--- a/tests/pos/Dropwhile.hs
+++ b/tests/pos/Dropwhile.hs
@@ -63,7 +63,7 @@ dropWhile f Emp  = Emp
 
 -- | This `witness` bound relates the predicate used in dropWhile
 
-{-@ bound witness @-}
+{- bound witness @-}
 witness :: Eq a => (a -> Bool) -> (a -> Bool -> Bool) -> a -> Bool -> a -> Bool
 witness p w = \ y b v -> (not b) ==> w y b ==> (v == y) ==> p v
 

--- a/tests/pos/RepeatHigherOrder.hs
+++ b/tests/pos/RepeatHigherOrder.hs
@@ -11,7 +11,7 @@ import Language.Haskell.Liquid.Prelude
 repeat :: Int -> (a -> a) -> a -> a
 goal   :: Int -> Int
      
-{-@ bound step @-}
+{- bound step @-}
 step :: (a -> a -> Bool) -> (Int -> a -> Bool) -> Int -> a -> a -> Bool
 step pf pr = \ i x x' -> pr (i - 1) x ==> pf x x' ==> pr i x'
 

--- a/tests/todo/ImportBoundLib.hs
+++ b/tests/todo/ImportBoundLib.hs
@@ -2,7 +2,7 @@ module ImportBoundLib where
 
 data Proof
 
-{-@ bound chain @-}
+{- bound chain @-}
 chain :: (Proof -> Bool) -> (Proof -> Bool) -> (Proof -> Bool)
       -> Proof -> Bool
 chain p q r = \v -> p v


### PR DESCRIPTION
Another step for #2169

There is a fix up for LHName classes here in 3bdd1ff, so resolved LHNames are considered equal even if their attached symbols differ.