### PR TITLE
Persist name resolution for reflected names

### DIFF
--- a/liquidhaskell-boot/liquidhaskell-boot.cabal
+++ b/liquidhaskell-boot/liquidhaskell-boot.cabal
@@ -126,7 +126,6 @@ library
                     , Diff                 >= 0.3 && < 0.6
                     , array
                     , aeson
-                    , base64
                     , binary
                     , bytestring           >= 0.10
                     , Cabal

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -645,6 +645,7 @@ import GHC.Types.Name                 as Ghc
 import GHC.Types.Name.Env             as Ghc
     ( NameEnv
     , lookupNameEnv
+    , mkNameEnv
     , mkNameEnvWith
     )
 import GHC.Types.Name.Set             as Ghc

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -272,6 +272,7 @@ makeGhcSpec0 cfg ghcTyLookupEnv tcg instEnvs localVars src lmap targetSpec depen
                 , reflects = Ms.reflects mySpec0
                 , cmeasures = Ms.cmeasures targetSpec
                 , embeds = Ms.embeds targetSpec
+                , privateReflects = mconcat $ map (privateReflects . snd) mspecs
                 }
     })
   where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -77,17 +77,17 @@ makeHaskellAxioms src env tycEnv name lmap spSig spec = do
 --   ``VV == pretendedFn arg1 arg2 ...`                                                      --
 -- * The assume reflect equation, linking the pretended and actual function:                 --
 --   `actualFn arg1 arg 2 ... = pretendedFn arg1 arg2 ...`                                   --
-makeAssumeReflectAxioms :: GhcSrc -> Bare.Env -> Bare.TycEnv -> ModName -> GhcSpecSig -> Ms.BareSpec
+makeAssumeReflectAxioms :: GhcSrc -> Bare.Env -> Bare.TycEnv -> GhcSpecSig -> Ms.BareSpec
                   -> Bare.Lookup [(Ghc.Var, LocSpecType, F.Equation)]
 -----------------------------------------------------------------------------------------------
-makeAssumeReflectAxioms src env tycEnv name spSig spec = do
+makeAssumeReflectAxioms src env tycEnv spSig spec = do
   -- Send an error message if we're redefining a reflection
   case findDuplicatePair val reflActSymbols <|> findDuplicateBetweenLists val refSymbols reflActSymbols of
     Just (x , y) -> Ex.throw $ mkError y $
                       "Duplicate reflection of " ++ show x ++ " and " ++ show y
     Nothing -> return $ turnIntoAxiom <$> Ms.asmReflectSigs spec
   where
-    turnIntoAxiom (actual, pretended) = makeAssumeReflectAxiom spSig env embs name (actual, pretended)
+    turnIntoAxiom (actual, pretended) = makeAssumeReflectAxiom spSig env embs (actual, pretended)
     refDefs                 = getReflectDefs src spSig spec env
     embs                    = Bare.tcEmbs       tycEnv
     refSymbols              =
@@ -98,11 +98,11 @@ makeAssumeReflectAxioms src env tycEnv name spSig spec = do
 -- Processes one `assume reflect` and returns its axiom element, as detailed in              --
 -- `makeAssumeReflectAxioms`. Can also be used to compute the updated SpecType of            --
 -- a type where we add the post-condition that actual and pretended are the same             --
-makeAssumeReflectAxiom :: GhcSpecSig -> Bare.Env -> F.TCEmb Ghc.TyCon -> ModName
+makeAssumeReflectAxiom :: GhcSpecSig -> Bare.Env -> F.TCEmb Ghc.TyCon
                        -> (Located LHName, Located LHName) -- actual function and pretended function
                        -> (Ghc.Var, LocSpecType, F.Equation)
 -----------------------------------------------------------------------------------------------
-makeAssumeReflectAxiom sig env tce name (actual, pretended) =
+makeAssumeReflectAxiom sig env tce (actual, pretended) =
    -- The actual and pretended function must have the same type
   if pretendedTy == actualTy then
     (actualV, actual{val = aty at}, actualEq)
@@ -121,8 +121,13 @@ makeAssumeReflectAxiom sig env tce name (actual, pretended) =
       Right x -> x
       Left _ -> panic (Just $ GM.fSrcSpan pretended) "function to reflect not in scope"
     -- Get the qualified name symbols for the actual and pretended functions
-    qActual = Bare.qualifyTop env name (F.loc actual) (getLHNameSymbol $ val actual)
-    qPretended = Bare.qualifyTop env name (F.loc pretended) (getLHNameSymbol $ val pretended)
+    lhNameToSymbol lx =
+      F.symbol $
+      Mb.fromMaybe (panic (Just $ GM.fSrcSpan lx) $ "expected a resolved Haskell name: " ++ show lx) $
+      getLHGHCName $
+      val lx
+    qActual = lhNameToSymbol actual
+    qPretended = lhNameToSymbol pretended
     -- Get the GHC type of the actual and pretended functions
     actualTy = Ghc.varType actualV
     pretendedTy = Ghc.varType pretendedV
@@ -144,7 +149,7 @@ strengthenSpecWithMeasure :: GhcSpecSig -> Bare.Env
                        -> Located AxiomType
 -----------------------------------------------------------------------------------------------
 strengthenSpecWithMeasure sig env actualV qPretended =
-    qPretended{ val = addSingletonApp allowTC qPretended rt}
+    qPretended{ val = addSingletonApp allowTC (val qPretended) rt}
   where
     -- Get the GHC type of the actual and pretended functions
     actualTy = Ghc.varType actualV
@@ -323,14 +328,15 @@ makeAssumeType
   -> Ghc.Var -> Ghc.CoreExpr
   -> (LocSpecType, F.Equation)
 makeAssumeType allowTC tce lmap dm sym mbT v def
-  = (sym {val = aty at `strengthenRes` F.subst su ref},  F.mkEquation (val sym) xts (F.subst su le) out)
+  = (sym {val = aty at `strengthenRes` F.subst su ref},  F.mkEquation symbolV xts (F.subst su le) out)
   where
+    symbolV = F.symbol v
     rt    = fromRTypeRep .
             (\trep@RTypeRep{..} ->
                 trep{ty_info = fmap (\i -> i{permitTC = Just allowTC}) ty_info}) .
             toRTypeRep $ Mb.fromMaybe (ofType τ) mbT
     τ     = Ghc.varType v
-    at    = addSingletonApp allowTC sym rt
+    at    = addSingletonApp allowTC symbolV rt
     out   = rTypeSort tce $ ares at
     xArgs = F.EVar . fst <$> aargs at
     _msg  = unwords [showpp sym, showpp mbT]
@@ -426,7 +432,7 @@ data AxiomType = AT { aty :: SpecType, aargs :: [(F.Symbol, SpecType)], ares :: 
 -- @addSingletonApp allowTC f (x:_ -> y: -> {v:_ | p}@ produces a type
 -- @x:_ -> y:_ -> {v:_ | p && v = f x y}@
 --
-addSingletonApp :: Bool -> LocSymbol -> SpecType -> AxiomType
+addSingletonApp :: Bool -> F.Symbol -> SpecType -> AxiomType
 addSingletonApp allowTC s st = AT to (reverse xts) res
   where
     (to, (_,xts, Just res)) = runState (go st) (1,[], Nothing)
@@ -451,7 +457,7 @@ unDummy x i
   | x /= F.dummySymbol = x
   | otherwise          = F.symbol ("lq" ++ show i)
 
-singletonApp :: F.Symbolic a => LocSymbol -> [a] -> UReft F.Reft
+singletonApp :: F.Symbolic a => F.Symbol -> [a] -> UReft F.Reft
 singletonApp s ys = MkUReft r mempty
   where
-    r             = F.exprReft (F.mkEApp s (F.eVar <$> ys))
+    r             = F.exprReft (F.eApps (F.EVar s) (F.eVar <$> ys))

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -16,6 +16,7 @@ module Language.Haskell.Liquid.Bare.Resolve
     makeEnv
   , makeLocalVars
   , makeGHCTyLookupEnv
+  , GHCTyLookupEnv(..)
 
     -- * Resolving symbols
   , ResolveSym (..)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -89,8 +89,7 @@ import           Language.Haskell.Liquid.Types.RType
 import           Language.Haskell.Liquid.Types.RTypeOp
 import qualified Language.Haskell.Liquid.Types.RefType as RT
 import           Language.Haskell.Liquid.Types.Types
-import           Language.Haskell.Liquid.Measure       (BareSpec)
-import           Language.Haskell.Liquid.Types.Specs   hiding (BareSpec)
+import           Language.Haskell.Liquid.Types.Specs
 import           Language.Haskell.Liquid.Types.Visitors
 import           Language.Haskell.Liquid.Bare.Types
 import           Language.Haskell.Liquid.UX.Config

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -73,7 +73,7 @@ import           Language.Haskell.Liquid.Types.Specs
 import           Language.Haskell.Liquid.Types.Types
 import           Language.Haskell.Liquid.Types.Visitors
 import           Language.Haskell.Liquid.Bare
-import           Language.Haskell.Liquid.Bare.Resolve (makeLocalVars)
+import qualified Language.Haskell.Liquid.Bare.Resolve as Resolve
 import           Language.Haskell.Liquid.UX.CmdLine
 import           Language.Haskell.Liquid.UX.Config
 
@@ -544,7 +544,7 @@ processModule LiquidHaskellContext{..} = do
     -- call 'evaluate' to force any exception and catch it, if we can.
 
     tcg <- getGblEnv
-    let localVars = makeLocalVars preNormalizedCore
+    let localVars = Resolve.makeLocalVars preNormalizedCore
         eBareSpec = resolveLHNames
           moduleCfg
           thisModule

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -45,7 +45,6 @@
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE TupleSections              #-}
 {-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE ViewPatterns               #-}
 
 module Language.Haskell.Liquid.LHNameResolution
   ( resolveLHNames
@@ -500,9 +499,7 @@ collectUnhandledLiftedSpecLogicNames sp =
 
 collectLiftedSpecLogicNames :: LiftedSpec -> [LHName]
 collectLiftedSpecLogicNames sp =
-    concat
-      [ map fst $ HS.toList $ liftedExpSigs sp
-      ]
+    map fst $ HS.toList $ liftedExpSigs sp
 
 -- | Resolves names in the logic namespace
 --

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -417,7 +417,6 @@ makeLogicEnvs impAvails thisModule spec dependencies =
           map unqualify unhandledNamesList ++ map (LH.qualifySymbol (symbol $ GHC.moduleName thisModule)) unhandledNamesList
         unhandledNamesList = concat $
           [ map (getLHNameSymbol . val) $ HS.toList $ hmeas spec
-          , map (getLHNameSymbol . val) $ HS.toList $ inlines spec
           , map (val . msName) $ measures spec
           , map (val . msName) $ cmeasures spec
           , map (rtName . val) $ ealiases spec
@@ -444,6 +443,7 @@ makeLogicEnvs impAvails thisModule spec dependencies =
               [ map fst (asmReflectSigs spec)
               , HS.toList (reflects spec)
               , HS.toList (opaqueReflects spec)
+              , HS.toList (inlines spec)
               ]
           ]
         privateReflectNames =

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -45,13 +45,14 @@
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE TupleSections              #-}
 {-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE ViewPatterns               #-}
 
 module Language.Haskell.Liquid.LHNameResolution
   ( resolveLHNames
   , exprArg
   , fromBareSpecLHName
   , toBareSpecLHName
-  , LogicNameEnv
+  , LogicNameEnv(..)
   ) where
 
 import qualified Liquid.GHC.API         as GHC hiding (Expr, panic)
@@ -72,12 +73,13 @@ import           Data.Generics (extT)
 
 import qualified Data.HashSet                            as HS
 import qualified Data.HashMap.Strict                     as HM
+import           Data.List (nub)
 import           Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import qualified Data.Text                               as Text
 import qualified GHC.Types.Name.Occurrence
 
 import           Language.Fixpoint.Types as F hiding (Error, panic)
-import           Language.Haskell.Liquid.Bare.Resolve (lookupLocalVar)
+import qualified Language.Haskell.Liquid.Bare.Resolve as Resolve
 import           Language.Haskell.Liquid.Bare.Types (LocalVars(lvNames), LocalVarDetails(lvdLclEnv))
 import           Language.Haskell.Liquid.Name.LogicNameEnv
 import qualified Language.Haskell.Liquid.Types.DataDecl as DataDecl
@@ -122,23 +124,31 @@ resolveLHNames
   -> BareSpecParsed
   -> TargetDependencies
   -> Either [Error] (BareSpec, LogicNameEnv)
-resolveLHNames cfg thisModule localVars impMods globalRdrEnv lmap bareSpec0 dependencies =
-    let (inScopeEnv, logicNameEnv, unhandledNames) =
-          makeInScopeExprEnv impMods thisModule bareSpec0 dependencies
-        (bs, (es, ns)) =
+resolveLHNames cfg thisModule localVars impMods globalRdrEnv lmap bareSpec0 dependencies = do
+    let ((bs, logicNameEnv), (es, ns)) =
           flip runState mempty $ do
             -- A generic traversal that resolves names of Haskell entities
             sp1 <- mapMLocLHNames (\l -> (<$ l) <$> resolveLHName l) $
                      fixExpressionArgsOfTypeAliases taliases bareSpec0
             -- Now we do a second traversal to resolve logic names
-            fromBareSpecLHName <$>
-              resolveLogicNames cfg inScopeEnv globalRdrEnv unhandledNames lmap localVars sp1
-        logicNameEnv' =
-          foldr (uncurry insertSEnv) logicNameEnv [ (logicNameToSymbol n, n) | n <- ns]
-     in if null es then
-          Right (bs, logicNameEnv')
-        else
-          Left es
+            let (inScopeEnv, logicNameEnv0, unhandledNames) =
+                  makeInScopeNonReflectedEnv impMods thisModule sp1 dependencies
+            sp2 <- fromBareSpecLHName <$>
+                     resolveLogicNames
+                       cfg
+                       inScopeEnv
+                       globalRdrEnv
+                       unhandledNames
+                       lmap
+                       localVars
+                       logicNameEnv0
+                       sp1
+            return (sp2, logicNameEnv0)
+        logicNameEnv' = extendLogicNameEnv logicNameEnv ns
+    if null es then
+      Right (bs, logicNameEnv')
+    else
+      Left es
   where
     taliases = collectTypeAliases thisModule bareSpec0 dependencies
 
@@ -158,7 +168,7 @@ resolveLHNames cfg thisModule localVars impMods globalRdrEnv lmap bareSpec0 depe
         | isDataCon s -> lookupGRELHName (LHDataConName lcl) lname s listToMaybe
         | otherwise ->
             lookupGRELHName ns lname s
-              (fmap (either id GHC.getName) . lookupLocalVar localVars (atLoc lname s))
+              (fmap (either id GHC.getName) . Resolve.lookupLocalVar localVars (atLoc lname s))
       LHNUnresolved ns s -> lookupGRELHName ns lname s listToMaybe
       n@(LHNResolved (LHRLocal _) _) -> pure n
       n ->
@@ -359,13 +369,13 @@ exprArg l msg = notracepp ("exprArg: " ++ msg) . go
 --
 -- For each symbol we have the aliases with which it is imported and the
 -- name corresponding to each alias.
-type InScopeExprEnv = SEnv [(GHC.ModuleName, LHName)]
+type InScopeNonReflectedEnv = SEnv [(GHC.ModuleName, LHName)]
 
 -- | Looks the names in scope with the given symbol.
 -- Returns a list of close but different symbols or a non empty list
 -- with the matched names.
-lookupInScopeExprEnv :: InScopeExprEnv -> Symbol -> Either [Symbol] [LHName]
-lookupInScopeExprEnv env s = do
+lookupInScopeNonReflectedEnv :: InScopeNonReflectedEnv -> Symbol -> Either [Symbol] [LHName]
+lookupInScopeNonReflectedEnv env s = do
     let n = LH.dropModuleNames s
     case lookupSEnvWithDistance n env of
       Alts closeSyms -> Left closeSyms
@@ -375,21 +385,22 @@ lookupInScopeExprEnv env s = do
            [] -> Left $ map ((`LH.qualifySymbol` n) . symbol . GHC.moduleNameString . fst) xs
            ys -> Right $ map snd ys
 
--- | Builds an 'InScopeExprEnv' from the module aliases for the current module,
--- the spec of the current module, and the specs of the dependencies.
+-- | Builds an environment of non-reflected names in scope from the module
+-- aliases for the current module, the spec of the current module, and the specs
+-- of the dependencies.
 --
 -- Also returns a LogicNameEnv constructed from the same names.
 -- Also returns the set of all names that aren't handled yet by name resolution.
-makeInScopeExprEnv
+makeInScopeNonReflectedEnv
   :: GHC.ImportedMods
   -> GHC.Module
   -> BareSpecParsed
   -> TargetDependencies
-  -> ( InScopeExprEnv
+  -> ( InScopeNonReflectedEnv
      , LogicNameEnv
      , HS.HashSet Symbol
      )
-makeInScopeExprEnv impAvails thisModule spec dependencies =
+makeInScopeNonReflectedEnv impAvails thisModule spec dependencies =
     let unqualify s =
           if s == LH.qualifySymbol (symbol $ GHC.moduleName thisModule) (LH.dropModuleNames s) then
             LH.dropModuleNames s
@@ -400,11 +411,8 @@ makeInScopeExprEnv impAvails thisModule spec dependencies =
         unhandledNames = HS.fromList $
           map unqualify unhandledNamesList ++ map (LH.qualifySymbol (symbol $ GHC.moduleName thisModule)) unhandledNamesList
         unhandledNamesList = concat $
-          [ map (getLHNameSymbol . val) $ HS.toList $ reflects spec
-          , map (getLHNameSymbol . val) $ HS.toList $ opaqueReflects spec
-          , map (getLHNameSymbol . val) $ HS.toList $ hmeas spec
+          [ map (getLHNameSymbol . val) $ HS.toList $ hmeas spec
           , map (getLHNameSymbol . val) $ HS.toList $ inlines spec
-          , map (getLHNameSymbol . val . fst) $ asmReflectSigs spec
           , map (val . msName) $ measures spec
           , map (val . msName) $ cmeasures spec
           , map (rtName . val) $ ealiases spec
@@ -415,15 +423,31 @@ makeInScopeExprEnv impAvails thisModule spec dependencies =
              mapMaybe DataDecl.tycDCons $
              dataDecls spec
           , map fst wiredSortedSyms
-          ] ++ map (map getLHNameSymbol . snd) logicNames
-        logicNames =
-          (thisModule, []) :
-          [ (GHC.unStableModule sm, collectLiftedSpecLogicNames sp)
-          | (sm, sp) <- HM.toList $ getDependencies dependencies
+          ] ++ map (map getLHNameSymbol . snd) unhandledLogicNames
+        unhandledLogicNames =
+          [ (GHC.unStableModule sm, collectUnhandledLiftedSpecLogicNames sp)
+          | (sm, sp) <- dependencyPairs
           ]
+        logicNames =
+          (thisModule, thisModuleNames) :
+          [ (GHC.unStableModule sm, collectLiftedSpecLogicNames sp)
+          | (sm, sp) <- dependencyPairs
+          ] ++ unhandledLogicNames
+        thisModuleNames =
+          [ reflectLHName thisModule (val n)
+          | n <- concat
+              [ map fst (asmReflectSigs spec)
+              , HS.toList (reflects spec)
+              , HS.toList (opaqueReflects spec)
+              ]
+          ]
+        privateReflectNames =
+          mconcat $
+            privateReflects spec : map (liftedPrivateReflects . snd) dependencyPairs
      in
         ( unionAliasEnvs $ map mkAliasEnv logicNames
-        , mkLogicNameEnv $ concatMap snd logicNames
+        , mkLogicNameEnv (concatMap snd logicNames)
+        , privateReflectNames
         , unhandledNames
         )
   where
@@ -431,11 +455,16 @@ makeInScopeExprEnv impAvails thisModule spec dependencies =
       let aliases = moduleAliases m
        in fromListSEnv
             [ (s,  map (,lhname) aliases)
-            | lhname@(LHNResolved (LHRLogic (LogicName s _ _))_) <- lhnames
+              -- Note that only non-reflected names go to the InScope environement
+            | lhname@(LHNResolved (LHRLogic (LogicName s _ Nothing))_) <- lhnames
             ]
 
-    unionAliasEnvs :: [InScopeExprEnv] -> InScopeExprEnv
-    unionAliasEnvs = coerce . foldl' (HM.unionWith (++)) HM.empty . coerce @[InScopeExprEnv] @[HM.HashMap Symbol [(GHC.ModuleName, LHName)]]
+    unionAliasEnvs :: [InScopeNonReflectedEnv] -> InScopeNonReflectedEnv
+    unionAliasEnvs =
+      coerce .
+      HM.map nub .
+      foldl' (HM.unionWith (++)) HM.empty .
+      coerce @_ @[HM.HashMap Symbol [(GHC.ModuleName, LHName)]]
 
     moduleAliases m =
       case GHC.lookupModuleEnv impAvails m of
@@ -446,32 +475,46 @@ makeInScopeExprEnv impAvails thisModule spec dependencies =
       | GHC.imv_qualified imv = [GHC.imv_name imv]
       | otherwise = [GHC.imv_name imv, GHC.mkModuleName ""]
 
-    mkLogicNameEnv names = fromListSEnv [ (logicNameToSymbol n, n) | n <- names ]
+    mkLogicNameEnv names =
+      LogicNameEnv
+        { lneLHName = fromListSEnv [ (logicNameToSymbol n, n) | n <- names ]
+        , lneReflected = GHC.mkNameEnv [(rn, n) | n <- names, Just rn <- [maybeReflectedLHName n]]
+        }
 
-collectLiftedSpecLogicNames :: LiftedSpec -> [LHName]
-collectLiftedSpecLogicNames sp =
+collectUnhandledLiftedSpecLogicNames :: LiftedSpec -> [LHName]
+collectUnhandledLiftedSpecLogicNames sp =
     concat
-      [ map (makeLocalLHName . LH.dropModuleNames . getLHNameSymbol . fst) $ HS.toList $ liftedExpSigs sp
-      , map (makeLocalLHName . LH.dropModuleNames . val . msName) $ HS.toList $ liftedCmeasures sp
+      [ map (makeLocalLHName . LH.dropModuleNames . val . msName) $ HS.toList $ liftedCmeasures sp
       , map (makeLocalLHName . LH.dropModuleNames . val . msName) $ HS.toList $ liftedMeasures sp
       , map (makeLocalLHName . LH.dropModuleNames . rtName . val) $ HS.toList $ liftedEaliases sp
       , map (makeLocalLHName . LH.dropModuleNames . fst) $
         concatMap DataDecl.dcFields $ concat $
         mapMaybe DataDecl.tycDCons $
         HS.toList $ liftedDataDecls sp
-      , map (makeLocalLHName . LH.dropModuleNames . eqName) $ HS.toList $ liftedAxeqs sp
       ]
 
+collectLiftedSpecLogicNames :: LiftedSpec -> [LHName]
+collectLiftedSpecLogicNames sp =
+    concat
+      [ map fst $ HS.toList $ liftedExpSigs sp
+      ]
+
+-- | Resolves names in the logic namespace
+--
+-- Returns the renamed spec.
+-- Adds in the monadic state the errors about ambiguous or missing names, and
+-- the names of data constructors that are found during renaming.
 resolveLogicNames
   :: Config
-  -> InScopeExprEnv
+  -> InScopeNonReflectedEnv
   -> GHC.GlobalRdrEnv
   -> HS.HashSet Symbol
   -> LogicMap
   -> LocalVars
+  -> LogicNameEnv
   -> BareSpecParsed
   -> State RenameOutput BareSpecLHName
-resolveLogicNames cfg env globalRdrEnv unhandledNames lmap0 localVars sp =
+resolveLogicNames cfg env globalRdrEnv unhandledNames lmap0 localVars lnameEnv sp =
     emapSpecM
       (bscope cfg)
       (map localVarToSymbol . maybe [] lvdLclEnv . (GHC.lookupNameEnv (lvNames localVars) <=< getLHGHCName))
@@ -483,12 +526,13 @@ resolveLogicNames cfg env globalRdrEnv unhandledNames lmap0 localVars sp =
 
     resolveLogicName :: [Symbol] -> LocSymbol -> State RenameOutput LHName
     resolveLogicName ss ls
+        -- The name is local
       | elem s ss = return $ makeLocalLHName s
       | otherwise =
-        case lookupInScopeExprEnv env s of
+        case lookupInScopeNonReflectedEnv env s of
           Left alts ->
             -- If names are not in the environment, they must be data constructors,
-            -- or they must be in the logicmap.
+            -- or they must be reflected functions, or they must be in the logicmap.
             case resolveDataConName ls `mplus` resolveVarName lmap0 ls of
               Just m -> m
               Nothing -> do
@@ -522,9 +566,6 @@ resolveLogicNames cfg env globalRdrEnv unhandledNames lmap0 localVars sp =
         return $ makeLocalLHName s
       | isTupleDC (symbolText s) = Just $
         return $ makeLocalLHName s
-        -- TODO: Remove this case when qualified names are handled
-      | LH.takeModuleNames s /= "" = Just $
-        return $ makeLocalLHName s
       where
         s = val ls
         isTupleDC t =
@@ -551,29 +592,47 @@ resolveLogicNames cfg env globalRdrEnv unhandledNames lmap0 localVars sp =
               )
             return $ makeLocalLHName $ val s
 
-    resolveVarName lmap s =
-      case GHC.lookupGRE globalRdrEnv (mkLookupGRE (LHVarName LHAnyModuleNameF) (val s)) of
-        [e] -> do
-          let n = GHC.greName e
-          if HM.member (symbol n) (lmSymDefs lmap) then
-            Just $ do
-              let lhName = makeLogicLHName (symbol n) (GHC.nameModule n) (Just n)
-              addName lhName
-              -- return lhName
-              return $ makeLocalLHName $ val s
-          else
+    -- Resolves names of reflected functions or names in the logic map
+    --
+    -- Names of reflected functions are resolved here because, to be in scope,
+    -- we ask the corresponding Haskell name to be in scope. In contrast, the
+    -- @InScopeNonReflectedEnv@ indicates where the reflect annotations were
+    -- imported from, but not where the Haskell names were imported from.
+    resolveVarName lmap s = do
+      let gres =
+            GHC.lookupGRE globalRdrEnv $
+            mkLookupGRE (LHVarName LHAnyModuleNameF) (val s)
+          refls = mapMaybe (findReflection . GHC.greName) gres
+      case refls of
+        [lhName] -> Just $ return lhName
+        _ -> case gres of
+          [e] -> do
+            let n = GHC.greName e
+            if HM.member (symbol n) (lmSymDefs lmap) then
+              Just $ do
+                let lhName = makeLogicLHName (symbol n) (GHC.nameModule n) Nothing
+                addName lhName
+                -- return lhName
+                return $ makeLocalLHName $ val s
+            -- TODO: Remove this case when qualified names are handled
+            else if LH.takeModuleNames (val s) /= "" then
+              Just $ return $ makeLocalLHName $ val s
+            else
+              Nothing
+          [] ->
             Nothing
-        [] ->
-          Nothing
-        es ->
-          Just $ do
-            addError
-              (ErrDupNames
-                 (LH.fSrcSpan s)
-                 (pprint $ val s)
-                 (map (PJ.text . GHC.showPprUnsafe) es)
-              )
-            return $ makeLocalLHName $ val s
+          es ->
+            Just $ do
+              addError
+                 (ErrDupNames
+                   (LH.fSrcSpan s)
+                   (pprint $ val s)
+                   (map (PJ.text . GHC.showPprUnsafe) es)
+                 )
+              return $ makeLocalLHName $ val s
+
+    findReflection :: GHC.Name -> Maybe LHName
+    findReflection n = GHC.lookupNameEnv (lneReflected lnameEnv) n
 
 toBareSpecLHName :: Config -> LogicNameEnv -> BareSpec -> BareSpecLHName
 toBareSpecLHName cfg env sp0 = runIdentity $ go sp0
@@ -595,7 +654,7 @@ toBareSpecLHName cfg env sp0 = runIdentity $ go sp0
     symbolToLHName ss s
       | elem s ss = return $ makeLocalLHName s
       | otherwise =
-        case lookupSEnv s env of
+        case lookupSEnv s (lneLHName env) of
           Nothing -> do
             unless (HS.member s unhandledNames) $
               panic Nothing $ "toBareSpecLHName: cannot find " ++ show s

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Name/LogicNameEnv.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Name/LogicNameEnv.hs
@@ -1,7 +1,9 @@
 module Language.Haskell.Liquid.Name.LogicNameEnv
-  ( LogicNameEnv
+  ( LogicNameEnv(..)
+  , extendLogicNameEnv
   ) where
 
+import qualified Liquid.GHC.API         as GHC
 import           Language.Fixpoint.Types
 import           Language.Haskell.Liquid.Types.Names
 
@@ -10,4 +12,15 @@ import           Language.Haskell.Liquid.Types.Names
 --
 -- Symbols are expected to have been created by 'logicNameToSymbol'.
 --
-type LogicNameEnv = SEnv LHName
+data LogicNameEnv = LogicNameEnv
+       { lneLHName :: SEnv LHName
+         -- | Haskell names that have a reflected counterpart
+       , lneReflected :: GHC.NameEnv LHName
+       }
+
+extendLogicNameEnv :: LogicNameEnv -> [LHName] -> LogicNameEnv
+extendLogicNameEnv env ns =
+    env
+      { lneLHName =
+          foldr (uncurry insertSEnv) (lneLHName env) [ (logicNameToSymbol n, n) | n <- ns]
+      }

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -449,14 +449,13 @@ makeApp _ _ f [e1, e2]
   , Just op <- M.lookup (mappendSym (symbol ("GHC.Internal.Num." :: String)) sym) bops
   = EBin op e1 e2
 
-makeApp def lmap f es
-  = eAppWithMap lmap f es def
+makeApp def lmap f es =
+    eAppWithMap lmap (val f) es def
   -- where msg = "makeApp f = " ++ show f ++ " es = " ++ show es ++ " def = " ++ show def
 
 eVarWithMap :: Id -> LogicMap -> Expr
 eVarWithMap x lmap = do
-  let f' = dummyLoc $ symbol x
-   in eAppWithMap lmap f' [] (EVar $ symbol x)
+    eAppWithMap lmap (symbol x) [] (EVar $ symbol x)
 
 brels :: M.HashMap Symbol Brel
 brels = M.fromList [ (symbol ("GHC.Classes.==" :: String), Eq)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
@@ -60,7 +60,8 @@ selfSymbol = symbol ("liquid_internal_this" :: String)
 -- For instance, this can be used to represent predicate aliases
 -- or uninterpreted functions.
 data LogicName = LogicName
-    { lnSymbol :: !Symbol
+    { -- | Unqualified symbol
+      lnSymbol :: !Symbol
       -- | Module where the entity was defined
     , lnModule :: !GHC.Module
       -- | If the named entity is the reflection of some Haskell name

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
@@ -25,15 +25,14 @@ module Language.Haskell.Liquid.Types.Names
   , makeUnresolvedLHName
   , mapLHNames
   , mapMLocLHNames
+  , maybeReflectedLHName
+  , reflectGHCName
+  , reflectLHName
   , updateLHNameSymbol
   ) where
 
 import Control.DeepSeq
-import qualified Data.Base64.Types                       as Base64
 import qualified Data.Binary as B
-import qualified Data.ByteString.Lazy                    as ByteString
-import qualified Data.ByteString.Base64                  as Base64
-import qualified Data.ByteString.Builder                 as Builder
 import Data.Data (Data, gmapM, gmapT)
 import Data.Generics (extM, extT)
 import Data.Hashable
@@ -253,9 +252,20 @@ updateLHNameSymbol :: (Symbol -> Symbol) -> LHName -> LHName
 updateLHNameSymbol f (LHNResolved n s) = LHNResolved n (f s)
 updateLHNameSymbol f (LHNUnresolved n s) = LHNUnresolved n (f s)
 
+-- | Converts logic names to symbols.
+--
+-- One important postcondition of this function is that the symbol for reflected
+-- names must match exactly the symbol for the corresponding Haskell function.
+-- Otherwise, LH would fail to link the two at various places where it is needed.
 logicNameToSymbol :: LHName -> Symbol
-logicNameToSymbol (LHNResolved (LHRLogic (LogicName s m _)) _) =
-    let msymbol = Text.pack $ GHC.moduleNameString $ GHC.moduleName m
+logicNameToSymbol (LHNResolved (LHRLogic (LogicName s om mReflectionOf)) _) =
+    let m = maybe om GHC.nameModule mReflectionOf
+        msymbol = Text.pack $ GHC.moduleNameString $ GHC.moduleName m
+     in symbol $ mconcat [msymbol, ".", symbolText s]
+        {-
+        TODO: Adding a prefix for the unit would allow LH to deal with
+              -XPackageImports. This prefix should be added here and in
+              the Symbolic instance of Name.
         munique =
           Text.dropEnd 2 $ -- Remove padding of two characters "=="
           Base64.extractBase64 $
@@ -268,6 +278,28 @@ logicNameToSymbol (LHNResolved (LHRLogic (LogicName s m _)) _) =
           GHC.unitIdString $
           GHC.moduleUnitId m
      in symbol $ mconcat ["u", munique, "##", msymbol, ".", symbolText s]
+          -}
 logicNameToSymbol (LHNResolved (LHRLocal s) _) = s
 logicNameToSymbol n = error $ "logicNameToSymbol: unexpected name: " ++ show n
 
+-- | Creates a name in the logic namespace for the given Haskell name.
+reflectLHName :: HasCallStack => GHC.Module -> LHName -> LHName
+reflectLHName thisModule (LHNResolved (LHRGHC n) _) = reflectGHCName thisModule n
+reflectLHName _ n = error $ "not a GHC Name: " ++ show n
+
+-- | Creates a name in the logic namespace for the given Haskell name.
+reflectGHCName :: GHC.Module -> GHC.Name -> LHName
+reflectGHCName thisModule n =
+    LHNResolved
+      (LHRLogic
+        (LogicName
+          (symbol (GHC.occNameString $ GHC.nameOccName n))
+          thisModule
+          (Just n)
+        )
+      )
+      (symbol n)
+
+maybeReflectedLHName :: LHName -> Maybe GHC.Name
+maybeReflectedLHName (LHNResolved (LHRLogic (LogicName _ _ m)) _) = m
+maybeReflectedLHName _ = Nothing

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -700,6 +700,8 @@ data LiftedSpec = LiftedSpec
     -- ^ User-defined properties for ADTs
   , liftedExpSigs    :: HashSet (LHName, F.Sort)
     -- ^ Exported logic symbols originated from reflecting functions
+  , liftedPrivateReflects :: HashSet F.LocSymbol
+    -- ^ Private functions that have been reflected
   , liftedAsmSigs    :: HashSet (F.Located LHName, LocBareTypeLHName)
     -- ^ Assumed (unchecked) types; including reflected signatures
   , liftedSigs       :: HashSet (F.Located LHName, LocBareTypeLHName)
@@ -769,6 +771,7 @@ emptyLiftedSpec :: LiftedSpec
 emptyLiftedSpec = LiftedSpec
   { liftedMeasures = mempty
   , liftedExpSigs  = mempty
+  , liftedPrivateReflects = mempty
   , liftedAsmSigs  = mempty
   , liftedSigs     = mempty
   , liftedInvariants = mempty
@@ -932,6 +935,7 @@ toLiftedSpec :: BareSpecLHName -> LiftedSpec
 toLiftedSpec a = LiftedSpec
   { liftedMeasures   = S.fromList . measures $ a
   , liftedExpSigs    = S.fromList . expSigs  $ a
+  , liftedPrivateReflects = privateReflects a
   , liftedAsmSigs    = S.fromList . asmSigs  $ a
   , liftedSigs       = S.fromList . sigs     $ a
   , liftedInvariants = S.fromList . invariants $ a
@@ -981,7 +985,7 @@ unsafeFromLiftedSpec a = Spec
   , rewrites   = mempty
   , rewriteWith = mempty
   , reflects   = mempty
-  , privateReflects = mempty
+  , privateReflects = liftedPrivateReflects a
   , opaqueReflects   = mempty
   , autois     = liftedAutois a
   , hmeas      = mempty

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -275,9 +275,9 @@ toLogicMap ls = mempty {lmSymDefs = M.fromList $ map toLMap ls}
   where
     toLMap (x, ys, e) = (F.val x, LMap {lmVar = x, lmArgs = ys, lmExpr = e})
 
-eAppWithMap :: LogicMap -> F.Located Symbol -> [Expr] -> Expr -> Expr
+eAppWithMap :: LogicMap -> Symbol -> [Expr] -> Expr -> Expr
 eAppWithMap lmap f es expr
-  | Just (LMap _ xs e) <- M.lookup (F.val f) (lmSymDefs lmap)
+  | Just (LMap _ xs e) <- M.lookup f (lmSymDefs lmap)
   , length xs == length es
   = F.subst (F.mkSubst $ zip xs es) e
   | otherwise

--- a/tests/basic/pos/ReflExt03A.hs
+++ b/tests/basic/pos/ReflExt03A.hs
@@ -13,3 +13,6 @@ import ReflExt03B
 -- 3 * 2 + 2 = 8
 {-@ lemma :: {f 3 2 = 8} @-}
 lemma = ()
+
+{-@ lemma2 :: { ReflExt03B.myAdd 3 2 = 5} @-}
+lemma2 = ()

--- a/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Check.hs
+++ b/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Check.hs
@@ -179,7 +179,7 @@ check globals = go Nil
   where
     {-@
       go :: ts :Language.Stitch.LH.Data.List.List Ty
-         -> VarsSmallerThan (Language.Stitch.LH.Data.List.length ts)
+         -> VarsSmallerThan (List.length ts)
          -> (e1 : WellTypedExp ts -> { t: Ty | exprType e1 = t } -> Either TyError b)
          -> Either TyError b
       @-}


### PR DESCRIPTION
Another step for #2169.

This PR has name resolution for reflected functions persisted and reused when specs are imported. Now it remains to do the same for expression aliases, measures, and wired-in things.