### PR TITLE
Handle empty alts when lifting core to logic

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -292,6 +292,7 @@ coreToLg (C.Case e b _ alts)
 -- coreToLg (C.Lam x e)           = do p     <- coreToLg e
 --                                     tce   <- lsEmb <$> getState
 --                                     return $ ELam (symbol x, typeSort tce (GM.expandVarType x)) p
+coreToLg (C.Case e _ _ [])     = coreToLg e
 coreToLg (C.Case e b _ alts)   = do p <- coreToLg e
                                     casesToLg b p alts
 coreToLg (C.Lit l)             = case mkLit l of


### PR DESCRIPTION
Code like the following were throwing a panic when called with -fdefer-typed-holes
```haskell
module Problem1 where

type Proof = ()

{-@ listLength :: xs:_ -> { v : Nat | v == len xs } @-}
listLength :: [a] -> Int
listLength _x = _hole
```
The problem reported looked like:

`./typedholes-proof-examples/Problem1.hs:7:21: error:
    Uh oh.
    CallStack (from HasCallStack):
  panic, called at src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs:354:22 in liquidhaskell-boot-0.9.10.1-inplace:Language.Haskell.Liquid.Transforms.CoreToLogic
    Unexpected empty cases in casesToLg: EApp (EVar "GHC.Internal.Control.Exception.Base.typeError") (ESym (SL "../typedholes-proof-examples/Problem1.hs:7:21: error: [\ESC]8;;https://errors.haskell.org/messages/GHC-88464\ESC\\GHC-88464\ESC]8;;\ESC\\]\n    \8226 Found hole: _hole :: Int\n      Or perhaps \8216_hole\8217 is mis-spelled, or not in scope\n    \8226 In the second argument of \8216(+)\8217, namely \8216_hole\8217\n      In the expression: 1 + _hole\n      In an equation for \8216listLength\8217: listLength _x = 1 + _hole\n    \8226 Relevant bindings include\n        _x :: [a] (bound at ../typedholes-proof-examples/Problem1.hs:7:12)\n        listLength :: [a] -> Int\n          (bound at ../typedholes-proof-examples/Problem1.hs:7:1)\n      Valid hole fits include\n        maxBound :: forall a. Bounded a => a\n          with maxBound @Int\n          (imported from \8216Prelude\8217 at ../ty`
    

Investigating... I ended up at [CoreLogic.hs](https://github.com/ucsd-progsys/liquidhaskell/blob/06f55b49a738dd68620ab462a7fa602fd192f5d7/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs#L348)

Is it a reasonable default to just lift the expr to logic and ignore the casestoLg when an empty case appear?

Thanks
