### PR TITLE
Initial version of typed holes support under allow-typed-holes flag

### DIFF
--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -12,3 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: andreasabel/fix-whitespace-action@v1
+        with:
+          version:    0.1
+          configfile: fix-whitespace.yaml
+          fix:        false
+          verbose:    true

--- a/docs/mkDocs/docs/options.md
+++ b/docs/mkDocs/docs/options.md
@@ -734,3 +734,52 @@ an import of a module coming from package `PACKAGE`. e.g.
 `--exclude-automatic-assumptions-for=vector` would stop loading
 `_LHAssumptions` modules for any imports coming from package
 `vector`.
+
+## Warn on Term Holes
+
+**Options:** `warn-on-term-holes`
+
+LiquidHaskell can be configured to emit warnings whenever it encounters incomplete terms, known as *holes*.
+
+This flag is particularly useful during development, ensuring that any placeholders in your specifications are reviewed and completed before final evaluation.
+
+To activate this behavior, use the `--warn-on-term-holes` flag either:
+
+1. As a pragma in your source file:
+    ```haskell
+    {-@ LIQUID "--warn-on-term-holes" @-}
+    ```
+2. As a plugin option:
+    ```
+    ghc-options: -fplugin-opt=LiquidHaskell:--warn-on-term-holes
+    ```
+
+When enabled, LiquidHaskell issues a warning for each term hole it discovers, for example:
+
+```haskell
+typed-holes/Example1.hs:25:13: error:
+    Hole Found
+Example1.hole :: {v : [a] | false}
+in the context
+  Example1.<> : forall a .
+                x1:[a] -> x2:[a] -> {VV : [a] | VV == Example1.<> x1 x2}
+
+  lq_anf$##7205759403792797257##dWZ : {v : [a] | v == Example1.<> lq_anf$##7205759403792797256##dWY x##aFc
+                                                 && GHC.Types_LHAssumptions.len v >= 0}
+
+  Example1.hole : forall a . a
+
+  Example1.empty : forall a .
+                   {VV : [a] | VV == Example1.empty
+                               && VV == GHC.Types.[]}
+
+  lq_anf$##7205759403792797256##dWY : {v : [a] | v == Example1.empty
+                                                 && v == GHC.Types.[]
+                                                 && GHC.Types_LHAssumptions.len v >= 0}
+
+  x##aFc : {VV##1043 : [a] | GHC.Types_LHAssumptions.len VV##1043 >= 0}
+hole found
+   |
+25 |         === hole
+   |             ^^^^
+```

--- a/docs/mkDocs/docs/options.md
+++ b/docs/mkDocs/docs/options.md
@@ -741,6 +741,21 @@ an import of a module coming from package `PACKAGE`. e.g.
 
 LiquidHaskell can be configured to emit warnings whenever it encounters incomplete terms, known as *holes*.
 
+To create a hole you need to have a binding with the name `hole` in the scope by adding:
+
+      hole = undefined
+
+To use a hole you simply insert the `hole` in any place
+where you want to get more type information. For example:
+```haskell
+hole = undefined
+
+{-@ listLength :: xs:[a] -> {v : Nat | v == len xs} @-}
+listLength :: [a] -> Int
+listLength [] = hole -- Hole inserted here
+listLength (_:xs) = 1 + listLength xs
+```
+
 This flag is particularly useful during development, ensuring that any placeholders in your specifications are reviewed and completed before final evaluation.
 
 To activate this behavior, use the `--warn-on-term-holes` flag either:

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -101,6 +101,7 @@ consAct γ cfg info = do
   fcs <- concat <$> mapM (splitC (typeclass (getConfig info))) hcs
   fws <- concat <$> mapM splitW hws
   checkStratCtors γ sSpc
+  when (warnOnTermHoles cfg) emitConsolidatedHoleWarnings
   modify $ \st -> st { fEnv     = fEnv    st `mappend` feEnv (fenv γ)
                      , cgLits   = litEnv   γ
                      , cgConsts = cgConsts st `mappend` constEnv γ
@@ -201,6 +202,25 @@ isSubterm ctors l r | l == r
                   = any (isSubterm ctors l) args
                   | otherwise
                   = False
+
+emitConsolidatedHoleWarnings :: CG ()
+emitConsolidatedHoleWarnings = do
+  holes     <- gets hsHoles
+  holeExprs <- gets hsHolesExprs
+
+  let mergedHoles
+                  = [(h
+                    , holeInfo
+                    , M.findWithDefault [] (h, srcSpan) holeExprs
+                    )
+                    | ((h, srcSpan), holeInfo) <- M.toList holes
+                    ]
+
+  forM_ mergedHoles $ \(h, holeInfo, anfs) -> do
+    let γ        = snd . info $ holeInfo
+    let anfs'    = map (\(v, x, t) -> (F.symbol v, x, t)) anfs
+    addWarning $ ErrHole (hloc holeInfo) "hole found" (reLocal $ renv γ) (F.symbol h) (htype holeInfo) anfs'
+
 
 --------------------------------------------------------------------------------
 -- | Ensure that the instance type is a subtype of the class type --------------
@@ -316,9 +336,17 @@ consCB _ γ (NonRec x def)
 
 consCB _ γ (NonRec x e)
   = do to  <- varTemplate γ (x, Nothing)
+       when (warnOnTermHoles (getConfig γ)) checkLetHole
        to' <- consBind False γ (x, e, to) >>= addPostTemplate γ
        extender γ (x, makeSingleton γ (simplify e) <$> to')
-
+  where
+    checkLetHole =
+      do
+        let isItHole = detectTypedHole e
+        case isItHole of
+          Just (srcSpan, var) -> do
+            linkANFToHole x (var, RealSrcSpan srcSpan Strict.Nothing)
+          _ -> return ()
 grepDictionary :: CoreExpr -> Maybe (Var, [Type])
 grepDictionary = go []
   where
@@ -394,28 +422,49 @@ addPToEnv γ π
   = do γπ <- γ += ("addSpec1", pname π, pvarRType π)
        foldM (+=) γπ [("addSpec2", x, ofRSort t) | (t, x, _) <- pargs π]
 
+detectTypedHole :: CoreExpr -> Maybe (RealSrcSpan, Var)
+detectTypedHole e =
+  case stripTicks e of
+    Var x | isVarHole x ->
+      case lastTick e of
+        Just (SourceNote src _) -> Just (src, x)
+        _                       -> Nothing
+    _ -> Nothing
 
-detectTypedHole ::  CGEnv -> CoreExpr -> CG (Maybe (RealSrcSpan, Var))
-detectTypedHole _ (App (Tick genTick (Var x)) _) | isVarHole x
-  = return (Just (getSrcSpanFromTick, x))
-    where
-      getSrcSpanFromTick = 
-        case genTick of
-          SourceNote src _ -> src
-          _ -> panic Nothing "Not a Source Note"
-      isStrHole s = 
-        case break (=='.') s of
-          (_, '.':rest) -> rest == "hole"
-          _             -> False
-      isVarHole = isStrHole . F.symbolString . F.symbol
-detectTypedHole  _ _ = return Nothing -- NOT A TYPED HOLE
+-- Remove Initial App and sequent Tick nodes from an expression.
+stripTicks :: CoreExpr -> CoreExpr
+stripTicks (App (Tick _ e) _) = stripTicks e
+stripTicks (Tick _ e)         = stripTicks e
+stripTicks e          = e
+
+-- Traverse the expression to get the last Tick information.
+lastTick :: Expr b -> Maybe CoreTickish
+lastTick (Tick t e) =
+  case lastTick e of
+    Just t' -> Just t'
+    Nothing -> Just t
+lastTick (App e a) =
+  case lastTick a of
+    Just ta -> Just ta
+    Nothing -> lastTick e
+lastTick _ = Nothing
+
+-- A helper to check if the variable name indicates a typed hole.
+isVarHole :: Var -> Bool
+isVarHole x = isHoleStr (F.symbolString (F.symbol x))
+  where
+    isHoleStr s =
+      case break (== '.') s of
+        (_, '.':rest) -> rest == "hole"
+        _             -> False
+
 --------------------------------------------------------------------------------
 -- | Bidirectional Constraint Generation: CHECKING -----------------------------
 --------------------------------------------------------------------------------
 cconsE :: CGEnv -> CoreExpr -> SpecType -> CG ()
 --------------------------------------------------------------------------------
 cconsE g e t = do
-  -- _ <- traceM $ Text.printf "cconsE:\n expr = %s\n GSHOW = %s \nexprType = %s\n lqType = %s\n" (showpp e) (gshow e) (showpp (exprType e)) (showpp t)
+  checkANFHoleInExpr e t
   cconsE' g e t
 
 --------------------------------------------------------------------------------
@@ -485,15 +534,16 @@ cconsE' γ e@(Cast e' c) t
 
 cconsE' γ e t
   = do 
-       _ <- when (warnOnTermHoles (getConfig γ))  maybeAddHole
+       when (warnOnTermHoles (getConfig γ))  maybeAddHole
        te  <- consE γ e
        te' <- instantiatePreds γ e te >>= addPost γ
        addC (SubC γ te' t) ("cconsE: " ++ "\n t = " ++ showpp t ++ "\n te = " ++ showpp te ++ GM.showPpr e)
   where 
     maybeAddHole = do
-      isItHole <- detectTypedHole γ e
+      let isItHole = detectTypedHole e
       case isItHole of
-        Just (srcSpan, x) -> addHole (RealSrcSpan srcSpan Strict.Nothing) x t γ
+        Just (srcSpan, x) -> do
+          addHole (RealSrcSpan srcSpan Strict.Nothing) x t γ
         _ -> return ()
 
 lambdaSingleton :: CGEnv -> F.TCEmb TyCon -> Var -> CoreExpr -> CG (UReft F.Reft)
@@ -617,44 +667,20 @@ consE γ (Var x)
 consE _ (Lit c)
   = refreshVV $ uRType $ literalFRefType c
 
-consE γ e'@(App e a@(Type τ))
-  = do RAllT α te _ <- checkAll ("Non-all TyApp with expr", e) γ <$> consE γ e
-       t            <- if not (nopolyinfer (getConfig γ)) && isPos α && isGenericVar (ty_var_value α) te
-                         then freshTyType (typeclass (getConfig γ)) TypeInstE e τ
-                         else trueTy (typeclass (getConfig γ)) τ
-       addW          $ WfC γ t
-       t'           <- refreshVV t
-       tt0          <- instantiatePreds γ e' (subsTyVarMeet' (ty_var_value α, t') te)
-       let tt        = makeSingleton γ (simplify e') $ subsTyReft γ (ty_var_value α) τ tt0
-       return $ case rTVarToBind α of
-         Just (x, _) -> maybe (checkUnbound γ e' x tt a) (F.subst1 tt . (x,)) (argType τ)
-         Nothing     -> tt
-  where
-    isPos α = not (extensionality (getConfig γ)) || rtv_is_pol (ty_var_info α)
-
-consE γ e'@(App e a) | Just aDict <- getExprDict γ a
-  = case dhasinfo (dlookup (denv γ) aDict) (getExprFun γ e) of
-      Just riSig -> return $ fromRISig riSig
-      _          -> do
-        ([], πs, te) <- bkUniv <$> consE γ e
-        te'          <- instantiatePreds γ e' $ foldr RAllP te πs
-        (γ', te''')  <- dropExists γ te'
-        te''         <- dropConstraints γ te'''
-        updateLocA {- πs -} (exprLoc e) te''
-        let RFun x _ tx t _ = checkFun ("Non-fun App with caller ", e') γ te''
-        cconsE γ' a tx
-        addPost γ'        $ maybe (checkUnbound γ' e' x t a) (F.subst1 t . (x,)) (argExpr γ a)
-
-consE γ e'@(App e a)
-  = do ([], πs, te) <- bkUniv <$> consE γ {- GM.tracePpr ("APP-EXPR: " ++ GM.showPpr (exprType e)) -} e
-       te1        <- instantiatePreds γ e' $ foldr RAllP te πs
-       (γ', te2)  <- dropExists γ te1
-       te3        <- dropConstraints γ te2
-       updateLocA (exprLoc e) te3
-       let RFun x _ tx t _ = checkFun ("Non-fun App with caller ", e') γ te3
-       cconsE γ' a tx
-       makeSingleton γ' (simplify e') <$> addPost γ' (maybe (checkUnbound γ' e' x t a) (F.subst1 t . (x,)) (argExpr γ $ simplify a))
-
+consE γ e'@(App _ _) =
+  do
+    t <- if warnOnTermHoles (getConfig γ) then synthesizeWithHole else consEApp γ e'
+    checkANFHoleInExpr e' t
+    return t
+  where 
+    synthesizeWithHole = do
+      let isItHole = detectTypedHole e'
+      t <- consEApp γ e'
+      _ <- case isItHole of
+        Just (srcSpan, x) -> do
+          addHole (RealSrcSpan srcSpan Strict.Nothing) x t γ
+        _ -> return ()
+      return t
 consE γ (Lam α e) | isTyVar α
   = do γ' <- updateEnvironment γ α
        t' <- consE γ' e
@@ -700,6 +726,27 @@ consE γ e@(Coercion _)
 
 consE _ e@(Type t)
   = panic Nothing $ "consE cannot handle type " ++ GM.showPpr (e, t)
+  
+checkANFHoleInExpr :: CoreExpr -> SpecType -> CG ()
+checkANFHoleInExpr e t = do
+  let vars = collectVars e
+  forM_ vars $ \var -> do
+    isANF <- isANFInHole var
+    case isANF of
+      Just uniqueVar -> addHoleANF uniqueVar var e t
+      _ -> return ()
+collectVars :: CoreExpr -> [Var]
+collectVars (Var x) = [x]
+collectVars (App e1 e2) = collectVars e1 ++ collectVars e2
+collectVars (Lam x e) = x : collectVars e
+collectVars (Let (NonRec x e1) e2) = x : collectVars e1 ++ collectVars e2
+collectVars (Let (Rec xes) e) = 
+  let (xs, es) = unzip xes
+  in xs ++ concatMap collectVars es ++ collectVars e
+collectVars (Case e x _ alts) = 
+  x : collectVars e ++ concatMap collectAltVars alts
+  where collectAltVars (Alt _ xs e') = xs ++ collectVars e'
+collectVars _ = []
 
 consEApp :: CGEnv -> CoreExpr -> CG SpecType
 consEApp γ e'@(App e a@(Type τ))

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -70,9 +70,9 @@ import           Language.Haskell.Liquid.Bare.DataType (dataConMap, makeDataConC
 import Language.Haskell.Liquid.UX.Config
     ( HasConfig(getConfig),
       Config(typeclass, checkDerived, extensionality,
-             nopolyinfer, dependantCase, rankNTypes, allowTypedHoles),
+             nopolyinfer, dependantCase, rankNTypes, warnOnTermHoles),
       patternFlag,
-      higherOrderFlag, allowTypedHoles )
+      higherOrderFlag, warnOnTermHoles )
 import qualified GHC.Data.Strict as Strict
 
 
@@ -410,7 +410,7 @@ detectTypedHole  _ _ = return Nothing -- NOT A TYPED HOLE
 cconsE :: CGEnv -> CoreExpr -> SpecType -> CG ()
 --------------------------------------------------------------------------------
 cconsE g e t = do
-  _ <- if (allowTypedHoles (getConfig g))  then (detectTypedHole g e) else return Nothing
+  -- _ <- traceM $ Text.printf "cconsE:\n expr = %s\n GSHOW = %s \nexprType = %s\n lqType = %s\n" (showpp e) (gshow e) (showpp (exprType e)) (showpp t)
   cconsE' g e t
 
 --------------------------------------------------------------------------------
@@ -427,9 +427,9 @@ cconsE' γ e t
 cconsE' γ e@(Let b@(NonRec x _) ee) t
   = do sp <- gets specLVars
        if x `S.member` sp
-        then cconsLazyLet γ e t
-        else do γ' <- consCBLet γ b
-                cconsE γ' ee t
+         then cconsLazyLet γ e t
+         else do γ' <- consCBLet γ b
+                 cconsE γ' ee t
 
 cconsE' γ e (RAllP p t)
   = cconsE γ' e t''
@@ -565,25 +565,12 @@ cconsLazyLet _ _ _
   = panic Nothing "Constraint.Generate.cconsLazyLet called on invalid inputs"
 
 
-consE :: CGEnv -> CoreExpr -> CG SpecType
---------------------------------------------------------------------------------
-consE g e = do
-  t <- if (allowTypedHoles (getConfig g)) then synthesizeWithHole else consE' g e
-  return t
-  where 
-    synthesizeWithHole = do
-      isItHole <- detectTypedHole g e
-      t <- consE' g e 
-      _ <- case isItHole of
-        Just (srcSpan, x) -> addHole (RealSrcSpan srcSpan Strict.Nothing) x t g
-        _ -> return ()
-      return t
---------------------------------------------------------------------------------
+---------------------------------------------------------
 -- | Bidirectional Constraint Generation: SYNTHESIS ----------------------------
 --------------------------------------------------------------------------------
-consE' :: CGEnv -> CoreExpr -> CG SpecType
+consE :: CGEnv -> CoreExpr -> CG SpecType
 --------------------------------------------------------------------------------
-consE' γ e
+consE γ e
   | patternFlag γ
   , Just p <- Rs.lift e
   = consPattern γ (F.notracepp "CONSE-PATTERN: " p) (exprType e)
@@ -598,7 +585,7 @@ consE' γ e
 
 -- If datacon definitions have references to self for fancy termination,
 -- ignore them at the construction.
-consE' γ (Var x) | GM.isDataConId x
+consE γ (Var x) | GM.isDataConId x
   = do t0 <- varRefType γ x
        -- NV: The check is expected to fail most times, so
        --     it is cheaper than direclty fmap ignoreSelf.
@@ -609,16 +596,77 @@ consE' γ (Var x) | GM.isDataConId x
        addLocA (Just x) (getLocation γ) (varAnn γ x t)
        return t
 
-consE' γ (Var x)
+consE γ (Var x)
   = do t <- varRefType γ x
        addLocA (Just x) (getLocation γ) (varAnn γ x t)
        return t
 
-consE' _ (Lit c)
+consE _ (Lit c)
   = refreshVV $ uRType $ literalFRefType c
 
-consE' γ e'@(App e a@(Type τ))
-  = do RAllT α te _ <- checkAll ("Non-all TyApp with expr", e) γ <$> consE γ e
+consE γ e'@(App _ _) =
+  do
+    t <- if (warnOnTermHoles (getConfig γ)) then synthesizeWithHole else consEApp γ e'
+    return t
+  where 
+    synthesizeWithHole = do
+      isItHole <- detectTypedHole γ e'
+      t <- consEApp γ e'
+      _ <- case isItHole of
+        Just (srcSpan, x) -> addHole (RealSrcSpan srcSpan Strict.Nothing) x t γ
+        _ -> return ()
+      return t
+
+consE γ (Lam α e) | isTyVar α
+  = do γ' <- updateEnvironment γ α
+       t' <- consE γ' e
+       return $ RAllT (makeRTVar $ rTyVar α) t' mempty
+
+consE γ  e@(Lam x e1)
+  = do tx      <- freshTyType (typeclass (getConfig γ)) LamE (Var x) τx
+       γ'      <- γ += ("consE", F.symbol x, tx)
+       t1      <- consE γ' e1
+       addIdA x $ AnnDef tx
+       addW     $ WfC γ tx
+       tce     <- gets tyConEmbed
+       lamSing <- lambdaSingleton γ tce x e1
+       return   $ RFun (F.symbol x) (mkRFInfo $ getConfig γ) tx t1 lamSing
+    where
+      FunTy { ft_arg = τx } = exprType e
+
+consE γ e@(Let _ _)
+  = cconsFreshE LetE γ e
+
+consE γ e@(Case _ _ _ [_])
+  | Just p@Rs.PatProject{} <- Rs.lift e
+  = consPattern γ p (exprType e)
+
+consE γ e@(Case _ _ _ cs)
+  = cconsFreshE (caseKVKind cs) γ e
+
+consE γ (Tick tt e)
+  = do t <- consE (setLocation γ (Sp.Tick tt)) e
+       addLocA Nothing (GM.tickSrcSpan tt) (AnnUse t)
+       return t
+
+-- See Note [Type classes with a single method]
+consE γ (Cast e co)
+  | Just f <- isClassConCo co
+  = consE γ (f e)
+
+consE γ e@(Cast e' c)
+  = castTy γ (exprType e) e' c
+
+consE γ e@(Coercion _)
+   = trueTy (typeclass (getConfig γ)) $ exprType e
+
+consE _ e@(Type t)
+  = panic Nothing $ "consE cannot handle type " ++ GM.showPpr (e, t)
+
+consEApp :: CGEnv -> CoreExpr -> CG SpecType
+consEApp γ e'@(App e a@(Type τ))
+  = do 
+       RAllT α te _ <- checkAll ("Non-all TyApp with expr", e) γ <$> consE γ e
        t            <- if not (nopolyinfer (getConfig γ)) && isPos α && isGenericVar (ty_var_value α) te
                          then freshTyType (typeclass (getConfig γ)) TypeInstE e τ
                          else trueTy (typeclass (getConfig γ)) τ
@@ -632,7 +680,7 @@ consE' γ e'@(App e a@(Type τ))
   where
     isPos α = not (extensionality (getConfig γ)) || rtv_is_pol (ty_var_info α)
 
-consE' γ e'@(App e a) | Just aDict <- getExprDict γ a
+consEApp γ e'@(App e a) | Just aDict <- getExprDict γ a
   = case dhasinfo (dlookup (denv γ) aDict) (getExprFun γ e) of
       Just riSig -> return $ fromRISig riSig
       _          -> do
@@ -645,7 +693,7 @@ consE' γ e'@(App e a) | Just aDict <- getExprDict γ a
         cconsE γ' a tx
         addPost γ'        $ maybe (checkUnbound γ' e' x t a) (F.subst1 t . (x,)) (argExpr γ a)
 
-consE' γ e'@(App e a)
+consEApp γ e'@(App e a)
   = do ([], πs, te) <- bkUniv <$> consE γ {- GM.tracePpr ("APP-EXPR: " ++ GM.showPpr (exprType e)) -} e
        te1        <- instantiatePreds γ e' $ foldr RAllP te πs
        (γ', te2)  <- dropExists γ te1
@@ -654,52 +702,7 @@ consE' γ e'@(App e a)
        let RFun x _ tx t _ = checkFun ("Non-fun App with caller ", e') γ te3
        cconsE γ' a tx
        makeSingleton γ' (simplify e') <$> addPost γ' (maybe (checkUnbound γ' e' x t a) (F.subst1 t . (x,)) (argExpr γ $ simplify a))
-
-consE' γ (Lam α e) | isTyVar α
-  = do γ' <- updateEnvironment γ α
-       t' <- consE γ' e
-       return $ RAllT (makeRTVar $ rTyVar α) t' mempty
-
-consE' γ  e@(Lam x e1)
-  = do tx      <- freshTyType (typeclass (getConfig γ)) LamE (Var x) τx
-       γ'      <- γ += ("consE", F.symbol x, tx)
-       t1      <- consE γ' e1
-       addIdA x $ AnnDef tx
-       addW     $ WfC γ tx
-       tce     <- gets tyConEmbed
-       lamSing <- lambdaSingleton γ tce x e1
-       return   $ RFun (F.symbol x) (mkRFInfo $ getConfig γ) tx t1 lamSing
-    where
-      FunTy { ft_arg = τx } = exprType e
-
-consE' γ e@(Let _ _)
-  = cconsFreshE LetE γ e
-
-consE' γ e@(Case _ _ _ [_])
-  | Just p@Rs.PatProject{} <- Rs.lift e
-  = consPattern γ p (exprType e)
-
-consE' γ e@(Case _ _ _ cs)
-  = cconsFreshE (caseKVKind cs) γ e
-
-consE' γ (Tick tt e)
-  = do t <- consE (setLocation γ (Sp.Tick tt)) e
-       addLocA Nothing (GM.tickSrcSpan tt) (AnnUse t)
-       return t
-
--- See Note [Type classes with a single method]
-consE' γ (Cast e co)
-  | Just f <- isClassConCo co
-  = consE γ (f e)
-
-consE' γ e@(Cast e' c)
-  = castTy γ (exprType e) e' c
-
-consE' γ e@(Coercion _)
-   = trueTy (typeclass (getConfig γ)) $ exprType e
-
-consE' _ e@(Type t)
-  = panic Nothing $ "consE cannot handle type " ++ GM.showPpr (e, t)
+consEApp _ _ = panic Nothing "Constraint.Generate.consEApp called on invalid inputs"
 
 caseKVKind ::[Alt Var] -> KVKind
 caseKVKind [Alt (DataAlt _) _ (Var _)] = ProjectE

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -533,12 +533,12 @@ cconsE' γ e@(Cast e' c) t
        addC (SubC γ (F.notracepp ("Casted Type for " ++ GM.showPpr e ++ "\n init type " ++ showpp t) t') t) ("cconsE Cast: " ++ GM.showPpr e)
 
 cconsE' γ e t
-  = do 
+  = do
        when (warnOnTermHoles (getConfig γ))  maybeAddHole
        te  <- consE γ e
        te' <- instantiatePreds γ e te >>= addPost γ
        addC (SubC γ te' t) ("cconsE: " ++ "\n t = " ++ showpp t ++ "\n te = " ++ showpp te ++ GM.showPpr e)
-  where 
+  where
     maybeAddHole = do
       let isItHole = detectTypedHole e
       case isItHole of
@@ -672,7 +672,7 @@ consE γ e'@(App _ _) =
     t <- if warnOnTermHoles (getConfig γ) then synthesizeWithHole else consEApp γ e'
     checkANFHoleInExpr e' t
     return t
-  where 
+  where
     synthesizeWithHole = do
       let isItHole = detectTypedHole e'
       t <- consEApp γ e'
@@ -726,7 +726,7 @@ consE γ e@(Coercion _)
 
 consE _ e@(Type t)
   = panic Nothing $ "consE cannot handle type " ++ GM.showPpr (e, t)
-  
+
 checkANFHoleInExpr :: CoreExpr -> SpecType -> CG ()
 checkANFHoleInExpr e t = do
   let vars = collectVars e
@@ -740,17 +740,17 @@ collectVars (Var x) = [x]
 collectVars (App e1 e2) = collectVars e1 ++ collectVars e2
 collectVars (Lam x e) = x : collectVars e
 collectVars (Let (NonRec x e1) e2) = x : collectVars e1 ++ collectVars e2
-collectVars (Let (Rec xes) e) = 
+collectVars (Let (Rec xes) e) =
   let (xs, es) = unzip xes
   in xs ++ concatMap collectVars es ++ collectVars e
-collectVars (Case e x _ alts) = 
+collectVars (Case e x _ alts) =
   x : collectVars e ++ concatMap collectAltVars alts
   where collectAltVars (Alt _ xs e') = xs ++ collectVars e'
 collectVars _ = []
 
 consEApp :: CGEnv -> CoreExpr -> CG SpecType
 consEApp γ e'@(App e a@(Type τ))
-  = do 
+  = do
        RAllT α te _ <- checkAll ("Non-all TyApp with expr", e) γ <$> consE γ e
        t            <- if not (nopolyinfer (getConfig γ)) && isPos α && isGenericVar (ty_var_value α) te
                          then freshTyType (typeclass (getConfig γ)) TypeInstE e τ

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -399,10 +399,15 @@ detectTypedHole ::  CGEnv -> CoreExpr -> CG (Maybe (RealSrcSpan, Var))
 detectTypedHole _ (App (Tick genTick (Var x)) _) | isVarHole x
   = return (Just (getSrcSpanFromTick, x))
     where
-      getSrcSpanFromTick = case genTick of
-        SourceNote src _ -> src
-        _ -> panic Nothing "Not a Source Note"
-      isVarHole =  L.isInfixOf "hole" . F.symbolString . F.symbol
+      getSrcSpanFromTick = 
+        case genTick of
+          SourceNote src _ -> src
+          _ -> panic Nothing "Not a Source Note"
+      isStrHole s = 
+        case break (=='.') s of
+          (_, '.':rest) -> rest == "hole"
+          _             -> False
+      isVarHole = isStrHole . F.symbolString . F.symbol
 detectTypedHole  _ _ = return Nothing -- NOT A TYPED HOLE
 --------------------------------------------------------------------------------
 -- | Bidirectional Constraint Generation: CHECKING -----------------------------

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -70,9 +70,11 @@ import           Language.Haskell.Liquid.Bare.DataType (dataConMap, makeDataConC
 import Language.Haskell.Liquid.UX.Config
     ( HasConfig(getConfig),
       Config(typeclass, checkDerived, extensionality,
-             nopolyinfer, dependantCase, rankNTypes),
+             nopolyinfer, dependantCase, rankNTypes, allowTypedHoles),
       patternFlag,
-      higherOrderFlag )
+      higherOrderFlag, allowTypedHoles )
+import qualified GHC.Data.Strict as Strict
+
 
 --------------------------------------------------------------------------------
 -- | Constraint Generation: Toplevel -------------------------------------------
@@ -392,14 +394,23 @@ addPToEnv γ π
   = do γπ <- γ += ("addSpec1", pname π, pvarRType π)
        foldM (+=) γπ [("addSpec2", x, ofRSort t) | (t, x, _) <- pargs π]
 
+
+detectTypedHole ::  CGEnv -> CoreExpr -> CG (Maybe (RealSrcSpan, Var))
+detectTypedHole _ (App (Tick genTick (Var x)) _) | isVarHole x
+  = return (Just (getSrcSpanFromTick, x))
+    where
+      getSrcSpanFromTick = case genTick of
+        SourceNote src _ -> src
+        _ -> panic Nothing "Not a Source Note"
+      isVarHole =  L.isInfixOf "hole" . F.symbolString . F.symbol
+detectTypedHole  _ _ = return Nothing -- NOT A TYPED HOLE
 --------------------------------------------------------------------------------
 -- | Bidirectional Constraint Generation: CHECKING -----------------------------
 --------------------------------------------------------------------------------
 cconsE :: CGEnv -> CoreExpr -> SpecType -> CG ()
 --------------------------------------------------------------------------------
 cconsE g e t = do
-  -- NOTE: tracing goes here
-  -- traceM $ printf "cconsE:\n  expr = %s\n  exprType = %s\n  lqType = %s\n" (showPpr e) (showPpr (exprType e)) (showpp t)
+  _ <- if (allowTypedHoles (getConfig g))  then (detectTypedHole g e) else return Nothing
   cconsE' g e t
 
 --------------------------------------------------------------------------------
@@ -416,9 +427,9 @@ cconsE' γ e t
 cconsE' γ e@(Let b@(NonRec x _) ee) t
   = do sp <- gets specLVars
        if x `S.member` sp
-         then cconsLazyLet γ e t
-         else do γ' <- consCBLet γ b
-                 cconsE γ' ee t
+        then cconsLazyLet γ e t
+        else do γ' <- consCBLet γ b
+                cconsE γ' ee t
 
 cconsE' γ e (RAllP p t)
   = cconsE γ' e t''
@@ -553,12 +564,26 @@ cconsLazyLet γ (Let (NonRec x ex) e) t
 cconsLazyLet _ _ _
   = panic Nothing "Constraint.Generate.cconsLazyLet called on invalid inputs"
 
+
+consE :: CGEnv -> CoreExpr -> CG SpecType
+--------------------------------------------------------------------------------
+consE g e = do
+  t <- if (allowTypedHoles (getConfig g)) then synthesizeWithHole else consE' g e
+  return t
+  where 
+    synthesizeWithHole = do
+      isItHole <- detectTypedHole g e
+      t <- consE' g e 
+      _ <- case isItHole of
+        Just (srcSpan, x) -> addHole (RealSrcSpan srcSpan Strict.Nothing) x t g
+        _ -> return ()
+      return t
 --------------------------------------------------------------------------------
 -- | Bidirectional Constraint Generation: SYNTHESIS ----------------------------
 --------------------------------------------------------------------------------
-consE :: CGEnv -> CoreExpr -> CG SpecType
+consE' :: CGEnv -> CoreExpr -> CG SpecType
 --------------------------------------------------------------------------------
-consE γ e
+consE' γ e
   | patternFlag γ
   , Just p <- Rs.lift e
   = consPattern γ (F.notracepp "CONSE-PATTERN: " p) (exprType e)
@@ -573,7 +598,7 @@ consE γ e
 
 -- If datacon definitions have references to self for fancy termination,
 -- ignore them at the construction.
-consE γ (Var x) | GM.isDataConId x
+consE' γ (Var x) | GM.isDataConId x
   = do t0 <- varRefType γ x
        -- NV: The check is expected to fail most times, so
        --     it is cheaper than direclty fmap ignoreSelf.
@@ -584,15 +609,15 @@ consE γ (Var x) | GM.isDataConId x
        addLocA (Just x) (getLocation γ) (varAnn γ x t)
        return t
 
-consE γ (Var x)
+consE' γ (Var x)
   = do t <- varRefType γ x
        addLocA (Just x) (getLocation γ) (varAnn γ x t)
        return t
 
-consE _ (Lit c)
+consE' _ (Lit c)
   = refreshVV $ uRType $ literalFRefType c
 
-consE γ e'@(App e a@(Type τ))
+consE' γ e'@(App e a@(Type τ))
   = do RAllT α te _ <- checkAll ("Non-all TyApp with expr", e) γ <$> consE γ e
        t            <- if not (nopolyinfer (getConfig γ)) && isPos α && isGenericVar (ty_var_value α) te
                          then freshTyType (typeclass (getConfig γ)) TypeInstE e τ
@@ -607,7 +632,7 @@ consE γ e'@(App e a@(Type τ))
   where
     isPos α = not (extensionality (getConfig γ)) || rtv_is_pol (ty_var_info α)
 
-consE γ e'@(App e a) | Just aDict <- getExprDict γ a
+consE' γ e'@(App e a) | Just aDict <- getExprDict γ a
   = case dhasinfo (dlookup (denv γ) aDict) (getExprFun γ e) of
       Just riSig -> return $ fromRISig riSig
       _          -> do
@@ -620,7 +645,7 @@ consE γ e'@(App e a) | Just aDict <- getExprDict γ a
         cconsE γ' a tx
         addPost γ'        $ maybe (checkUnbound γ' e' x t a) (F.subst1 t . (x,)) (argExpr γ a)
 
-consE γ e'@(App e a)
+consE' γ e'@(App e a)
   = do ([], πs, te) <- bkUniv <$> consE γ {- GM.tracePpr ("APP-EXPR: " ++ GM.showPpr (exprType e)) -} e
        te1        <- instantiatePreds γ e' $ foldr RAllP te πs
        (γ', te2)  <- dropExists γ te1
@@ -630,12 +655,12 @@ consE γ e'@(App e a)
        cconsE γ' a tx
        makeSingleton γ' (simplify e') <$> addPost γ' (maybe (checkUnbound γ' e' x t a) (F.subst1 t . (x,)) (argExpr γ $ simplify a))
 
-consE γ (Lam α e) | isTyVar α
+consE' γ (Lam α e) | isTyVar α
   = do γ' <- updateEnvironment γ α
        t' <- consE γ' e
        return $ RAllT (makeRTVar $ rTyVar α) t' mempty
 
-consE γ  e@(Lam x e1)
+consE' γ  e@(Lam x e1)
   = do tx      <- freshTyType (typeclass (getConfig γ)) LamE (Var x) τx
        γ'      <- γ += ("consE", F.symbol x, tx)
        t1      <- consE γ' e1
@@ -647,33 +672,33 @@ consE γ  e@(Lam x e1)
     where
       FunTy { ft_arg = τx } = exprType e
 
-consE γ e@(Let _ _)
+consE' γ e@(Let _ _)
   = cconsFreshE LetE γ e
 
-consE γ e@(Case _ _ _ [_])
+consE' γ e@(Case _ _ _ [_])
   | Just p@Rs.PatProject{} <- Rs.lift e
   = consPattern γ p (exprType e)
 
-consE γ e@(Case _ _ _ cs)
+consE' γ e@(Case _ _ _ cs)
   = cconsFreshE (caseKVKind cs) γ e
 
-consE γ (Tick tt e)
+consE' γ (Tick tt e)
   = do t <- consE (setLocation γ (Sp.Tick tt)) e
        addLocA Nothing (GM.tickSrcSpan tt) (AnnUse t)
        return t
 
 -- See Note [Type classes with a single method]
-consE γ (Cast e co)
+consE' γ (Cast e co)
   | Just f <- isClassConCo co
   = consE γ (f e)
 
-consE γ e@(Cast e' c)
+consE' γ e@(Cast e' c)
   = castTy γ (exprType e) e' c
 
-consE γ e@(Coercion _)
+consE' γ e@(Coercion _)
    = trueTy (typeclass (getConfig γ)) $ exprType e
 
-consE _ e@(Type t)
+consE' _ e@(Type t)
   = panic Nothing $ "consE cannot handle type " ++ GM.showPpr (e, t)
 
 caseKVKind ::[Alt Var] -> KVKind

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -484,9 +484,17 @@ cconsE' γ e@(Cast e' c) t
        addC (SubC γ (F.notracepp ("Casted Type for " ++ GM.showPpr e ++ "\n init type " ++ showpp t) t') t) ("cconsE Cast: " ++ GM.showPpr e)
 
 cconsE' γ e t
-  = do te  <- consE γ e
+  = do 
+       _ <- when (warnOnTermHoles (getConfig γ))  maybeAddHole
+       te  <- consE γ e
        te' <- instantiatePreds γ e te >>= addPost γ
        addC (SubC γ te' t) ("cconsE: " ++ "\n t = " ++ showpp t ++ "\n te = " ++ showpp te ++ GM.showPpr e)
+  where 
+    maybeAddHole = do
+      isItHole <- detectTypedHole γ e
+      case isItHole of
+        Just (srcSpan, x) -> addHole (RealSrcSpan srcSpan Strict.Nothing) x t γ
+        _ -> return ()
 
 lambdaSingleton :: CGEnv -> F.TCEmb TyCon -> Var -> CoreExpr -> CG (UReft F.Reft)
 lambdaSingleton γ tce x e
@@ -609,18 +617,43 @@ consE γ (Var x)
 consE _ (Lit c)
   = refreshVV $ uRType $ literalFRefType c
 
-consE γ e'@(App _ _) =
-  do
-    t <- if (warnOnTermHoles (getConfig γ)) then synthesizeWithHole else consEApp γ e'
-    return t
-  where 
-    synthesizeWithHole = do
-      isItHole <- detectTypedHole γ e'
-      t <- consEApp γ e'
-      _ <- case isItHole of
-        Just (srcSpan, x) -> addHole (RealSrcSpan srcSpan Strict.Nothing) x t γ
-        _ -> return ()
-      return t
+consE γ e'@(App e a@(Type τ))
+  = do RAllT α te _ <- checkAll ("Non-all TyApp with expr", e) γ <$> consE γ e
+       t            <- if not (nopolyinfer (getConfig γ)) && isPos α && isGenericVar (ty_var_value α) te
+                         then freshTyType (typeclass (getConfig γ)) TypeInstE e τ
+                         else trueTy (typeclass (getConfig γ)) τ
+       addW          $ WfC γ t
+       t'           <- refreshVV t
+       tt0          <- instantiatePreds γ e' (subsTyVarMeet' (ty_var_value α, t') te)
+       let tt        = makeSingleton γ (simplify e') $ subsTyReft γ (ty_var_value α) τ tt0
+       return $ case rTVarToBind α of
+         Just (x, _) -> maybe (checkUnbound γ e' x tt a) (F.subst1 tt . (x,)) (argType τ)
+         Nothing     -> tt
+  where
+    isPos α = not (extensionality (getConfig γ)) || rtv_is_pol (ty_var_info α)
+
+consE γ e'@(App e a) | Just aDict <- getExprDict γ a
+  = case dhasinfo (dlookup (denv γ) aDict) (getExprFun γ e) of
+      Just riSig -> return $ fromRISig riSig
+      _          -> do
+        ([], πs, te) <- bkUniv <$> consE γ e
+        te'          <- instantiatePreds γ e' $ foldr RAllP te πs
+        (γ', te''')  <- dropExists γ te'
+        te''         <- dropConstraints γ te'''
+        updateLocA {- πs -} (exprLoc e) te''
+        let RFun x _ tx t _ = checkFun ("Non-fun App with caller ", e') γ te''
+        cconsE γ' a tx
+        addPost γ'        $ maybe (checkUnbound γ' e' x t a) (F.subst1 t . (x,)) (argExpr γ a)
+
+consE γ e'@(App e a)
+  = do ([], πs, te) <- bkUniv <$> consE γ {- GM.tracePpr ("APP-EXPR: " ++ GM.showPpr (exprType e)) -} e
+       te1        <- instantiatePreds γ e' $ foldr RAllP te πs
+       (γ', te2)  <- dropExists γ te1
+       te3        <- dropConstraints γ te2
+       updateLocA (exprLoc e) te3
+       let RFun x _ tx t _ = checkFun ("Non-fun App with caller ", e') γ te3
+       cconsE γ' a tx
+       makeSingleton γ' (simplify e') <$> addPost γ' (maybe (checkUnbound γ' e' x t a) (F.subst1 t . (x,)) (argExpr γ $ simplify a))
 
 consE γ (Lam α e) | isTyVar α
   = do γ' <- updateEnvironment γ α

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Init.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Init.hs
@@ -301,6 +301,8 @@ initCGI cfg info = CGInfo {
   , ghcI          = info
   , unsorted      = F.notracepp "UNSORTED" $ F.makeTemplates $ gsUnsorted $ gsData spc
   , hsHoles      = M.empty
+  , hsANFHoles   = M.empty
+  , hsHolesExprs = M.empty
   }
   where
     tce        = gsTcEmbeds nspc

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Init.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Init.hs
@@ -300,6 +300,7 @@ initCGI cfg info = CGInfo {
   , allowHO       = higherOrderFlag cfg
   , ghcI          = info
   , unsorted      = F.notracepp "UNSORTED" $ F.makeTemplates $ gsUnsorted $ gsData spc
+  , hsHoles      = M.empty
   }
   where
     tce        = gsTcEmbeds nspc

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Monad.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Monad.hs
@@ -20,7 +20,6 @@ import           Language.Haskell.Liquid.Constraint.Env
 import           Language.Fixpoint.Misc hiding (errorstar)
 import           Language.Haskell.Liquid.GHC.Misc -- (concatMapM)
 import           Liquid.GHC.API as Ghc hiding (panic, showPpr)
-import qualified       Language.Fixpoint.Types     as  FT
 
 
 --------------------------------------------------------------------------------
@@ -120,15 +119,22 @@ addA _ _ _ !a
 
 addHole :: SrcSpan -> Var -> SpecType -> CGEnv -> CG ()
 addHole loc x t γ = do
-  modify $ \s -> s { hsHoles = M.insert x (holeInfo (s, γ)) $ hsHoles s } 
-  addWarning $ ErrHole loc ("hole found") (reLocal $ renv γ) x' t
+  exists <- gets (M.member (x, loc) . hsHoles)
+  unless exists $
+    modify $ \s -> s { hsHoles = M.insert (x, loc) (holeInfo (s, γ)) $ hsHoles s }   
   where
     holeInfo = HoleInfo t loc env
     env      = mconcat [renv γ, grtys γ, assms γ, intys γ]
-    x'       = FT.symbol x
 
-isVarInHole :: Var -> CG Bool
-isVarInHole x = gets (M.member x . hsHoles)
+addHoleANF :: (Var, SrcSpan) -> Var -> CoreExpr -> SpecType -> CG ()
+addHoleANF uniqueVar anfVar e t = 
+  modify $ \s -> s { hsHolesExprs = M.insertWith (++) uniqueVar [(anfVar, e, t)] (hsHolesExprs s) }
+
+linkANFToHole :: Var -> (Var, SrcSpan) -> CG ()
+linkANFToHole anf h = modify $ \s -> s { hsANFHoles = M.insert anf h $ hsANFHoles s }
+
+isANFInHole :: Var -> CG (Maybe (Var, SrcSpan))
+isANFInHole anf = gets (M.lookup anf . hsANFHoles)
 
 lookupNewType :: Ghc.TyCon -> CG (Maybe SpecType)
 lookupNewType tc

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Monad.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Monad.hs
@@ -121,7 +121,7 @@ addA _ _ _ !a
 addHole :: SrcSpan -> Var -> SpecType -> CGEnv -> CG ()
 addHole loc x t γ = do
   modify $ \s -> s { hsHoles = M.insert x (holeInfo (s, γ)) $ hsHoles s } 
-  addWarning $ ErrHole loc ("hole found") (reGlobal env <> reLocal env) x' t
+  addWarning $ ErrHole loc ("hole found") (reLocal $ renv γ) x' t
   where
     holeInfo = HoleInfo t loc env
     env      = mconcat [renv γ, grtys γ, assms γ, intys γ]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Monad.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Monad.hs
@@ -121,13 +121,13 @@ addHole :: SrcSpan -> Var -> SpecType -> CGEnv -> CG ()
 addHole loc x t γ = do
   exists <- gets (M.member (x, loc) . hsHoles)
   unless exists $
-    modify $ \s -> s { hsHoles = M.insert (x, loc) (holeInfo (s, γ)) $ hsHoles s }   
+    modify $ \s -> s { hsHoles = M.insert (x, loc) (holeInfo (s, γ)) $ hsHoles s }
   where
     holeInfo = HoleInfo t loc env
     env      = mconcat [renv γ, grtys γ, assms γ, intys γ]
 
 addHoleANF :: (Var, SrcSpan) -> Var -> CoreExpr -> SpecType -> CG ()
-addHoleANF uniqueVar anfVar e t = 
+addHoleANF uniqueVar anfVar e t =
   modify $ \s -> s { hsHolesExprs = M.insertWith (++) uniqueVar [(anfVar, e, t)] (hsHolesExprs s) }
 
 linkANFToHole :: Var -> (Var, SrcSpan) -> CG ()

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Monad.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Monad.hs
@@ -20,6 +20,8 @@ import           Language.Haskell.Liquid.Constraint.Env
 import           Language.Fixpoint.Misc hiding (errorstar)
 import           Language.Haskell.Liquid.GHC.Misc -- (concatMapM)
 import           Liquid.GHC.API as Ghc hiding (panic, showPpr)
+import qualified       Language.Fixpoint.Types     as  FT
+
 
 --------------------------------------------------------------------------------
 -- | `addC` adds a subtyping constraint into the global pool.
@@ -116,6 +118,17 @@ addA !l xo@Nothing  !t (AI m)
 addA _ _ _ !a
   = a
 
+addHole :: SrcSpan -> Var -> SpecType -> CGEnv -> CG ()
+addHole loc x t γ = do
+  modify $ \s -> s { hsHoles = M.insert x (holeInfo (s, γ)) $ hsHoles s } 
+  addWarning $ ErrHole loc ("hole found") (reGlobal env <> reLocal env) x' t
+  where
+    holeInfo = HoleInfo t loc env
+    env      = mconcat [renv γ, grtys γ, assms γ, intys γ]
+    x'       = FT.symbol x
+
+isVarInHole :: Var -> CG Bool
+isVarInHole x = gets (M.member x . hsHoles)
 
 lookupNewType :: Ghc.TyCon -> CG (Maybe SpecType)
 lookupNewType tc

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Types.hs
@@ -239,6 +239,7 @@ data CGInfo = CGInfo
   , ghcI          :: !TargetInfo
   , dataConTys    :: ![(Var, SpecType)]                  -- ^ Refined Types of Data Constructors
   , unsorted      :: !F.Templates                        -- ^ Potentially unsorted expressions
+  , hsHoles      :: !(M.HashMap Var (HoleInfo (CGInfo, CGEnv) SpecType)) -- Information about holes
   }
 
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Types.hs
@@ -239,7 +239,7 @@ data CGInfo = CGInfo
   , ghcI          :: !TargetInfo
   , dataConTys    :: ![(Var, SpecType)]                  -- ^ Refined Types of Data Constructors
   , unsorted      :: !F.Templates                        -- ^ Potentially unsorted expressions
-  , hsHoles      :: !(M.HashMap Var (HoleInfo (CGInfo, CGEnv) SpecType)) -- Information about holes
+  , hsHoles      :: !(M.HashMap Var (HoleInfo (CGInfo, CGEnv) SpecType)) -- Information about holes in terms
   }
 
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Types.hs
@@ -240,7 +240,7 @@ data CGInfo = CGInfo
   , dataConTys    :: ![(Var, SpecType)]                  -- ^ Refined Types of Data Constructors
   , unsorted      :: !F.Templates                        -- ^ Potentially unsorted expressions
   , hsHoles       :: !(M.HashMap (Var, SrcSpan) (HoleInfo (CGInfo, CGEnv) SpecType)) -- Information about holes in terms
-  , hsANFHoles    :: !(M.HashMap Var  (Var, SrcSpan))    
+  , hsANFHoles    :: !(M.HashMap Var  (Var, SrcSpan))
   , hsHolesExprs  :: !(M.HashMap (Var, SrcSpan)  [(Var, CoreExpr, SpecType)])
   }
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Types.hs
@@ -239,7 +239,9 @@ data CGInfo = CGInfo
   , ghcI          :: !TargetInfo
   , dataConTys    :: ![(Var, SpecType)]                  -- ^ Refined Types of Data Constructors
   , unsorted      :: !F.Templates                        -- ^ Potentially unsorted expressions
-  , hsHoles      :: !(M.HashMap Var (HoleInfo (CGInfo, CGEnv) SpecType)) -- Information about holes in terms
+  , hsHoles       :: !(M.HashMap (Var, SrcSpan) (HoleInfo (CGInfo, CGEnv) SpecType)) -- Information about holes in terms
+  , hsANFHoles    :: !(M.HashMap Var  (Var, SrcSpan))    
+  , hsHolesExprs  :: !(M.HashMap (Var, SrcSpan)  [(Var, CoreExpr, SpecType)])
   }
 
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
@@ -126,7 +126,6 @@ dumpCs cgi = do
   putStrLn $ render $ pprintMany (fixCs cgi)
   putStrLn "***************************** WfCs ********************************"
   putStrLn $ render $ pprintMany (hsWfs cgi)
-
 pprintMany :: (PPrint a) => [a] -> Doc
 pprintMany xs = vcat [ F.pprint x $+$ text " " | x <- xs ]
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
@@ -126,6 +126,7 @@ dumpCs cgi = do
   putStrLn $ render $ pprintMany (fixCs cgi)
   putStrLn "***************************** WfCs ********************************"
   putStrLn $ render $ pprintMany (hsWfs cgi)
+
 pprintMany :: (PPrint a) => [a] -> Doc
 pprintMany xs = vcat [ F.pprint x $+$ text " " | x <- xs ]
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Errors.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Errors.hs
@@ -248,8 +248,9 @@ data TError t =
                , ctx  :: !(M.HashMap Symbol t)
                , svar :: !Symbol
                , thl  :: !t
+               , anf  :: ![(Symbol, CoreExpr, t)]
                } -- ^ hole type
-
+  
   | ErrHoleCycle
                { pos  :: !SrcSpan
                , holesCycle :: [Symbol] -- Var?
@@ -816,12 +817,25 @@ ppError' _td _dCtx (ErrHoleCycle _ holes)
   = "Cycle of holes found"
         $+$ pprint holes
 
-ppError' td dCtx (ErrHole _ msg c x t)
+ppError' td dCtx (ErrHole _ msg c x t a)
   = "Hole Found"
         $+$ pprint x <+> "::" <+> pprint t
         $+$ dCtx
         $+$ ppContext td c
         $+$ msg
+        $+$ "Extra Constraints where hole appears as ANF var"
+        $+$ (if null a
+             then empty 
+             else nests 2 [ text "with expression types"
+                          , vsep (
+                              map (
+                                \(v, e, t') -> 
+                                  text "ANF VAR is" <+> pprint v 
+                                  $+$ text "Expression is ["  <+> ppCoreExpr e <+> text "] and has type:"
+                                  $+$ pprint t'
+                              ) a
+                            )
+                          ])
 
 ppError' td dCtx (ErrSubType _ _ cid c tA tE)
   = text "Liquid Type Mismatch"
@@ -1161,6 +1175,9 @@ ppNames ds = ppList "Could refer to any of the names" ds -- [text "-" <+> d | d 
 ppList :: (PPrint a) => Doc -> [a] -> Doc
 ppList d ls
   = nest 4 (sepVcat blankLine (d : [ text "*" <+> pprint l | l <- ls ]))
+
+ppCoreExpr :: CoreExpr -> Doc
+ppCoreExpr = text . showSDocQualified . ppr
 
 -- | Convert a GHC error into a list of our errors.
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Errors.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Errors.hs
@@ -250,7 +250,7 @@ data TError t =
                , thl  :: !t
                , anf  :: ![(Symbol, CoreExpr, t)]
                } -- ^ hole type
-  
+
   | ErrHoleCycle
                { pos  :: !SrcSpan
                , holesCycle :: [Symbol] -- Var?
@@ -825,12 +825,12 @@ ppError' td dCtx (ErrHole _ msg c x t a)
         $+$ msg
         $+$ "Extra Constraints where hole appears as ANF var"
         $+$ (if null a
-             then empty 
+             then empty
              else nests 2 [ text "with expression types"
                           , vsep (
                               map (
-                                \(v, e, t') -> 
-                                  text "ANF VAR is" <+> pprint v 
+                                \(v, e, t') ->
+                                  text "ANF VAR is" <+> pprint v
                                   $+$ text "Expression is ["  <+> ppCoreExpr e <+> text "] and has type:"
                                   $+$ pprint t'
                               ) a

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Errors.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Errors.hs
@@ -816,9 +816,11 @@ ppError' _td _dCtx (ErrHoleCycle _ holes)
   = "Cycle of holes found"
         $+$ pprint holes
 
-ppError' _td _dCtx (ErrHole _ msg _ x t)
+ppError' td dCtx (ErrHole _ msg c x t)
   = "Hole Found"
         $+$ pprint x <+> "::" <+> pprint t
+        $+$ dCtx
+        $+$ ppContext td c
         $+$ msg
 
 ppError' td dCtx (ErrSubType _ _ cid c tA tE)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -488,7 +488,8 @@ printWarning logger (Warning srcSpan doc) = GHC.putWarnMsg logger srcSpan doc
 type ErrorResult    = F.FixResult UserError
 type Error          = TError SpecType
 
-
+instance NFData CoreExpr where
+  rnf _ = () -- Simple implementation that doesn't traverse the structure
 instance NFData a => NFData (TError a)
 
 --------------------------------------------------------------------------------

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -427,9 +427,9 @@ defConfig = Config {
   , modern
     = False &= help "Enable modern features; enables --reflection, --ple, --etabeta, --dependantcase"
             &= name "modern"
-  , allowTypedHoles
-    = False &= help "Allow typed holes in implementation"
-          &= name "allow-typed-holes"
+  , warnOnTermHoles
+    = False &= help "Warn about holes in terms"
+          &= name "warn-on-term-holes"
           &= explicit
   } &= program "liquidhaskell"
     &= help    "Refinement Types for Haskell"

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -427,6 +427,10 @@ defConfig = Config {
   , modern
     = False &= help "Enable modern features; enables --reflection, --ple, --etabeta, --dependantcase"
             &= name "modern"
+  , allowTypedHoles
+    = False &= help "Allow typed holes in implementation"
+          &= name "allow-typed-holes"
+          &= explicit
   } &= program "liquidhaskell"
     &= help    "Refinement Types for Haskell"
     &= summary copyright

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Config.hs
@@ -116,6 +116,7 @@ data Config = Config
   , ddumpTimings             :: Bool       -- ^ Dump time measures of the Liquid Haskell plugin
                                            -- Only needed to work around https://github.com/haskell/cabal/issues/11116
   , modern                   :: Bool       -- ^ Enable modern features; enables reflection, ple, etabeta, dependantcase, adt
+  , allowTypedHoles          :: Bool       -- ^ Allow typed holes in the source code
   } deriving (Generic, Data, Show, Eq)
 
 allowPLE :: Config -> Bool

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Config.hs
@@ -116,7 +116,7 @@ data Config = Config
   , ddumpTimings             :: Bool       -- ^ Dump time measures of the Liquid Haskell plugin
                                            -- Only needed to work around https://github.com/haskell/cabal/issues/11116
   , modern                   :: Bool       -- ^ Enable modern features; enables reflection, ple, etabeta, dependantcase, adt
-  , allowTypedHoles          :: Bool       -- ^ Allow typed holes in the source code
+  , warnOnTermHoles          :: Bool       -- ^ Warn about holes in the terms
   } deriving (Generic, Data, Show, Eq)
 
 allowPLE :: Config -> Bool

--- a/tests/harness/Test/Groups.hs
+++ b/tests/harness/Test/Groups.hs
@@ -37,6 +37,7 @@ microTestGroups =
   , "terminate-neg"
   , "pattern-pos"
   , "typeclass-pos"
+  , "typed-holes"
   ]
 
 benchmarkTestGroups :: [Text]

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2659,7 +2659,10 @@ flag typed-holes
      default: False
 
 executable typed-holes
+    import:           common-ghc-options
     main-is:          Main.hs
+    if !flag(typed-holes) && flag(stack)
+      buildable:      False
 
     ghc-options:      -fplugin=LiquidHaskell
     other-modules:    Example0
@@ -2677,6 +2680,7 @@ executable typed-holes
                     , typed-holes
 
     default-language: Haskell2010
+
 -- This test suite is for internal function unit tests, not for checking LH on
 -- source files.
 test-suite tasty

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2653,6 +2653,24 @@ executable typeclass-pos
     hs-source-dirs:   app
                     , typeclasses/pos
 
+    default-language: Haskell2010
+
+flag typed-holes
+     default: False
+
+executable typed-holes
+    main-is:          Main.hs
+
+    ghc-options:      -fplugin=LiquidHaskell
+    other-modules:    Example1
+    build-depends:    base
+                    , liquid-prelude
+                    , liquidhaskell
+
+    hs-source-dirs:   app
+                    , typed-holes
+
+    default-language: Haskell2010
 -- This test suite is for internal function unit tests, not for checking LH on
 -- source files.
 test-suite tasty

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2665,6 +2665,10 @@ executable typed-holes
     other-modules:    Example0
                     , Example1
                     , Example2
+                    , Example3
+                    , Example4
+                    , Example5
+                    , Example6
     build-depends:    base
                     , liquid-prelude
                     , liquidhaskell

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2662,7 +2662,9 @@ executable typed-holes
     main-is:          Main.hs
 
     ghc-options:      -fplugin=LiquidHaskell
-    other-modules:    Example1
+    other-modules:    Example0
+                    , Example1
+                    , Example2
     build-depends:    base
                     , liquid-prelude
                     , liquidhaskell

--- a/tests/typed-holes/Example0.hs
+++ b/tests/typed-holes/Example0.hs
@@ -7,4 +7,4 @@ module Example0 where
     {-@ listLength :: xs:[a] -> {v : Nat | v == len xs} @-}
     listLength :: [a] -> Int
     listLength [] = hole
-    listLength (_:xs) = 1 + listLength xs
+    listLength (_:xs) = 1 + hole

--- a/tests/typed-holes/Example0.hs
+++ b/tests/typed-holes/Example0.hs
@@ -1,0 +1,10 @@
+{-@ LIQUID "--expect-error-containing=Hole Found" @-}
+{-@ LIQUID "--warn-on-term-holes" @-}
+
+module Example0 where
+    hole = undefined
+
+    {-@ listLength :: xs:[a] -> {v : Nat | v == len xs} @-}
+    listLength :: [a] -> Int
+    listLength [] = hole
+    listLength (_:xs) = 1 + listLength xs

--- a/tests/typed-holes/Example1.hs
+++ b/tests/typed-holes/Example1.hs
@@ -3,13 +3,13 @@
 
 module Example1 where
     import Language.Haskell.Liquid.ProofCombinators (Proof)
-
     hole = undefined
 
     {-@ listLength :: xs:[a] -> {v : Nat | v == len xs} @-}
     listLength :: [a] -> Int
     listLength [] = 0
     listLength (_:xs) = 1 + listLength xs
+
     {-@ measure listLength @-}
 
     {-@ listLengthProof :: xs:[a] -> {listLength xs == len xs} @-}

--- a/tests/typed-holes/Example1.hs
+++ b/tests/typed-holes/Example1.hs
@@ -1,28 +1,17 @@
 {-@ LIQUID "--expect-error-containing=Hole Found" @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--warn-on-term-holes" @-}
--- Based on https://ucsd-progsys.github.io/liquidhaskell-blog/2016/10/06/structural-induction.lhs/
 
 module Example1 where
-    import Prelude hiding ((<>))
-    import Language.Haskell.Liquid.ProofCombinators ((===), (***), QED(QED), Proof)
-    
+    import Language.Haskell.Liquid.ProofCombinators (Proof)
+
     hole = undefined
 
-    {-@ reflect empty @-}
-    empty  :: [a]
-    empty  = []
+    {-@ listLength :: xs:[a] -> {v : Nat | v == len xs} @-}
+    listLength :: [a] -> Int
+    listLength [] = 0
+    listLength (_:xs) = 1 + listLength xs
+    {-@ measure listLength @-}
 
-    {-@ infix <> @-}
-    {-@ reflect <> @-}
-    (<>) :: [a] -> [a] -> [a]
-    [] <> xs = xs
-    (x:xs) <> ys = x : (xs <> ys)
-
-    {-@ leftId  :: x:[a] -> { (empty <> x) == x } @-}
-    leftId :: [a] -> Proof
-    leftId x
-        =   empty <> x
-        === hole
-        === x
-        *** QED
+    {-@ listLengthProof :: xs:[a] -> {listLength xs == len xs} @-}
+    listLengthProof :: [a] -> Proof
+    listLengthProof = hole

--- a/tests/typed-holes/Example1.hs
+++ b/tests/typed-holes/Example1.hs
@@ -1,6 +1,6 @@
 {-@ LIQUID "--expect-error-containing=Hole Found" @-}
 {-@ LIQUID "--exact-data-cons" @-}
-{-@ LIQUID "--allow-typed-holes" @-}
+{-@ LIQUID "--warn-on-term-holes" @-}
 -- Based on https://ucsd-progsys.github.io/liquidhaskell-blog/2016/10/06/structural-induction.lhs/
 
 module Example1 where

--- a/tests/typed-holes/Example1.hs
+++ b/tests/typed-holes/Example1.hs
@@ -1,0 +1,28 @@
+{-@ LIQUID "--expect-error-containing=Hole Found" @-}
+{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--allow-typed-holes" @-}
+-- Based on https://ucsd-progsys.github.io/liquidhaskell-blog/2016/10/06/structural-induction.lhs/
+
+module Example1 where
+    import Prelude hiding ((<>))
+    import Language.Haskell.Liquid.ProofCombinators ((===), (***), QED(QED), Proof)
+    
+    hole = undefined
+
+    {-@ reflect empty @-}
+    empty  :: [a]
+    empty  = []
+
+    {-@ infix <> @-}
+    {-@ reflect <> @-}
+    (<>) :: [a] -> [a] -> [a]
+    [] <> xs = xs
+    (x:xs) <> ys = x : (xs <> ys)
+
+    {-@ leftId  :: x:[a] -> { (empty <> x) == x } @-}
+    leftId :: [a] -> Proof
+    leftId x
+        =   empty <> x
+        === hole
+        === x
+        *** QED

--- a/tests/typed-holes/Example2.hs
+++ b/tests/typed-holes/Example2.hs
@@ -1,0 +1,28 @@
+{-@ LIQUID "--expect-error-containing=Hole Found" @-}
+{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--warn-on-term-holes" @-}
+-- Based on https://ucsd-progsys.github.io/liquidhaskell-blog/2016/10/06/structural-induction.lhs/
+
+module Example2 where
+    import Prelude hiding ((<>))
+    import Language.Haskell.Liquid.ProofCombinators ((===), (***), QED(QED), Proof)
+    
+    hole = undefined
+
+    {-@ reflect empty @-}
+    empty  :: [a]
+    empty  = []
+
+    {-@ infix <> @-}
+    {-@ reflect <> @-}
+    (<>) :: [a] -> [a] -> [a]
+    [] <> xs = xs
+    (x:xs) <> ys = x : (xs <> ys)
+
+    {-@ leftId  :: x:[a] -> { (empty <> x) == x } @-}
+    leftId :: [a] -> Proof
+    leftId x
+        =   empty <> x
+        === hole
+        === x
+        *** QED

--- a/tests/typed-holes/Example2.hs
+++ b/tests/typed-holes/Example2.hs
@@ -1,12 +1,11 @@
 {-@ LIQUID "--expect-error-containing=Hole Found" @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--warn-on-term-holes" @-}
 -- Based on https://ucsd-progsys.github.io/liquidhaskell-blog/2016/10/06/structural-induction.lhs/
 
 module Example2 where
     import Prelude hiding ((<>))
     import Language.Haskell.Liquid.ProofCombinators ((===), (***), QED(QED), Proof)
-    
+
     hole = undefined
 
     {-@ reflect empty @-}
@@ -24,7 +23,7 @@ module Example2 where
     leftId x
         =   empty <> x
         === hole
-        === x          
+        === x
         *** QED
 
     {-@ rightId  :: x:[a] -> { (x <> empty) == x } @-}

--- a/tests/typed-holes/Example2.hs
+++ b/tests/typed-holes/Example2.hs
@@ -24,5 +24,13 @@ module Example2 where
     leftId x
         =   empty <> x
         === hole
-        === x
+        === x          
         *** QED
+
+    {-@ rightId  :: x:[a] -> { (x <> empty) == x } @-}
+    rightId :: [a] -> Proof
+    rightId x = hole
+
+    {-@ assoc  :: x:[a] -> y:[a] -> z:[a] -> { (x <> (y <> z)) == ((x <> y) <> z) } @-}
+    assoc :: [a] -> [a] -> [a] -> Proof
+    assoc x y z = hole

--- a/tests/typed-holes/Example3.hs
+++ b/tests/typed-holes/Example3.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--expect-error-containing=Hole Found" @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--warn-on-term-holes" @-}
 -- Based on paper: Theorem Proving for All: Equational Reasoning in Liquid Haskell (Functional Pearl)
 
@@ -8,7 +7,7 @@ module Example3 where
     import Language.Haskell.Liquid.ProofCombinators ((===), (***), QED(QED), Proof)
 
     hole = undefined
-    
+
     {-@ length :: [a] -> {v:Int | 0 <= v } @-}
     length :: [a] -> Int
     length [] = 0

--- a/tests/typed-holes/Example3.hs
+++ b/tests/typed-holes/Example3.hs
@@ -1,0 +1,40 @@
+{-@ LIQUID "--expect-error-containing=Hole Found" @-}
+{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--warn-on-term-holes" @-}
+-- Based on paper: Theorem Proving for All: Equational Reasoning in Liquid Haskell (Functional Pearl)
+
+module Example3 where
+    import Prelude hiding ((<>), reverse, length, (++))
+    import Language.Haskell.Liquid.ProofCombinators ((===), (***), QED(QED), Proof)
+
+    hole = undefined
+    
+    {-@ length :: [a] -> {v:Int | 0 <= v } @-}
+    length :: [a] -> Int
+    length [] = 0
+    length (_:xs) = 1 + length xs
+    {-@ measure length @-}
+
+    {-@ reverse :: is:[a] -> {os:[a] | length is == length os} @-}
+    reverse :: [a] -> [a]
+    reverse [] = []
+    reverse (x:xs) = reverse xs ++ [x]
+
+    {-@ (++) :: xs:[a] -> ys:[a] -> {zs:[a] | length zs == length xs + length ys} @-}
+    (++) :: [a] -> [a] -> [a]
+    [] ++ ys = ys
+    (x:xs) ++ ys = x : (xs ++ ys)
+    {-@ infixl ++ @-}
+
+    {-@ reflect reverse @-}
+    {-@ reflect ++ @-}
+
+
+    --- Structural Induction will be needed. It could suggest as the next step.
+    {-@ involutionProof :: xs:[a] -> { reverse (reverse xs) == xs } @-}
+    involutionProof :: [a] -> Proof
+    involutionProof xs = hole
+
+    {-@ distributivityP :: xs:[a] -> ys:[a] -> { reverse (xs ++ ys) == reverse ys ++ reverse xs } @-}
+    distributivityP :: [a] -> [a] -> Proof
+    distributivityP xs ys = hole

--- a/tests/typed-holes/Example4.hs
+++ b/tests/typed-holes/Example4.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--expect-error-containing=Hole Found" @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--warn-on-term-holes" @-}
 -- Based on paper: Theorem Proving for All: Equational Reasoning in Liquid Haskell (Functional Pearl)
 
@@ -30,11 +29,11 @@ module Example4 where
 
     {-@ reverseApp :: xs:[a] -> ys:[a] -> {zs:[a] | zs == reverse xs ++ ys} @-}
     reverseApp :: [a] -> [a] -> [a]
-    reverseApp [] ys     
+    reverseApp [] ys
         = reverse [] ++ ys
-        === [] ++ ys 
+        === [] ++ ys
         === ys
-    reverseApp (x:xs) ys 
+    reverseApp (x:xs) ys
         = reverse (x:xs) ++ ys
         === (reverse xs ++ [x]) ++ ys
         === (reverse xs ++ [x] ++ ys) ? hole -- I need a lemma here! Can the hole help me?

--- a/tests/typed-holes/Example4.hs
+++ b/tests/typed-holes/Example4.hs
@@ -1,0 +1,42 @@
+{-@ LIQUID "--expect-error-containing=Hole Found" @-}
+{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--warn-on-term-holes" @-}
+-- Based on paper: Theorem Proving for All: Equational Reasoning in Liquid Haskell (Functional Pearl)
+
+module Example4 where
+    import Prelude hiding ((<>), reverse, length, (++))
+    import Language.Haskell.Liquid.ProofCombinators ((===), (***), (?), QED(QED), Proof)
+
+    hole = undefined
+    {-@ length :: [a] -> {v:Int | 0 <= v } @-}
+    length :: [a] -> Int
+    length [] = 0
+    length (_:xs) = 1 + length xs
+    {-@ measure length @-}
+
+    {-@ reverse :: is:[a] -> {os:[a] | length is == length os} @-}
+    reverse :: [a] -> [a]
+    reverse [] = []
+    reverse (x:xs) = reverse xs ++ [x]
+
+    {-@ (++) :: xs:[a] -> ys:[a] -> {zs:[a] | length zs == length xs + length ys} @-}
+    (++) :: [a] -> [a] -> [a]
+    [] ++ ys = ys
+    (x:xs) ++ ys = x : (xs ++ ys)
+    {-@ infixl ++ @-}
+
+    {-@ reflect reverse @-}
+    {-@ reflect ++ @-}
+
+    {-@ reverseApp :: xs:[a] -> ys:[a] -> {zs:[a] | zs == reverse xs ++ ys} @-}
+    reverseApp :: [a] -> [a] -> [a]
+    reverseApp [] ys     
+        = reverse [] ++ ys
+        === [] ++ ys 
+        === ys
+    reverseApp (x:xs) ys 
+        = reverse (x:xs) ++ ys
+        === (reverse xs ++ [x]) ++ ys
+        === (reverse xs ++ [x] ++ ys) ? hole -- I need a lemma here! Can the hole help me?
+        === reverse xs ++ ([x] ++ ys)
+        -- It continues here following the

--- a/tests/typed-holes/Example5.hs
+++ b/tests/typed-holes/Example5.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--expect-error-containing=Hole Found" @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--warn-on-term-holes" @-}
 -- Based on paper: Theorem Proving for All: Equational Reasoning in Liquid Haskell (Functional Pearl)
 
@@ -29,7 +28,7 @@ module Example5 where
     (x:xs) ++ ys = x : (xs ++ ys)
     {-@ infixl ++ @-}
     {-@ reflect ++ @-}
-    
+
 
     {-@ flattenApp :: t:Tree -> ns:[Int] -> { v:[Int] | v == flatten t ++ ns } @-}
     flattenApp :: Tree -> [Int] -> [Int]

--- a/tests/typed-holes/Example5.hs
+++ b/tests/typed-holes/Example5.hs
@@ -1,0 +1,36 @@
+{-@ LIQUID "--expect-error-containing=Hole Found" @-}
+{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--warn-on-term-holes" @-}
+-- Based on paper: Theorem Proving for All: Equational Reasoning in Liquid Haskell (Functional Pearl)
+
+module Example5 where
+    import Prelude hiding ((<>), reverse, length, (++))
+    import Language.Haskell.Liquid.ProofCombinators ((===), (***), (?), QED(QED), Proof)
+
+    hole = undefined
+
+    data Tree = Leaf Int | Node Tree Tree
+
+    {-@ reflect flatten @-}
+    flatten :: Tree -> [Int]
+    flatten (Leaf x) = [x]
+    flatten (Node l r) = flatten l ++ flatten r
+
+
+    {-@ length :: [a] -> {v:Int | 0 <= v } @-}
+    length :: [a] -> Int
+    length [] = 0
+    length (_:xs) = 1 + length xs
+    {-@ measure length @-}
+
+    {-@ (++) :: xs:[a] -> ys:[a] -> {zs:[a] | length zs == length xs + length ys} @-}
+    (++) :: [a] -> [a] -> [a]
+    [] ++ ys = ys
+    (x:xs) ++ ys = x : (xs ++ ys)
+    {-@ infixl ++ @-}
+    {-@ reflect ++ @-}
+    
+
+    {-@ flattenApp :: t:Tree -> ns:[Int] -> { v:[Int] | v == flatten t ++ ns } @-}
+    flattenApp :: Tree -> [Int] -> [Int]
+    flattenApp t ns = hole -- Structural Induction

--- a/tests/typed-holes/Example6.hs
+++ b/tests/typed-holes/Example6.hs
@@ -1,0 +1,52 @@
+{-@ LIQUID "--expect-error-containing=Hole Found" @-}
+{-@ LIQUID "--exact-data-cons" @-}
+{-@ LIQUID "--warn-on-term-holes" @-}
+-- Based on paper: Theorem Proving for All: Equational Reasoning in Liquid Haskell (Functional Pearl)
+{-@ infix    :   @-}
+
+module Example6 where
+    import Prelude hiding ((<>), reverse, length, (++))
+    import Language.Haskell.Liquid.ProofCombinators ((===), (***), (?), QED(QED), Proof)
+    hole = undefined
+    {-@ length :: [a] -> {v:Int | 0 <= v } @-}
+    length :: [a] -> Int
+    length [] = 0
+    length (_:xs) = 1 + length xs
+    {-@ measure length @-}
+
+    {-@ (++) :: xs:[a] -> ys:[a] -> {zs:[a] | length zs == length xs + length ys} @-}
+    (++) :: [a] -> [a] -> [a]
+    [] ++ ys = ys
+    (x:xs) ++ ys = x : (xs ++ ys)
+    {-@ infixl ++ @-}
+    {-@ reflect ++ @-}
+
+
+    data Expr = Val Int |  Add Expr Expr
+
+    {-@ reflect eval @-}
+    eval :: Expr -> Int
+    eval (Val n) = n
+    eval (Add e1 e2) = eval e1 + eval e2
+
+    type Stack = [Int]
+    type Code  = [Op]
+    data Op  = PUSH Int | ADD
+
+    {-@ reflect exec @-}
+    exec :: Code -> Stack -> Maybe Stack
+    exec []           s = Just s
+    exec (PUSH n : c) s = exec c (n:s)
+    exec (ADD : c)    (m:n:s) = exec c (m+n:s)
+    exec _ _            = Nothing
+
+    {-@ reflect comp @-}
+    comp :: Expr -> Code
+    comp (Val n) = [PUSH n]
+    comp (Add x y) = comp x ++ comp y ++ [ADD]
+
+    {-@ generalizedCorrectness 
+         :: e:Expr -> s:Stack -> {exec (comp e) s == Just ((eval  e):s) } 
+    @-}
+    generalizedCorrectness :: Expr -> Stack -> Proof
+    generalizedCorrectness e s = hole -- Structural Induction

--- a/tests/typed-holes/Example6.hs
+++ b/tests/typed-holes/Example6.hs
@@ -1,5 +1,4 @@
 {-@ LIQUID "--expect-error-containing=Hole Found" @-}
-{-@ LIQUID "--exact-data-cons" @-}
 {-@ LIQUID "--warn-on-term-holes" @-}
 -- Based on paper: Theorem Proving for All: Equational Reasoning in Liquid Haskell (Functional Pearl)
 {-@ infix    :   @-}


### PR DESCRIPTION
Based on [PR#1140](https://github.com/ucsd-progsys/liquidhaskell/pull/1440)

I am adding a flag --allow-typed-holes
and detecting holes which are bindings with `hole` as infix.

These holes are currently being saved in the CGInfo and a warning is being presented to the user showing the refinement type.

I added one example in the test that shows how to use this experimental feature.
