### PR TITLE
Update LF after preserving location of operators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ cabal-dev
 *.log
 *.html
 *.pyc
-build.sh
 config.make
 *.scalarlog
 *.tags

--- a/liquidhaskell-boot/liquidhaskell-boot.cabal
+++ b/liquidhaskell-boot/liquidhaskell-boot.cabal
@@ -76,6 +76,7 @@ library
                       Language.Haskell.Liquid.Liquid
                       Language.Haskell.Liquid.Measure
                       Language.Haskell.Liquid.Misc
+                      Language.Haskell.Liquid.Name.LogicNameEnv
                       Language.Haskell.Liquid.Parse
                       Language.Haskell.Liquid.Termination.Structural
                       Language.Haskell.Liquid.Transforms.ANF

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Class.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Class.hs
@@ -145,7 +145,7 @@ makeClasses env sigEnv myName specs = do
     classTcs = [ (name, cls, tc) | (name, spec) <- M.toList specs
                                  , cls          <- Ms.classes spec
                                  , tc           <- Mb.maybeToList (classTc cls) ]
-    classTc = either (const Nothing) Just . Bare.lookupGhcTyConLHName env . btc_tc . rcName
+    classTc = either (const Nothing) Just . Bare.lookupGhcTyConLHName (reTyLookupEnv env) . btc_tc . rcName
 
 mkClass :: Bare.Env -> Bare.SigEnv -> ModName -> ModName -> RClass LocBareType -> Ghc.TyCon
         -> Bare.Lookup (Maybe (DataConP, [(ModName, Ghc.Var, LocSpecType)]))
@@ -248,7 +248,7 @@ resolveDictionaries env = map $ \ri ->
          Right v -> v
     lookupDFun (RI c _ ts _) = do
        let tys = map (toType False . dropUniv . val) ts
-       case Bare.lookupGhcTyConLHName env (btc_tc c) of
+       case Bare.lookupGhcTyConLHName (reTyLookupEnv env) (btc_tc c) of
          Left _ ->
            panic (Just $ GM.fSrcSpan $ btc_tc c) "cannot find type class"
          Right tc -> case Ghc.tyConClass_maybe tc of

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/DataType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/DataType.hs
@@ -610,7 +610,7 @@ ofBDataDecl env name (Just dd@(DataDecl tc as ps cts pos sfun pt _)) maybe_invar
     err            = ErrBadData (GM.fSrcSpan tc) (pprint tc) "Mismatch in number of type variables"
 
 ofBDataDecl env name Nothing (Just (tc, is)) =
-  case Bare.lookupGhcTyConLHName env tc of
+  case Bare.lookupGhcTyConLHName (Bare.reTyLookupEnv env) tc of
     Left e    -> Left e
     Right tc' -> Right ((name, TyConP srcpos tc' [] [] tcov tcontr Nothing, Nothing), [])
   where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
@@ -121,7 +121,7 @@ compileClasses src env (name, spec) rest =
       ++ concatMap (Mb.mapMaybe resolveClassMaybe . dataDecls . snd) rest
   resolveClassMaybe :: DataDecl -> Maybe Ghc.Class
   resolveClassMaybe d =
-    either (const Nothing) Just (Bare.lookupGhcTyConLHName env $ dataNameSymbol $ tycName d)
+    either (const Nothing) Just (Bare.lookupGhcTyConLHName (Bare.reTyLookupEnv env) $ dataNameSymbol $ tycName d)
       >>= Ghc.tyConClass_maybe
 
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Types.hs
@@ -5,6 +5,7 @@
 module Language.Haskell.Liquid.Bare.Types 
   ( -- * Name resolution environment 
     Env (..)
+  , GHCTyLookupEnv (..)
   , TyThingMap 
   , ModSpecs
   , LocalVars(..)
@@ -70,9 +71,8 @@ plugSrc _        = Nothing
 -- | Name resolution environment 
 -------------------------------------------------------------------------------
 data Env = RE 
-  { reSession   :: Ghc.Session
+  { reTyLookupEnv :: GHCTyLookupEnv
   , reTcGblEnv  :: Ghc.TcGblEnv
-  , reTypeEnv   :: Ghc.TypeEnv
   , reInstEnvs  :: Ghc.InstEnvs
   , reUsedExternals :: Ghc.NameSet
   , reLMap      :: LogicMap
@@ -85,6 +85,11 @@ data Env = RE
   , reGlobSyms  :: S.HashSet F.Symbol       -- ^ global symbols, typically unlifted measures like 'len', 'fromJust'
   , reSrc       :: GhcSrc                   -- ^ all source info
   }
+
+data GHCTyLookupEnv = GHCTyLookupEnv
+       { gtleSession :: Ghc.Session
+       , gtleTypeEnv :: Ghc.TypeEnv
+       }
 
 instance HasConfig Env where 
   getConfig = reCfg 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -79,6 +79,7 @@ import qualified GHC.Types.Name.Occurrence
 import           Language.Fixpoint.Types as F hiding (Error, panic)
 import           Language.Haskell.Liquid.Bare.Resolve (lookupLocalVar)
 import           Language.Haskell.Liquid.Bare.Types (LocalVars(lvNames), LocalVarDetails(lvdLclEnv))
+import           Language.Haskell.Liquid.Name.LogicNameEnv
 import qualified Language.Haskell.Liquid.Types.DataDecl as DataDecl
 import           Language.Haskell.Liquid.Types.Errors (TError(ErrDupNames, ErrResolve), panic)
 import           Language.Haskell.Liquid.Types.Specs as Specs
@@ -373,16 +374,6 @@ lookupInScopeExprEnv env s = do
          case filter ((GHC.mkFastString (symbolString q) ==) . GHC.moduleNameFS . fst) xs of
            [] -> Left $ map ((`LH.qualifySymbol` n) . symbol . GHC.moduleNameString . fst) xs
            ys -> Right $ map snd ys
-
--- | For every symbol tells the corresponding LHName
---
--- Symbols are expected to follow a precise syntax
---
--- > <package unique> ## module name ## name
---
--- as created by 'logicNameToSymbol'.
---
-type LogicNameEnv = SEnv LHName
 
 -- | Builds an 'InScopeExprEnv' from the module aliases for the current module,
 -- the spec of the current module, and the specs of the dependencies.

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -54,7 +54,7 @@ module Language.Haskell.Liquid.LHNameResolution
   , LogicNameEnv
   ) where
 
-import           Liquid.GHC.API         as GHC hiding (Expr, panic)
+import qualified Liquid.GHC.API         as GHC hiding (Expr, panic)
 import qualified Language.Haskell.Liquid.GHC.Misc        as LH
 import           Language.Haskell.Liquid.Types.Names
 import           Language.Haskell.Liquid.Types.RType
@@ -95,14 +95,14 @@ import qualified Text.Printf               as Printf
 -- Type alias names cannot be qualified at the moment, and therefore their
 -- names identify them uniquely.
 collectTypeAliases
-  :: Module
+  :: GHC.Module
   -> BareSpecParsed
   -> TargetDependencies
   -> HM.HashMap Symbol (GHC.Module, RTAlias Symbol ())
 collectTypeAliases m spec deps =
     let bsAliases = [ (rtName a, (m, void a)) | a <- map val (aliases spec) ]
         depAliases =
-          [ (rtName a, (unStableModule sm, void a))
+          [ (rtName a, (GHC.unStableModule sm, void a))
           | (sm, lspec) <- HM.toList (getDependencies deps)
           , a <- map val (HS.toList $ liftedAliases lspec)
           ]
@@ -113,10 +113,10 @@ collectTypeAliases m spec deps =
 -- type aliases and GlobalRdrEnv.
 resolveLHNames
   :: Config
-  -> Module
+  -> GHC.Module
   -> LocalVars
   -> GHC.ImportedMods
-  -> GlobalRdrEnv
+  -> GHC.GlobalRdrEnv
   -> LogicMap
   -> BareSpecParsed
   -> TargetDependencies
@@ -180,7 +180,7 @@ resolveLHNames cfg thisModule localVars impMods globalRdrEnv lmap bareSpec0 depe
                 (ErrDupNames
                    (LH.fSrcSpan lname)
                    (pprint s)
-                   (map (PJ.text . showPprUnsafe) es)
+                   (map (PJ.text . GHC.showPprUnsafe) es)
                 )
               pure $ val lname
         [] ->
@@ -234,7 +234,7 @@ addError e = modify (first (e :))
 addName :: LHName -> State RenameOutput ()
 addName n = modify (fmap (n:))
 
-mkLookupGRE :: LHNameSpace -> Symbol -> LookupGRE GHC.GREInfo
+mkLookupGRE :: LHNameSpace -> Symbol -> GHC.LookupGRE GHC.GREInfo
 mkLookupGRE ns s =
     let m = LH.takeModuleNames s
         n = LH.dropModuleNames s
@@ -247,7 +247,7 @@ mkLookupGRE ns s =
             GHC.mkRdrQual (GHC.mkModuleName $ symbolString m) oname
      in GHC.LookupRdrName rdrn (mkWhichGREs ns)
   where
-    mkWhichGREs :: LHNameSpace -> WhichGREs GHC.GREInfo
+    mkWhichGREs :: LHNameSpace -> GHC.WhichGREs GHC.GREInfo
     mkWhichGREs = \case
       LHTcName -> GHC.SameNameSpace
       LHDataConName _ -> GHC.SameNameSpace
@@ -296,7 +296,7 @@ resolveBoundVarsInTypeAliases = updateAliases resolveBoundVars
 -- the parser builds a type for @Ev (plus n n)@.
 --
 fixExpressionArgsOfTypeAliases
-  :: HM.HashMap Symbol (Module, RTAlias Symbol ())
+  :: HM.HashMap Symbol (GHC.Module, RTAlias Symbol ())
   -> BareSpecParsed
   -> BareSpecParsed
 fixExpressionArgsOfTypeAliases taliases =
@@ -370,7 +370,7 @@ lookupInScopeExprEnv env s = do
       Alts closeSyms -> Left closeSyms
       F.Found xs -> do
          let q = LH.takeModuleNames s
-         case filter ((mkFastString (symbolString q) ==) . GHC.moduleNameFS . fst) xs of
+         case filter ((GHC.mkFastString (symbolString q) ==) . GHC.moduleNameFS . fst) xs of
            [] -> Left $ map ((`LH.qualifySymbol` n) . symbol . GHC.moduleNameString . fst) xs
            ys -> Right $ map snd ys
 
@@ -427,7 +427,7 @@ makeInScopeExprEnv impAvails thisModule spec dependencies =
           ] ++ map (map getLHNameSymbol . snd) logicNames
         logicNames =
           (thisModule, []) :
-          [ (unStableModule sm, collectLiftedSpecLogicNames sp)
+          [ (GHC.unStableModule sm, collectLiftedSpecLogicNames sp)
           | (sm, sp) <- HM.toList $ getDependencies dependencies
           ]
      in
@@ -556,7 +556,7 @@ resolveLogicNames cfg env globalRdrEnv unhandledNames lmap0 localVars sp =
               (ErrDupNames
                  (LH.fSrcSpan s)
                  (pprint $ val s)
-                 (map (PJ.text . showPprUnsafe) es)
+                 (map (PJ.text . GHC.showPprUnsafe) es)
               )
             return $ makeLocalLHName $ val s
 
@@ -583,7 +583,7 @@ resolveLogicNames cfg env globalRdrEnv unhandledNames lmap0 localVars sp =
               (ErrDupNames
                  (LH.fSrcSpan s)
                  (pprint $ val s)
-                 (map (PJ.text . showPprUnsafe) es)
+                 (map (PJ.text . GHC.showPprUnsafe) es)
               )
             return $ makeLocalLHName $ val s
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Name/LogicNameEnv.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Name/LogicNameEnv.hs
@@ -1,0 +1,13 @@
+module Language.Haskell.Liquid.Name.LogicNameEnv
+  ( LogicNameEnv
+  ) where
+
+import           Language.Fixpoint.Types
+import           Language.Haskell.Liquid.Types.Names
+
+
+-- | For every symbol tells the corresponding LHName and Sort
+--
+-- Symbols are expected to have been created by 'logicNameToSymbol'.
+--
+type LogicNameEnv = SEnv LHName

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -92,15 +92,15 @@ instance ParseableV LocSymbol where
     where
       notTrivial (x, EVar y) = x /= val y
       notTrivial _           = True
-  vFromString = dummyLoc . symbol
+  vFromString = fmap symbol
 
 initPStateWithList :: LHPState
 initPStateWithList
   = (initPState composeFun)
-               { empList    = Just (EVar (dummyLoc "GHC.Types.[]"))
-               , singList   = Just (\e -> EApp (EApp (EVar (dummyLoc "GHC.Types.:")) e) (EVar (dummyLoc "GHC.Types.[]")))
+               { empList    = Just $ \lx -> EVar ("GHC.Types.[]" <$ lx)
+               , singList   = Just (\lx e -> EApp (EApp (EVar ("GHC.Types.:" <$ lx)) e) (EVar ("GHC.Types.[]" <$ lx)))
                }
-  where composeFun = Just $ EVar $ dummyLoc functionComposisionSymbol
+  where composeFun = Just $ EVar . (functionComposisionSymbol <$)
 
 -------------------------------------------------------------------------------
 singleSpecP :: SourcePos -> String -> Either (ParseErrorBundle String Void) BPspec

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -457,25 +457,7 @@ eVarWithMap :: Id -> LogicMap -> LogicM Expr
 eVarWithMap x lmap = do
   f'     <- tosymbol' (C.Var x :: C.CoreExpr)
   -- let msg = "eVarWithMap x = " ++ show x ++ " f' = " ++ show f'
-  return $ eAppWithMap lmap f' [] (varExpr x)
-
-varExpr :: Var -> Expr
-varExpr x
-  | isPolyCst t = mkEApp (dummyLoc s) []
-  | otherwise   = EVar s
-  where
-    t           = GM.expandVarType x
-    s           = symbol x
-
-isPolyCst :: Type -> Bool
-isPolyCst (ForAllTy _ t) = isCst t
-isPolyCst _              = False
-
-isCst :: Type -> Bool
-isCst (ForAllTy _ t) = isCst t
-isCst FunTy{}        = False
-isCst _              = True
-
+  return $ eAppWithMap lmap f' [] (EVar $ symbol x)
 
 brels :: M.HashMap Symbol Brel
 brels = M.fromList [ (symbol ("GHC.Classes.==" :: String), Eq)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -272,7 +272,7 @@ coreToLg allowTC (C.App (C.Var v) e)
 coreToLg _allowTC (C.Var x)
   | x == falseDataConId        = return PFalse
   | x == trueDataConId         = return PTrue
-  | otherwise                  = getState >>= eVarWithMap x . lsSymMap
+  | otherwise                  = eVarWithMap x . lsSymMap <$> getState
 coreToLg allowTC e@(C.App _ _)         = toPredApp allowTC e
 coreToLg allowTC (C.Case e b _ alts)
   | eqType (GM.expandVarType b) boolTy  = checkBoolAlts alts >>= coreToIte allowTC e
@@ -453,11 +453,10 @@ makeApp def lmap f es
   = eAppWithMap lmap f es def
   -- where msg = "makeApp f = " ++ show f ++ " es = " ++ show es ++ " def = " ++ show def
 
-eVarWithMap :: Id -> LogicMap -> LogicM Expr
+eVarWithMap :: Id -> LogicMap -> Expr
 eVarWithMap x lmap = do
-  f'     <- tosymbol' (C.Var x :: C.CoreExpr)
-  -- let msg = "eVarWithMap x = " ++ show x ++ " f' = " ++ show f'
-  return $ eAppWithMap lmap f' [] (EVar $ symbol x)
+  let f' = dummyLoc $ symbol x
+   in eAppWithMap lmap f' [] (EVar $ symbol x)
 
 brels :: M.HashMap Symbol Brel
 brels = M.fromList [ (symbol ("GHC.Classes.==" :: String), Eq)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -701,7 +701,7 @@ data LiftedSpec = LiftedSpec
   { liftedMeasures   :: HashSet (MeasureV LHName LocBareTypeLHName F.LocSymbol)
     -- ^ User-defined properties for ADTs
   , liftedExpSigs    :: HashSet (LHName, F.Sort)
-    -- ^ Exported logic symbols
+    -- ^ Exported logic symbols originated from reflecting functions
   , liftedAsmSigs    :: HashSet (F.Located LHName, LocBareTypeLHName)
     -- ^ Assumed (unchecked) types; including reflected signatures
   , liftedSigs       :: HashSet (F.Located LHName, LocBareTypeLHName)
@@ -731,9 +731,9 @@ data LiftedSpec = LiftedSpec
   , liftedCmeasures  :: HashSet (MeasureV LHName LocBareTypeLHName ())
     -- ^ Measures attached to a type-class
   , liftedImeasures  :: HashSet (MeasureV LHName LocBareTypeLHName F.LocSymbol)
-    -- Lifted opaque reflection measures
-  , liftedOmeasures  :: HashSet (MeasureV LHName LocBareTypeLHName F.LocSymbol)
     -- ^ Mappings from (measure,type) -> measure
+  , liftedOmeasures  :: HashSet (MeasureV LHName LocBareTypeLHName F.LocSymbol)
+    -- ^ Lifted opaque reflection measures
   , liftedClasses    :: HashSet (RClass LocBareTypeLHName)
     -- ^ Refined Type-Classes
   , liftedRinstance  :: HashSet (RInstance LocBareTypeLHName)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -383,7 +383,7 @@ type BareSpecParsed = Spec LocSymbol BareTypeParsed
 -- non-interpreted functions and type aliases.
 data Spec lname ty = Spec
   { measures   :: ![MeasureV lname (F.Located ty) LocSymbol]          -- ^ User-defined properties for ADTs
-  , expSigs    :: ![(lname, F.Sort)]                                  -- ^ Exported logic symbols
+  , expSigs    :: ![(lname, F.Sort)]                                  -- ^ Exported logic symbols originated by reflecting functions
   , asmSigs    :: ![(F.Located LHName, F.Located ty)]                 -- ^ Assumed (unchecked) types; including reflected signatures
   , asmReflectSigs :: ![(F.Located LHName, F.Located LHName)]         -- ^ Assume reflects : left is the actual function and right the pretended one
   , sigs       :: ![(F.Located LHName, F.Located (BareTypeV lname))]  -- ^ Asserted spec signatures

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -280,22 +280,8 @@ eAppWithMap lmap f es expr
   | Just (LMap _ xs e) <- M.lookup (F.val f) (lmSymDefs lmap)
   , length xs == length es
   = F.subst (F.mkSubst $ zip xs es) e
-  | Just (LMap _ xs e) <- M.lookup (F.val f) (lmSymDefs lmap)
-  , isApp e
-  = F.subst (F.mkSubst $ zip xs es) $ dropApp e (length xs - length es)
   | otherwise
   = expr
-
-dropApp :: Expr -> Int -> Expr
-dropApp e i | i <= 0 = e
-dropApp (F.EApp e _) i = dropApp e (i-1)
-dropApp _ _          = errorstar "impossible"
-
-isApp :: Expr -> Bool
-isApp (F.EApp (F.EVar _) (F.EVar _)) = True
-isApp (F.EApp e (F.EVar _))          = isApp e
-isApp _                              = False
-
 
 --------------------------------------------------------------------------------
 -- | Refined Instances ---------------------------------------------------------

--- a/scripts/ghc.head/build.sh
+++ b/scripts/ghc.head/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -eux
+git clone https://gitlab.haskell.org/ghc/ghc.git ghc.head
+cd ghc.head
+git submodule update --init --recursive
+NIX_SHELL="nix-shell -p haskell.compiler.ghc982 happy alex ncurses python3 gmp cabal-install autoconf automake --run"
+$NIX_SHELL "./boot"
+$NIX_SHELL "./configure"
+$NIX_SHELL "./hadrian/build -j"

--- a/scripts/ghc.head/lh.build.sh
+++ b/scripts/ghc.head/lh.build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -eux
+git clone https://github.com/ucsd-progsys/liquidhaskell.git liquidhaskell.ci.ghc.head
+cd liquidhaskell.ci.ghc.head
+git submodule update --init --recursive
+curl https://ghc.gitlab.haskell.org/head.hackage/cabal.project | grep -v liquidhaskell-boot > cabal.project.local
+NIX_SHELL="nix-shell -p z3 cabal-install ncurses gmp --run"
+$NIX_SHELL "PATH=$PWD/../ghc.head/_build/stage1/bin:$PATH ./scripts/test/test_plugin.sh"


### PR DESCRIPTION
In this PR, besides getting precise locations for infix operators in scope errors, I'm contributing some code clean ups.

There is also a commit adding a couple of bash scripts to build GHC HEAD from scratch and LH with it. These have been helpful to prepare patches for the `ci/ghc-head` branch.