### PR TITLE
Split testsuites and stop linking during tests

### DIFF
--- a/tests/harness/Test/Groups.hs
+++ b/tests/harness/Test/Groups.hs
@@ -10,6 +10,8 @@ microTestGroups =
     "unit-pos-1"
   , "unit-pos-2"
   , "unit-pos-3"
+  , "unit-pos-4"
+  , "unit-pos-5"
   , "unit-neg"
   , "basic-pos"
   , "basic-neg"

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -1485,92 +1485,6 @@ executable unit-pos-1
                     , Poly2
                     , Poly3a
                     , Poly3
-                    , Poly4
-                    , PolySet
-                    , PolyBag
-                    , Polyfun
-                    , Polyqual
-                    , PositivityCheck
-                    , Poslist_dc
-                    , Poslist
-                    , Pragma0
-                    , Pred
-                    , PrimInt0
-                    , Product
-                    , Profcrasher
-                    , PromotedDataCons
-                    , Propability
-                    , Propmeasure1
-                    , Propmeasure
-                    , QQTySig
-                    , QQTySigTyVars
-                    , QQTySyn
-                    , QualTest
-                    , Range1
-                    , RangeAdt
-                    , Range
-                    , RBTree_col_height
-                    , RBTree_color
-                    , RBTree_height
-                    , RBTree
-                    , RBTree_ord
-                    , RealProps
-                    , Rebind
-                    , Rec_annot_go
-                    , Record0
-                    , Record1
-                    , RecordSelectorError
-                    , RecQSort0
-                    , RecQSort
-                    , RecSelector
-                    , Recursion0
-                    , Reduction
-                    , RefinedADTs
-                    , Reflect0
-                    , ReflectAlias
-                    , ReflectBooleanFunctions
-                    , ReflectMutual
-                    , RelativeComplete
-                    , RepeatHigherOrder
-                    , Repeat
-                    , ResolveA
-                    , ResolveB
-                    , Resolve
-                    , ResolvePred
-                    , Rest
-                    , ReWrite10
-                    , ReWrite2
-                    , ReWrite3
-                    , ReWrite4
-                    , ReWrite5
-                    , ReWrite6
-                    , ReWrite7
-                    , ReWrite8
-                    , ReWrite9
-                    , ReWrite
-                    , Risers
-                    , Rta
-                    , SafePartialFunctions
-                    , Scanr
-                    , SelfList
-                    , SimplerNotation
-                    , SimplifyTup00
-                    , SingletonLists
-                    , SinPosTest
-                    , Solver
-                    , SqrtPosTest
-                    , Spec0
-                    , StackClass
-                    , StackMachine
-                    , Stacks0
-                    , State00
-                    , StateConstraints00
-                    , StateConstraints0
-                    , StateConstraints
-                    , StateF00
-                    , State
-                    , StateInvarint
-                    , StateLib
 
     -- LANGUAGE extensions used by modules in this package.
     -- other-extensions:
@@ -1607,115 +1521,7 @@ executable unit-pos-2
       buildable:      False
 
     other-modules:
-                      Abs
-                    , AbsPosTest
-                    , Absref_crash0
-                    , Absref_crash
-                    , Ackermann
-                    , Adt0
-                    , AdtList0
-                    , AdtList1
-                    , AdtList2
-                    , AdtList3
-                    , AdtList4
-                    , AdtList5
-                    , AdtPeano0
-                    , AdtPeano1
-                    , Alias00
-                    , Alias01
-                    , Alphaconvert_List
-                    , Alphaconvert_Set
-                    , AmortizedQueue
-                    , Anfbug
-                    , Anftest
-                    , Anish1
-                    , AssumedRecursive
-                    , Assume
-                    , Automate
-                    , AutoSize
-                    , AutoTerm1
-                    , AutoTerm
-                    , Avg
-                    , AVL
-                    , AVLRJ
-                    , Bag1
-                    , BangPatterns
-                    , BinarySearch
-                    , BinarySearchOverflow
-                    , Books
-                    , Bool0
-                    , Bool1
-                    , Bool2
-                    , Bounds1
-                    , BST000
-                    , BST
-                    , Case_lambda_join
-                    , CasesToLogic
-                    , Cat
-                    , CharLiterals
-                    , CheckedNum
-                    , Chunks
-                    , Class2
-                    , Class
-                    , ClassReg
-                    , Client521
-                    , ClojurVector
-                    , Cmptag0
-                    , Coercion
-                    , Comma
-                    , CommentedOut
-                    , Compare1
-                    , Compare2
-                    , CompareConstraints
-                    , Compare
-                    , Comprehension
-                    , ComprehensionTerm
-                    , ConstraintsAppend
-                    , Constraints
-                    , Coretologic
-                    , CosPosTest
-                    , CountMonad
-                    , Csgordon_issue_296
-                    , Cut00
-                    , Data2
-                    , DataBase
-                    , Datacon0
-                    , Datacon1
-                    , Datacon_inv
-                    , DataConQuals
-                    , DB00
-                    , Deepmeas0
-                    , DepData
-                    , DependentPairsFun
-                    , DependentPairs
-                    , DepTriples
-                    , Deptup1
-                    , Deptup3
-                    , Deptup
-                    , DeptupW
-                    , Div000
-                    , Dropwhile
-                    , Duplicate_bind
-                    , Elements
-                    , Elems
-                    , Elim00
-                    , Elim01
-                    , Elim_ex_compose
-                    , Elim_ex_let
-                    , Elim_ex_list
-                    , Elim_ex_map_1
-                    , Elim_ex_map_2
-                    , Elim_ex_map_3
-                    , Eqelems
-                    , Eq_poly_measure
-                    , Eval
-                    , EvalQuery
-                    , Even0
-                    , Even
-                    , Ex01
-                    , Ex0
-                    , Ex1
-                    , ExactADT6
+                      ExactADT6
                     , ExactGADT0
                     , ExactGADT1
                     , ExactGADT2
@@ -2035,6 +1841,266 @@ executable unit-pos-3
                     --- IGNORED
                     -- , Variance
 
+
+    -- LANGUAGE extensions used by modules in this package.
+    -- other-extensions:
+    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
+    if flag(measure-timings)
+      ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
+    build-depends:    base
+                    , liquid-prelude
+                    , containers
+                    , liquid-vector
+                    , bytestring
+                    , ghc-prim
+                    , liquidhaskell
+                    , transformers
+                    , primitive
+                    , template-haskell
+                    , deepseq
+                    , vector
+
+    hs-source-dirs:   app
+                    , pos
+
+    c-sources:        ffi-include/foo.c
+    include-dirs:     ffi-include
+    default-language: Haskell2010
+
+
+flag unit-pos-4
+     default: False
+
+executable unit-pos-4
+    main-is:          Main.hs
+    -- Modules included in this executable, other than Main.
+    if !flag(unit-pos-4) && flag(stack)
+      buildable:      False
+
+    other-modules:
+                      Abs
+                    , AbsPosTest
+                    , Absref_crash0
+                    , Absref_crash
+                    , Ackermann
+                    , Adt0
+                    , AdtList0
+                    , AdtList1
+                    , AdtList2
+                    , AdtList3
+                    , AdtList4
+                    , AdtList5
+                    , AdtPeano0
+                    , AdtPeano1
+                    , Alias00
+                    , Alias01
+                    , Alphaconvert_List
+                    , Alphaconvert_Set
+                    , AmortizedQueue
+                    , Anfbug
+                    , Anftest
+                    , Anish1
+                    , AssumedRecursive
+                    , Assume
+                    , Automate
+                    , AutoSize
+                    , AutoTerm1
+                    , AutoTerm
+                    , Avg
+                    , AVL
+                    , AVLRJ
+                    , Bag1
+                    , BangPatterns
+                    , BinarySearch
+                    , BinarySearchOverflow
+                    , Books
+                    , Bool0
+                    , Bool1
+                    , Bool2
+                    , Bounds1
+                    , BST000
+                    , BST
+                    , Case_lambda_join
+                    , CasesToLogic
+                    , Cat
+                    , CharLiterals
+                    , CheckedNum
+                    , Chunks
+                    , Class2
+                    , Class
+                    , ClassReg
+                    , Client521
+                    , ClojurVector
+                    , Cmptag0
+                    , Coercion
+                    , Comma
+                    , CommentedOut
+                    , Compare1
+                    , Compare2
+                    , CompareConstraints
+                    , Compare
+                    , Comprehension
+                    , ComprehensionTerm
+                    , ConstraintsAppend
+                    , Constraints
+                    , Coretologic
+                    , CosPosTest
+                    , CountMonad
+                    , Csgordon_issue_296
+                    , Cut00
+                    , Data2
+                    , DataBase
+                    , Datacon0
+                    , Datacon1
+                    , Datacon_inv
+                    , DataConQuals
+                    , DB00
+                    , Deepmeas0
+                    , DepData
+                    , DependentPairsFun
+                    , DependentPairs
+                    , DepTriples
+                    , Deptup1
+                    , Deptup3
+                    , Deptup
+                    , DeptupW
+                    , Div000
+                    , Dropwhile
+                    , Duplicate_bind
+                    , Elements
+                    , Elems
+                    , Elim00
+                    , Elim01
+                    , Elim_ex_compose
+                    , Elim_ex_let
+                    , Elim_ex_list
+                    , Elim_ex_map_1
+                    , Elim_ex_map_2
+                    , Elim_ex_map_3
+                    , Eqelems
+                    , Eq_poly_measure
+                    , Eval
+                    , EvalQuery
+                    , Even0
+                    , Even
+                    , Ex01
+                    , Ex0
+                    , Ex1
+
+    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
+    if flag(measure-timings)
+      ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
+    build-depends:    base
+                    , liquid-prelude
+                    , containers
+                    , liquid-vector
+                    , bytestring
+                    , ghc-prim
+                    , liquidhaskell
+                    , transformers
+                    , primitive
+                    , template-haskell
+                    , deepseq
+                    , vector
+
+    hs-source-dirs:   app
+                    , pos
+
+    c-sources:        ffi-include/foo.c
+    include-dirs:     ffi-include
+    default-language: Haskell2010
+
+
+flag unit-pos-5
+     default: False
+
+executable unit-pos-5
+    main-is:          Main.hs
+    -- Modules included in this executable, other than Main.
+    if !flag(unit-pos-5) && flag(stack)
+      buildable:      False
+
+    other-modules:
+                      Malformed0
+                    , Map0
+                    , Map2
+                    , MapFusion
+                    , Map
+                    , Mapreduce_bare
+                    , MapReduceVerified
+                    , Maps1
+                    , Maps
+                    , MapTvCrash
+                    , MaskError
+                    , Maybe000
+                    , Maybe0
+                    , Maybe1
+                    , Maybe2
+                    , Maybe3
+                    , Maybe4
+                    , Maybe5
+                    , Maybe
+                    , Meas00a
+                    , Meas00
+                    , Meas0a
+                    , Meas0
+                    , Meas10
+                    , Meas11
+                    , Meas1
+                    , Meas2
+                    , Meas4
+                    , Meas5
+                    , Meas6
+                    , Meas7
+                    , Meas8
+                    , Meas9
+                    , MeasureContains
+                    , MeasureDups
+                    , Measures1
+                    , MeasureSets
+                    , Measures
+                    , Merge1
+                    , MergeSort_bag
+                    , MergeSort
+                    , Mod
+                    , ModLib
+                    , ModTest
+                    , Monad2
+                    , Monad5
+                    , Monad6
+                    , Multi_pred_app_00
+                    , Mutrec
+                    , MutuallyDependentADT
+                    , MutualRec
+                    , Nats
+                    , Niki1
+                    , Niki
+                    , NoCaseExpand
+                    , NoExhaustiveGuardsError
+                    , NoPositivityCheck
+                    , Null
+                    , OrdList
+                    , ORM
+                    , Pair00
+                    , Pair0
+                    , Pair
+                    , PairMeasure0
+                    , PairMeasure
+                    , Pargs1
+                    , Pargs
+                    , Partialmeasure
+                    , Partial_tycon
+                    , Permutation
+                    , PersistentVector
+                    , Ple1
+                    , PointDist
+                    , Poly0
+                    , Poly1
+                    , Poly2_degenerate
+                    , Poly2
+                    , Poly3a
+                    , Poly3
+                    , Poly4
 
     -- LANGUAGE extensions used by modules in this package.
     -- other-extensions:

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -52,6 +52,7 @@ common common-ghc-options
     ghc-options:      -fplugin=LiquidHaskell
                       -fkeep-going
                       -O0
+                      -no-link
 
 flag benchmark-stitch-lh
      default: False

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -48,10 +48,16 @@ executable test-driver
     default-language: Haskell2010
     ghc-options:      -O2 -j -Wall -Werror
 
+common common-ghc-options
+    ghc-options:      -fplugin=LiquidHaskell
+                      -fkeep-going
+                      -O0
+
 flag benchmark-stitch-lh
      default: False
 
 executable benchmark-stitch-lh
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(benchmark-stitch-lh) && flag(stack)
       buildable:      False
@@ -105,11 +111,8 @@ executable benchmark-stitch-lh
 
 
     ghc-options:      -Wall
-                      -fplugin=LiquidHaskell
                       -Wno-unticked-promoted-constructors
                       -fno-warn-name-shadowing
-                      -fkeep-going
-                      -O0
 
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
@@ -119,6 +122,7 @@ flag benchmark-bytestring
      default: False
 
 executable benchmark-bytestring
+  import:             common-ghc-options
   main-is:            Main.hs
 
   if !flag(benchmark-bytestring) && flag(stack)
@@ -144,7 +148,7 @@ executable benchmark-bytestring
                     , liquidhaskell
                     , array >= 0.5.4
 
-  ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0 -Wno-inline-rule-shadowing
+  ghc-options:      -Wno-inline-rule-shadowing
   if flag(measure-timings)
     ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
   default-language: Haskell2010
@@ -153,6 +157,7 @@ flag benchmark-vector-algorithms
      default: False
 
 executable benchmark-vector-algorithms
+  import:             common-ghc-options
   main-is:            Main.hs
 
   if !flag(benchmark-vector-algorithms) && flag(stack)
@@ -181,7 +186,6 @@ executable benchmark-vector-algorithms
                     , liquidhaskell
                     , vector
 
-  ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
   if flag(measure-timings)
     ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
   default-language: Haskell2010
@@ -190,6 +194,7 @@ flag benchmark-cse230
      default: False
 
 executable benchmark-cse230
+  import:             common-ghc-options
   main-is:            Main.hs
 
   if !flag(benchmark-cse230) && flag(stack)
@@ -212,7 +217,6 @@ executable benchmark-cse230
                     , liquid-prelude
                     , liquidhaskell
 
-  ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
   if flag(measure-timings)
     ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
   default-language: Haskell2010
@@ -221,6 +225,7 @@ flag benchmark-esop2013
      default: False
 
 executable benchmark-esop2013
+  import:             common-ghc-options
   main-is:            Main.hs
   if !flag(benchmark-esop2013) && flag(stack)
     buildable:        False
@@ -242,7 +247,7 @@ executable benchmark-esop2013
                     , liquidhaskell
                     , deepseq >= 1.4
 
-  ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0 -Wno-inline-rule-shadowing
+  ghc-options:      -Wno-inline-rule-shadowing
   if flag(measure-timings)
     ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
   default-language: Haskell2010
@@ -251,6 +256,7 @@ flag benchmark-icfp15-pos
      default: False
 
 executable benchmark-icfp15-pos
+  import:             common-ghc-options
   main-is:            Main.hs
   if !flag(benchmark-icfp15-pos) && flag(stack)
     buildable:        False
@@ -287,7 +293,6 @@ executable benchmark-icfp15-pos
                     , ghc-prim
                     , liquidhaskell
 
-  ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
   if flag(measure-timings)
     ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
   default-language: Haskell2010
@@ -296,6 +301,7 @@ flag benchmark-icfp15-neg
      default: False
 
 executable benchmark-icfp15-neg
+  import:             common-ghc-options
   main-is:            Main.hs
   if !flag(benchmark-icfp15-neg) && flag(stack)
     buildable:        False
@@ -319,7 +325,6 @@ executable benchmark-icfp15-neg
                     , ghc-prim
                     , liquidhaskell
 
-  ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
   if flag(measure-timings)
     ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
   default-language: Haskell2010
@@ -328,6 +333,7 @@ flag prover-foundations
      default: False
 
 executable prover-foundations
+  import:             common-ghc-options
   main-is:            Main.hs
   if !flag(prover-foundations) && flag(stack)
     buildable:        False
@@ -344,7 +350,6 @@ executable prover-foundations
                     , liquid-prelude
                     , liquidhaskell
 
-  ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
   if flag(measure-timings)
     ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
   default-language: Haskell2010
@@ -353,6 +358,7 @@ flag prover-nople-pos
      default: False
 
 executable prover-nople-pos
+  import:             common-ghc-options
   main-is:            Main.hs
   if !flag(prover-nople-pos) && flag(stack)
     buildable:        False
@@ -399,7 +405,6 @@ executable prover-nople-pos
                     , liquidhaskell
                     , prover-ple-lib
 
-  ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
   if flag(measure-timings)
     ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
   default-language: Haskell2010
@@ -408,6 +413,7 @@ flag prover-nople-neg
      default: False
 
 executable prover-nople-neg
+  import:             common-ghc-options
   main-is:            Main.hs
   if !flag(prover-nople-neg) && flag(stack)
     buildable:        False
@@ -437,7 +443,6 @@ executable prover-nople-neg
                     , liquidhaskell
                     , prover-ple-lib
 
-  ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
   if flag(measure-timings)
     ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
   default-language: Haskell2010
@@ -446,6 +451,7 @@ flag prover-ple-pos
      default: False
 
 executable prover-ple-pos
+  import:             common-ghc-options
   main-is:            Main.hs
   if !flag(prover-ple-pos) && flag(stack)
     buildable:        False
@@ -489,7 +495,6 @@ executable prover-ple-pos
                     , liquidhaskell
                     , prover-ple-lib
 
-  ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
   if flag(measure-timings)
     ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
   default-language: Haskell2010
@@ -498,6 +503,7 @@ flag benchmark-text
      default: False
 
 executable benchmark-text
+  import: common-ghc-options
   main-is: Main.hs
   -- XXX(matt.walker): Get this working!
 
@@ -571,9 +577,7 @@ executable benchmark-text
 
   default-language: Haskell2010
 
-  ghc-options: -fplugin=LiquidHaskell
-               -fkeep-going
-               -fplugin-opt=LiquidHaskell=--no-check-imports
+  ghc-options: -fplugin-opt=LiquidHaskell=--no-check-imports
   if flag(measure-timings)
     ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
 
@@ -581,6 +585,7 @@ flag parsing-errors
      default: False
 
 executable parsing-errors
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(parsing-errors) && flag(stack)
       buildable:      False
@@ -590,7 +595,7 @@ executable parsing-errors
                     , ParseBind
                     , ParseClass
 
-    ghc-options:      -fplugin=LiquidHaskell -fplugin-opt=LiquidHaskell:--expect-error-containing=parse -fkeep-going -O0
+    ghc-options:      -fplugin-opt=LiquidHaskell:--expect-error-containing=parse
 
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
@@ -609,6 +614,7 @@ flag errors
      default: False
 
 executable errors
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(errors) && flag(stack)
       buildable:      False
@@ -716,8 +722,6 @@ executable errors
                     , UnboundVarInLocSig
                     , UnboundVarInSpec
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
-
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
 
@@ -736,6 +740,7 @@ flag parser-pos
      default: False
 
 executable parser-pos
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(parser-pos) && flag(stack)
       buildable:      False
@@ -755,7 +760,6 @@ executable parser-pos
                     , TokensAsPrefixes
                     , Tuples
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -771,6 +775,7 @@ flag names-pos
      default: False
 
 executable names-pos
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(names-pos) && flag(stack)
       buildable:      False
@@ -808,7 +813,6 @@ executable names-pos
                     , Vector0
                     , Vector1
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -828,6 +832,7 @@ flag names-neg
      default: False
 
 executable names-neg
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(names-neg) && flag(stack)
       buildable:      False
@@ -844,7 +849,6 @@ executable names-neg
                     , Vector0
                     , Vector1
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -864,6 +868,7 @@ flag name-resolution-pos
      default: False
 
 executable name-resolution-pos
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(names-neg) && flag(stack)
       buildable:      False
@@ -879,9 +884,6 @@ executable name-resolution-pos
 
 
     ghc-options:      -Wall
-                      -fplugin=LiquidHaskell
-                      -fkeep-going
-                      -O0
 
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
@@ -898,6 +900,7 @@ flag reflect-pos
      default: False
 
 executable reflect-pos
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(reflect-pos) && flag(stack)
       buildable:      False
@@ -908,7 +911,6 @@ executable reflect-pos
                     , ReflString1
                     , T2405
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -924,6 +926,7 @@ flag class-pos
       default: False
 
 executable class-pos
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(class-pos) && flag(stack)
       buildable:      False
@@ -938,7 +941,6 @@ executable class-pos
                     , RealProps1
                     , TypeEquality01
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -954,6 +956,7 @@ flag class-neg
       default: False
 
 executable class-neg
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(class-neg) && flag(stack)
       buildable:      False
@@ -964,7 +967,6 @@ executable class-neg
                     , Inst00
                     , RealProps0
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -980,6 +982,7 @@ flag reflect-neg
      default: False
 
 executable reflect-neg
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(reflect-neg) && flag(stack)
       buildable:      False
@@ -989,7 +992,6 @@ executable reflect-neg
                     , ReflString0
                     , ReflString1
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -1005,6 +1007,7 @@ flag measure-pos
      default: False
 
 executable measure-pos
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(measure-pos) && flag(stack)
       buildable:      False
@@ -1036,7 +1039,6 @@ executable measure-pos
                     , RecordAccessors
                     , Using00
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -1052,6 +1054,7 @@ flag measure-neg
      default: False
 
 executable measure-neg
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(measure-neg) && flag(stack)
       buildable:      False
@@ -1072,7 +1075,6 @@ executable measure-neg
                     , Ple1Lib
                     , Using00
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -1089,6 +1091,7 @@ flag datacon-pos
      default: False
 
 executable datacon-pos
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(datacon-pos) && flag(stack)
       buildable:      False
@@ -1109,7 +1112,6 @@ executable datacon-pos
                     , T1477
                     , T1777
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -1125,6 +1127,7 @@ flag datacon-neg
      default: False
 
 executable datacon-neg
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(datacon-neg) && flag(stack)
       buildable:      False
@@ -1140,7 +1143,6 @@ executable datacon-neg
                     -- , NewTypes0
                     , NewTypes
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -1156,6 +1158,7 @@ flag unit-neg
      default: False
 
 executable unit-neg
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(unit-neg) && flag(stack)
       buildable:      False
@@ -1381,7 +1384,7 @@ executable unit-neg
                     -- , QQTySyn2
                     -- , Variance1
 
-    ghc-options:      -fplugin=LiquidHaskell -ddump-to-file -fkeep-going -O0
+    ghc-options:      -ddump-to-file
     build-depends:    base
                     , liquid-prelude
                     , containers
@@ -1400,6 +1403,7 @@ flag unit-pos-1
      default: False
 
 executable unit-pos-1
+    import:           common-ghc-options
     main-is:          Main.hs
     -- Modules included in this executable, other than Main.
     if !flag(unit-pos-1) && flag(stack)
@@ -1488,7 +1492,6 @@ executable unit-pos-1
 
     -- LANGUAGE extensions used by modules in this package.
     -- other-extensions:
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -1515,6 +1518,7 @@ flag unit-pos-2
      default: False
 
 executable unit-pos-2
+    import:           common-ghc-options
     main-is:          Main.hs
     -- Modules included in this executable, other than Main.
     if !flag(unit-pos-2) && flag(stack)
@@ -1637,7 +1641,6 @@ executable unit-pos-2
                     , LooLibLib
                     , LNot
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -1665,6 +1668,7 @@ flag unit-pos-3
      default: False
 
 executable unit-pos-3
+    import:           common-ghc-options
     main-is:          Main.hs
     -- Modules included in this executable, other than Main.
     if !flag(unit-pos-3) && flag(stack)
@@ -1844,7 +1848,6 @@ executable unit-pos-3
 
     -- LANGUAGE extensions used by modules in this package.
     -- other-extensions:
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -1872,6 +1875,7 @@ flag unit-pos-4
      default: False
 
 executable unit-pos-4
+    import:           common-ghc-options
     main-is:          Main.hs
     -- Modules included in this executable, other than Main.
     if !flag(unit-pos-4) && flag(stack)
@@ -1987,7 +1991,6 @@ executable unit-pos-4
                     , Ex0
                     , Ex1
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -2015,6 +2018,7 @@ flag unit-pos-5
      default: False
 
 executable unit-pos-5
+    import:           common-ghc-options
     main-is:          Main.hs
     -- Modules included in this executable, other than Main.
     if !flag(unit-pos-5) && flag(stack)
@@ -2104,7 +2108,6 @@ executable unit-pos-5
 
     -- LANGUAGE extensions used by modules in this package.
     -- other-extensions:
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -2132,6 +2135,7 @@ flag absref-pos
      default: False
 
 executable absref-pos
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(absref-pos) && flag(stack)
       buildable:      False
@@ -2150,7 +2154,6 @@ executable absref-pos
                     , State00
                     , VectorLoop
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -2168,6 +2171,7 @@ flag absref-neg
      default: False
 
 executable absref-neg
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(absref-neg) && flag(stack)
       buildable:      False
@@ -2181,7 +2185,6 @@ executable absref-neg
                     , ListISort_LType
                     , ListQSort
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -2199,6 +2202,7 @@ flag relational-pos
      default: False
 
 executable relational-pos
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(relational-pos) && flag(stack)
       buildable:      False
@@ -2213,7 +2217,6 @@ executable relational-pos
                     , MutRec
                     , SndOrdPredNonRel
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -2231,6 +2234,7 @@ flag relational-neg
      default: False
 
 executable relational-neg
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(relational-neg) && flag(stack)
       buildable:      False
@@ -2244,7 +2248,6 @@ executable relational-neg
                     , CheckedImp
                     , SndOrdPred
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -2262,6 +2265,7 @@ flag basic-neg
      default: False
 
 executable basic-neg
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(basic-neg) && flag(stack)
       buildable:      False
@@ -2288,7 +2292,6 @@ executable basic-neg
                     , T1459
                     , T2349
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -2305,6 +2308,7 @@ flag basic-pos
      default: False
 
 executable basic-pos
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(basic-pos) && flag(stack)
       buildable:      False
@@ -2370,7 +2374,6 @@ executable basic-pos
                     , T2349
                     , T2369
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -2386,6 +2389,7 @@ flag import-cli
      default: False
 
 executable import-cli
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(import-cli) && flag(stack)
       buildable:      False
@@ -2463,11 +2467,6 @@ executable import-cli
                     , B
                     , C
 
-    ghc-options:      -fplugin=LiquidHaskell
-                      -fkeep-going
-                      -O0
-                      -- XXX(matt.walker) it's odd, but I have to include the lib dir.
-                      -iimport-cli/lib
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -2484,6 +2483,7 @@ flag ple-pos
      default: False
 
 executable ple-pos
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(ple-pos) && flag(stack)
       buildable:      False
@@ -2555,7 +2555,6 @@ executable ple-pos
     --   other-modules:  T1302b
 
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -2572,6 +2571,7 @@ flag ple-neg
      default: False
 
 executable ple-neg
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(ple-neg) && flag(stack)
       buildable:      False
@@ -2594,8 +2594,6 @@ executable ple-neg
                     , T1409
                     , T1424
 
-                    -- XXX(matt.walker): SEGFAUTS WITH  (!?)
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -2612,6 +2610,7 @@ flag rankN-pos
      default: False
 
 executable rankN-pos
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(rankN-pos) && flag(stack)
       buildable:      False
@@ -2622,7 +2621,6 @@ executable rankN-pos
                     , Test1
 
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -2638,6 +2636,7 @@ flag terminate-pos
      default: False
 
 executable terminate-pos
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(terminate-pos) && flag(stack)
       buildable:      False
@@ -2665,7 +2664,6 @@ executable terminate-pos
                     , T1403
                     , Term00
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -2682,6 +2680,7 @@ flag terminate-neg
      default: False
 
 executable terminate-neg
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(terminate-neg) && flag(stack)
       buildable:      False
@@ -2704,7 +2703,6 @@ executable terminate-neg
                     , Total01
                     , Total02
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -2720,6 +2718,7 @@ flag pattern-pos
      default: False
 
 executable pattern-pos
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(pattern-pos) && flag(stack)
       buildable:      False
@@ -2738,7 +2737,6 @@ executable pattern-pos
                     , TemplateHaskell
                     , TemplateHaskellLib
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base
@@ -2756,6 +2754,7 @@ flag typeclass-pos
      default: False
 
 executable typeclass-pos
+    import:           common-ghc-options
     main-is:          Main.hs
     if !flag(typeclass-pos) && flag(stack)
       buildable:      False
@@ -2769,7 +2768,6 @@ executable typeclass-pos
                     , PNat
                     , SemigroupLib
 
-    ghc-options:      -fplugin=LiquidHaskell -fkeep-going -O0
     if flag(measure-timings)
       ghc-options:    -fforce-recomp -ddump-timings -ddump-to-file
     build-depends:    base


### PR DESCRIPTION
Splitting the testsuites allows machines with sufficient parallelism to run the tests faster.

In addition, linking is not necessary to run Liquid Haskell, so this PR arranges to skip it in tests.