### PR TITLE
Expand type aliases in dependent pairs

### DIFF
--- a/tests/names/pos/ExpandsDependentPairs.hs
+++ b/tests/names/pos/ExpandsDependentPairs.hs
@@ -1,0 +1,12 @@
+-- | Tests that Id is correctly expanded. Before fixing, this test would
+-- fail with
+--
+-- > lookupTyThing: cannot resolve a LHRLogic name "Id"
+--
+module ExpandsDependentPairs where
+
+{-@ type Id = {v:Int | v >= 0} @-}
+
+{-@ lemma :: l:Id -> (id::Id, { true }) @-}
+lemma :: Int -> (Int, ())
+lemma x = (x, ())

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -785,6 +785,7 @@ executable names-pos
                     , Capture01
                     , Capture02
                     , ClojurVector
+                    , ExpandsDependentPairs
                     , HideName00
                     , HidePrelude
                     , List00


### PR DESCRIPTION
Before this patch, the following test would fail
```Haskell
{-@ type Id = {v:Int | v >= 0} @-}
{-@ lemma :: l:Id -> (id::Id, { true }) @-}
lemma :: Int -> (Int, ())
lemma x = (x, ())
```
with
```
Test.hs:6:27: error:
    Uh oh.
    CallStack (from HasCallStack):
  panic, called at src/Language/Haskell/Liquid/Bare/Resolve.hs:972:37 in liquidhaskell-boot-0.9.10.1-inplace:Language.Haskell.Liquid.Bare.Resolve
    lookupTyThing: cannot resolve a LHRLogic name "Id"
  |
6 | {-@ lemma :: l:Id -> (id::Id, { true }) @-}
  |                           ^^
```
