### PR TITLE
Various small refactorings

### DIFF
--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -670,6 +670,7 @@ import GHC.Types.Name.Reader          as Ghc
     , getRdrName
     , globalRdrEnvElts
     , greName
+    , isLocalGRE
     , lookupGRE
     , lookupGRE_Name
     , mkQual

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -329,6 +329,9 @@ makeGhcSpec0 cfg session tcg instEnvs localVars src lmap targetSpec dependencySp
                 , rinstance = specInstances
                   -- Preserve rinstances.
                 , asmReflectSigs = Ms.asmReflectSigs mySpec
+                , reflects = Ms.reflects mySpec0
+                , cmeasures = Ms.cmeasures targetSpec
+                , embeds = Ms.embeds targetSpec
                 }
     })
   where
@@ -434,16 +437,7 @@ makeLiftedSpec0 :: Config -> GhcSrc -> F.TCEmb Ghc.TyCon -> LogicMap -> Ms.BareS
                 -> Ms.BareSpec
 makeLiftedSpec0 cfg src embs lmap mySpec = mempty
   { Ms.ealiases  = lmapEAlias . snd <$> Bare.makeHaskellInlines (typeclass cfg) src embs lmap mySpec
-  , Ms.reflects  = Ms.reflects mySpec
   , Ms.dataDecls = Bare.makeHaskellDataDecls cfg name mySpec tcs
-  , Ms.embeds    = Ms.embeds mySpec
-  -- We do want 'embeds' to survive and to be present into the final 'LiftedSpec'. The
-  -- caveat is to decide which format is more appropriate. We obviously cannot store
-  -- them as a 'TCEmb TyCon' as serialising a 'TyCon' would be fairly exponsive. This
-  -- needs more thinking.
-  , Ms.cmeasures = Ms.cmeasures mySpec
-  -- We do want 'cmeasures' to survive and to be present into the final 'LiftedSpec'. The
-  -- caveat is to decide which format is more appropriate. This needs more thinking.
   }
   where
     tcs          = uniqNub (_gsTcs src ++ refTcs)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -16,15 +16,10 @@ module Language.Haskell.Liquid.Bare (
   -- * Creating a TargetSpec
   -- $creatingTargetSpecs
     makeTargetSpec
-
-  -- * Loading and Saving lifted specs from/to disk
-  , loadLiftedSpec
-  , saveLiftedSpec
   ) where
 
 import           Control.Monad                              (forM, mplus, when)
 import qualified Control.Exception                          as Ex
-import qualified Data.Binary                                as B
 import           Data.IORef (newIORef)
 import qualified Data.Maybe                                 as Mb
 import qualified Data.List                                  as L
@@ -32,8 +27,6 @@ import qualified Data.HashMap.Strict                        as M
 import qualified Data.HashSet                               as S
 import           Text.PrettyPrint.HughesPJ                  hiding (first, (<>)) -- (text, (<+>))
 import           System.FilePath                            (dropExtension)
-import           System.Directory                           (doesFileExist)
-import           System.Console.CmdArgs.Verbosity           (whenLoud)
 import           Language.Fixpoint.Utils.Files              as Files
 import           Language.Fixpoint.Misc                     as Misc
 import           Language.Fixpoint.Types                    hiding (dcFields, DataDecl, Error, panic)
@@ -71,35 +64,6 @@ import Data.Hashable (Hashable)
 import Data.Bifunctor (bimap, first)
 import Data.Function (on)
 
---------------------------------------------------------------------------------
--- | De/Serializing Spec files
---------------------------------------------------------------------------------
-
-loadLiftedSpec :: Config -> FilePath -> IO (Maybe Ms.BareSpec)
-loadLiftedSpec cfg srcF
-  | noLiftedImport cfg = putStrLn "No LIFTED Import" >> return Nothing
-  | otherwise          = do
-      let specF = extFileName BinSpec srcF
-      ex  <- doesFileExist specF
-      whenLoud $ putStrLn $ "Loading Binary Lifted Spec: " ++ specF ++ " " ++ "for source-file: " ++ show srcF ++ " " ++ show ex
-      lSp <- if ex
-               then Just <$> B.decodeFile specF
-               else {- warnMissingLiftedSpec srcF specF >> -} return Nothing
-      Ex.evaluate lSp
-
--- warnMissingLiftedSpec :: FilePath -> FilePath -> IO ()
--- warnMissingLiftedSpec srcF specF = do
---   incDir <- Misc.getIncludeDir
---   unless (Misc.isIncludeFile incDir srcF)
---     $ Ex.throw (errMissingSpec srcF specF)
-
-saveLiftedSpec :: FilePath -> Ms.BareSpec -> IO ()
-saveLiftedSpec srcF lspec = do
-  ensurePath specF
-  B.encodeFile specF lspec
-  -- print (errorP "DIE" "HERE" :: String)
-  where
-    specF = extFileName BinSpec srcF
 
 {- $creatingTargetSpecs
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -512,7 +512,7 @@ makeSpecQual _cfg env tycEnv measEnv _rtEnv specs = SpQual
                    ++ (fst <$> Bare.meSyms measEnv)
                    ++ (fst <$> Bare.meClassSyms measEnv)
 
-makeQualifiers :: Bare.Env -> Bare.TycEnv -> (ModName, Ms.Spec ty bndr) -> [F.Qualifier]
+makeQualifiers :: Bare.Env -> Bare.TycEnv -> (ModName, Ms.Spec ty) -> [F.Qualifier]
 makeQualifiers env tycEnv (modn, spec)
   = fmap        (Bare.qualifyTopDummy env        modn)
   . Mb.mapMaybe (resolveQParams       env tycEnv modn)
@@ -610,7 +610,7 @@ makeRewrite env spec =
 makeRewriteWith :: Bare.Env -> Ms.BareSpec -> Bare.Lookup (M.HashMap Ghc.Var [Ghc.Var])
 makeRewriteWith env spec = M.fromList <$> makeRewriteWith' env spec
 
-makeRewriteWith' :: Bare.Env -> Spec ty bndr -> Bare.Lookup [(Ghc.Var, [Ghc.Var])]
+makeRewriteWith' :: Bare.Env -> Spec ty -> Bare.Lookup [(Ghc.Var, [Ghc.Var])]
 makeRewriteWith' env spec =
   forM (M.toList $ Ms.rewriteWith spec) $ \(x, xs) -> do
     xv  <- Bare.lookupGhcIdLHName env x

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -1054,11 +1054,7 @@ addSymSort _ _ _ t
   = t
 
 addSymSortRef :: (PPrint s) => Ghc.SrcSpan -> s -> RPVar -> SpecProp -> Int -> SpecProp
-addSymSortRef sp rc p r i
-  | isPropPV p
-  = addSymSortRef' sp rc i p r
-  | otherwise
-  = panic Nothing "addSymSortRef: malformed ref application"
+addSymSortRef sp rc p r i = addSymSortRef' sp rc i p r
 
 addSymSortRef' :: (PPrint s) => Ghc.SrcSpan -> s -> Int -> RPVar -> SpecProp -> SpecProp
 addSymSortRef' _ _ _ p (RProp s (RVar v r)) | isDummy v

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/ToBare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/ToBare.hs
@@ -85,5 +85,5 @@ txPV :: (c1 -> c2) -> (tv1 -> tv2) -> PVU c1 tv1 -> PVU c2 tv2
 txPV cF vF (PV sym k y txes) = PV sym k' y txes'
   where
     txes'                  = [ (tx t, x, e) | (t, x, e) <- txes]
-    k'                     = tx <$> k
+    k'                     = tx k
     tx                     = txRType cF vF

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -976,17 +976,13 @@ varAnn γ x t
 -- | Helpers: Creating Fresh Refinement -------------------------------
 -----------------------------------------------------------------------
 freshPredRef :: CGEnv -> CoreExpr -> PVar RSort -> CG SpecProp
-freshPredRef γ e (PV _ (PVProp rsort) _ as)
+freshPredRef γ e (PV _ rsort _ as)
   = do t    <- freshTyType (typeclass (getConfig γ))  PredInstE e (toType False rsort)
        args <- mapM (const fresh) as
        let targs = [(x, s) | (x, (s, y, z)) <- zip args as, F.EVar y == z ]
        γ' <- foldM (+=) γ [("freshPredRef", x, ofRSort τ) | (x, τ) <- targs]
        addW $ WfC γ' t
        return $ RProp targs t
-
-freshPredRef _ _ (PV _ PVHProp _ _)
-  = todo Nothing "EFFECTS:freshPredRef"
-
 
 --------------------------------------------------------------------------------
 -- | Helpers: Creating Refinement Types For Various Things ---------------------

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -400,7 +400,7 @@ liquidHaskellCheckWithConfig
   :: Config -> PipelineData -> ModSummary -> TcM (Either LiquidCheckException LiquidLib)
 liquidHaskellCheckWithConfig cfg pipelineData modSummary = do
   -- Parse the spec comments stored in the pipeline data.
-  let inputSpec = toBareSpec . snd $
+  let inputSpec = snd $
         hsSpecificationP (moduleName thisModule) (pdSpecComments pipelineData)
 
   processInputSpec cfg pipelineData modSummary inputSpec
@@ -430,7 +430,7 @@ checkLiquidHaskellContext lhContext = do
       let bareSpec = lhInputSpec lhContext
           file = LH.modSummaryHsFile $ lhModuleSummary lhContext
 
-      withPragmas (lhGlobalCfg lhContext) file (Ms.pragmas $ fromBareSpec bareSpec) $ \moduleCfg ->  do
+      withPragmas (lhGlobalCfg lhContext) file (Ms.pragmas bareSpec) $ \moduleCfg ->  do
         let filters = getFilters moduleCfg
         -- Report the outcome of the checking
         LH.reportResult (errorLogger file filters) moduleCfg [giTarget (giSrc pmrTargetInfo)] out
@@ -458,7 +458,7 @@ errorLogger file filters outputResult = do
     (LH.orMessages outputResult)
 
 isIgnore :: BareSpec -> Bool
-isIgnore (MkBareSpec sp) = any ((== "--skip-module") . F.val) (pragmas sp)
+isIgnore sp = any ((== "--skip-module") . F.val) (pragmas sp)
 
 --------------------------------------------------------------------------------
 -- | Working with bare & lifted specs ------------------------------------------
@@ -521,9 +521,9 @@ processModule LiquidHaskellContext{..} = do
   -- (cfr. 'allowExtResolution').
   let file            = LH.modSummaryHsFile lhModuleSummary
 
-  _                   <- liftIO $ LH.checkFilePragmas $ Ms.pragmas (fromBareSpec bareSpec0)
+  _                   <- liftIO $ LH.checkFilePragmas $ Ms.pragmas bareSpec0
 
-  withPragmas lhGlobalCfg file (Ms.pragmas $ fromBareSpec bareSpec0) $ \moduleCfg -> do
+  withPragmas lhGlobalCfg file (Ms.pragmas bareSpec0) $ \moduleCfg -> do
     dependencies <- loadDependencies moduleCfg (S.toList lhRelevantModules)
 
     debugLog $ "Found " <> show (HM.size $ getDependencies dependencies) <> " dependencies:"

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -22,7 +22,7 @@ import qualified Language.Fixpoint.Types                 as F
 import qualified  Language.Haskell.Liquid.GHC.Misc        as LH
 import qualified Language.Haskell.Liquid.UX.CmdLine      as LH
 import qualified Language.Haskell.Liquid.GHC.Interface   as LH
-import           Language.Haskell.Liquid.LHNameResolution (collectTypeAliases, resolveLHNames)
+import           Language.Haskell.Liquid.LHNameResolution (resolveLHNames)
 import qualified Language.Haskell.Liquid.Liquid          as LH
 import qualified Language.Haskell.Liquid.Types.PrettyPrint as LH ( filterReportErrors
                                                                  , filterReportErrorsWith
@@ -544,13 +544,13 @@ processModule LiquidHaskellContext{..} = do
     -- call 'evaluate' to force any exception and catch it, if we can.
 
     tcg <- getGblEnv
-    let rtAliases = collectTypeAliases thisModule bareSpec0 (HM.toList $ getDependencies dependencies)
-        localVars = makeLocalVars preNormalizedCore
+    let localVars = makeLocalVars preNormalizedCore
         eBareSpec = resolveLHNames
+          thisModule
           localVars
-          rtAliases
           (tcg_rdr_env tcg)
           bareSpec0
+          dependencies
     result <-
       case eBareSpec of
         Left errors -> pure $ Left $ mkDiagnostics [] errors

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -50,9 +50,8 @@ collectTypeAliases
   -> BareSpec
   -> [(StableModule, LiftedSpec)]
   -> HM.HashMap Symbol (GHC.Module, RTAlias Symbol BareType)
-collectTypeAliases m bs deps =
-    let spec = getBareSpec bs
-        bsAliases = [ (rtName a, (m, a)) | a <- map val (aliases spec) ]
+collectTypeAliases m spec deps =
+    let bsAliases = [ (rtName a, (m, a)) | a <- map val (aliases spec) ]
         depAliases =
           [ (rtName a, (unStableModule sm, a))
           | (sm, lspec) <- deps
@@ -198,9 +197,8 @@ resolveBoundVarsInTypeAliases = updateAliases resolveBoundVars
 
     -- Applies a function to the body of type aliases, passes to every call the
     -- arguments of the alias.
-    updateAliases f bs =
-      let spec = getBareSpec bs
-       in MkBareSpec spec
+    updateAliases f spec =
+       spec
             { aliases = [ Loc sp0 sp1 (a { rtBody = mapLHNames (f args) (rtBody a) })
                         | Loc sp0 sp1 a <- aliases spec
                         , let args = rtTArgs a ++ rtVArgs a

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Measure.hs
@@ -43,11 +43,9 @@ import           Language.Haskell.Liquid.Types.Types
 import           Language.Haskell.Liquid.Types.RefType
 -- import           Language.Haskell.Liquid.Types.Variance
 -- import           Language.Haskell.Liquid.Types.Bounds
-import           Language.Haskell.Liquid.Types.Specs hiding (BareSpec)
+import           Language.Haskell.Liquid.Types.Specs
 import           Language.Haskell.Liquid.UX.Tidy
 
--- /FIXME/: This needs to be removed once the port to the new API is complete.
-type BareSpec = Spec LocBareType LocSymbol
 
 mkM ::  LocSymbol -> ty -> [Def ty bndr] -> MeasureKind -> UnSortedExprs -> Measure ty bndr
 mkM name typ eqns kind u

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -1026,7 +1026,7 @@ ppPspec k (AssmRel (lxl, lxr, tl, tr, q, p))
 -- signatues) are being qualified, i.e., the binding occurrences are prefixed
 -- with the module name.
 --
-mkSpec :: [BPspec] -> Measure.Spec LocBareType LocSymbol
+mkSpec :: [BPspec] -> Measure.Spec LocBareType
 mkSpec xs         = Measure.Spec
   { Measure.measures   = [m | Meas   m <- xs]
   , Measure.asmSigs    = [a | Assm   a <- xs]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -835,7 +835,6 @@ data Pspec ty ctor
   | Assm    (Located LHName, ty)                          -- ^ 'assume' signature (unchecked)
   | AssmReflect (Located LHName, Located LHName)          -- ^ 'assume reflects' signature (unchecked)
   | Asrt    (Located LHName, ty)                          -- ^ 'assert' signature (checked)
-  | LAsrt   (LocSymbol, ty)                               -- ^ 'local' assertion -- TODO RJ: what is this
   | Asrts   ([Located LHName], (ty, Maybe [Located Expr]))     -- ^ sym0, ..., symn :: ty / [m0,..., mn]
   | DDecl   DataDecl                                      -- ^ refined 'data'    declaration
   | NTDecl  DataDecl                                      -- ^ refined 'newtype' declaration
@@ -904,8 +903,6 @@ ppPspec k (AssmReflect (lx, ly))
   = "assume reflect"  <+> pprintTidy k (val lx) <+> "as" <+> pprintTidy k (val ly)
 ppPspec k (Asrt (lx, t))
   = "assert"  <+> pprintTidy k (val lx) <+> "::" <+> pprintTidy k t
-ppPspec k (LAsrt (lx, t))
-  = "local assert"  <+> pprintTidy k (val lx) <+> "::" <+> pprintTidy k t
 ppPspec k (Asrts (lxs, (t, les)))
   = ppAsserts k lxs t les
 ppPspec k (DDecl d)
@@ -991,7 +988,6 @@ ppPspec k (AssmRel (lxl, lxr, tl, tr, q, p))
   show (Meas   _) = "Meas"
   show (Assm   _) = "Assm"
   show (Asrt   _) = "Asrt"
-  show (LAsrt  _) = "LAsrt"
   show (Asrts  _) = "Asrts"
   show (Impt   _) = "Impt"
   shcl  _) = "DDecl"
@@ -1082,7 +1078,6 @@ specP
         <|>                            fmap Assm   tyBindLHNameP  )
     <|> fallbackSpecP "assert"      (fmap Asrt    tyBindLocalLHNameP)
     <|> fallbackSpecP "autosize"    (fmap ASize   tyConBindLHNameP)
-    <|> (reserved "local"         >> fmap LAsrt   tyBindP  )
 
     -- TODO: These next two are synonyms, kill one
     <|> fallbackSpecP "axiomatize"  (fmap Reflect locBinderLHNameP)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -586,7 +586,7 @@ predVarIdP
   = symbol <$> tyVarIdP
 
 bPVar :: Symbol -> t -> [(Symbol, t1)] -> PVar t1
-bPVar p _ xts  = PV p (PVProp τ) dummySymbol τxs
+bPVar p _ xts  = PV p τ dummySymbol τxs
   where
     (_, τ) = safeLast "bPVar last" xts
     τxs    = [ (τ', x, EVar x) | (x, τ') <- init xts ]
@@ -691,7 +691,7 @@ monoPredicate1P
 predVarUseP :: Parser (PVar String)
 predVarUseP
   = do (p, xs) <- funArgsP
-       return   $ PV p (PVProp dummyTyId) dummySymbol [ (dummyTyId, dummySymbol, x) | x <- xs ]
+       return   $ PV p dummyTyId dummySymbol [ (dummyTyId, dummySymbol, x) | x <- xs ]
 
 funArgsP :: Parser (Symbol, [Expr])
 funArgsP  = try realP <|> empP <?> "funArgsP"

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Bounds.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Bounds.hs
@@ -141,7 +141,7 @@ toUsedPVars _ _ = impossible Nothing "This cannot happen"
 
 toUsedPVar :: [(F.Symbol, F.Symbol)] -> F.Expr -> PVar ()
 toUsedPVar penv ee@(F.EApp _ _)
-  = PV q (PVProp ()) e (((), F.dummySymbol,) <$> es')
+  = PV q () e (((), F.dummySymbol,) <$> es')
    where
      F.EVar e = {- unProp $ -} last es
      es'    = init es

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
@@ -10,6 +10,7 @@ module Language.Haskell.Liquid.Types.Names
   , LHResolvedName (..)
   , LHName (..)
   , LHNameSpace (..)
+  , LHThisModuleNameFlag (..)
   , makeResolvedLHName
   , getLHNameResolved
   , getLHNameSymbol
@@ -106,13 +107,22 @@ instance Hashable LHName where
 
 data LHNameSpace
     = LHTcName
-    | LHDataConName
-    | LHVarName
-  deriving (Data, Eq, Generic, Ord)
+    | LHDataConName LHThisModuleNameFlag
+    | LHVarName LHThisModuleNameFlag
+  deriving (Data, Eq, Generic, Ord, Show)
 
 instance B.Binary LHNameSpace
 instance NFData LHNameSpace
 instance Hashable LHNameSpace
+
+-- | Whether the name should be looked up in the current module only or in any
+-- module
+data LHThisModuleNameFlag = LHThisModuleNameF | LHAnyModuleNameF
+  deriving (Data, Eq, Generic, Ord, Show)
+
+instance B.Binary LHThisModuleNameFlag
+instance NFData LHThisModuleNameFlag
+instance Hashable LHThisModuleNameFlag
 
 instance Ord LogicName where
   compare (LogicName s1 m1) (LogicName s2 m2) =

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PredType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PredType.hs
@@ -247,19 +247,13 @@ pvarRType (PV _ k {- (PVProp τ) -} _ args) = rpredType k (fst3 <$> args) -- (ty
   --   ty  = uRTypeGen τ
   --   tys = uRTypeGen . fst3 <$> args
 
-
--- rpredType    :: (PPrint r, Reftable r) => PVKind (RRType r) -> [RRType r] -> RRType r
 rpredType :: Reftable r
-          => PVKind (RType RTyCon tv a)
+          => RType RTyCon tv a
           -> [RType RTyCon tv a] -> RType RTyCon tv r
-rpredType (PVProp t) ts = RApp predRTyCon  (uRTypeGen <$> t : ts) [] mempty
-rpredType PVHProp    ts = RApp wpredRTyCon (uRTypeGen <$>     ts) [] mempty
+rpredType t ts = RApp predRTyCon  (uRTypeGen <$> t : ts) [] mempty
 
 predRTyCon   :: RTyCon
 predRTyCon   = symbolRTyCon predName
-
-wpredRTyCon   :: RTyCon
-wpredRTyCon   = symbolRTyCon wpredName
 
 symbolRTyCon   :: F.Symbol -> RTyCon
 symbolRTyCon n = RTyCon (stringTyCon 'x' 42 $ F.symbolString n) [] defaultTyConInfo
@@ -508,9 +502,8 @@ meetListWithPSubRef ss (RProp s1 r1) (RProp s2 r2) π
 predType   :: Type
 predType   = symbolType predName
 
-wpredName, predName :: F.Symbol
+predName :: F.Symbol
 predName   = "Pred"
-wpredName  = "WPred"
 
 symbolType :: F.Symbol -> Type
 symbolType = TyVarTy . symbolTyVar

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
@@ -405,9 +405,8 @@ pprPvarDef bb p (PV s t _ xts)
     dargs = [pprPvarSort bb p xt | (xt,_,_) <- xts]
 
 
-pprPvarKind :: (OkRT c tv ()) => PPEnv -> Prec -> PVKind (RType c tv ()) -> Doc
-pprPvarKind bb p (PVProp t) = pprPvarSort bb p t <+> arrow <+> pprName F.boolConName -- propConName
-pprPvarKind _ _ PVHProp     = panic Nothing "TODO: pprPvarKind:hprop" -- pprName hpropConName
+pprPvarKind :: (OkRT c tv ()) => PPEnv -> Prec -> RType c tv () -> Doc
+pprPvarKind bb p t = pprPvarSort bb p t <+> arrow <+> pprName F.boolConName
 
 pprName :: F.Symbol -> Doc
 pprName                      = text . F.symbolString

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
@@ -287,8 +287,7 @@ maybeParen ctxt_prec inner_prec pretty
 
 ppExists
   :: (OkRT c tv r, PPrint c, PPrint tv, PPrint (RType c tv r),
-      PPrint (RType c tv ()), Reftable (RTProp c tv r),
-      Reftable (RTProp c tv ()))
+      PPrint (RType c tv ()))
   => PPEnv -> Prec -> RType c tv r -> Doc
 ppExists bb p rt
   = text "exists" <+> brackets (intersperse comma [pprDbind bb topPrec x t | (x, t) <- ws]) <-> dot <-> pprRtype bb p rt'

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -762,11 +762,7 @@ rtPropTop
       SubsTy tv (RType c tv ()) tv,
       SubsTy tv (RType c tv ()) (RTVar tv (RType c tv ())))
    => PVar (RType c tv ()) -> Ref (RType c tv ()) (RType c tv r)
-rtPropTop pv = case ptype pv of
-                 PVProp t -> RProp xts $ ofRSort t
-                 PVHProp  -> RProp xts mempty
-               where
-                 xts      =  pvArgs pv
+rtPropTop pv = RProp (pvArgs pv) $ ofRSort $ ptype pv
 
 rtPropPV :: (Fixpoint a, Reftable r)
          => a
@@ -1288,10 +1284,6 @@ instance SubsTy RTyVar RSort Sort where
     | symbol v == s = typeSort mempty (toType True sv)
     | otherwise     = FObj s
   subt _ s          = s
-
-instance (SubsTy tv ty ty) => SubsTy tv ty (PVKind ty) where
-  subt su (PVProp t) = PVProp (subt su t)
-  subt _   PVHProp   = PVHProp
 
 instance (SubsTy tv ty ty) => SubsTy tv ty (PVar ty) where
   subt su (PV n pvk v xts) = PV n (subt su pvk) v [(subt su t, x, y) | (t,x,y) <- xts]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -407,7 +407,6 @@ data Spec ty = Spec
   , axeqs      :: ![F.Equation]                                       -- ^ Equalities used for Proof-By-Evaluation
   } deriving (Data, Generic, Show)
 
-instance Binary (Spec LocBareType)
 
 instance (Show ty, F.PPrint ty) => F.PPrint (Spec ty) where
     pprintTidy k sp = text "dataDecls = " <+> pprintTidy k  (dataDecls sp)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -24,7 +24,7 @@ module Language.Haskell.Liquid.Types.Specs (
   , TargetSpec(..)
   -- * BareSpec
   -- $bareSpec
-  , BareSpec(..)
+  , BareSpec
   -- * LiftedSpec
   -- $liftedSpec
   , LiftedSpec(..)
@@ -59,8 +59,6 @@ module Language.Haskell.Liquid.Types.Specs (
   , toTargetSrc
   , fromTargetSrc
   , toTargetSpec
-  , toBareSpec
-  , fromBareSpec
   , toLiftedSpec
   , unsafeFromLiftedSpec
   , emptyLiftedSpec
@@ -362,18 +360,7 @@ type SpecMeasure   = Measure LocSpecType DataCon
 --
 -- Also, a 'BareSpec' has not yet been subject to name resolution, so it may refer
 -- to undefined or out-of-scope entities.
-newtype BareSpec =
-  MkBareSpec { getBareSpec :: Spec LocBareType F.LocSymbol }
-  deriving (Data, Generic, Show, Binary)
-
-instance Semigroup BareSpec where
-  x <> y = MkBareSpec { getBareSpec = getBareSpec x <> getBareSpec y }
-
-instance Monoid BareSpec where
-  mempty = MkBareSpec { getBareSpec = mempty }
-
-
--- instance Semigroup (Spec ty bndr) where
+type BareSpec = Spec LocBareType LocSymbol
 
 -- | A generic 'Spec' type, polymorphic over the inner choice of type and binder.
 data Spec ty bndr  = Spec
@@ -756,12 +743,6 @@ toTargetSpec ghcSpec =
       , gsImps   = _gsImps ghcSpec
       , gsConfig = _gsConfig ghcSpec
       }
-
-toBareSpec :: Spec LocBareType F.LocSymbol -> BareSpec
-toBareSpec = MkBareSpec
-
-fromBareSpec :: BareSpec -> Spec LocBareType F.LocSymbol
-fromBareSpec = getBareSpec
 
 toLiftedSpec :: Spec LocBareType F.LocSymbol -> LiftedSpec
 toLiftedSpec a = LiftedSpec

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
 -- | This module contains the top-level structures that hold
 --   information about specifications.
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/QuasiQuoter.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/QuasiQuoter.hs
@@ -85,9 +85,6 @@ mkSpecDecs :: BPspec -> Either UserError [Dec]
 mkSpecDecs (Asrt (name, ty)) =
   return . SigD (lhNameToName name)
     <$> simplifyBareType name (quantifyFreeRTy $ val ty)
-mkSpecDecs (LAsrt (name, ty)) =
-  return . SigD (symbolName name)
-    <$> simplifyBareType name (quantifyFreeRTy $ val ty)
 mkSpecDecs (Asrts (names, (ty, _))) =
   (\t -> (`SigD` t) . lhNameToName <$> names)
     <$> simplifyBareType (head names) (quantifyFreeRTy $ val ty)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/WiredIn.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/WiredIn.hs
@@ -143,8 +143,8 @@ listTyDataCons   = ( [TyConP l0 c [RTV tyv] [p] [Covariant] [Covariant] (Just fs
       fld        = "fldList"
       xHead      = "head"
       xTail      = "tail"
-      p          = PV "p" (PVProp t) (F.vv Nothing) [(t, fld, F.EVar fld)]
-      px         = pdVarReft $ PV "p" (PVProp t) (F.vv Nothing) [(t, fld, F.EVar xHead)]
+      p          = PV "p" t (F.vv Nothing) [(t, fld, F.EVar fld)]
+      px         = pdVarReft $ PV "p" t (F.vv Nothing) [(t, fld, F.EVar xHead)]
       lt         = rApp c [xt] [rPropP [] $ pdVarReft p] mempty
       xt         = rVar tyv
       xst        = rApp c [RVar (RTV tyv) px] [rPropP [] $ pdVarReft p] mempty
@@ -193,7 +193,7 @@ mkps_ :: [F.Symbol]
 mkps_ []     _       _          _    ps = ps
 mkps_ (n:ns) (t:ts) ((f, x):xs) args ps = mkps_ ns ts xs (a:args) (p:ps)
   where
-    p                                   = PV n (PVProp t) (F.vv Nothing) args
+    p                                   = PV n t (F.vv Nothing) args
     a                                   = (t, f, x)
 mkps_ _     _       _          _    _ = panic Nothing "Bare : mkps_"
 

--- a/liquidhaskell-boot/tests/Parser.hs
+++ b/liquidhaskell-boot/tests/Parser.hs
@@ -63,10 +63,6 @@ testSpecP =
        parseSingleSpec "autosize List" @?==
             "autosize List"
 
-    , testCase "local" $
-       parseSingleSpec "local foo :: Nat -> Nat" @?==
-            "local assert foo :: lq_tmp$db##0:Nat -> Nat"
-
     , testCase "axiomatize" $
        parseSingleSpec "axiomatize fibA" @?==
             "reflect fibA"


### PR DESCRIPTION
92ea9147 involves a change in behavior. Various annotations that are supposed to refer to definitions in the current module, could sometimes produce errors about ambiguity if the same names were imported. This has been changed so LH favors the local definition.

I think this is how LH used to work, but the behavior might have been affected by the latest work on name resolution.