### PR TITLE
Simplify representation of measure names

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -94,7 +94,7 @@ checkBareSpec sp
     inlines   = S.map (fmap getLHNameSymbol) (Ms.inlines sp)
     hmeasures = S.map (fmap getLHNameSymbol) (Ms.hmeas sp)
     reflects  = S.map (fmap getLHNameSymbol) (Ms.reflects sp)
-    measures  = msName    <$> Ms.measures sp
+    measures  = fmap getLHNameSymbol . msName <$> Ms.measures sp
     fields    = concatMap dataDeclFields (Ms.dataDecls sp)
 
 dataDeclFields :: DataDecl -> [F.LocSymbol]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -136,7 +136,7 @@ getGlobalSyms (_, spec)
       ++ (mbName <$> imeasures spec)
       ++ (mbName <$> omeasures spec)
   where
-    mbName = F.val . msName
+    mbName = logicNameToSymbol . F.val . msName
 
 makeLocalVars :: [Ghc.CoreBind] -> LocalVars
 makeLocalVars = localVarMap . localBinds
@@ -392,7 +392,7 @@ instance Qualify RTyCon where
 
 instance Qualify (Measure SpecType Ghc.DataCon) where
   qualify env name _ bs m = m -- FIXME substEnv env name bs $
-    { msName = qualify env name l bs     lname
+    { msName = updateLHNameSymbol (qualify env name l bs) <$> lname
     , msEqns = qualify env name l bs <$> msEqns m
     }
     where
@@ -951,7 +951,7 @@ lookupTyThingMaybe env lc@(Loc _ _ c0) = unsafePerformIO $ do
       LHNResolved rn _ -> case rn of
         LHRLocal _ -> panic (Just $ GM.fSrcSpan lc) $ "cannot resolve a local name: " ++ show c0
         LHRIndex i -> panic (Just $ GM.fSrcSpan lc) $ "cannot resolve a LHRIndex " ++ show i
-        LHRLogic (LogicName s _ _) -> panic (Just $ GM.fSrcSpan lc) $ "lookupTyThing: cannot resolve a LHRLogic name " ++ show s
+        LHRLogic _ -> panic (Just $ GM.fSrcSpan lc) $ "lookupTyThing: cannot resolve a LHRLogic name " ++ show (logicNameToSymbol c0)
         LHRGHC n ->
           Ghc.reflectGhc (Interface.lookupTyThing (gtleTypeEnv env) n) (gtleSession env)
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -144,7 +144,6 @@ resolveLHNames cfg thisModule localVars impMods globalRdrEnv lmap bareSpec0 depe
                        localVars
                        logicNameEnv0
                        privateReflectNames
-                       thisModule
                        sp1
             return (sp2, logicNameEnv0)
         logicNameEnv' = extendLogicNameEnv logicNameEnv ns
@@ -172,8 +171,12 @@ resolveLHNames cfg thisModule localVars impMods globalRdrEnv lmap bareSpec0 depe
         | otherwise ->
             lookupGRELHName ns lname s
               (fmap (either id GHC.getName) . Resolve.lookupLocalVar localVars (atLoc lname s))
+      LHNUnresolved LHLogicNameBinder s ->
+        pure $ makeLogicLHName s thisModule Nothing
+      n@(LHNUnresolved LHLogicName _) ->
+        -- This one will be resolved by resolveLogicNames
+        pure n
       LHNUnresolved ns s -> lookupGRELHName ns lname s listToMaybe
-      n@(LHNResolved (LHRLocal _) _) -> pure n
       n -> pure n
 
     lookupGRELHName ns lname s localNameLookup =
@@ -215,6 +218,8 @@ resolveLHNames cfg thisModule localVars impMods globalRdrEnv lmap bareSpec0 depe
       LHDataConName lcl -> lcl == LHThisModuleNameF
       LHVarName lcl -> lcl == LHThisModuleNameF
       LHTcName -> False
+      LHLogicNameBinder -> False
+      LHLogicName -> False
 
     nameSpaceKind :: LHNameSpace -> PJ.Doc
     nameSpaceKind = \case
@@ -223,6 +228,8 @@ resolveLHNames cfg thisModule localVars impMods globalRdrEnv lmap bareSpec0 depe
       LHDataConName LHThisModuleNameF -> "locally-defined data constructor"
       LHVarName LHAnyModuleNameF -> "variable"
       LHVarName LHThisModuleNameF -> "variable from the current module"
+      LHLogicNameBinder -> "logic name binder"
+      LHLogicName -> "logic name"
 
     tupleArity s =
       let a = read $ drop 5 $ symbolString s
@@ -268,11 +275,15 @@ mkLookupGRE ns s =
         , GHC.lookupVariablesForFields = True
         , GHC.lookupTyConsAsWell = False
         }
+      LHLogicNameBinder -> panic Nothing "mkWhichGREs: unexpected namespace LHLogicNameBinder"
+      LHLogicName -> panic Nothing "mkWhichGREs: unexpected namespace LHLogicName"
 
     mkGHCNameSpace = \case
       LHTcName -> GHC.tcName
       LHDataConName _ -> GHC.dataName
       LHVarName _ -> GHC.Types.Name.Occurrence.varName
+      LHLogicNameBinder -> panic Nothing "mkGHCNameSpace: unexpected namespace LHLogicNameBinder"
+      LHLogicName -> panic Nothing "mkGHCNameSpace: unexpected namespace LHLogicName"
 
 -- | Changes unresolved names to local resolved names in the body of type
 -- aliases.
@@ -441,8 +452,8 @@ makeLogicEnvs impAvails thisModule spec dependencies =
               , HS.toList (hmeas spec)
               ]
             ]
-          , [ makeLogicLHName (val (msName m)) thisModule Nothing | m <- measures spec ]
-          , [ makeLogicLHName (val (msName m)) thisModule Nothing | m <- cmeasures spec ]
+          , [ val (msName m) | m <- measures spec ]
+          , [ val (msName m) | m <- cmeasures spec ]
           ]
         privateReflectNames =
           mconcat $
@@ -523,8 +534,8 @@ collectUnhandledLiftedSpecLogicNames sp =
 collectLiftedSpecLogicNames :: LiftedSpec -> [LHName]
 collectLiftedSpecLogicNames sp = concat
     [ map fst (HS.toList $ liftedExpSigs sp)
-    , map (fst . snd) (HM.toList $ liftedMeasures sp)
-    , map (fst . snd) (HM.toList $ liftedCmeasures sp)
+    , map (val . msName) (HM.elems $ liftedMeasures sp)
+    , map (val . msName) (HM.elems $ liftedCmeasures sp)
     ]
 
 -- | Resolves names in the logic namespace
@@ -541,28 +552,25 @@ resolveLogicNames
   -> LocalVars
   -> LogicNameEnv
   -> HS.HashSet LocSymbol
-  -> GHC.Module
   -> BareSpecParsed
   -> State RenameOutput BareSpecLHName
-resolveLogicNames cfg env globalRdrEnv unhandledNames lmap0 localVars lnameEnv privateReflectNames thisModule sp = do
+resolveLogicNames cfg env globalRdrEnv unhandledNames lmap0 localVars lnameEnv privateReflectNames sp = do
     -- Instance measures must be defined for names of class measures.
     -- The names of class measures should be in @env@
-    imeasures <- mapM (mapMeasureNamesM (\lx -> (<$ lx) . logicNameToSymbol <$> resolveLogicName [] lx)) (imeasures sp)
+    imeasures <- mapM (mapMeasureNamesM resolveIMeasLogicName) (imeasures sp)
     emapSpecM
       (bscope cfg)
       (map localVarToSymbol . maybe [] lvdLclEnv . (GHC.lookupNameEnv (lvNames localVars) <=< getLHGHCName))
       resolveLogicName
       (emapBareTypeVM (bscope cfg) resolveLogicName)
-      sp { -- Measures and cmeasures aren't parametric on the type used for
-           -- logic names. We make sure that they are properly qualified here.
-           measures = runIdentity $ mapM (mapMeasureNamesM (return . fmap qualifyName)) (measures sp)
-         , cmeasures = runIdentity $ mapM (mapMeasureNamesM (return . fmap qualifyName)) (cmeasures sp)
-         , imeasures
-         }
+      sp { imeasures }
   where
-    localVarToSymbol = F.symbol . GHC.occNameString . GHC.nameOccName . GHC.varName
+    resolveIMeasLogicName lx =
+      case val lx of
+        LHNUnresolved LHLogicName s -> (<$ lx) <$> resolveLogicName [] (s <$ lx)
+        _ -> panic (Just $ LH.fSrcSpan lx) $ "unexpected name: " ++ show lx
 
-    qualifyName = LH.qualifySymbol (symbol $ GHC.moduleNameString $ GHC.moduleName thisModule)
+    localVarToSymbol = F.symbol . GHC.occNameString . GHC.nameOccName . GHC.varName
 
     resolveLogicName :: [Symbol] -> LocSymbol -> State RenameOutput LHName
     resolveLogicName ss ls
@@ -688,7 +696,7 @@ resolveLogicNames cfg env globalRdrEnv unhandledNames lmap0 localVars lnameEnv p
     findReflection :: GHC.Name -> Maybe LHName
     findReflection n = GHC.lookupNameEnv (lneReflected lnameEnv) n
 
-mapMeasureNamesM :: Monad m => (LocSymbol -> m LocSymbol) -> MeasureV v ty ctor -> m (MeasureV v ty ctor)
+mapMeasureNamesM :: Monad m => (Located LHName -> m (Located LHName)) -> MeasureV v ty ctor -> m (MeasureV v ty ctor)
 mapMeasureNamesM f m = do
     msName <- f (msName m)
     msEqns <- mapM mapDefNameM (msEqns m)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -149,7 +149,7 @@ resolveLHNames cfg thisModule localVars impMods globalRdrEnv lmap bareSpec0 depe
                          sp1
               return (sp2, logicNameEnv0)
             else
-              return (error "invalid spec", error "invalid logic environment")
+              return (error "resolveLHNames: invalid spec", error "resolveLHNames: invalid logic environment")
         logicNameEnv' = extendLogicNameEnv logicNameEnv ns
     if null es then
       Right (bs, logicNameEnv')

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -131,21 +131,25 @@ resolveLHNames cfg thisModule localVars impMods globalRdrEnv lmap bareSpec0 depe
             -- A generic traversal that resolves names of Haskell entities
             sp1 <- mapMLocLHNames (\l -> (<$ l) <$> resolveLHName l) $
                      fixExpressionArgsOfTypeAliases taliases bareSpec0
-            -- Now we do a second traversal to resolve logic names
-            let (inScopeEnv, logicNameEnv0, privateReflectNames, unhandledNames) =
-                  makeLogicEnvs impMods thisModule sp1 dependencies
-            sp2 <- fromBareSpecLHName <$>
-                     resolveLogicNames
-                       cfg
-                       inScopeEnv
-                       globalRdrEnv
-                       unhandledNames
-                       lmap
-                       localVars
-                       logicNameEnv0
-                       privateReflectNames
-                       sp1
-            return (sp2, logicNameEnv0)
+            (es0,_) <- get
+            if null es0 then do
+              -- Now we do a second traversal to resolve logic names
+              let (inScopeEnv, logicNameEnv0, privateReflectNames, unhandledNames) =
+                    makeLogicEnvs impMods thisModule sp1 dependencies
+              sp2 <- fromBareSpecLHName <$>
+                       resolveLogicNames
+                         cfg
+                         inScopeEnv
+                         globalRdrEnv
+                         unhandledNames
+                         lmap
+                         localVars
+                         logicNameEnv0
+                         privateReflectNames
+                         sp1
+              return (sp2, logicNameEnv0)
+            else
+              return (error "invalid spec", error "invalid logic environment")
         logicNameEnv' = extendLogicNameEnv logicNameEnv ns
     if null es then
       Right (bs, logicNameEnv')

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
@@ -63,13 +63,12 @@ selfSymbol = symbol ("liquid_internal_this" :: String)
 -- or uninterpreted functions.
 data LogicName =
     LogicName
-      { -- | Unqualified symbol
-        lnSymbol :: !Symbol
+       -- | Unqualified symbol
+      !Symbol
         -- | Module where the entity was defined
-      , lnModule :: !GHC.Module
+      !GHC.Module
         -- | If the named entity is the reflection of some Haskell name
-      , lnReflected :: !(Maybe GHC.Name)
-      }
+      !(Maybe GHC.Name)
     | GeneratedLogicName Symbol
   deriving (Data, Eq, Generic)
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
@@ -29,6 +29,7 @@ module Language.Haskell.Liquid.Types.Names
   , maybeReflectedLHName
   , reflectGHCName
   , reflectLHName
+  , showLHNameDebug
   , updateLHNameSymbol
   ) where
 
@@ -253,7 +254,19 @@ getLHNameSymbol (LHNUnresolved _ s) = s
 -- | Get the unresolved Symbol from an LHName.
 getLHNameResolved :: HasCallStack => LHName -> LHResolvedName
 getLHNameResolved (LHNResolved n _) = n
-getLHNameResolved n@LHNUnresolved{} = error $ "getLHNameResolved: unresolved name: " ++ show n
+getLHNameResolved n@LHNUnresolved{} = error $ "getLHNameResolved: unresolved name: " ++ showLHNameDebug n
+
+showLHNameDebug :: LHName -> String
+showLHNameDebug (LHNResolved n s) = "LHNResolved (" ++ showLHResolved n ++ ") " ++ show s
+  where
+    showLHResolved (LHRGHC n1) = "LHRGHC " ++ GHC.showPprDebug n1
+    showLHResolved (LHRLogic n1) = "LHRLogic (" ++ showLogicName n1 ++ ")"
+    showLHResolved (LHRLocal n1) = "LHRLocal " ++ show n1
+    showLHResolved (LHRIndex i) = "LHRIndex " ++ show i
+
+    showLogicName (LogicName s1 m mr) = "LogicName " ++ show s1 ++ " " ++ GHC.showPprDebug m ++ " " ++ GHC.showPprDebug mr
+    showLogicName (GeneratedLogicName s1) = "GeneratedLogicName " ++ show s1
+showLHNameDebug (LHNUnresolved ns s) = "LHNUnresolved (" ++ show ns ++ ") " ++ show s
 
 getLHGHCName :: LHName -> Maybe GHC.Name
 getLHGHCName (LHNResolved (LHRGHC n) _) = Just n
@@ -309,7 +322,7 @@ logicNameToSymbol n = error $ "logicNameToSymbol: unexpected name: " ++ show n
 -- | Creates a name in the logic namespace for the given Haskell name.
 reflectLHName :: HasCallStack => GHC.Module -> LHName -> LHName
 reflectLHName thisModule (LHNResolved (LHRGHC n) _) = reflectGHCName thisModule n
-reflectLHName _ n = error $ "not a GHC Name: " ++ show n
+reflectLHName _ n = error $ "not a GHC Name: " ++ showLHNameDebug n
 
 -- | Creates a name in the logic namespace for the given Haskell name.
 reflectGHCName :: GHC.Module -> GHC.Name -> LHName

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -607,7 +607,7 @@ instance TyConable BTyCon where
       LHRGHC n -> text $ showPpr n
       LHRLocal s -> ppTycon s
       LHRIndex i -> text $ "(Unknown LHRIndex " ++ show i ++ ")"
-      LHRLogic (LogicName s _ _) -> ppTycon s
+      LHRLogic _ -> ppTycon $ logicNameToSymbol $ F.val $ btc_tc b
 
 instance Eq RTyCon where
   x == y = rtc_tc x == rtc_tc y
@@ -628,7 +628,7 @@ instance F.Fixpoint BTyCon where
       LHRGHC n -> text $ F.symbolString $ F.symbol n
       LHRLocal s -> text $ F.symbolString s
       LHRIndex i -> panic (Just $ fSrcSpan b) $ "toFix BTyCon: Unknown LHRIndex " ++ show i
-      LHRLogic (LogicName s _ _) -> text $ F.symbolString s
+      LHRLogic _ -> text $ F.symbolString $ logicNameToSymbol $ F.val $ btc_tc b
 
 instance F.PPrint RTyCon where
   pprintTidy k c
@@ -645,7 +645,7 @@ instance F.PPrint BTyCon where
       LHRGHC n -> text $ F.symbolString $ F.symbol n
       LHRLocal s -> text $ F.symbolString s
       LHRIndex i -> text $ "(Unknown LHRIndex " ++ show i ++ ")"
-      LHRLogic (LogicName s _ _) -> text $ F.symbolString s
+      LHRLogic _ -> text $ F.symbolString $ logicNameToSymbol $ F.val $ btc_tc b
 
 instance F.PPrint v => F.PPrint (RTVar v s) where
   pprintTidy k (RTVar x _) = F.pprintTidy k x

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -85,11 +85,8 @@ import           Data.HashSet            (HashSet)
 import qualified Data.HashMap.Lazy       as Lazy.M
 import qualified Data.HashMap.Strict     as M
 import           Data.HashMap.Strict     (HashMap)
-import           Data.Maybe
-import           Language.Haskell.Liquid.GHC.Misc (dropModuleNames, fSrcSpan)
-import           Language.Haskell.Liquid.Name.LogicNameEnv
+import           Language.Haskell.Liquid.GHC.Misc (dropModuleNames)
 import           Language.Haskell.Liquid.Types.DataDecl
-import           Language.Haskell.Liquid.Types.Errors
 import           Language.Haskell.Liquid.Types.Names
 import           Language.Haskell.Liquid.Types.RType
 import           Language.Haskell.Liquid.Types.RTypeOp
@@ -708,7 +705,7 @@ data LiftedSpec = LiftedSpec
     -- conflicting measures will be exported.
     --
     -- Tested in MeasureOverlapC.hs
-    liftedMeasures   :: HashMap F.Symbol (LHName, MeasureV LHName LocBareTypeLHName (F.Located LHName))
+    liftedMeasures   :: HashMap F.Symbol (MeasureV LHName LocBareTypeLHName (F.Located LHName))
   , liftedExpSigs    :: HashSet (LHName, F.Sort)
     -- ^ Exported logic symbols originated from reflecting functions
   , liftedPrivateReflects :: HashSet F.LocSymbol
@@ -743,7 +740,7 @@ data LiftedSpec = LiftedSpec
     -- | Measures attached to a type-class
     --
     -- Imitates the arrangement for 'liftedMeasures'
-  , liftedCmeasures  :: HashMap F.Symbol (LHName, MeasureV LHName LocBareTypeLHName ())
+  , liftedCmeasures  :: HashMap F.Symbol (MeasureV LHName LocBareTypeLHName ())
   , liftedImeasures  :: HashSet (MeasureV LHName LocBareTypeLHName (F.Located LHName))
     -- ^ Mappings from (measure,type) -> measure
   , liftedOmeasures  :: HashSet (MeasureV LHName LocBareTypeLHName (F.Located LHName))
@@ -945,14 +942,13 @@ toTargetSpec ghcSpec = TargetSpec
       , gsConfig = _gsConfig ghcSpec
       }
 
-toLiftedSpec :: LogicNameEnv -> BareSpecLHName -> LiftedSpec
-toLiftedSpec lenv a = LiftedSpec
+toLiftedSpec :: BareSpecLHName -> LiftedSpec
+toLiftedSpec a = LiftedSpec
   { liftedMeasures   =
       M.fromList
-        [ (dropModuleNames $ logicNameToSymbol n, (n, m))
+        [ (dropModuleNames $ logicNameToSymbol n, m)
         | m <- measures a
-        , let n = fromMaybe (panic (Just $ fSrcSpan (msName m)) "cannot find logic name") $
-                    F.lookupSEnv (val $ msName m) (lneLHName lenv)
+        , let n = val $ msName m
         ]
   , liftedExpSigs    = S.fromList . expSigs  $ a
   , liftedPrivateReflects = privateReflects a
@@ -971,12 +967,10 @@ toLiftedSpec lenv a = LiftedSpec
   , liftedAutosize   = autosize a
   , liftedCmeasures  =
       M.fromList
-        [ (dropModuleNames $ logicNameToSymbol n, (n, m))
+        [ (dropModuleNames $ logicNameToSymbol n, m)
         | m <- cmeasures a
-        , let n = fromMaybe (panic (Just $ fSrcSpan (msName m)) "cannot find logic name") $
-                    F.lookupSEnv (val $ msName m) (lneLHName lenv)
+        , let n = val $ msName m
         ]
-
   , liftedImeasures  = S.fromList . imeasures $ a
   , liftedOmeasures  = S.fromList . omeasures $ a
   , liftedClasses    = S.fromList . classes $ a
@@ -991,7 +985,7 @@ toLiftedSpec lenv a = LiftedSpec
 -- suitable for 'makeGhcSpec'.
 unsafeFromLiftedSpec :: LiftedSpec -> BareSpecLHName
 unsafeFromLiftedSpec a = Spec
-  { measures   = map snd $ M.elems $ liftedMeasures a
+  { measures   = M.elems $ liftedMeasures a
   , expSigs    = S.toList . liftedExpSigs $ a
   , asmSigs    = S.toList . liftedAsmSigs $ a
   , asmReflectSigs = mempty
@@ -1020,7 +1014,7 @@ unsafeFromLiftedSpec a = Spec
   , ignores    = mempty
   , autosize   = liftedAutosize a
   , pragmas    = mempty
-  , cmeasures  = map snd $ M.elems $ liftedCmeasures a
+  , cmeasures  = M.elems $ liftedCmeasures a
   , imeasures  = S.toList . liftedImeasures $ a
   , omeasures  = S.toList . liftedOmeasures $ a
   , classes    = S.toList . liftedClasses $ a

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -597,7 +597,7 @@ emapBody f b = case b of
 
 type Def ty ctor = DefV Symbol ty ctor
 data DefV v ty ctor = Def
-  { measure :: F.LocSymbol
+  { measure :: F.Located LHName
   , ctor    :: ctor
   , dsort   :: Maybe ty
   , binds   :: [(Symbol, Maybe ty)]    -- measure binders: the ADT argument fields
@@ -634,7 +634,7 @@ mapDefV f Def{..} =
 
 type Measure ty ctor = MeasureV Symbol ty ctor
 data MeasureV v ty ctor = M
-  { msName :: F.LocSymbol
+  { msName :: F.Located LHName
   , msSort :: ty
   , msEqns :: [DefV v ty ctor]
   , msKind :: !MeasureKind
@@ -704,7 +704,7 @@ instance Bifunctor (MeasureV v) where
 -- deriveBifunctor ''Measure
 
 data CMeasure ty = CM
-  { cName :: F.LocSymbol
+  { cName :: F.Located LHName
   , cSort :: ty
   } deriving (Data, Typeable, Generic, Functor)
 
@@ -952,8 +952,8 @@ liquidEnd = ['@', '-', '}']
 
 data MSpec ty ctor = MSpec
   { ctorMap  :: M.HashMap LHName [Def ty ctor]
-  , measMap  :: M.HashMap F.LocSymbol (Measure ty ctor)
-  , cmeasMap :: M.HashMap F.LocSymbol (Measure ty ())
+  , measMap  :: M.HashMap (F.Located LHName) (Measure ty ctor)
+  , cmeasMap :: M.HashMap (F.Located LHName) (Measure ty ())
   , imeas    :: ![Measure ty ctor]
   } deriving (Data, Typeable, Generic, Functor)
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/QuasiQuoter.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/QuasiQuoter.hs
@@ -118,8 +118,8 @@ lhNameToName lname = case val lname of
             (GHC.getOccString n)
       LHRLocal s -> symbolName s
       LHRIndex i -> panic (Just $ fSrcSpan lname) $ "Cannot produce a TH Name for a LHRIndex " ++ show i
-      LHRLogic (LogicName s _m _r) ->
-        panic (Just $ fSrcSpan lname) $ "Cannot produce a TH Name for a LogicName: " ++ show s
+      LHRLogic _ ->
+        panic (Just $ fSrcSpan lname) $ "Cannot produce a TH Name for a LogicName: " ++ show (logicNameToSymbol $ val lname)
 
   where
     toTHNameSpace :: GHC.NameSpace -> NameSpace

--- a/tests/errors/DupMeasure.hs
+++ b/tests/errors/DupMeasure.hs
@@ -1,4 +1,4 @@
-{-@ LIQUID "--expect-error-containing=Multiple specifications for `DupMeasure.lenA`" @-}
+{-@ LIQUID "--expect-error-containing=Multiple specifications for `lenA`" @-}
 module DupMeasure where
 
 

--- a/tests/errors/MultiInstMeasures.hs
+++ b/tests/errors/MultiInstMeasures.hs
@@ -1,4 +1,4 @@
-{-@ LIQUID "--expect-error-containing=Multiple instance measures `MultiInstMeasures.sizeOf` for type `GHC.Internal.Ptr.Ptr`" @-}
+{-@ LIQUID "--expect-error-containing=Multiple instance measures `sizeOf` for type `GHC.Internal.Ptr.Ptr`" @-}
 module MultiInstMeasures where
 
 import Data.Word

--- a/tests/errors/ShadowMeasure.hs
+++ b/tests/errors/ShadowMeasure.hs
@@ -1,4 +1,4 @@
-{-@ LIQUID "--expect-error-containing=Multiple measures named `ShadowMeasure.shadow`" @-}
+{-@ LIQUID "--expect-error-containing=Multiple specifications for `shadow`" @-}
 
 -- ISSUE: Currently this doesn't CRASH because the two sorts for `shadow` are the
 -- same, but that is a happy coincidence. We should REJECT this program as the


### PR DESCRIPTION
This PR changes the name field of measures to use LHName instead of Symbol. This makes possible to store more information in the name field, instead of paring the `Measure` records with LHName in specs.

I considered generalizing the type of the field instead of hard-coding it to LHName, but the new type parameter would have propagated to specs and it was a lot of changes and an extra parameter for no clear benefit.

Another commit provides a show function for LHNames that prints the structure of the name. And yet another commit fixes a problem where name resolution would panic if early stages produced an error and we allowed the resolution to proceed anyway, now we interrupt name resolution early if there are errors.