### PR TITLE
Add custom error message for missing infix declarations

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -177,7 +177,12 @@ parseErrorError     :: (ParseError, SourcePos) -> Error
 parseErrorError (e, pos) = ErrParse sp msg e
   where
     sp              = sourcePosSrcSpan pos
-    msg             = "Error Parsing Specification from:" <+> PJ.text (sourceName pos)
+    msg             = "Error Parsing Specification from:" <+> PJ.text (sourceName pos) <+> infixSuggestion e
+
+infixSuggestion :: ParseError -> PJ.Doc
+infixSuggestion e
+  | "unknown operator" `isInfixOf` show e = " - Perhaps an infix declaration is missing?"
+  | otherwise                             = ""
 
 --------------------------------------------------------------------------------
 -- | BareTypes -----------------------------------------------------------------


### PR DESCRIPTION
- Modified `parseErrorError` function to include a suggestion for missing infix declarations when an unknown operator is encountered.
- Added `infixSuggestion` function to check for "unknown operator" in the error message and append a suggestion.

Adresses #2217