### PR TITLE
Better error message for reflection faliures due to missing reflection of constructors + refactor of core to logic

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -295,6 +295,7 @@ makeGhcSpec0 cfg ghcTyLookupEnv tcg instEnvs lenv localVars src lmap targetSpec 
              embs
              lmap
              dm
+             cfg
              (\x -> todo Nothing ("coreToLogic not working " ++ x))
              (CoreToLogic.coreToLogic allowTC ce) of
         Left msg -> panic Nothing (F.showpp msg)
@@ -366,7 +367,7 @@ makeTyConEmbeds env spec
 makeLiftedSpec1 :: Config -> GhcSrc -> Bare.TycEnv -> LogicMap -> Ms.BareSpec
                 -> Ms.BareSpec
 makeLiftedSpec1 config src tycEnv lmap mySpec = mempty
-  { Ms.measures  = Bare.makeHaskellMeasures (typeclass config) src tycEnv lmap mySpec }
+  { Ms.measures  = Bare.makeHaskellMeasures config (typeclass config) src tycEnv lmap mySpec }
 
 --------------------------------------------------------------------------------
 -- | [NOTE]: LIFTING-STAGES
@@ -383,7 +384,7 @@ makeLiftedSpec1 config src tycEnv lmap mySpec = mempty
 makeLiftedSpec0 :: Config -> GhcSrc -> F.TCEmb Ghc.TyCon -> LogicMap -> Ms.BareSpec
                 -> Ms.BareSpec
 makeLiftedSpec0 cfg src embs lmap mySpec = mempty
-  { Ms.ealiases  = lmapEAlias . snd <$> Bare.makeHaskellInlines (typeclass cfg) src embs lmap mySpec
+  { Ms.ealiases  = lmapEAlias . snd <$> Bare.makeHaskellInlines cfg (typeclass cfg) src embs lmap mySpec
   , Ms.dataDecls = Bare.makeHaskellDataDecls cfg name mySpec tcs
   }
   where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -297,7 +297,7 @@ makeGhcSpec0 cfg ghcTyLookupEnv tcg instEnvs lenv localVars src lmap targetSpec 
              dm
              cfg
              (\x -> todo Nothing ("coreToLogic not working " ++ x))
-             (CoreToLogic.coreToLogic allowTC ce) of
+             (CoreToLogic.coreToLogic ce) of
         Left msg -> panic Nothing (F.showpp msg)
         Right e -> e
     elaborateSig si auxsig = do
@@ -367,7 +367,7 @@ makeTyConEmbeds env spec
 makeLiftedSpec1 :: Config -> GhcSrc -> Bare.TycEnv -> LogicMap -> Ms.BareSpec
                 -> Ms.BareSpec
 makeLiftedSpec1 config src tycEnv lmap mySpec = mempty
-  { Ms.measures  = Bare.makeHaskellMeasures config (typeclass config) src tycEnv lmap mySpec }
+  { Ms.measures  = Bare.makeHaskellMeasures config src tycEnv lmap mySpec }
 
 --------------------------------------------------------------------------------
 -- | [NOTE]: LIFTING-STAGES
@@ -384,7 +384,7 @@ makeLiftedSpec1 config src tycEnv lmap mySpec = mempty
 makeLiftedSpec0 :: Config -> GhcSrc -> F.TCEmb Ghc.TyCon -> LogicMap -> Ms.BareSpec
                 -> Ms.BareSpec
 makeLiftedSpec0 cfg src embs lmap mySpec = mempty
-  { Ms.ealiases  = lmapEAlias . snd <$> Bare.makeHaskellInlines cfg (typeclass cfg) src embs lmap mySpec
+  { Ms.ealiases  = lmapEAlias . snd <$> Bare.makeHaskellInlines cfg src embs lmap mySpec
   , Ms.dataDecls = Bare.makeHaskellDataDecls cfg name mySpec tcs
   }
   where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -352,7 +352,7 @@ makeAssumeType cfg tce lmap dm sym mbT v def
     _msg  = unwords [showpp sym, showpp mbT]
     le    = case runToLogicWithBoolBinds bbs tce lmap dm cfg mkErr (coreToLogic def') of
               Right e -> e
-              Left  e -> panic Nothing (show e)
+              Left  e -> panic (Just $ sourcePosSrcSpan $ loc sym) (show e)
     ref        = F.Reft (F.vv_, F.PAtom F.Eq (F.EVar F.vv_) le)
     mkErr s    = ErrHMeas (sourcePosSrcSpan $ loc sym) (pprint $ val sym) (PJ.text s)
     bbs        = filter isBoolBind xs

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -317,21 +317,20 @@ makeAxiom :: Bare.Env -> Bare.TycEnv -> LogicMap
 makeAxiom env tycEnv lmap (x, mbT, v, def)
             = (v, t, e)
   where
-    (t, e)  = makeAssumeType (getConfig env) allowTC embs lmap dm x mbT v def
+    (t, e)  = makeAssumeType (getConfig env) embs lmap dm x mbT v def
     embs    = Bare.tcEmbs       tycEnv
     dm      = Bare.tcDataConMap tycEnv
-    allowTC = typeclass (getConfig env)
 
 mkError :: PPrint a => Located a -> String -> Error
 mkError x str = ErrHMeas (sourcePosSrcSpan $ loc x) (pprint $ val x) (PJ.text str)
 
 -- This function is uded to generate the fixpoint code for reflected functions
 makeAssumeType
-  :: Config -> Bool -- ^ typeclass enabled
+  :: Config
   -> F.TCEmb Ghc.TyCon -> LogicMap -> DataConMap -> LocSymbol -> Maybe SpecType
   -> Ghc.Var -> Ghc.CoreExpr
   -> (LocSpecType, F.Equation)
-makeAssumeType cfg allowTC tce lmap dm sym mbT v def
+makeAssumeType cfg tce lmap dm sym mbT v def
   = ( sym {val = aty at `strengthenRes` F.subst su ref}
     , F.mkEquation 
         symbolV 
@@ -340,6 +339,7 @@ makeAssumeType cfg allowTC tce lmap dm sym mbT v def
         (F.sortSubst sortSub out)
     )
   where
+    allowTC = typeclass cfg
     symbolV = F.symbol v
     rt    = fromRTypeRep .
             (\trep@RTypeRep{..} ->
@@ -350,7 +350,7 @@ makeAssumeType cfg allowTC tce lmap dm sym mbT v def
     out   = rTypeSort tce $ ares at
     xArgs = F.EVar . fst <$> aargs at
     _msg  = unwords [showpp sym, showpp mbT]
-    le    = case runToLogicWithBoolBinds bbs tce lmap dm cfg mkErr (coreToLogic allowTC def') of
+    le    = case runToLogicWithBoolBinds bbs tce lmap dm cfg mkErr (coreToLogic def') of
               Right e -> e
               Left  e -> panic Nothing (show e)
     ref        = F.Reft (F.vv_, F.PAtom F.Eq (F.EVar F.vv_) le)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -352,7 +352,7 @@ makeAssumeType cfg tce lmap dm sym mbT v def
     _msg  = unwords [showpp sym, showpp mbT]
     le    = case runToLogicWithBoolBinds bbs tce lmap dm cfg mkErr (coreToLogic def') of
               Right e -> e
-              Left  e -> panic (Just $ sourcePosSrcSpan $ loc sym) (show e)
+              Left  e -> Ex.throw e
     ref        = F.Reft (F.vv_, F.PAtom F.Eq (F.EVar F.vv_) le)
     mkErr s    = ErrHMeas (sourcePosSrcSpan $ loc sym) (pprint $ val sym) (PJ.text s)
     bbs        = filter isBoolBind xs

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -60,20 +60,20 @@ import Control.Monad (mapM)
 import qualified Data.List as L
 
 --------------------------------------------------------------------------------
-makeHaskellMeasures :: Bool -> GhcSrc -> Bare.TycEnv -> LogicMap -> Ms.BareSpec
+makeHaskellMeasures :: Config -> Bool -> GhcSrc -> Bare.TycEnv -> LogicMap -> Ms.BareSpec
                     -> [Measure (Located BareType) (Located LHName)]
 --------------------------------------------------------------------------------
-makeHaskellMeasures allowTC src tycEnv lmap spec
+makeHaskellMeasures cfg allowTC src tycEnv lmap spec
           = Bare.measureToBare <$> ms
   where
-    ms    = makeMeasureDefinition allowTC tycEnv lmap cbs <$> mSyms
+    ms    = makeMeasureDefinition cfg allowTC tycEnv lmap cbs <$> mSyms
     cbs   = Ghc.flattenBinds (_giCbs src)
     mSyms = S.toList (Ms.hmeas spec)
 
 makeMeasureDefinition
-  :: Bool -> Bare.TycEnv -> LogicMap -> [(Ghc.Id, Ghc.CoreExpr)] -> Located LHName
+  :: Config -> Bool -> Bare.TycEnv -> LogicMap -> [(Ghc.Id, Ghc.CoreExpr)] -> Located LHName
   -> Measure LocSpecType Ghc.DataCon
-makeMeasureDefinition allowTC tycEnv lmap cbs x =
+makeMeasureDefinition cfg allowTC tycEnv lmap cbs x =
   case L.find ((x ==) . makeGHCLHNameLocatedFromId . fst) cbs of
     Nothing ->
       Ex.throw $
@@ -81,7 +81,7 @@ makeMeasureDefinition allowTC tycEnv lmap cbs x =
     Just (v, cexp) -> Ms.mkM vx vinfo mdef MsLifted (makeUnSorted allowTC (Ghc.varType v) mdef)
                      where
                        vx           = reflectLHName (Ghc.nameModule $ Ghc.getName v) <$> x
-                       mdef         = coreToDef' allowTC tycEnv lmap vx v cexp
+                       mdef         = coreToDef' cfg allowTC tycEnv lmap vx v cexp
                        vinfo        = GM.varLocInfo (logicType allowTC) v
 
 makeUnSorted :: Bool -> Ghc.Type -> [Def LocSpecType Ghc.DataCon] -> UnSortedExprs
@@ -108,10 +108,10 @@ makeUnSorted allowTC ty defs
     xx = F.vv $ Just 10000
     isErasable = if allowTC then GM.isEmbeddedDictType else Ghc.isClassPred
 
-coreToDef' :: Bool -> Bare.TycEnv -> LogicMap -> Located LHName -> Ghc.Var -> Ghc.CoreExpr
+coreToDef' :: Config -> Bool -> Bare.TycEnv -> LogicMap -> Located LHName -> Ghc.Var -> Ghc.CoreExpr
            -> [Def LocSpecType Ghc.DataCon]
-coreToDef' allowTC tycEnv lmap vx v defn =
-  case runToLogic embs lmap dm (errHMeas vx) (coreToDef allowTC vx v defn) of
+coreToDef' cfg allowTC tycEnv lmap vx v defn =
+  case runToLogic embs lmap dm cfg (errHMeas vx) (coreToDef allowTC vx v defn) of
     Right l -> l
     Left e  -> Ex.throw e
   where
@@ -122,22 +122,22 @@ errHMeas :: Located LHName -> String -> Error
 errHMeas x str = ErrHMeas (GM.sourcePosSrcSpan $ loc x) (pprint $ val x) (text str)
 
 --------------------------------------------------------------------------------
-makeHaskellInlines :: Bool -> GhcSrc -> F.TCEmb Ghc.TyCon -> LogicMap -> Ms.BareSpec
+makeHaskellInlines :: Config -> Bool -> GhcSrc -> F.TCEmb Ghc.TyCon -> LogicMap -> Ms.BareSpec
                    -> [(LocSymbol, LMap)]
 --------------------------------------------------------------------------------
-makeHaskellInlines allowTC src embs lmap spec
-         = makeMeasureInline allowTC embs lmap cbs <$> inls
+makeHaskellInlines cfg allowTC src embs lmap spec
+         = makeMeasureInline cfg allowTC embs lmap cbs <$> inls
   where
     cbs  = Ghc.flattenBinds (_giCbs src)
     inls = S.toList        (Ms.inlines spec)
 
 makeMeasureInline
-  :: Bool -> F.TCEmb Ghc.TyCon -> LogicMap -> [(Ghc.Id, Ghc.CoreExpr)] -> Located LHName
+  :: Config -> Bool -> F.TCEmb Ghc.TyCon -> LogicMap -> [(Ghc.Id, Ghc.CoreExpr)] -> Located LHName
   -> (LocSymbol, LMap)
-makeMeasureInline allowTC embs lmap cbs x =
+makeMeasureInline cfg allowTC embs lmap cbs x =
   case L.find ((val x ==) . makeGHCLHNameFromId . fst) cbs of
     Nothing        -> Ex.throw $ errHMeas x "Cannot inline haskell function"
-    Just (v, defn) -> (vx, coreToFun' allowTC embs Nothing lmap vx v defn ok)
+    Just (v, defn) -> (vx, coreToFun' cfg allowTC embs Nothing lmap vx v defn ok)
                      where
                        vx         = F.atLoc x (F.symbol v)
                        ok (xs, e) = LMap vx (F.symbol <$> xs) (either id id e)
@@ -147,11 +147,11 @@ makeMeasureInline allowTC embs lmap cbs x =
 --   but NOT when lifting inlines (which do not have case-of).
 --   For details, see [NOTE:Lifting-Stages]
 
-coreToFun' :: Bool -> F.TCEmb Ghc.TyCon -> Maybe Bare.DataConMap -> LogicMap -> LocSymbol -> Ghc.Var -> Ghc.CoreExpr
+coreToFun' :: Config -> Bool -> F.TCEmb Ghc.TyCon -> Maybe Bare.DataConMap -> LogicMap -> LocSymbol -> Ghc.Var -> Ghc.CoreExpr
            -> (([Ghc.Var], Either F.Expr F.Expr) -> a) -> a
-coreToFun' allowTC embs dmMb lmap x v defn ok = either Ex.throw ok act
+coreToFun' cfg allowTC embs dmMb lmap x v defn ok = either Ex.throw ok act
   where
-    act  = runToLogic embs lmap dm err xFun
+    act  = runToLogic embs lmap dm cfg err xFun
     xFun = coreToFun allowTC x v defn
     err  str = ErrHMeas (GM.sourcePosSrcSpan $ loc x) (pprint $ val x) (text str)
     dm   = Mb.fromMaybe mempty dmMb

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -65,7 +65,12 @@ import           Language.Haskell.Liquid.Constraint.Termination
 import           Language.Haskell.Liquid.Constraint.RewriteCase
 import           Language.Haskell.Liquid.Transforms.CoreToLogic (weakenResult, runToLogic, coreToLogic)
 import           Language.Haskell.Liquid.Bare.DataType (dataConMap, makeDataConChecker)
-import           Language.Haskell.Liquid.UX.Config
+import Language.Haskell.Liquid.UX.Config
+    ( HasConfig(getConfig),
+      Config(typeclass, gradual, checkDerived, extensionality,
+             nopolyinfer, noADT, dependantCase, exactDC, rankNTypes),
+      patternFlag,
+      higherOrderFlag )
 
 --------------------------------------------------------------------------------
 -- | Constraint Generation: Toplevel -------------------------------------------
@@ -1010,7 +1015,7 @@ lamExpr g e = do
     adts <- gets cgADTs
     allowTC <- gets cgiTypeclass
     let dm = dataConMap adts
-    return $ eitherToMaybe $ runToLogic (emb g) mempty dm
+    return $ eitherToMaybe $ runToLogic (emb g) mempty dm (getConfig g)
       (\x -> todo Nothing ("coreToLogic not working lamExpr: " ++ x))
       (coreToLogic allowTC e)
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -1013,11 +1013,10 @@ argExpr _ _                = Nothing
 lamExpr :: CGEnv -> CoreExpr -> CG (Maybe F.Expr)
 lamExpr g e = do
     adts <- gets cgADTs
-    allowTC <- gets cgiTypeclass
     let dm = dataConMap adts
     return $ eitherToMaybe $ runToLogic (emb g) mempty dm (getConfig g)
       (\x -> todo Nothing ("coreToLogic not working lamExpr: " ++ x))
-      (coreToLogic allowTC e)
+      (coreToLogic e)
 
 --------------------------------------------------------------------------------
 (??=) :: (?callStack :: CallStack) => CGEnv -> Var -> CG SpecType

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -169,9 +169,9 @@ runToLogicWithBoolBinds xs tce lmap dm cfg ferror m
       , lsConfig = cfg
       }
 
-coreAltToDef :: (Reftable r) => Bool -> Located LHName -> Var -> [Var] -> Var -> Type -> [C.CoreAlt]
+coreAltToDef :: (Reftable r) => Located LHName -> Var -> [Var] -> Var -> Type -> [C.CoreAlt]
              -> LogicM [Def (Located (RRType r)) DataCon]
-coreAltToDef allowTC locSym z zs y t alts
+coreAltToDef locSym z zs y t alts
   | not (null litAlts) = measureFail locSym "Cannot lift definition with literal alternatives"
   | otherwise          = do
       d1s <- F.notracepp "coreAltDefs-1" <$> mapM (mkAlt locSym cc myArgs z) dataAlts
@@ -187,16 +187,18 @@ coreAltToDef allowTC locSym z zs y t alts
 
     -- mkAlt :: LocSymbol -> (Expr -> Body) -> [Var] -> Var -> (C.AltCon, [Var], C.CoreExpr)
     mkAlt x ctor _args dx (Alt (C.DataAlt d) xs e)
-      = Def x {- (toArgs id args) -} d (Just $ varRType dx) (toArgs Just xs')
-      . ctor
-      . (`subst1` (F.symbol dx, F.mkEApp (GM.namedLocSymbol d) (F.eVar <$> xs')))
-     <$> coreToLg allowTC e
-      where xs' = filter (not . if allowTC then GM.isEmbeddedDictVar else GM.isEvVar) xs
+      = do
+          allowTC <- reader (typeclass . lsConfig)
+          let xs' = filter (not . if allowTC then GM.isEmbeddedDictVar else GM.isEvVar) xs
+          Def x {- (toArgs id args) -} d (Just $ varRType dx) (toArgs Just xs')
+               . ctor
+               . (`subst1` (F.symbol dx, F.mkEApp (GM.namedLocSymbol d) (F.eVar <$> xs')))
+              <$> coreToLg e
     mkAlt _ _ _ _ alt
       = throw $ "Bad alternative" ++ GM.showPpr alt
 
     mkDef x ctor _args dx (Just dtss) (Just e) = do
-      eDef   <- ctor <$> coreToLg allowTC e
+      eDef   <- ctor <$> coreToLg e
       -- let ys  = toArgs id args
       let dxt = Just (varRType dx)
       return  [ Def x {- ys -} d dxt (defArgs x ts) eDef | (d, _, ts) <- dtss ]
@@ -213,15 +215,17 @@ defArgs x     = zipWith (\i t -> (defArg i, defRTyp t)) [0..]
     defArg    = tempSymbol (lhNameToResolvedSymbol $ val x)
     defRTyp   = Just . F.atLoc x . ofType
 
-coreToDef :: Reftable r => Bool -> Located LHName -> Var -> C.CoreExpr
+coreToDef :: Reftable r => Located LHName -> Var -> C.CoreExpr
           -> LogicM [Def (Located (RRType r)) DataCon]
-coreToDef allowTC locSym _                   = go [] . inlinePreds . simplify allowTC
+coreToDef locSym _ s              = do 
+    allowTC <- reader $ typeclass . lsConfig
+    go [] $ inlinePreds $ simplify allowTC s
   where
     go args   (C.Lam  x e)        = go (x:args) e
     go args   (C.Tick _ e)        = go args e
-    go (z:zs) (C.Case _ y t alts) = coreAltToDef allowTC locSym z zs y t alts
+    go (z:zs) (C.Case _ y t alts) = coreAltToDef locSym z zs y t alts
     go (z:zs) e
-      | Just t <- isMeasureArg z  = coreAltToDef allowTC locSym z zs z t [Alt C.DEFAULT [] e]
+      | Just t <- isMeasureArg z  = coreAltToDef locSym z zs z t [Alt C.DEFAULT [] e]
     go _ _                        = measureFail locSym "Does not have a case-of at the top-level"
 
     inlinePreds   = inline (eqType boolTy . GM.expandVarType)
@@ -247,56 +251,61 @@ isMeasureArg x
 varRType :: (Reftable r) => Var -> Located (RRType r)
 varRType = GM.varLocInfo ofType
 
-coreToFun :: Bool -> LocSymbol -> Var -> C.CoreExpr ->  LogicM ([Var], Either Expr Expr)
-coreToFun allowTC _ _v = go [] . normalize allowTC
+coreToFun :: LocSymbol -> Var -> C.CoreExpr ->  LogicM ([Var], Either Expr Expr)
+coreToFun _ _v s = do 
+  allowTC <- reader $ typeclass . lsConfig
+  go [] $ normalize allowTC s
   where
-    isE = if allowTC then GM.isEmbeddedDictVar else isErasable
-    go acc (C.Lam x e)  | isTyVar    x = go acc e
-    go acc (C.Lam x e)  | isE x = go acc e
-    go acc (C.Lam x e)  = go (x:acc) e
+    go acc (C.Lam x e)  | isTyVar x = go acc e
+    go acc (C.Lam x e)  = do 
+      allowTC <- reader $ typeclass . lsConfig
+      let isE = if allowTC then GM.isEmbeddedDictVar else isErasable
+      if isE x then go acc e else go (x:acc) e
     go acc (C.Tick _ e) = go acc e
-    go acc e            = (reverse acc,) . Right <$> coreToLg allowTC e
+    go acc e            = (reverse acc,) . Right <$> coreToLg e
 
 
 instance Show C.CoreExpr where
   show = GM.showPpr
 
-coreToLogic :: Bool -> C.CoreExpr -> LogicM Expr
-coreToLogic allowTC cb = coreToLg allowTC (normalize allowTC cb)
+coreToLogic :: C.CoreExpr -> LogicM Expr
+coreToLogic cb = do
+  allowTC <- reader $ typeclass . lsConfig
+  coreToLg $ normalize allowTC cb
 
 
-coreToLg :: Bool -> C.CoreExpr -> LogicM Expr
-coreToLg allowTC  (C.Let (C.NonRec x (C.Coercion c)) e)
-  = coreToLg allowTC (C.substExpr (C.extendCvSubst C.emptySubst x c) e)
-coreToLg allowTC  (C.Let b e)
-  = subst1 <$> coreToLg allowTC e <*>  makesub allowTC b
-coreToLg allowTC (C.Tick _ e)          = coreToLg allowTC e
-coreToLg allowTC (C.App (C.Var v) e)
-  | ignoreVar v                = coreToLg allowTC e
-coreToLg _allowTC (C.Var x)
+coreToLg :: C.CoreExpr -> LogicM Expr
+coreToLg (C.Let (C.NonRec x (C.Coercion c)) e)
+  = coreToLg (C.substExpr (C.extendCvSubst C.emptySubst x c) e)
+coreToLg (C.Let b e)
+  = subst1 <$> coreToLg e <*> makesub b
+coreToLg (C.Tick _ e)          = coreToLg e
+coreToLg (C.App (C.Var v) e)
+  | ignoreVar v                = coreToLg e
+coreToLg (C.Var x)
   | x == falseDataConId        = return PFalse
   | x == trueDataConId         = return PTrue
   | otherwise                  = eVarWithMap x . lsSymMap <$> getState
-coreToLg allowTC e@(C.App _ _)         = toPredApp allowTC e
-coreToLg allowTC (C.Case e b _ alts)
-  | eqType (GM.expandVarType b) boolTy  = checkBoolAlts alts >>= coreToIte allowTC e
+coreToLg e@(C.App _ _)         = toPredApp e
+coreToLg (C.Case e b _ alts)
+  | eqType (GM.expandVarType b) boolTy  = checkBoolAlts alts >>= coreToIte e
 -- coreToLg (C.Lam x e)           = do p     <- coreToLg e
 --                                     tce   <- lsEmb <$> getState
 --                                     return $ ELam (symbol x, typeSort tce (GM.expandVarType x)) p
-coreToLg allowTC (C.Case e b _ alts)   = do p <- coreToLg allowTC e
-                                            casesToLg allowTC b p alts
-coreToLg _ (C.Lit l)             = case mkLit l of
+coreToLg (C.Case e b _ alts)   = do p <- coreToLg e
+                                    casesToLg b p alts
+coreToLg (C.Lit l)             = case mkLit l of
                                           Nothing -> throw $ "Bad Literal in measure definition" ++ GM.showPpr l
                                           Just i  -> return i
-coreToLg allowTC (C.Cast e c)          = do (s, t) <- coerceToLg c
-                                            e'     <- coreToLg allowTC e
-                                            return (ECoerc s t e')
+coreToLg (C.Cast e c)          = do (s, t) <- coerceToLg c
+                                    e'     <- coreToLg e
+                                    return (ECoerc s t e')
 -- elaboration reuses coretologic
 -- TODO: fix this
-coreToLg allowTC    (C.Lam x e) = do p     <- coreToLg allowTC e
-                                     tce   <- lsEmb <$> getState
-                                     return $ ELam (symbol x, typeSort tce (GM.expandVarType x)) p
-coreToLg _ e                     = throw ("Cannot transform to Logic:\t" ++ GM.showPpr e)
+coreToLg (C.Lam x e) = do p     <- coreToLg e
+                          tce   <- lsEmb <$> getState
+                          return $ ELam (symbol x, typeSort tce (GM.expandVarType x)) p
+coreToLg e                     = throw ("Cannot transform to Logic:\t" ++ GM.showPpr e)
 
 
 
@@ -327,8 +336,8 @@ checkBoolAlts [Alt (C.DataAlt true) [] etrue, Alt (C.DataAlt false) [] efalse]
 checkBoolAlts alts
   = throw ("checkBoolAlts failed on " ++ GM.showPpr alts)
 
-casesToLg :: Bool -> Var -> Expr -> [C.CoreAlt] -> LogicM Expr
-casesToLg allowTC v e alts = mapM (altToLg allowTC e) normAlts >>= go
+casesToLg :: Var -> Expr -> [C.CoreAlt] -> LogicM Expr
+casesToLg v e alts = mapM (altToLg e) normAlts >>= go
   where
     normAlts       = normalizeAlts alts
     go :: [(C.AltCon, Expr)] -> LogicM Expr
@@ -353,20 +362,21 @@ normalizeAlts alts      = ctorAlts ++ defAlts
     (defAlts, ctorAlts) = L.partition isDefault alts
     isDefault (Alt c _ _)   = c == C.DEFAULT
 
-altToLg :: Bool -> Expr -> C.CoreAlt -> LogicM (C.AltCon, Expr)
-altToLg allowTC de (Alt a@(C.DataAlt d) xs e) = do
+altToLg :: Expr -> C.CoreAlt -> LogicM (C.AltCon, Expr)
+altToLg de (Alt a@(C.DataAlt d) xs e) = do
   ctorReflected <- reader (exactDCFlag . lsConfig)
   if not ctorReflected && not (primDataCon d) then do
     throw $ "coreToLg: Cannot lift to logic the constructor `" ++ show d
              ++ "` consider enabling one of the flags --exactdc or --reflection"
   else do
-    p  <- coreToLg allowTC e
+    p  <- coreToLg e
     dm <- reader lsDCMap
+    allowTC <- reader (typeclass . lsConfig)
     let su = mkSubst $ concat [ dataConProj dm de d x i | (x, i) <- zip (filter (not . if allowTC then GM.isEmbeddedDictVar else GM.isEvVar) xs) [1..]]
     return (a, subst su p)
 
-altToLg allowTC _ (Alt a _ e)
-  = (a, ) <$> coreToLg allowTC e
+altToLg _ (Alt a _ e)
+  = (a, ) <$> coreToLg e
 
 dataConProj :: DataConMap -> Expr -> DataCon -> Var -> Int -> [(Symbol, Expr)]
 dataConProj dm de d x i = [(symbol x, t), (GM.simplesymbol x, t)]
@@ -377,41 +387,43 @@ dataConProj dm de d x i = [(symbol x, t), (GM.simplesymbol x, t)]
 primDataCon :: DataCon -> Bool
 primDataCon d = d == intDataCon
 
-coreToIte :: Bool -> C.CoreExpr -> (C.CoreExpr, C.CoreExpr) -> LogicM Expr
-coreToIte allowTC e (efalse, etrue)
-  = do p  <- coreToLg allowTC e
-       e1 <- coreToLg allowTC efalse
-       e2 <- coreToLg allowTC etrue
+coreToIte :: C.CoreExpr -> (C.CoreExpr, C.CoreExpr) -> LogicM Expr
+coreToIte e (efalse, etrue)
+  = do p  <- coreToLg e
+       e1 <- coreToLg efalse
+       e2 <- coreToLg etrue
        return $ EIte p e2 e1
 
-toPredApp :: Bool -> C.CoreExpr -> LogicM Expr
-toPredApp allowTC p = go . first opSym . splitArgs allowTC $ p
+toPredApp :: C.CoreExpr -> LogicM Expr
+toPredApp p = do
+  allowTC <- reader (typeclass . lsConfig)
+  go . first opSym . splitArgs allowTC $ p
   where
     opSym = tomaybesymbol
     go (Just f, [e1, e2])
       | Just rel <- M.lookup f brels
-      = PAtom rel <$> coreToLg allowTC e1 <*> coreToLg allowTC e2
+      = PAtom rel <$> coreToLg e1 <*> coreToLg e2
     go (Just f, [e])
       | f == symbol ("GHC.Classes.not" :: String)
-      = PNot <$>  coreToLg allowTC e
+      = PNot <$>  coreToLg e
     go (Just f, [e1, e2])
       | f == symbol ("GHC.Classes.||" :: String)
-      = POr <$> mapM (coreToLg allowTC) [e1, e2]
+      = POr <$> mapM coreToLg [e1, e2]
       | f == symbol ("GHC.Classes.&&" :: String)
-      = PAnd <$> mapM (coreToLg allowTC) [e1, e2]
+      = PAnd <$> mapM coreToLg [e1, e2]
       | f == symbol ("Language.Haskell.Liquid.Prelude.==>" :: String)
-      = PImp <$> coreToLg allowTC e1 <*> coreToLg allowTC e2
+      = PImp <$> coreToLg e1 <*> coreToLg e2
       | f == symbol ("Language.Haskell.Liquid.Prelude.<=>" :: String)
-      = PIff <$> coreToLg allowTC e1 <*> coreToLg allowTC e2
+      = PIff <$> coreToLg e1 <*> coreToLg e2
       | f == symbol ("GHC.Base.const" :: String)
-      = coreToLg allowTC e1
+      = coreToLg e1
     go (Just f, [es])
       | f == symbol ("GHC.Internal.Data.Foldable.or" :: String)
-      = POr  . deList <$> coreToLg allowTC es
+      = POr  . deList <$> coreToLg es
       | f == symbol ("GHC.Internal.Data.Foldable.and" :: String)
-      = PAnd . deList <$> coreToLg allowTC es
+      = PAnd . deList <$> coreToLg es
     go (_, _)
-      = toLogicApp allowTC p
+      = toLogicApp p
 
     deList :: Expr -> [Expr]
     deList (EApp (EApp (EVar cons) e) es)
@@ -423,16 +435,17 @@ toPredApp allowTC p = go . first opSym . splitArgs allowTC $ p
     deList e
       = [e]
 
-toLogicApp :: Bool -> C.CoreExpr -> LogicM Expr
-toLogicApp allowTC e = do
+toLogicApp :: C.CoreExpr -> LogicM Expr
+toLogicApp e = do
+  allowTC <- reader (typeclass . lsConfig)
   let (f, es) = splitArgs allowTC e
   case f of
-    C.Var _ -> do args <- mapM (coreToLg allowTC) es
+    C.Var _ -> do args <- mapM coreToLg es
                   lmap <- lsSymMap <$> getState
                   def  <- (`mkEApp` args) <$> tosymbol f
                   (\x -> makeApp def lmap x args) <$> tosymbol' f
-    _       -> do fe   <- coreToLg allowTC f
-                  args <- mapM (coreToLg allowTC) es
+    _       -> do fe   <- coreToLg f
+                  args <- mapM coreToLg es
                   return $ foldl EApp fe args
 
 makeApp :: Expr -> LogicMap -> Located Symbol-> [Expr] -> Expr
@@ -526,9 +539,9 @@ tosymbol' :: C.CoreExpr -> LogicM (Located Symbol)
 tosymbol' (C.Var x) = return $ dummyLoc $ symbol x
 tosymbol' e        = throw ("Bad Measure Definition:\n" ++ GM.showPpr e ++ "\t cannot be applied")
 
-makesub :: Bool -> C.CoreBind -> LogicM (Symbol, Expr)
-makesub allowTC (C.NonRec x e) =  (symbol x,) <$> coreToLg allowTC e
-makesub _       _              = throw "Cannot make Logical Substitution of Recursive Definitions"
+makesub :: C.CoreBind -> LogicM (Symbol, Expr)
+makesub (C.NonRec x e) = (symbol x,) <$> coreToLg e
+makesub _              = throw "Cannot make Logical Substitution of Recursive Definitions"
 
 mkLit :: Literal -> Maybe Expr
 mkLit (LitNumber _ n) = mkI n

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -366,8 +366,8 @@ altToLg :: Expr -> C.CoreAlt -> LogicM (C.AltCon, Expr)
 altToLg de (Alt a@(C.DataAlt d) xs e) = do
   ctorReflected <- reader (exactDCFlag . lsConfig)
   if not ctorReflected && not (primDataCon d) then do
-    throw $ "coreToLg: Cannot lift to logic the constructor `" ++ show d
-             ++ "` consider enabling one of the flags --exactdc or --reflection"
+    throw $  "Cannot lift to logic the constructor `" ++ show d
+          ++ "` consider enabling either --exactdc or --reflection"
   else do
     p  <- coreToLg e
     dm <- reader lsDCMap

--- a/tests/basic/neg/ReflExt02A.hs
+++ b/tests/basic/neg/ReflExt02A.hs
@@ -1,6 +1,6 @@
 -- | test the error message when doing reflection of foreign functions with data selectors
 -- | W/O having specified the `exactdc`/`reflection` flag
-{-@ LIQUID "--expect-error-containing=Illegal type specification for `ReflExt02B.calories`" @-}
+{-@ LIQUID "--expect-error-containing=Cannot lift Haskell function `calories` to logic" @-}
 
 module ReflExt02A where
 


### PR DESCRIPTION
The error message was very unhelpful before (See #2457)


From
```
   Illegal type specification for `Fin.unFin`
    Fin.unFin :: forall n .
                 lq_tmp$db##0:(Fin.Fin n) -> {VV : GHC.Types.Int | VV == lqdc##$select##Fin.MkFin##1 lq_tmp$db##0
                                                                   && VV >= 0
                                                                   && VV < n}
    Sort Error in Refinement: {VV : int | VV == lqdc##$select##Fin.MkFin##1 lq_tmp$db##0
                                          && VV >= 0
                                          && VV < n}
    Unbound symbol lqdc##$select##Fin.MkFin##1 --- perhaps you meant: Fin.MkFin ?
    Just
   |
26 | unFin (MkFin i) = i
   | ^^^
```
To:
```
test/Testone2.hs:19:13: error:
    Uh oh.
    CallStack (from HasCallStack):
  panic, called at src/Language/Haskell/Liquid/Bare/Axiom.hs:355:26 in liquidhaskell-boot-0.9.10.1-inplace:Language.Haskell.Liquid.Bare.Axiom
    test/Testone2.hs:19:13 Cannot lift Haskell function `p2i` to logic
                           Cannot lift to logic the constructor `Fixme.P` consider enabling either --exactdc or --reflection
   |
19 | {-@ reflect p2i @-}
   |             ^
```

I think to make it even better we should either handle the panic gracefully (best solution) or at least remove all the call stack information since is rather unhelpful to the user
