### PR TITLE
Remove the unneeded old symbol resolution

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -973,11 +973,8 @@ getAsmSigs myName name spec
   | otherwise      =
       [ (False, x, t)
       | (x, t) <- Ms.asmSigs spec
-                  ++ map (first (fmap (updateLHNameSymbol qSym))) (Ms.sigs spec)
+                  ++ Ms.sigs spec
       ]
-  where
-    qSym           = GM.qualifySymbol ns
-    ns             = F.symbol name
 
 makeSigEnv :: F.TCEmb Ghc.TyCon -> Bare.TyConMap -> S.HashSet StableName -> BareRTEnv -> Bare.SigEnv
 makeSigEnv embs tyi exports rtEnv = Bare.SigEnv

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -208,7 +208,7 @@ makeGhcSpec0
 makeGhcSpec0 cfg ghcTyLookupEnv tcg instEnvs lenv localVars src lmap targetSpec dependencySpecs = do
   globalRdrEnv <- Ghc.tcg_rdr_env <$> Ghc.getGblEnv
   -- build up environments
-  tycEnv <- makeTycEnv1 name env (tycEnv0, datacons) coreToLg simplifier
+  tycEnv <- makeTycEnv1 env (tycEnv0, datacons) coreToLg simplifier
   let tyi      = Bare.tcTyConMap   tycEnv
   let sigEnv   = makeSigEnv  embs tyi (_gsExports src) rtEnv
   let lSpec1   = makeLiftedSpec1 cfg src tycEnv lmap mySpec1
@@ -1184,16 +1184,15 @@ makeTycEnv0 cfg myName env embs mySpec iSpecs = (diag0 <> diag1, datacons, Bare.
 
 
 makeTycEnv1 ::
-     ModName
-  -> Bare.Env
+     Bare.Env
   -> (Bare.TycEnv, [Located DataConP])
   -> (Ghc.CoreExpr -> F.Expr)
   -> (Ghc.CoreExpr -> Ghc.TcRn Ghc.CoreExpr)
   -> Ghc.TcRn Bare.TycEnv
-makeTycEnv1 myName env (tycEnv, datacons) coreToLg simplifier = do
+makeTycEnv1 env (tycEnv, datacons) coreToLg simplifier = do
   -- fst for selector generation, snd for dataconsig generation
   lclassdcs <- forM classdcs $ traverse (Bare.elaborateClassDcp coreToLg simplifier)
-  let recSelectors = Bare.makeRecordSelectorSigs env myName (dcs ++ (fmap . fmap) snd lclassdcs)
+  let recSelectors = Bare.makeRecordSelectorSigs env (dcs ++ (fmap . fmap) snd lclassdcs)
   pure $
     tycEnv {Bare.tcSelVars = recSelectors, Bare.tcDataCons = F.val <$> ((fmap . fmap) fst lclassdcs ++ dcs )}
   where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -386,13 +386,12 @@ makeLiftedSpec0 :: Config -> GhcSrc -> F.TCEmb Ghc.TyCon -> LogicMap -> Ms.BareS
                 -> Ms.BareSpec
 makeLiftedSpec0 cfg src embs lmap mySpec = mempty
   { Ms.ealiases  = lmapEAlias . snd <$> Bare.makeHaskellInlines cfg src embs lmap mySpec
-  , Ms.dataDecls = Bare.makeHaskellDataDecls cfg name mySpec tcs
+  , Ms.dataDecls = Bare.makeHaskellDataDecls cfg mySpec tcs
   }
   where
     tcs          = uniqNub (_gsTcs src ++ refTcs)
     refTcs       = reflectedTyCons cfg embs cbs  mySpec
     cbs          = _giCbs       src
-    name         = _giTargetMod src
 
 uniqNub :: (Ghc.Uniquable a) => [a] -> [a]
 uniqNub xs = M.elems $ M.fromList [ (index x, x) | x <- xs ]
@@ -1276,7 +1275,7 @@ addOpaqueReflMeas cfg tycEnv env spec measEnv specs eqs = do
       , shouldBeUsedForScanning $ makeGHCLHName (Ghc.getName v) (symbol v)
       ]
     tcs           = S.toList $ Ghc.dataConTyCon `S.map` Bare.getReflDCs measEnv varsUsedForTcScanning
-    dataDecls     = Bare.makeHaskellDataDecls cfg name spec tcs
+    dataDecls     = Bare.makeHaskellDataDecls cfg spec tcs
     tyi           = Bare.tcTyConMap    tycEnv
     embs          = Bare.tcEmbs        tycEnv
     dm            = Bare.tcDataConMap  tycEnv

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -1173,8 +1173,8 @@ makeTycEnv0 cfg myName env embs mySpec iSpecs = (diag0 <> diag1, datacons, Bare.
     tyi           = makeTyConInfo embs fiTcs tycons
     -- tycons        = F.tracepp "TYCONS" $ Misc.replaceWith tcpCon tcs wiredTyCons
     -- datacons      =  Bare.makePluggedDataCons embs tyi (Misc.replaceWith (dcpCon . val) (F.tracepp "DATACONS" $ concat dcs) wiredDataCons)
-    tycons        = tcs ++ knownWiredTyCons env myName
-    datacons      = Bare.makePluggedDataCon (typeclass cfg) embs tyi <$> (concat dcs ++ knownWiredDataCons env myName)
+    tycons        = tcs ++ wiredTyCons
+    datacons      = Bare.makePluggedDataCon (typeclass cfg) embs tyi <$> (concat dcs ++ wiredDataCons)
     tds           = [(name, tcpCon tcp, dd) | (name, tcp, Just dd) <- tcDds]
     (diag1, adts) = Bare.makeDataDecls cfg embs myName tds       datacons
     dm            = Bare.dataConMap adts
@@ -1200,18 +1200,6 @@ makeTycEnv1 myName env (tycEnv, datacons) coreToLg simplifier = do
     (classdcs, dcs) =
       L.partition
         (Ghc.isClassTyCon . Ghc.dataConTyCon . dcpCon . F.val) datacons
-
-
-knownWiredDataCons :: Bare.Env -> ModName -> [Located DataConP]
-knownWiredDataCons env name = filter isKnown wiredDataCons
-  where
-    isKnown                 = Bare.knownGhcDataCon env name . GM.namedLocSymbol . dcpCon . val
-
-knownWiredTyCons :: Bare.Env -> ModName -> [TyConP]
-knownWiredTyCons env name = filter isKnown wiredTyCons
-  where
-    isKnown               = Bare.knownGhcTyCon env name . GM.namedLocSymbol . tcpCon
-
 
 -- REBARE: formerly, makeGhcCHOP2
 -------------------------------------------------------------------------------------------

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/DataType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/DataType.hs
@@ -775,8 +775,8 @@ unDummy :: F.Symbol -> Int -> F.Symbol
 unDummy x i | x /= F.dummySymbol = x
             | otherwise          = F.symbol ("_cls_lq" ++ show i)
 
-makeRecordSelectorSigs :: Bare.Env -> ModName -> [Located DataConP] -> [(Ghc.Var, LocSpecType)]
-makeRecordSelectorSigs env name = checkRecordSelectorSigs . concatMap makeOne
+makeRecordSelectorSigs :: Bare.Env -> [Located DataConP] -> [(Ghc.Var, LocSpecType)]
+makeRecordSelectorSigs env = checkRecordSelectorSigs . concatMap makeOne
   where
   makeOne (Loc l l' dcp)
     | Just cls <- maybe_cls
@@ -793,7 +793,7 @@ makeRecordSelectorSigs env name = checkRecordSelectorSigs . concatMap makeOne
       maybe_cls = Ghc.tyConClass_maybe (Ghc.dataConTyCon dc)
       dc  = dcpCon dcp
       fls = Ghc.dataConFieldLabels dc
-      fs  = Bare.lookupGhcNamedVar env name . Ghc.flSelector <$> fls
+      fs  = Bare.lookupGhcId env . Ghc.flSelector <$> fls
       ts :: [ LocSpecType ]
       ts = [ Loc l l' (mkArrow (map (, mempty) (makeRTVar <$> dcpFreeTyVars dcp)) []
                                  [(z, classRFInfo True, res, mempty)]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -23,7 +23,6 @@ module Language.Haskell.Liquid.Bare.Resolve
   , Lookup
 
   -- * Looking up names
-  , lookupGhcDataCon
   , lookupGhcDataConLHName
   , lookupGhcDnTyCon
   , lookupGhcTyCon
@@ -348,9 +347,6 @@ lookupLocalVar localVars lx gvs = findNearest lxn kvs
     argMin :: (Ord k) => [(k, v)] -> Maybe v
     argMin = Mb.listToMaybe . map snd . L.sortBy (compare `on` fst)
 
-
-lookupGhcDataCon :: Env -> ModName -> String -> LocSymbol -> Lookup Ghc.DataCon
-lookupGhcDataCon = resolveLocSym -- strictResolveSym
 
 lookupGhcTyCon :: Env -> ModName -> String -> LocSymbol -> Lookup Ghc.TyCon
 lookupGhcTyCon env name k lx = myTracepp ("LOOKUP-TYCON: " ++ F.showpp (val lx))

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -35,9 +35,6 @@ module Language.Haskell.Liquid.Bare.Resolve
   , lookupGhcTyConLHName
 
   -- * Checking if names exist
-  , knownGhcVar
-  , knownGhcTyCon
-  , knownGhcDataCon
   , knownGhcType
 
   -- * Misc
@@ -412,29 +409,6 @@ _rTypeTyCons        = Misc.sortNub . foldRType f []
   where
     f acc t@RApp {} = rt_tycon t : acc
     f acc _         = acc
-
--- Aargh. Silly that each of these is the SAME code, only difference is the type.
-
-knownGhcVar :: Env -> ModName -> LocSymbol -> Bool
-knownGhcVar env name lx = Mb.isJust v
-  where
-    v :: Maybe Ghc.Var -- This annotation is crucial
-    v = myTracepp ("knownGhcVar " ++ F.showpp lx)
-      $ maybeResolveSym env name "known-var" lx
-
-knownGhcTyCon :: Env -> ModName -> LocSymbol -> Bool
-knownGhcTyCon env name lx = myTracepp  msg $ Mb.isJust v
-  where
-    msg = "knownGhcTyCon: "  ++ F.showpp lx
-    v :: Maybe Ghc.TyCon -- This annotation is crucial
-    v = maybeResolveSym env name "known-tycon" lx
-
-knownGhcDataCon :: Env -> ModName -> LocSymbol -> Bool
-knownGhcDataCon env name lx = Mb.isJust v
-  where
-    v :: Maybe Ghc.DataCon -- This annotation is crucial
-    v = myTracepp ("knownGhcDataCon" ++ F.showpp lx)
-      $ maybeResolveSym env name "known-datacon" lx
 
 -------------------------------------------------------------------------------
 -- | Using the environment

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -25,8 +25,6 @@ module Language.Haskell.Liquid.Bare.Resolve
   -- * Looking up names
   , lookupGhcDataConLHName
   , lookupGhcDnTyCon
-  , lookupGhcTyCon
-  , lookupGhcVar
   , lookupGhcIdLHName
   , lookupLocalVar
   , lookupGhcTyConLHName
@@ -304,15 +302,6 @@ srcVars src = filter Ghc.isId .  fmap Misc.thd3 . Misc.fstByRank $ concat
 dataConVars :: [Ghc.DataCon] -> [Ghc.Var]
 dataConVars dcs = (Ghc.dataConWorkId <$> dcs) ++ (Ghc.dataConWrapId <$> dcs)
 
-lookupGhcVar :: Env -> ModName -> String -> LocSymbol -> Lookup Ghc.Var
-lookupGhcVar env name kind lx = case resolveLocSym env name kind lx of
-    Right v -> Mb.maybe (Right v) (either Right Right) (lookupLocalVar (reLocalVars env) lx [v])
-    Left  e -> Mb.maybe (Left  e) (either Right Right) (lookupLocalVar (reLocalVars env) lx [])
-
-  -- where
-    -- err e   = Misc.errorP "error-lookupGhcVar" (F.showpp (e, F.loc lx, lx))
-  --  err     = Ex.throw
-
 -- | @lookupLocalVar@ takes as input the list of "global" (top-level) vars
 --   that also match the name @lx@; we then pick the "closest" definition.
 --   See tests/names/LocalSpec.hs for a motivating example.
@@ -347,10 +336,6 @@ lookupLocalVar localVars lx gvs = findNearest lxn kvs
     argMin :: (Ord k) => [(k, v)] -> Maybe v
     argMin = Mb.listToMaybe . map snd . L.sortBy (compare `on` fst)
 
-
-lookupGhcTyCon :: Env -> ModName -> String -> LocSymbol -> Lookup Ghc.TyCon
-lookupGhcTyCon env name k lx = myTracepp ("LOOKUP-TYCON: " ++ F.showpp (val lx))
-                               $ {- strictResolveSym -} resolveLocSym env name k lx
 
 lookupGhcDnTyCon :: Env -> ModName -> DataName -> Lookup (Maybe Ghc.TyCon)
 lookupGhcDnTyCon env name = failMaybe env name . lookupGhcDnTyConE env

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE ConstraintKinds       #-}

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -23,14 +23,12 @@ module Language.Haskell.Liquid.Bare.Resolve
   , Lookup
 
   -- * Looking up names
-  , maybeResolveSym
   , lookupGhcDataCon
   , lookupGhcDataConLHName
   , lookupGhcDnTyCon
   , lookupGhcTyCon
   , lookupGhcVar
   , lookupGhcIdLHName
-  , lookupGhcNamedVar
   , lookupLocalVar
   , lookupGhcTyConLHName
   , lookupGhcId
@@ -306,13 +304,6 @@ srcVars src = filter Ghc.isId .  fmap Misc.thd3 . Misc.fstByRank $ concat
 
 dataConVars :: [Ghc.DataCon] -> [Ghc.Var]
 dataConVars dcs = (Ghc.dataConWorkId <$> dcs) ++ (Ghc.dataConWrapId <$> dcs)
-
--------------------------------------------------------------------------------
-lookupGhcNamedVar :: (Ghc.NamedThing a, F.Symbolic a) => Env -> ModName -> a -> Maybe Ghc.Var
--------------------------------------------------------------------------------
-lookupGhcNamedVar env name z = maybeResolveSym  env name "Var" lx
-  where
-    lx                       = GM.namedLocSymbol z
 
 lookupGhcVar :: Env -> ModName -> String -> LocSymbol -> Lookup Ghc.Var
 lookupGhcVar env name kind lx = case resolveLocSym env name kind lx of
@@ -633,20 +624,6 @@ splitModuleNameExact x' = myTracepp ("splitModuleNameExact for " ++ F.showpp x)
 
 errResolve :: PJ.Doc -> String -> LocSymbol -> Error
 errResolve k msg lx = ErrResolve (GM.fSrcSpan lx) k (F.pprint (F.val lx)) (PJ.text msg)
-
--- -- | @strictResolve@ wraps the plain @resolve@ to throw an error
--- --   if the name being searched for is unknown.
--- strictResolveSym :: (ResolveSym a) => Env -> ModName -> String -> LocSymbol -> a
--- strictResolveSym env name kind x = case resolveLocSym env name kind x of
---   Left  err -> Misc.errorP "error-strictResolveSym" (F.showpp err)
---   Right val -> val
-
--- | @maybeResolve@ wraps the plain @resolve@ to return @Nothing@
---   if the name being searched for is unknown.
-maybeResolveSym :: (ResolveSym a) => Env -> ModName -> String -> LocSymbol -> Maybe a
-maybeResolveSym env name kind x = case resolveLocSym env name kind x of
-  Left  _   -> Nothing
-  Right val -> Just val
 
 -------------------------------------------------------------------------------
 -- | @ofBareType@ and @ofBareTypeE@ should be the _only_ @SpecType@ constructors

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -74,7 +74,7 @@ module Language.Haskell.Liquid.Types.Types (
   -- * Modules and Imports
   , ModName (..), ModType (..)
   , isSrcImport, isSpecImport, isTarget
-  , getModName, getModString, qualifyModName
+  , getModName, getModString
 
   -- * Refinement Type Aliases
   , RTEnv (..), BareRTEnv, SpecRTEnv, BareRTAlias, SpecRTAlias
@@ -557,11 +557,6 @@ getModName (ModName _ m) = m
 
 getModString :: ModName -> String
 getModString = moduleNameString . getModName
-
-qualifyModName :: ModName -> Symbol -> Symbol
-qualifyModName n = qualifySymbol nSym
-  where
-    nSym         = F.symbol n
 
 --------------------------------------------------------------------------------
 -- | Refinement Type Aliases ---------------------------------------------------

--- a/tests/basic/neg/T2349.hs
+++ b/tests/basic/neg/T2349.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE GADTs #-}
 {-@ LIQUID "--expect-error-containing=is not a subtype of the required type
-      VV : {VV##1456 : [GHC.Types.Int] | GHC.Types_LHAssumptions.len VV##1456 == ?b + 1}" @-}
+      VV : {VV##1534 : [GHC.Types.Int] | GHC.Types_LHAssumptions.len VV##1534 == ?b + 1}" @-}
 {-@ LIQUID "--reflection" @-}
 -- | Test that the refinement types produced for GADTs are
 -- compatible with the Haskell types.

--- a/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Eval.hs
+++ b/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Eval.hs
@@ -19,8 +19,6 @@
 
 module Language.Stitch.LH.Eval where
 
--- XXX: Needed to avoid missing symbols in LH
-import qualified Data.Map as Map
 import Language.Haskell.Liquid.ProofCombinators (Proof, trivial, (?))
 import Language.Stitch.LH.Data.List (List(..))
 import qualified Language.Stitch.LH.Data.List as List

--- a/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Repl.hs
+++ b/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Repl.hs
@@ -21,8 +21,6 @@ module Language.Stitch.LH.Repl ( main ) where
 
 import Prelude hiding ( lex )
 
--- XXX: LH requires Map to be in scope ??
-import Data.Map (Map)
 import Language.Stitch.LH.Data.List (List)
 import qualified Language.Stitch.LH.Data.List as List -- XXX: required by LH
 import Language.Stitch.LH.Check

--- a/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Step.hs
+++ b/tests/benchmarks/stitch-lh/src/Language/Stitch/LH/Step.hs
@@ -18,11 +18,8 @@
 
 module Language.Stitch.LH.Step where
 
--- XXX: Needed to avoid missing symbols in LH
-import qualified Data.Map as Map
 import Language.Haskell.Liquid.ProofCombinators
 import Language.Stitch.LH.Data.List (List(..))
--- XXX: Needed to avoid missing symbols in LH
 import qualified Language.Stitch.LH.Data.List as List
 import Language.Stitch.LH.Data.Nat
 import Language.Stitch.LH.Check

--- a/tests/benchmarks/stitch-lh/tests/Tests/Check.hs
+++ b/tests/benchmarks/stitch-lh/tests/Tests/Check.hs
@@ -5,7 +5,6 @@ module Tests.Check where
 
 import Prelude hiding ( lex )
 
-import qualified Data.Map as Map -- XXX: Needed for LH
 import Language.Stitch.LH.Check
 import qualified Language.Stitch.LH.Data.List as List -- XXX: Needed for LH
 import Language.Stitch.LH.Parse


### PR DESCRIPTION
Another step for #2169.

The functions removed have been replaced in earlier PRs by the new name resolution based on LHNames.