### PR TITLE
Get rid of wiredin reflections

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -551,9 +551,6 @@ resolveLogicNames cfg env globalRdrEnv unhandledNames lmap0 localVars sp =
               )
             return $ makeLocalLHName $ val s
 
-    resolveVarName _ s
-      | val s == "GHC.Internal.Base.." = Just $ do
-        return $ makeLocalLHName $ val s
     resolveVarName lmap s =
       case GHC.lookupGRE globalRdrEnv (mkLookupGRE (LHVarName LHAnyModuleNameF) (val s)) of
         [e] -> do

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -100,7 +100,7 @@ initPStateWithList
                { empList    = Just $ \lx -> EVar ("GHC.Types.[]" <$ lx)
                , singList   = Just (\lx e -> EApp (EApp (EVar ("GHC.Types.:" <$ lx)) e) (EVar ("GHC.Types.[]" <$ lx)))
                }
-  where composeFun = Just $ EVar . (functionComposisionSymbol <$)
+  where composeFun = Nothing
 
 -------------------------------------------------------------------------------
 singleSpecP :: SourcePos -> String -> Either (ParseErrorBundle String Void) BPspec

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
@@ -5,7 +5,6 @@
 module Language.Haskell.Liquid.Types.Names
   ( lenLocSymbol
   , anyTypeSymbol
-  , functionComposisionSymbol
   , selfSymbol
   , LogicName (..)
   , LHResolvedName (..)
@@ -53,12 +52,6 @@ lenLocSymbol = dummyLoc $ symbol ("autolen" :: String)
 
 anyTypeSymbol :: Symbol
 anyTypeSymbol = symbol ("GHC.Prim.Any" :: String)
-
-
---  defined in include/GHC/Base.hs
-functionComposisionSymbol :: Symbol
-functionComposisionSymbol = symbol ("GHC.Internal.Base.." :: String)
-
 
 selfSymbol :: Symbol
 selfSymbol = symbol ("liquid_internal_this" :: String)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -331,7 +331,6 @@ data GhcSpecRefl = SpRefl
   , gsMyAxioms     :: ![F.Equation]                     -- ^ Axioms from my reflected functions
   , gsReflects     :: ![Var]                            -- ^ Binders for reflected functions
   , gsLogicMap     :: !LogicMap
-  , gsWiredReft    :: ![Var]
   , gsRewrites     :: S.HashSet (F.Located Var)
   , gsRewritesWith :: M.HashMap Var [Var]
   }
@@ -345,7 +344,6 @@ instance Semigroup GhcSpecRefl where
     , gsMyAxioms = gsMyAxioms x <> gsMyAxioms y
     , gsReflects = gsReflects x <> gsReflects y
     , gsLogicMap = gsLogicMap x <> gsLogicMap y
-    , gsWiredReft = gsWiredReft x <> gsWiredReft y
     , gsRewrites = gsRewrites x <> gsRewrites y
     , gsRewritesWith = gsRewritesWith x <> gsRewritesWith y
     }
@@ -353,7 +351,7 @@ instance Semigroup GhcSpecRefl where
 instance Monoid GhcSpecRefl where
   mempty = SpRefl mempty mempty mempty
                   mempty mempty mempty
-                  mempty mempty mempty
+                  mempty mempty
 
 type VarOrLocSymbol = Either Var LocSymbol
 type BareMeasure   = Measure LocBareType F.LocSymbol

--- a/src/GHC/Base_LHAssumptions.hs
+++ b/src/GHC/Base_LHAssumptions.hs
@@ -8,6 +8,13 @@ import GHC.Exts_LHAssumptions()
 import GHC.Types_LHAssumptions()
 import Data.Tuple_LHAssumptions()
 
+{-@ LIQUID "--higherorder" @-}
+{-@ reflect comp @-}
+{-@ assume reflect . as comp @-}
+comp :: (b -> c) -> (a -> b) -> a -> c
+comp f g x = f (g x)
+
+
 {-@
 
 assume . :: forall <p :: b -> c -> Bool, q :: a -> b -> Bool, r :: a -> c -> Bool>.

--- a/tests/basic/neg/T2349.hs
+++ b/tests/basic/neg/T2349.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE GADTs #-}
 {-@ LIQUID "--expect-error-containing=is not a subtype of the required type
-      VV : {VV##1461 : [GHC.Types.Int] | len VV##1461 == ?b + 1}" @-}
+      VV : {VV##1456 : [GHC.Types.Int] | len VV##1456 == ?b + 1}" @-}
 {-@ LIQUID "--reflection" @-}
 -- | Test that the refinement types produced for GADTs are
 -- compatible with the Haskell types.

--- a/tests/pos/LNot.hs
+++ b/tests/pos/LNot.hs
@@ -4,7 +4,6 @@ module LNot where
 import Prelude  hiding (any, all, filter, nub, foldr, flip)
 
 
-
 {-@  lemma_all_ex_not :: f:(a->Bool) -> ls:[a] -> { (bnot (any f ls)) == all (bnot . f) ls} @-}
 lemma_all_ex_not :: (a->Bool) -> [a] -> ()
 lemma_all_ex_not f [] = ()

--- a/tests/pos/T1548.hs
+++ b/tests/pos/T1548.hs
@@ -1,5 +1,5 @@
 {-@ LIQUID "--reflection" @-}
-
+{-@ LIQUID "--ple" @-}
 
 module T1548 where
 


### PR DESCRIPTION
The only wired-in reflected function was composition (`.`), and it turned out that it can be implemented with `assume reflect`. Therefore this PR eliminates all the mechanism for wiredin reflects.

This PR also fixes a flaw I found along the way. LH was omitting to add the sorts of imported reflected functions in the fixpoint queries. This only happened when the corresponding Haskell function is not in scope, which can be the case when functions are defined in `LHAssumption` modules.