### PR TITLE
Get default methods from the GHC API instead of using maybeResolveSym

### DIFF
--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -255,6 +255,7 @@ import GHC.Core                       as Ghc
 import GHC.Core.Class                 as Ghc
     ( classAllSelIds
     , classBigSig
+    , classOpItems
     , classSCSelIds
     , Class
        ( classKey
@@ -558,6 +559,7 @@ import GHC.Types.Avail                as Ghc
 import GHC.Types.Basic                as Ghc
     ( Arity
     , Boxity(Boxed)
+    , DefMethSpec(VanillaDM)
     , PprPrec
     , PromotionFlag(NotPromoted)
     , TopLevelFlag(NotTopLevel)
@@ -601,7 +603,7 @@ import GHC.Types.Id                   as Ghc
     )
 import GHC.Types.Id.Info              as Ghc
     ( CafInfo(NoCafRefs)
-    , IdDetails(DataConWorkId, DataConWrapId, RecSelId, VanillaId)
+    , IdDetails(ClassOpId, DataConWorkId, DataConWrapId, RecSelId, VanillaId)
     , IdInfo(occInfo, realUnfoldingInfo)
     , cafInfo
     , inlinePragInfo

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Relational.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Relational.hs
@@ -531,7 +531,7 @@ consRelSub γ f1@(RFun g1 _ s1@RFun{} t1 _) f2@(RFun g2 _ s2@RFun{} t2 _)
     consRelSub γ s1 s2 qr2 qr1
     γ' <- γ += ("consRelSub HOF", F.symbol g1, s1)
     γ'' <- γ' += ("consRelSub HOF", F.symbol g2, s2)
-    let psubst = unapplyArg resL g1 <> unapplyArg resR g2
+    let psubst x = unapplyArg resL g1 x F.&.& unapplyArg resR g2 x
     consRelSub γ'' t1 t2 (psubst p1) (psubst p2)
 consRelSub γ f1@(RFun g1 _ s1@RFun{} t1 _) f2@(RFun g2 _ s2@RFun{} t2 _)
              pr1@(F.PAnd [F.PImp qr1@F.PImp{} p1])            pr2@(F.PImp qr2@F.PImp{} p2)
@@ -539,7 +539,7 @@ consRelSub γ f1@(RFun g1 _ s1@RFun{} t1 _) f2@(RFun g2 _ s2@RFun{} t2 _)
     consRelSub γ s1 s2 qr2 qr1
     γ' <- γ += ("consRelSub HOF", F.symbol g1, s1)
     γ'' <- γ' += ("consRelSub HOF", F.symbol g2, s2)
-    let psubst = unapplyArg resL g1 <> unapplyArg resR g2
+    let psubst x = unapplyArg resL g1 x F.&.& unapplyArg resR g2 x
     consRelSub γ'' t1 t2 (psubst p1) (psubst p2)
 consRelSub γ f1@(RFun x1 _ s1 e1 _) f2 p1 p2 =
   traceSub "fun" f1 f2 p1 p2 $ do

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Simplify.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Simplify.hs
@@ -17,7 +17,7 @@ simplifyBounds = fmap go
 dropBoundLike :: Expr -> Expr
 dropBoundLike p
   | isKvar p          = p
-  | isBoundLikePred p = mempty
+  | isBoundLikePred p = PTrue
   | otherwise         = p
   where
     isKvar            = not . null . kvarsExpr

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Bounds.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Bounds.hs
@@ -109,7 +109,7 @@ makeBoundType penv (q:qs) xts = go xts
     go [(x, t)]      = [(F.dummySymbol, tp t x), (F.dummySymbol, tq t x)]
     go ((x, t):xtss) = (val x, mkt t x) : go xtss
 
-    mkt t x = ofRSort t `strengthen` ofUReft (MkUReft (F.Reft (val x, mempty))
+    mkt t x = ofRSort t `strengthen` ofUReft (MkUReft (F.Reft (val x, F.PTrue))
                                                 (Pr $ M.lookupDefault [] (val x) ps))
     tp t x  = ofRSort t `strengthen` ofUReft (MkUReft (F.Reft (val x, F.pAnd rs))
                                                 (Pr $ M.lookupDefault [] (val x) ps))
@@ -160,7 +160,7 @@ makeRef penv v (F.PAnd rs) = ofUReft (MkUReft (F.Reft (val v, F.pAnd rrs)) r)
     (pps, rrs)           = partition (isPApp penv) rs
 
 makeRef penv v rr
-  | isPApp penv rr       = ofUReft (MkUReft (F.Reft(val v, mempty)) r)
+  | isPApp penv rr       = ofUReft (MkUReft (F.Reft(val v, F.PTrue)) r)
   where
     r                    = Pr [toUsedPVar penv rr]
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Fresh.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Fresh.hs
@@ -62,7 +62,7 @@ instance (Freshable m Integer, Monad m, Applicative m) => Freshable m [F.Expr] w
 
 instance (Freshable m Integer, Monad m, Applicative m) => Freshable m F.Reft where
   fresh                  = panic Nothing "fresh Reft"
-  true    _ (F.Reft (v,_)) = return $ F.Reft (v, mempty)
+  true    _ (F.Reft (v,_)) = return $ F.Reft (v, F.PTrue)
   refresh _ (F.Reft (_,_)) = (F.Reft .) . (,) <$> freshVV <*> fresh
     where
       freshVV            = F.vv . Just <$> fresh

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PredType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PredType.hs
@@ -220,7 +220,7 @@ replacePredsWithRefs :: (UsedPVar, (F.Symbol, [((), F.Symbol, F.Expr)]) -> F.Exp
 replacePredsWithRefs (p, r) (MkUReft (F.Reft(v, rs)) (Pr ps))
   = MkUReft (F.Reft (v, rs'')) (Pr ps2)
   where
-    rs''             = mconcat $ rs : rs'
+    rs''             = foldr (F.&.&) F.PTrue $ rs : rs'
     rs'              = r . (v,) . pargs <$> ps1
     (ps1, ps2)       = L.partition (== p) ps
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -891,20 +891,27 @@ class (Monoid r, F.Subable r) => Reftable r where
   toReft  :: r -> F.Reft
   ofReft  :: F.Reft -> r
 
+instance Semigroup F.Reft where
+  (<>) = F.meetReft
+
+instance Monoid F.Reft where
+  mempty  = F.trueReft
+  mappend = (<>)
+
 instance Reftable () where
   isTauto _ = True
   ppTy _  d = d
   top  _    = ()
   meet _ _  = ()
-  toReft _  = mempty
-  ofReft _  = mempty
+  toReft _  = F.trueReft
+  ofReft _  = ()
 
 instance Reftable F.Reft where
   isTauto  = all F.isTautoPred . F.conjuncts . F.reftPred
   ppTy     = pprReft
   toReft   = id
   ofReft   = id
-  top (F.Reft (v,_)) = F.Reft (v, mempty)
+  top (F.Reft (v,_)) = F.Reft (v, F.PTrue)
 
 instance F.Subable r => F.Subable (UReft r) where
   syms (MkUReft r p)     = F.syms r ++ F.syms p
@@ -943,7 +950,7 @@ instance Reftable Predicate where
            | otherwise        = d <-> angleBrackets (F.pprint r)
 
   toReft (Pr ps@(p:_))        = F.Reft (parg p, F.pAnd $ pToRef <$> ps)
-  toReft _                    = mempty
+  toReft _                    = F.trueReft
 
   ofReft = todo Nothing "TODO: Predicate.ofReft"
 


### PR DESCRIPTION
... also updates LF after removing monoid instances from there.