### PR TITLE
collect type aliases unsing env

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -1437,7 +1437,7 @@ mkRTE tAs eAs   = RTE
   { typeAliases = M.fromList [ (aName a, a) | a <- tAs ]
   , exprAliases = M.fromList [ (aName a, a) | a <- eAs ]
   }
-  where aName   = rtName . F.val
+  where aName   = getLHNameSymbol . rtName . F.val
 
 normalizeBareAlias :: Bare.Env -> Bare.SigEnv -> ModName -> Located BareRTAlias
                    -> Located BareRTAlias

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -1437,7 +1437,7 @@ mkRTE tAs eAs   = RTE
   { typeAliases = M.fromList [ (aName a, a) | a <- tAs ]
   , exprAliases = M.fromList [ (aName a, a) | a <- eAs ]
   }
-  where aName   = getLHNameSymbol . rtName . F.val
+  where aName   = getLHNameSymbol . F.val . rtName . F.val
 
 normalizeBareAlias :: Bare.Env -> Bare.SigEnv -> ModName -> Located BareRTAlias
                    -> Located BareRTAlias

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -1437,7 +1437,7 @@ mkRTE tAs eAs   = RTE
   { typeAliases = M.fromList [ (aName a, a) | a <- tAs ]
   , exprAliases = M.fromList [ (aName a, a) | a <- eAs ]
   }
-  where aName   = getLHNameSymbol . F.val . rtName . F.val
+  where aName   = lhNameToUnqualifiedSymbol . F.val . rtName . F.val
 
 normalizeBareAlias :: Bare.Env -> Bare.SigEnv -> ModName -> Located BareRTAlias
                    -> Located BareRTAlias

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -464,7 +464,9 @@ checkDuplicateRTAlias s tas = mkDiagnostics mempty (map mkError dups)
                                           (pprint . rtName . val $ x)
                                           (GM.fSrcSpan <$> xs)
     mkError []                = panic Nothing "mkError: called on empty list"
-    dups                    = [z | z@(_:_:_) <- groupDuplicatesOn (rtName . val) tas]
+    -- TEMP-NOTE: Duplicate aliases where not detected, as they were checked against
+    -- a Located LHName: the actual symbol is needed here to detect the overlap.
+    dups                    = [z | z@(_:_:_) <- groupDuplicatesOn ( lhNameToUnqualifiedSymbol . val . rtName . val) tas]
 
 groupDuplicatesOn :: Ord b => (a -> b) -> [a] -> [[a]]
 groupDuplicatesOn f = L.groupBy ((==) `on` f) . L.sortOn f

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Expand.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Expand.hs
@@ -106,7 +106,7 @@ renameTys :: RTAlias F.Symbol BareType -> RTAlias F.Symbol BareType
 renameTys rt = rt { rtTArgs = ys, rtBody = sbts (rtBody rt) (zip xs ys) }
   where
     xs    = rtTArgs rt
-    ys    = (`F.suffixSymbol` (getLHNameSymbol . rtName $ rt)) <$> xs
+    ys    = (`F.suffixSymbol` (getLHNameSymbol . val . rtName $ rt)) <$> xs
     sbts  = foldl (flip subt)
 
 
@@ -150,12 +150,12 @@ graphExpand buildEdges expBody env lxts
 setRTAlias :: RTEnv x t -> Located (RTAlias x t) -> RTEnv x t
 setRTAlias env a = env { typeAliases =  M.insert n a (typeAliases env) }
   where
-    n            = getLHNameSymbol . rtName $ val a
+    n            = getLHNameSymbol . val . rtName $ val a
 
 setREAlias :: RTEnv x t -> Located (RTAlias F.Symbol F.Expr) -> RTEnv x t
 setREAlias env a = env { exprAliases = M.insert n a (exprAliases env) }
   where
-    n            = getLHNameSymbol . rtName $ val a
+    n            = getLHNameSymbol . val . rtName $ val a
 
 
 
@@ -163,7 +163,7 @@ setREAlias env a = env { exprAliases = M.insert n a (exprAliases env) }
 type AliasTable x t = M.HashMap F.Symbol (Located (RTAlias x t))
 
 buildAliasTable :: [Located (RTAlias x t)] -> AliasTable x t
-buildAliasTable = M.fromList . map (\rta -> (getLHNameSymbol . rtName $ val rta, rta))
+buildAliasTable = M.fromList . map (\rta -> (getLHNameSymbol . val . rtName $ val rta, rta))
 
 fromAliasSymbol :: AliasTable x t -> F.Symbol -> Located (RTAlias x t)
 fromAliasSymbol table sym
@@ -180,7 +180,7 @@ buildAliasGraph buildEdges = map (buildAliasNode buildEdges)
 
 buildAliasNode :: (PPrint t) => (t -> [F.Symbol]) -> Located (RTAlias x t)
                -> Node F.Symbol
-buildAliasNode f la = (getLHNameSymbol $ rtName a, getLHNameSymbol $ rtName a, f (rtBody a))
+buildAliasNode f la = (getLHNameSymbol . val $ rtName a, getLHNameSymbol . val $ rtName a, f (rtBody a))
   where
     a               = val la
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Expand.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Expand.hs
@@ -106,7 +106,7 @@ renameTys :: RTAlias F.Symbol BareType -> RTAlias F.Symbol BareType
 renameTys rt = rt { rtTArgs = ys, rtBody = sbts (rtBody rt) (zip xs ys) }
   where
     xs    = rtTArgs rt
-    ys    = (`F.suffixSymbol` rtName rt) <$> xs
+    ys    = (`F.suffixSymbol` (getLHNameSymbol . rtName $ rt)) <$> xs
     sbts  = foldl (flip subt)
 
 
@@ -150,12 +150,12 @@ graphExpand buildEdges expBody env lxts
 setRTAlias :: RTEnv x t -> Located (RTAlias x t) -> RTEnv x t
 setRTAlias env a = env { typeAliases =  M.insert n a (typeAliases env) }
   where
-    n            = rtName (val a)
+    n            = getLHNameSymbol . rtName $ val a
 
 setREAlias :: RTEnv x t -> Located (RTAlias F.Symbol F.Expr) -> RTEnv x t
 setREAlias env a = env { exprAliases = M.insert n a (exprAliases env) }
   where
-    n            = rtName (val a)
+    n            = getLHNameSymbol . rtName $ val a
 
 
 
@@ -163,7 +163,7 @@ setREAlias env a = env { exprAliases = M.insert n a (exprAliases env) }
 type AliasTable x t = M.HashMap F.Symbol (Located (RTAlias x t))
 
 buildAliasTable :: [Located (RTAlias x t)] -> AliasTable x t
-buildAliasTable = M.fromList . map (\rta -> (rtName (val rta), rta))
+buildAliasTable = M.fromList . map (\rta -> (getLHNameSymbol . rtName $ val rta, rta))
 
 fromAliasSymbol :: AliasTable x t -> F.Symbol -> Located (RTAlias x t)
 fromAliasSymbol table sym
@@ -180,7 +180,7 @@ buildAliasGraph buildEdges = map (buildAliasNode buildEdges)
 
 buildAliasNode :: (PPrint t) => (t -> [F.Symbol]) -> Located (RTAlias x t)
                -> Node F.Symbol
-buildAliasNode f la = (rtName a, rtName a, f (rtBody a))
+buildAliasNode f la = (getLHNameSymbol $ rtName a, getLHNameSymbol $ rtName a, f (rtBody a))
   where
     a               = val la
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -402,7 +402,7 @@ getDefinedSymbolsInLogic env measEnv specs =
         concat (tycDCons `Mb.mapMaybe` (dataDecls spec ++ newtyDecls spec))
     getFromDataCtor decl = S.fromList $
       map lhNameToResolvedSymbol $ val (dcName decl) : (fst <$> dcFields decl)
-    getAliases spec = S.fromList $ getLHNameSymbol . rtName . val <$> Ms.ealiases spec
+    getAliases spec = S.fromList $ getLHNameSymbol . val . rtName . val <$> Ms.ealiases spec
 
 -- Get the set of `DataCon`s (DCs) needed for the reflection of a given list of variables,
 -- and which are not already present in the logic

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -402,7 +402,7 @@ getDefinedSymbolsInLogic env measEnv specs =
         concat (tycDCons `Mb.mapMaybe` (dataDecls spec ++ newtyDecls spec))
     getFromDataCtor decl = S.fromList $
       map lhNameToResolvedSymbol $ val (dcName decl) : (fst <$> dcFields decl)
-    getAliases spec = S.fromList $ rtName . val <$> Ms.ealiases spec
+    getAliases spec = S.fromList $ getLHNameSymbol . rtName . val <$> Ms.ealiases spec
 
 -- Get the set of `DataCon`s (DCs) needed for the reflection of a given list of variables,
 -- and which are not already present in the logic

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -448,6 +448,7 @@ isIgnore sp = any ((== "--skip-module") . F.val) (pragmas sp)
 -- | Working with bare & lifted specs ------------------------------------------
 --------------------------------------------------------------------------------
 
+-- | Loads the specs of direct dependencies and /their/ dependencies as well.
 loadDependencies :: Config -> [Module] -> TcM TargetDependencies
 loadDependencies currentModuleConfig mods = do
   hscEnv    <- env_top <$> getEnv

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -106,9 +106,9 @@ collectTypeAliases
   -> TargetDependencies
   -> InScopeEnv (RTAlias Symbol ())
 collectTypeAliases impMods thisModule spec deps =
-    let bsAliases = mkAliasEnvUnfiltered thisModule impMods (thisModule, bsNames)
+    let bsAliases = mkAliasEnv thisModule impMods (thisModule, bsNames)
         bsNames = [ (val . rtName $ rta, void rta) | rta <- map val (aliases spec)]
-        depAliases = map (mkAliasEnvUnfiltered thisModule impMods) $
+        depAliases = map (mkAliasEnv thisModule impMods) $
           [ (m, depNames)
           | (sm, lspec) <- HM.toList (getDependencies deps)
           , let m = GHC.unStableModule sm
@@ -474,8 +474,9 @@ type InScopeEnv a = SEnv [(GHC.ModuleName, (GHC.Module, LHName, a))]
 
 type InScopeNonReflectedEnv = InScopeEnv ()
 
--- | Looks the names in scope with the given symbol.
--- Returns a list of close but different symbols or a non empty list
+-- | Looks the names in scope with the given symbol, taking possible qualification
+-- prefixes into account.
+-- Returns a list of close but different symbols or a non-empty list
 -- with the matched names.
 lookupInScopeNonReflectedEnv
   :: InScopeEnv a -> Symbol -> Either [Symbol] [(GHC.Module, LHName, a)]
@@ -529,11 +530,12 @@ makeLogicEnvs impMods thisModule spec dependencies =
           ++ concatMap (map getLHNameSymbol . snd) unhandledLogicNames
         unhandledLogicNames =
           map (fmap collectUnhandledLiftedSpecLogicNames) dependencyPairs
+        -- TEMP-NOTE: possible optimization: avoid duplicate names here instead
+        -- of doing it at 'unionAliasEnvs'.
         logicNames =
           (thisModule, thisModuleNames) :
           map (fmap collectLiftedSpecLogicNames) dependencyPairs
           ++ unhandledLogicNames
-        logicNamesWithUnit = map (\(m,lhnames) -> (m, map (,()) lhnames)) logicNames
         thisModuleNames = concat
           [ [ reflectLHName thisModule (val n)
             | n <- concat
@@ -555,7 +557,13 @@ makeLogicEnvs impMods thisModule spec dependencies =
           mconcat $
             privateReflects spec : map (liftedPrivateReflects . snd) dependencyPairs
      in
-        ( unionAliasEnvs $ map (mkAliasEnv thisModule impMods) $ logicNamesWithUnit
+        ( unionAliasEnvs $ map (mkAliasEnv thisModule impMods) $
+          [ (m, lhnamesWithUnit)
+          | (m, lhnames) <- logicNames
+          -- We take only the non-reflected names
+          , LHNResolved (LHRLogic (LogicName _ _ Nothing)) _ <- lhnames
+          , let lhnamesWithUnit = map ( ,()) lhnames
+          ]
         , mkLogicNameEnv (concatMap snd logicNames)
         , privateReflectNames
         , unhandledNames
@@ -578,31 +586,20 @@ unionAliasEnvs =
     foldl' (HM.unionWith (++)) HM.empty .
     coerce @_ @[HM.HashMap Symbol [(GHC.ModuleName, (GHC.Module, LHName, a))]]
 
--- TEMP-NOTE: Creates an environment packing the resolved logic names of a module
--- with the aliases it is imported.
-mkAliasEnv :: GHC.Module -> GHC.ImportedMods -> (GHC.Module, [(LHName, a)]) -> InScopeEnv a
-mkAliasEnv thisModule impAvails (m, lhnames) =
-    let aliases = moduleAliases thisModule impAvails m
-     in fromListSEnv
-          [ (s, map (,(m, lhname, x)) aliases)
-            -- Note that only non-reflected names go to the InScope environment.
-            -- See the local function resolveVarName for more details.
-          | (lhname@(LHNResolved (LHRLogic (LogicName s _ Nothing)) _), x) <- lhnames
-          ]
-
--- TEMP-NOTE: Creates an environment packing the names of a module
--- with the aliases it is imported.
-mkAliasEnvUnfiltered :: GHC.Module -> GHC.ImportedMods -> (GHC.Module, [(LHName, a)]) -> InScopeEnv a
-mkAliasEnvUnfiltered thisModule impMods (m, lhnames) =
+-- | Creates an environment with the names of a module.
+mkAliasEnv:: GHC.Module -> GHC.ImportedMods -> (GHC.Module, [(LHName, a)]) -> InScopeEnv a
+mkAliasEnv thisModule impMods (m, lhnames) =
     let aliases = moduleAliases thisModule impMods m
      in fromListSEnv
           [ (getLHNameSymbol lhname, map (,(m, lhname, x)) aliases)
           | (lhname, x) <- lhnames
           ]
 
+-- | Produceds the aliases of a module. The first parameters holds the reference
+-- to the current module.
 moduleAliases :: GHC.Module -> GHC.ImportedMods -> GHC.Module -> [GHC.ModuleName]
-moduleAliases thisModule impAvails m =
-    case Map.lookup m impAvails of
+moduleAliases thisModule impMods m =
+    case Map.lookup m impMods of
       Just impBys -> concatMap imvAliases $ GHC.importedByUser impBys
       Nothing
         | thisModule == m ->
@@ -614,7 +611,7 @@ moduleAliases thisModule impAvails m =
             concat $ maybeToList $ do
               pString <- dropLHAssumptionsSuffix
               pMod <- findDependency pString
-              Map.lookup pMod impAvails
+              Map.lookup pMod impMods
   where
     dropLHAssumptionsSuffix =
       let mString = GHC.moduleNameString (GHC.moduleName m)
@@ -626,7 +623,7 @@ moduleAliases thisModule impAvails m =
 
     findDependency ms =
       find ((ms ==) . GHC.moduleNameString . GHC.moduleName) $
-      Map.keys impAvails
+      Map.keys impMods
 
     imvAliases imv
       | GHC.imv_qualified imv = [GHC.imv_name imv]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -102,11 +102,11 @@ collectTypeAliases
   :: GHC.Module
   -> BareSpecParsed
   -> TargetDependencies
-  -> HM.HashMap LHName (GHC.Module, RTAlias Symbol ())
+  -> HM.HashMap Symbol (GHC.Module, RTAlias Symbol ())
 collectTypeAliases m spec deps =
-    let bsAliases = [ (rtName a, (m, void a)) | a <- map val (aliases spec) ]
+    let bsAliases = [ (getLHNameSymbol $ rtName a, (m, void a)) | a <- map val (aliases spec) ]
         depAliases =
-          [ (rtName a, (GHC.unStableModule sm, void a))
+          [ (getLHNameSymbol $ rtName a, (GHC.unStableModule sm, void a))
           | (sm, lspec) <- HM.toList (getDependencies deps)
           , a <- map val (HS.toList $ liftedAliases lspec)
           ]
@@ -116,11 +116,11 @@ collectTypeAliases m spec deps =
 collectExprAliases
   :: BareSpecParsed
   -> TargetDependencies
-  -> HS.HashSet LHName
+  -> HS.HashSet Symbol
 collectExprAliases spec deps =
-    let bsAliases = HS.fromList $ map (rtName . val) (ealiases spec)
+    let bsAliases = HS.fromList $ map (getLHNameSymbol . rtName . val) (ealiases spec)
         depAliases =
-          [ HS.map (rtName . val) $ liftedEaliases lspec
+          [ HS.map (getLHNameSymbol . rtName . val) $ liftedEaliases lspec
           | (_, lspec) <- HM.toList (getDependencies deps)
           ]
      in
@@ -213,7 +213,7 @@ resolveLHNames cfg thisModule localVars impMods globalRdrEnv bareSpec0 dependenc
           | s == "*" ->
             pure $ LHNResolved (LHRGHC GHC.liftedTypeKindTyConName) s
           | otherwise ->
-            case HM.lookup (val lname) taliases of
+            case HM.lookup s taliases of
               Just (m, _) -> pure $ LHNResolved (LHRLogic $ LogicName s m Nothing) s
               Nothing -> lookupGRELHName LHTcName lname s listToMaybe
         LHNUnresolved ns@(LHVarName lcl) s
@@ -402,7 +402,7 @@ resolveBoundVarsInTypeAliases = updateAliases resolveBoundVars
 --
 -- TEMP-NOTE: what's going on here?
 fixExpressionArgsOfTypeAliases
-  :: HM.HashMap LHName (GHC.Module, RTAlias Symbol ())
+  :: HM.HashMap Symbol (GHC.Module, RTAlias Symbol ())
   -> BareSpecParsed
   -> BareSpecParsed
 fixExpressionArgsOfTypeAliases taliases =
@@ -410,7 +410,7 @@ fixExpressionArgsOfTypeAliases taliases =
   where
     go :: BareTypeParsed -> BareTypeParsed
     go (RApp c@(BTyCon { btc_tc = Loc _ _ (LHNUnresolved LHTcName s) }) ts rs r)
-      | Just (_, rta) <- HM.lookup (makeUnresolvedLHName LHLogicName s) taliases =
+      | Just (_, rta) <- HM.lookup  s taliases =
         RApp c (fixExprArgs (btc_tc c) rta (map go ts)) (map goRef rs) r
     go (RApp c ts rs r) =
         RApp c (map go ts) (map goRef rs) r
@@ -636,7 +636,7 @@ resolveLogicNames
   -> LocalVars
   -> LogicNameEnv
   -> HS.HashSet LocSymbol
-  -> HS.HashSet LHName
+  -> HS.HashSet Symbol
   -> BareSpecParsed
   -> State RenameOutput BareSpecLHName
 resolveLogicNames cfg env globalRdrEnv unhandledNames lmap0 localVars lnameEnv privateReflectNames allEaliases sp = do
@@ -769,7 +769,7 @@ resolveLogicNames cfg env globalRdrEnv unhandledNames lmap0 localVars lnameEnv p
             -- TEMP-NOTE: Will this check be redundant afterwards?
             -- TODO: The check for allEaliases should be redundant when
             -- ealiases are put in the logic environments
-            if HM.member (symbol n) (lmSymDefs lmap) || HS.member (makeUnresolvedLHName LHLogicName $ symbol n) allEaliases then
+            if HM.member (symbol n) (lmSymDefs lmap) || HS.member  (symbol n) allEaliases then
               Just $ do
                 let lhName = makeLogicLHName (symbol $ GHC.getOccString n) (GHC.nameModule n) Nothing
                 addName lhName

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -186,7 +186,6 @@ resolveLHNames cfg thisModule localVars impMods globalRdrEnv bareSpec0 dependenc
     else
       Left (roErrors ro)
   where
-    -- TEMP-NOTE: (3) At this point aliases are collected for name resolution.
     taliases = collectTypeAliases thisModule bareSpec0 dependencies
     allEaliases = collectExprAliases bareSpec0 dependencies
 
@@ -555,7 +554,7 @@ makeLogicEnvs impAvails thisModule spec dependencies =
     dependencyPairs = map (first GHC.unStableModule) $ HM.toList $ getDependencies dependencies
 
     mkAliasEnv (m, lhnames) =
-      let aliases = moduleAliases m
+      let aliases = moduleAliases thisModule impAvails m
        in fromListSEnv
             [ (s, map (,(m, lhname)) aliases)
               -- Note that only non-reflected names go to the InScope environment.
@@ -570,22 +569,31 @@ makeLogicEnvs impAvails thisModule spec dependencies =
       foldl' (HM.unionWith (++)) HM.empty .
       coerce @_ @[HM.HashMap Symbol [(GHC.ModuleName, (GHC.Module, LHName))]]
 
-    moduleAliases m =
-      case Map.lookup m impAvails of
-        Just impBys -> concatMap imvAliases $ GHC.importedByUser impBys
-        Nothing
-          | thisModule == m ->
-            -- Aliases for the current module
-            [GHC.moduleName m, GHC.mkModuleName ""]
-          | otherwise ->
-            -- Use the aliases of the unsuffixed module
-            concatMap imvAliases $ GHC.importedByUser $
-              concat $ maybeToList $ do
-                pString <- dropLHAssumptionsSuffix m
-                pMod <- findDependency pString
-                Map.lookup pMod impAvails
+    mkLogicNameEnv names =
+      LogicNameEnv
+        -- TEMP-NOTE: A symbol-map of all resolved logic names. Note only local and generated names are not qualified.
+        { lneLHName = fromListSEnv [ (lhNameToResolvedSymbol n, n) | n <- names ]
+        -- TEMP-NOTE: A name-map of all logic names comming from reflected Haskell functions.
+        , lneReflected = GHC.mkNameEnv [(rn, n) | n <- names, Just rn <- [maybeReflectedLHName n]]
+        }
 
-    dropLHAssumptionsSuffix m =
+moduleAliases :: GHC.Module -> GHC.ImportedMods -> GHC.Module -> [GHC.ModuleName]
+moduleAliases thisModule impAvails m =
+  case Map.lookup m impAvails of
+    Just impBys -> concatMap imvAliases $ GHC.importedByUser impBys
+    Nothing
+      | thisModule == m ->
+        -- Aliases for the current module
+        [GHC.moduleName m, GHC.mkModuleName ""]
+      | otherwise ->
+        -- Use the aliases of the unsuffixed module
+        concatMap imvAliases $ GHC.importedByUser $
+          concat $ maybeToList $ do
+            pString <- dropLHAssumptionsSuffix
+            pMod <- findDependency pString
+            Map.lookup pMod impAvails
+  where
+    dropLHAssumptionsSuffix =
       let mString = GHC.moduleNameString (GHC.moduleName m)
           sfx = "_LHAssumptions"
        in if isSuffixOf sfx mString then
@@ -600,12 +608,6 @@ makeLogicEnvs impAvails thisModule spec dependencies =
     imvAliases imv
       | GHC.imv_qualified imv = [GHC.imv_name imv]
       | otherwise = [GHC.imv_name imv, GHC.mkModuleName ""]
-
-    mkLogicNameEnv names =
-      LogicNameEnv
-        { lneLHName = fromListSEnv [ (lhNameToResolvedSymbol n, n) | n <- names ]
-        , lneReflected = GHC.mkNameEnv [(rn, n) | n <- names, Just rn <- [maybeReflectedLHName n]]
-        }
 
 {- HLINT ignore collectUnhandledLiftedSpecLogicNames "Use ++" -}
 collectUnhandledLiftedSpecLogicNames :: LiftedSpec -> [LHName]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -410,7 +410,7 @@ fixExpressionArgsOfTypeAliases taliases =
   where
     go :: BareTypeParsed -> BareTypeParsed
     go (RApp c@(BTyCon { btc_tc = Loc _ _ (LHNUnresolved LHTcName s) }) ts rs r)
-      | Just (_, rta) <- HM.lookup  s taliases =
+      | Just (_, rta) <- HM.lookup s taliases =
         RApp c (fixExprArgs (btc_tc c) rta (map go ts)) (map goRef rs) r
     go (RApp c ts rs r) =
         RApp c (map go ts) (map goRef rs) r
@@ -769,7 +769,7 @@ resolveLogicNames cfg env globalRdrEnv unhandledNames lmap0 localVars lnameEnv p
             -- TEMP-NOTE: Will this check be redundant afterwards?
             -- TODO: The check for allEaliases should be redundant when
             -- ealiases are put in the logic environments
-            if HM.member (symbol n) (lmSymDefs lmap) || HS.member  (symbol n) allEaliases then
+            if HM.member (symbol n) (lmSymDefs lmap) || HS.member (symbol n) allEaliases then
               Just $ do
                 let lhName = makeLogicLHName (symbol $ GHC.getOccString n) (GHC.nameModule n) Nothing
                 addName lhName

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -102,7 +102,7 @@ collectTypeAliases
   :: GHC.Module
   -> BareSpecParsed
   -> TargetDependencies
-  -> HM.HashMap Symbol (GHC.Module, RTAlias Symbol ())
+  -> HM.HashMap LHName (GHC.Module, RTAlias Symbol ())
 collectTypeAliases m spec deps =
     let bsAliases = [ (rtName a, (m, void a)) | a <- map val (aliases spec) ]
         depAliases =
@@ -116,7 +116,7 @@ collectTypeAliases m spec deps =
 collectExprAliases
   :: BareSpecParsed
   -> TargetDependencies
-  -> HS.HashSet Symbol
+  -> HS.HashSet LHName
 collectExprAliases spec deps =
     let bsAliases = HS.fromList $ map (rtName . val) (ealiases spec)
         depAliases =
@@ -213,7 +213,7 @@ resolveLHNames cfg thisModule localVars impMods globalRdrEnv bareSpec0 dependenc
           | s == "*" ->
             pure $ LHNResolved (LHRGHC GHC.liftedTypeKindTyConName) s
           | otherwise ->
-            case HM.lookup s taliases of
+            case HM.lookup (val lname) taliases of
               Just (m, _) -> pure $ LHNResolved (LHRLogic $ LogicName s m Nothing) s
               Nothing -> lookupGRELHName LHTcName lname s listToMaybe
         LHNUnresolved ns@(LHVarName lcl) s
@@ -402,7 +402,7 @@ resolveBoundVarsInTypeAliases = updateAliases resolveBoundVars
 --
 -- TEMP-NOTE: what's going on here?
 fixExpressionArgsOfTypeAliases
-  :: HM.HashMap Symbol (GHC.Module, RTAlias Symbol ())
+  :: HM.HashMap LHName (GHC.Module, RTAlias Symbol ())
   -> BareSpecParsed
   -> BareSpecParsed
 fixExpressionArgsOfTypeAliases taliases =
@@ -410,7 +410,7 @@ fixExpressionArgsOfTypeAliases taliases =
   where
     go :: BareTypeParsed -> BareTypeParsed
     go (RApp c@(BTyCon { btc_tc = Loc _ _ (LHNUnresolved LHTcName s) }) ts rs r)
-      | Just (_, rta) <- HM.lookup s taliases =
+      | Just (_, rta) <- HM.lookup (makeUnresolvedLHName LHLogicName s) taliases =
         RApp c (fixExprArgs (btc_tc c) rta (map go ts)) (map goRef rs) r
     go (RApp c ts rs r) =
         RApp c (map go ts) (map goRef rs) r
@@ -484,7 +484,7 @@ lookupInScopeNonReflectedEnv env s = do
     maybeQualifySymbol n m =
       if m == "" then n else LH.qualifySymbol m n
 
--- | Builds an environment of non-reflected names in scope from the module
+-- | Builds an environment of non-reflected names in scope from the
 -- aliases for the current module, the spec of the current module, and the specs
 -- of the dependencies.
 --
@@ -514,8 +514,10 @@ makeLogicEnvs impAvails thisModule spec dependencies =
         unhandledNames = HS.fromList $
           map unqualify unhandledNamesList ++ map (LH.qualifySymbol (symbol $ GHC.moduleName thisModule)) unhandledNamesList
         unhandledNamesList =
-          -- TEMP-NOTE: aliases are added to the environment here
-          map (rtName . val) (ealiases spec)
+          -- TEMP-NOTE: predicate aliases are added to the environment here
+          -- For now I keep the symbol to minimise propagation, but could later
+          -- try to use the full LHName.
+          map (getLHNameSymbol . rtName . val) (ealiases spec)
           ++ concatMap (map getLHNameSymbol . snd) unhandledLogicNames
         unhandledLogicNames =
           map (fmap collectUnhandledLiftedSpecLogicNames) dependencyPairs
@@ -608,7 +610,7 @@ makeLogicEnvs impAvails thisModule spec dependencies =
 {- HLINT ignore collectUnhandledLiftedSpecLogicNames "Use ++" -}
 collectUnhandledLiftedSpecLogicNames :: LiftedSpec -> [LHName]
 collectUnhandledLiftedSpecLogicNames sp =
-    map (makeLocalLHName . LH.dropModuleNames . rtName . val) $ HS.toList $ liftedEaliases sp
+    map (makeLocalLHName . LH.dropModuleNames . lhNameToResolvedSymbol. rtName . val) $ HS.toList $ liftedEaliases sp
 
 collectLiftedSpecLogicNames :: LiftedSpec -> [LHName]
 collectLiftedSpecLogicNames sp = concat
@@ -634,7 +636,7 @@ resolveLogicNames
   -> LocalVars
   -> LogicNameEnv
   -> HS.HashSet LocSymbol
-  -> HS.HashSet Symbol
+  -> HS.HashSet LHName
   -> BareSpecParsed
   -> State RenameOutput BareSpecLHName
 resolveLogicNames cfg env globalRdrEnv unhandledNames lmap0 localVars lnameEnv privateReflectNames allEaliases sp = do
@@ -764,9 +766,10 @@ resolveLogicNames cfg env globalRdrEnv unhandledNames lmap0 localVars lnameEnv p
           -> case gres of
           [e] -> do
             let n = GHC.greName e
+            -- TEMP-NOTE: Will this check be redundant afterwards?
             -- TODO: The check for allEaliases should be redundant when
             -- ealiases are put in the logic environments
-            if HM.member (symbol n) (lmSymDefs lmap) || HS.member (symbol n) allEaliases then
+            if HM.member (symbol n) (lmSymDefs lmap) || HS.member (makeUnresolvedLHName LHLogicName $ symbol n) allEaliases then
               Just $ do
                 let lhName = makeLogicLHName (symbol $ GHC.getOccString n) (GHC.nameModule n) Nothing
                 addName lhName

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -536,6 +536,13 @@ makeLogicEnvs impMods thisModule spec dependencies =
           (thisModule, thisModuleNames) :
           map (fmap collectLiftedSpecLogicNames) dependencyPairs
           ++ unhandledLogicNames
+        nonReflectedNamesWithUnit =
+          [ (m, lhnamesWithUnit)
+          | (m, lhnames) <- logicNames
+          -- We take only the non-reflected names
+          , LHNResolved (LHRLogic (LogicName _ _ Nothing)) _ <- lhnames
+          , let lhnamesWithUnit = map ( ,()) lhnames
+          ]
         thisModuleNames = concat
           [ [ reflectLHName thisModule (val n)
             | n <- concat
@@ -557,13 +564,7 @@ makeLogicEnvs impMods thisModule spec dependencies =
           mconcat $
             privateReflects spec : map (liftedPrivateReflects . snd) dependencyPairs
      in
-        ( unionAliasEnvs $ map (mkAliasEnv thisModule impMods) $
-          [ (m, lhnamesWithUnit)
-          | (m, lhnames) <- logicNames
-          -- We take only the non-reflected names
-          , LHNResolved (LHRLogic (LogicName _ _ Nothing)) _ <- lhnames
-          , let lhnamesWithUnit = map ( ,()) lhnames
-          ]
+        ( unionAliasEnvs $ map (mkAliasEnv thisModule impMods) nonReflectedNamesWithUnit
         , mkLogicNameEnv (concatMap snd logicNames)
         , privateReflectNames
         , unhandledNames

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -502,6 +502,7 @@ makeLogicEnvs
      , HS.HashSet Symbol
      )
 makeLogicEnvs impAvails thisModule spec dependencies =
+    -- TEMP-NOTE: Qualified names for the logic environment are handled here
     let unqualify s =
           if s == LH.qualifySymbol (symbol $ GHC.moduleName thisModule) (LH.dropModuleNames s) then
             LH.dropModuleNames s
@@ -513,6 +514,7 @@ makeLogicEnvs impAvails thisModule spec dependencies =
         unhandledNames = HS.fromList $
           map unqualify unhandledNamesList ++ map (LH.qualifySymbol (symbol $ GHC.moduleName thisModule)) unhandledNamesList
         unhandledNamesList =
+          -- TEMP-NOTE: aliases are added to the environment here
           map (rtName . val) (ealiases spec)
           ++ concatMap (map getLHNameSymbol . snd) unhandledLogicNames
         unhandledLogicNames =

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -104,9 +104,9 @@ collectTypeAliases
   -> TargetDependencies
   -> HM.HashMap Symbol (GHC.Module, RTAlias Symbol ())
 collectTypeAliases m spec deps =
-    let bsAliases = [ (getLHNameSymbol $ rtName a, (m, void a)) | a <- map val (aliases spec) ]
+    let bsAliases = [ (getLHNameSymbol . val $ rtName a, (m, void a)) | a <- map val (aliases spec) ]
         depAliases =
-          [ (getLHNameSymbol $ rtName a, (GHC.unStableModule sm, void a))
+          [ (getLHNameSymbol . val $ rtName a, (GHC.unStableModule sm, void a))
           | (sm, lspec) <- HM.toList (getDependencies deps)
           , a <- map val (HS.toList $ liftedAliases lspec)
           ]
@@ -118,9 +118,9 @@ collectExprAliases
   -> TargetDependencies
   -> HS.HashSet Symbol
 collectExprAliases spec deps =
-    let bsAliases = HS.fromList $ map (getLHNameSymbol . rtName . val) (ealiases spec)
+    let bsAliases = HS.fromList $ map (getLHNameSymbol . val . rtName . val) (ealiases spec)
         depAliases =
-          [ HS.map (getLHNameSymbol . rtName . val) $ liftedEaliases lspec
+          [ HS.map (getLHNameSymbol . val . rtName . val) $ liftedEaliases lspec
           | (_, lspec) <- HM.toList (getDependencies deps)
           ]
      in
@@ -517,7 +517,7 @@ makeLogicEnvs impAvails thisModule spec dependencies =
           -- TEMP-NOTE: predicate aliases are added to the environment here
           -- For now I keep the symbol to minimise propagation, but could later
           -- try to use the full LHName.
-          map (getLHNameSymbol . rtName . val) (ealiases spec)
+          map (getLHNameSymbol . val . rtName . val) (ealiases spec)
           ++ concatMap (map getLHNameSymbol . snd) unhandledLogicNames
         unhandledLogicNames =
           map (fmap collectUnhandledLiftedSpecLogicNames) dependencyPairs
@@ -610,7 +610,7 @@ makeLogicEnvs impAvails thisModule spec dependencies =
 {- HLINT ignore collectUnhandledLiftedSpecLogicNames "Use ++" -}
 collectUnhandledLiftedSpecLogicNames :: LiftedSpec -> [LHName]
 collectUnhandledLiftedSpecLogicNames sp =
-    map (makeLocalLHName . LH.dropModuleNames . lhNameToResolvedSymbol. rtName . val) $ HS.toList $ liftedEaliases sp
+    map (makeLocalLHName . LH.dropModuleNames . lhNameToResolvedSymbol. val . rtName . val) $ HS.toList $ liftedEaliases sp
 
 collectLiftedSpecLogicNames :: LiftedSpec -> [LHName]
 collectLiftedSpecLogicNames sp = concat

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -9,7 +9,7 @@
 -- entities remains work in progress.
 --
 -- Haskell entities include all functions that LH might reflect, or types that
--- might be referred in refinment types, type aliases or other annotations.
+-- might be referred in refinement types, type aliases or other annotations.
 --
 -- Logic entities include the names of reflected functions, inlined functions,
 -- uninterpreted functions, predefined functions, local bindings, reflected data
@@ -186,6 +186,7 @@ resolveLHNames cfg thisModule localVars impMods globalRdrEnv bareSpec0 dependenc
     else
       Left (roErrors ro)
   where
+    -- TEMP-NOTE: (3) At this point aliases are collected for name resolution.
     taliases = collectTypeAliases thisModule bareSpec0 dependencies
     allEaliases = collectExprAliases bareSpec0 dependencies
 
@@ -399,6 +400,7 @@ resolveBoundVarsInTypeAliases = updateAliases resolveBoundVars
 --
 -- the parser builds a type for @Ev (plus n n)@.
 --
+-- TEMP-NOTE: what's going on here?
 fixExpressionArgsOfTypeAliases
   :: HM.HashMap Symbol (GHC.Module, RTAlias Symbol ())
   -> BareSpecParsed

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -500,7 +500,7 @@ makeLogicEnvs
      , HS.HashSet LocSymbol
      , HS.HashSet Symbol
      )
-makeLogicEnvs impAvails thisModule spec dependencies =
+makeLogicEnvs impMods thisModule spec dependencies =
     -- TEMP-NOTE: Qualified names for the logic environment are handled here
     let unqualify s =
           if s == LH.qualifySymbol (symbol $ GHC.moduleName thisModule) (LH.dropModuleNames s) then
@@ -545,29 +545,13 @@ makeLogicEnvs impAvails thisModule spec dependencies =
           mconcat $
             privateReflects spec : map (liftedPrivateReflects . snd) dependencyPairs
      in
-        ( unionAliasEnvs $ map mkAliasEnv logicNames
+        ( unionAliasEnvs $ map (mkAliasEnv thisModule impMods) logicNames
         , mkLogicNameEnv (concatMap snd logicNames)
         , privateReflectNames
         , unhandledNames
         )
   where
     dependencyPairs = map (first GHC.unStableModule) $ HM.toList $ getDependencies dependencies
-
-    mkAliasEnv (m, lhnames) =
-      let aliases = moduleAliases thisModule impAvails m
-       in fromListSEnv
-            [ (s, map (,(m, lhname)) aliases)
-              -- Note that only non-reflected names go to the InScope environment.
-              -- See the local function resolveVarName for more details.
-            | lhname@(LHNResolved (LHRLogic (LogicName s _ Nothing)) _) <- lhnames
-            ]
-
-    unionAliasEnvs :: [InScopeNonReflectedEnv] -> InScopeNonReflectedEnv
-    unionAliasEnvs =
-      coerce .
-      HM.map (nubBy (\(alias1, (_, n1)) (alias2, (_, n2)) -> alias1 == alias2 && n1 == n2)) .
-      foldl' (HM.unionWith (++)) HM.empty .
-      coerce @_ @[HM.HashMap Symbol [(GHC.ModuleName, (GHC.Module, LHName))]]
 
     mkLogicNameEnv names =
       LogicNameEnv
@@ -577,21 +561,39 @@ makeLogicEnvs impAvails thisModule spec dependencies =
         , lneReflected = GHC.mkNameEnv [(rn, n) | n <- names, Just rn <- [maybeReflectedLHName n]]
         }
 
+unionAliasEnvs :: [InScopeNonReflectedEnv] -> InScopeNonReflectedEnv
+unionAliasEnvs =
+    coerce .
+    HM.map (nubBy (\(alias1, (_, n1)) (alias2, (_, n2)) -> alias1 == alias2 && n1 == n2)) .
+    foldl' (HM.unionWith (++)) HM.empty .
+    coerce @_ @[HM.HashMap Symbol [(GHC.ModuleName, (GHC.Module, LHName))]]
+
+mkAliasEnv :: GHC.Module -> GHC.ImportedMods -> (GHC.Module, [LHName]) -> InScopeNonReflectedEnv
+mkAliasEnv thisModule impAvails (m, lhnames) =
+    let aliases = moduleAliases thisModule impAvails m
+     in fromListSEnv
+          [ (s, map (,(m, lhname)) aliases)
+            -- Note that only non-reflected names go to the InScope environment.
+            -- See the local function resolveVarName for more details.
+          | lhname@(LHNResolved (LHRLogic (LogicName s _ Nothing)) _) <- lhnames
+          ]
+
+
 moduleAliases :: GHC.Module -> GHC.ImportedMods -> GHC.Module -> [GHC.ModuleName]
 moduleAliases thisModule impAvails m =
-  case Map.lookup m impAvails of
-    Just impBys -> concatMap imvAliases $ GHC.importedByUser impBys
-    Nothing
-      | thisModule == m ->
-        -- Aliases for the current module
-        [GHC.moduleName m, GHC.mkModuleName ""]
-      | otherwise ->
-        -- Use the aliases of the unsuffixed module
-        concatMap imvAliases $ GHC.importedByUser $
-          concat $ maybeToList $ do
-            pString <- dropLHAssumptionsSuffix
-            pMod <- findDependency pString
-            Map.lookup pMod impAvails
+    case Map.lookup m impAvails of
+      Just impBys -> concatMap imvAliases $ GHC.importedByUser impBys
+      Nothing
+        | thisModule == m ->
+          -- Aliases for the current module
+          [GHC.moduleName m, GHC.mkModuleName ""]
+        | otherwise ->
+          -- Use the aliases of the unsuffixed module
+          concatMap imvAliases $ GHC.importedByUser $
+            concat $ maybeToList $ do
+              pString <- dropLHAssumptionsSuffix
+              pMod <- findDependency pString
+              Map.lookup pMod impAvails
   where
     dropLHAssumptionsSuffix =
       let mString = GHC.moduleNameString (GHC.moduleName m)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -106,9 +106,9 @@ collectTypeAliases
   -> TargetDependencies
   -> InScopeEnv (RTAlias Symbol ())
 collectTypeAliases impMods thisModule spec deps =
-    let bsAliases = mkAliasEnv thisModule impMods (thisModule, bsNames)
+    let bsAliases = mkAliasEnv thisModule deps impMods (thisModule, bsNames)
         bsNames = [ (val . rtName $ rta, void rta) | rta <- map val (aliases spec)]
-        depAliases = map (mkAliasEnv thisModule impMods) $
+        depAliases = map (mkAliasEnv thisModule deps impMods) $
           [ (m, depNames)
           | (sm, lspec) <- HM.toList (getDependencies deps)
           , let m = GHC.unStableModule sm
@@ -469,7 +469,7 @@ exprArg l msg = notracepp ("exprArg: " ++ msg) . go
 --
 -- For each symbol we have the aliases with which it is imported and the
 -- name corresponding to each alias.
--- TEMP-NOTE: update doc
+-- TEMP-NOTE: update doc. Posibly rename to AliasEnv or similar.
 type InScopeEnv a = SEnv [(GHC.ModuleName, (GHC.Module, LHName, a))]
 
 type InScopeNonReflectedEnv = InScopeEnv ()
@@ -481,6 +481,8 @@ type InScopeNonReflectedEnv = InScopeEnv ()
 lookupInScopeNonReflectedEnv
   :: InScopeEnv a -> Symbol -> Either [Symbol] [(GHC.Module, LHName, a)]
 lookupInScopeNonReflectedEnv env s = do
+    -- The symbol might be qualified or not,
+    -- but we use the unqualified symbol for the lookup.
     let n = LH.dropModuleNames s
     case lookupSEnvWithDistance n env of
       Alts closeSyms -> Left closeSyms
@@ -539,7 +541,7 @@ makeLogicEnvs impMods thisModule spec dependencies =
         nonReflectedNamesWithUnit =
           [ (m, lhnamesWithUnit)
           | (m, lhnames) <- logicNames
-          -- We take only the non-reflected names
+          -- Take non-reflected names only.
           , LHNResolved (LHRLogic (LogicName _ _ Nothing)) _ <- lhnames
           , let lhnamesWithUnit = map ( ,()) lhnames
           ]
@@ -564,7 +566,7 @@ makeLogicEnvs impMods thisModule spec dependencies =
           mconcat $
             privateReflects spec : map (liftedPrivateReflects . snd) dependencyPairs
      in
-        ( unionAliasEnvs $ map (mkAliasEnv thisModule impMods) nonReflectedNamesWithUnit
+        ( unionAliasEnvs $ map (mkAliasEnv thisModule dependencies impMods) nonReflectedNamesWithUnit
         , mkLogicNameEnv (concatMap snd logicNames)
         , privateReflectNames
         , unhandledNames
@@ -583,31 +585,45 @@ makeLogicEnvs impMods thisModule spec dependencies =
 unionAliasEnvs :: forall a. [InScopeEnv a] -> InScopeEnv a
 unionAliasEnvs =
     coerce .
+    -- TEMP-NOTE: Previously, only resolved names went through this environment.
+    -- Now we get unresolved names when collecting (type) aliases before the first pass,
+    -- so its nees to be verified that name and module alias equality
+    -- remove the expected ambiguities in this case.
     HM.map (nubBy (\(alias1, (_, n1, _)) (alias2, (_, n2, _)) -> alias1 == alias2 && n1 == n2)) .
     foldl' (HM.unionWith (++)) HM.empty .
     coerce @_ @[HM.HashMap Symbol [(GHC.ModuleName, (GHC.Module, LHName, a))]]
 
--- | Creates an environment with the names of a module.
-mkAliasEnv:: GHC.Module -> GHC.ImportedMods -> (GHC.Module, [(LHName, a)]) -> InScopeEnv a
-mkAliasEnv thisModule impMods (m, lhnames) =
-    let aliases = moduleAliases thisModule impMods m
+-- | Creates an environment of names contained in a module (the tuple argument)
+-- with the aliases given to it at the current module (first argument).
+-- We expect this module is a direct import, or otherwise a transitive dependency
+-- from the 'TargetDependencies'.
+-- TEMP-NOTE: The 'TargetDependencies' argument was introduced to account for names needed
+-- when collecting type aliases comming from modules not in scope. It must be verified that
+-- no spurius names are introduced when building the original 'InScopeNonReflectedEnv' build
+-- by 'makeLogicEnvs'.
+mkAliasEnv:: GHC.Module -> TargetDependencies -> GHC.ImportedMods -> (GHC.Module, [(LHName, a)]) -> InScopeEnv a
+mkAliasEnv thisModule deps impMods (m, lhnames) =
+    let aliases = moduleAliases thisModule deps impMods m
      in fromListSEnv
           [ (getLHNameSymbol lhname, map (,(m, lhname, x)) aliases)
           | (lhname, x) <- lhnames
           ]
 
--- | Produceds the aliases of a module. The first parameters holds the reference
+-- | Produces the list of aliases a module is imported with. The first parameters holds the reference
 -- to the current module.
-moduleAliases :: GHC.Module -> GHC.ImportedMods -> GHC.Module -> [GHC.ModuleName]
-moduleAliases thisModule impMods m =
+moduleAliases :: GHC.Module -> TargetDependencies -> GHC.ImportedMods -> GHC.Module -> [GHC.ModuleName]
+moduleAliases thisModule deps impMods m =
     case Map.lookup m impMods of
+      -- Aliases for imported modules
       Just impBys -> concatMap imvAliases $ GHC.importedByUser impBys
       Nothing
         | thisModule == m ->
           -- Aliases for the current module
           [GHC.moduleName m, GHC.mkModuleName ""]
+          -- Dependencies not in scope get an empty alias
+        | HM.member (GHC.toStableModule m) (getDependencies deps) -> [GHC.mkModuleName ""]
         | otherwise ->
-          -- Use the aliases of the unsuffixed module
+          -- For LHAssumptions modules, use the aliases of the unsuffixed module
           concatMap imvAliases $ GHC.importedByUser $
             concat $ maybeToList $ do
               pString <- dropLHAssumptionsSuffix

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -98,20 +98,26 @@ import qualified Text.Printf               as Printf
 -- It doesn't matter at the moment in which module a type alias is defined.
 -- Type alias names cannot be qualified at the moment, and therefore their
 -- names identify them uniquely.
+-- TEMP-NOTE: Update doc
 collectTypeAliases
-  :: GHC.Module
+  :: GHC.ImportedMods
+  -> GHC.Module
   -> BareSpecParsed
   -> TargetDependencies
-  -> HM.HashMap Symbol (GHC.Module, RTAlias Symbol ())
-collectTypeAliases m spec deps =
-    let bsAliases = [ (getLHNameSymbol . val $ rtName a, (m, void a)) | a <- map val (aliases spec) ]
-        depAliases =
-          [ (getLHNameSymbol . val $ rtName a, (GHC.unStableModule sm, void a))
+  -> InScopeEnv (RTAlias Symbol ())
+collectTypeAliases impMods thisModule spec deps =
+    let bsAliases = mkAliasEnvUnfiltered thisModule impMods (thisModule, bsNames)
+        bsNames = [ (val . rtName $ rta, void rta) | rta <- map val (aliases spec)]
+        depAliases = map (mkAliasEnvUnfiltered thisModule impMods) $
+          [ (m, depNames)
           | (sm, lspec) <- HM.toList (getDependencies deps)
-          , a <- map val (HS.toList $ liftedAliases lspec)
+          , let m = GHC.unStableModule sm
+          , let depNames = [ (val . rtName $ rta , void rta)
+                           | rta <- map val $ HS.toList $ liftedAliases lspec
+                           ]
           ]
      in
-        HM.fromList $ bsAliases ++ depAliases
+        unionAliasEnvs $ bsAliases : depAliases
 
 collectExprAliases
   :: BareSpecParsed
@@ -186,7 +192,7 @@ resolveLHNames cfg thisModule localVars impMods globalRdrEnv bareSpec0 dependenc
     else
       Left (roErrors ro)
   where
-    taliases = collectTypeAliases thisModule bareSpec0 dependencies
+    taliases = collectTypeAliases impMods thisModule bareSpec0 dependencies
     allEaliases = collectExprAliases bareSpec0 dependencies
 
     -- add defines from dependencies to the logical map
@@ -212,9 +218,10 @@ resolveLHNames cfg thisModule localVars impMods globalRdrEnv bareSpec0 dependenc
           | s == "*" ->
             pure $ LHNResolved (LHRGHC GHC.liftedTypeKindTyConName) s
           | otherwise ->
-            case HM.lookup s taliases of
-              Just (m, _) -> pure $ LHNResolved (LHRLogic $ LogicName s m Nothing) s
-              Nothing -> lookupGRELHName LHTcName lname s listToMaybe
+            case lookupInScopeNonReflectedEnv taliases s of
+              Right [(m, _, _)] -> pure $ LHNResolved (LHRLogic $ LogicName s m Nothing) s
+              -- TEMP-NOTE: might have to handle multiple matches here
+              _ -> lookupGRELHName LHTcName lname s listToMaybe
         LHNUnresolved ns@(LHVarName lcl) s
           | isDataCon s ->
               lookupGRELHName (LHDataConName lcl) lname s listToMaybe
@@ -399,9 +406,8 @@ resolveBoundVarsInTypeAliases = updateAliases resolveBoundVars
 --
 -- the parser builds a type for @Ev (plus n n)@.
 --
--- TEMP-NOTE: what's going on here?
 fixExpressionArgsOfTypeAliases
-  :: HM.HashMap Symbol (GHC.Module, RTAlias Symbol ())
+  :: InScopeEnv (RTAlias Symbol ())
   -> BareSpecParsed
   -> BareSpecParsed
 fixExpressionArgsOfTypeAliases taliases =
@@ -409,8 +415,8 @@ fixExpressionArgsOfTypeAliases taliases =
   where
     go :: BareTypeParsed -> BareTypeParsed
     go (RApp c@(BTyCon { btc_tc = Loc _ _ (LHNUnresolved LHTcName s) }) ts rs r)
-      | Just (_, rta) <- HM.lookup s taliases =
-        RApp c (fixExprArgs (btc_tc c) rta (map go ts)) (map goRef rs) r
+      | Right [(_, _, rta)] <- lookupInScopeNonReflectedEnv taliases s =
+          RApp c (fixExprArgs (btc_tc c) rta (map go ts)) (map goRef rs) r
     go (RApp c ts rs r) =
         RApp c (map go ts) (map goRef rs) r
     go (RAppTy t1 t2 r)  = RAppTy (go t1) (go t2) r
@@ -463,13 +469,16 @@ exprArg l msg = notracepp ("exprArg: " ++ msg) . go
 --
 -- For each symbol we have the aliases with which it is imported and the
 -- name corresponding to each alias.
-type InScopeNonReflectedEnv = SEnv [(GHC.ModuleName, (GHC.Module, LHName))]
+-- TEMP-NOTE: update doc
+type InScopeEnv a = SEnv [(GHC.ModuleName, (GHC.Module, LHName, a))]
+
+type InScopeNonReflectedEnv = InScopeEnv ()
 
 -- | Looks the names in scope with the given symbol.
 -- Returns a list of close but different symbols or a non empty list
 -- with the matched names.
 lookupInScopeNonReflectedEnv
-  :: InScopeNonReflectedEnv -> Symbol -> Either [Symbol] [(GHC.Module, LHName)]
+  :: InScopeEnv a -> Symbol -> Either [Symbol] [(GHC.Module, LHName, a)]
 lookupInScopeNonReflectedEnv env s = do
     let n = LH.dropModuleNames s
     case lookupSEnvWithDistance n env of
@@ -524,6 +533,7 @@ makeLogicEnvs impMods thisModule spec dependencies =
           (thisModule, thisModuleNames) :
           map (fmap collectLiftedSpecLogicNames) dependencyPairs
           ++ unhandledLogicNames
+        logicNamesWithUnit = map (\(m,lhnames) -> (m, map (,()) lhnames)) logicNames
         thisModuleNames = concat
           [ [ reflectLHName thisModule (val n)
             | n <- concat
@@ -545,7 +555,7 @@ makeLogicEnvs impMods thisModule spec dependencies =
           mconcat $
             privateReflects spec : map (liftedPrivateReflects . snd) dependencyPairs
      in
-        ( unionAliasEnvs $ map (mkAliasEnv thisModule impMods) logicNames
+        ( unionAliasEnvs $ map (mkAliasEnv thisModule impMods) $ logicNamesWithUnit
         , mkLogicNameEnv (concatMap snd logicNames)
         , privateReflectNames
         , unhandledNames
@@ -561,23 +571,34 @@ makeLogicEnvs impMods thisModule spec dependencies =
         , lneReflected = GHC.mkNameEnv [(rn, n) | n <- names, Just rn <- [maybeReflectedLHName n]]
         }
 
-unionAliasEnvs :: [InScopeNonReflectedEnv] -> InScopeNonReflectedEnv
+unionAliasEnvs :: forall a. [InScopeEnv a] -> InScopeEnv a
 unionAliasEnvs =
     coerce .
-    HM.map (nubBy (\(alias1, (_, n1)) (alias2, (_, n2)) -> alias1 == alias2 && n1 == n2)) .
+    HM.map (nubBy (\(alias1, (_, n1, _)) (alias2, (_, n2, _)) -> alias1 == alias2 && n1 == n2)) .
     foldl' (HM.unionWith (++)) HM.empty .
-    coerce @_ @[HM.HashMap Symbol [(GHC.ModuleName, (GHC.Module, LHName))]]
+    coerce @_ @[HM.HashMap Symbol [(GHC.ModuleName, (GHC.Module, LHName, a))]]
 
-mkAliasEnv :: GHC.Module -> GHC.ImportedMods -> (GHC.Module, [LHName]) -> InScopeNonReflectedEnv
+-- TEMP-NOTE: Creates an environment packing the resolved logic names of a module
+-- with the aliases it is imported.
+mkAliasEnv :: GHC.Module -> GHC.ImportedMods -> (GHC.Module, [(LHName, a)]) -> InScopeEnv a
 mkAliasEnv thisModule impAvails (m, lhnames) =
     let aliases = moduleAliases thisModule impAvails m
      in fromListSEnv
-          [ (s, map (,(m, lhname)) aliases)
+          [ (s, map (,(m, lhname, x)) aliases)
             -- Note that only non-reflected names go to the InScope environment.
             -- See the local function resolveVarName for more details.
-          | lhname@(LHNResolved (LHRLogic (LogicName s _ Nothing)) _) <- lhnames
+          | (lhname@(LHNResolved (LHRLogic (LogicName s _ Nothing)) _), x) <- lhnames
           ]
 
+-- TEMP-NOTE: Creates an environment packing the names of a module
+-- with the aliases it is imported.
+mkAliasEnvUnfiltered :: GHC.Module -> GHC.ImportedMods -> (GHC.Module, [(LHName, a)]) -> InScopeEnv a
+mkAliasEnvUnfiltered thisModule impMods (m, lhnames) =
+    let aliases = moduleAliases thisModule impMods m
+     in fromListSEnv
+          [ (getLHNameSymbol lhname, map (,(m, lhname, x)) aliases)
+          | (lhname, x) <- lhnames
+          ]
 
 moduleAliases :: GHC.Module -> GHC.ImportedMods -> GHC.Module -> [GHC.ModuleName]
 moduleAliases thisModule impAvails m =
@@ -679,7 +700,7 @@ resolveLogicNames cfg env globalRdrEnv unhandledNames lmap0 localVars lnameEnv p
                   unless (HS.member s unhandledNames) $
                     addError (errResolveLogicName ls alts)
                   return $ makeLocalLHName s
-          Right [(_, lhname)] ->
+          Right [(_, lhname, _)] ->
             return lhname
           Right names -> do
             addError $
@@ -689,7 +710,7 @@ resolveLogicNames cfg env globalRdrEnv unhandledNames lmap0 localVars lnameEnv p
                 [ pprint (lhNameToResolvedSymbol n) PJ.<+>
                   PJ.text
                     ("imported from " ++ GHC.moduleNameString (GHC.moduleName m))
-                | (m, n) <- names
+                | (m, n, _) <- names
                 ]
             return $ makeLocalLHName s
       where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -887,6 +887,8 @@ data BPspec
   | RInst   (RInstance LocBareTypeParsed)                 -- ^ refined 'instance' definition
   | Invt    LocBareTypeParsed                             -- ^ 'invariant' specification
   | Using  (LocBareTypeParsed, LocBareTypeParsed)         -- ^ 'using' declaration (for local invariants on a type)
+  -- TEMP-NOTE: (1) This are the representation of aliases on
+  -- the first transformation (parsing) of the spec comments.
   | Alias   (Located (RTAlias Symbol BareTypeParsed))     -- ^ 'type' alias declaration
   | EAlias  (Located (RTAlias Symbol (ExprV LocSymbol)))  -- ^ 'predicate' alias declaration
   | Embed   (Located LHName, FTycon, TCArgs)              -- ^ 'embed' declaration
@@ -1083,6 +1085,8 @@ mkSpec xs = Measure.Spec
   , Measure.ialiases   = [t | Using t <- xs]
   , Measure.dataDecls  = [d | DDecl  d <- xs] ++ [d | NTDecl d <- xs]
   , Measure.newtyDecls = [d | NTDecl d <- xs]
+  -- TEMP-NOTE: (2) This is the second parsing of the spec, which just groups
+  -- the specs directives to form the BarseSpecParsed.
   , Measure.aliases    = [a | Alias  a <- xs]
   , Measure.ealiases   = [e | EAlias e <- xs]
   , Measure.embeds     = tceFromList [(c, (fTyconSort tc, a)) | Embed (c, tc, a) <- xs]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -1312,7 +1312,8 @@ rtAliasP f bodyP
        body <- bodyP
        posE <- getSourcePos
        let (tArgs, vArgs) = partition (isSmall . headSym) args
-       return $ Loc pos posE (RTA (makeUnresolvedLHName LHLogicName name) (f <$> tArgs) vArgs body)
+       -- TEMP-NOTE: Parsing produces un-resolved names.
+       return $ Loc pos posE (RTA (makeUnresolvedLHName LHLogicNameBinder name) (f <$> tArgs) vArgs body)
 
 logDefineP :: Parser BPspec
 logDefineP =

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -1307,13 +1307,14 @@ rtAliasP :: (Symbol -> tv) -> Parser ty -> Parser (Located (RTAlias tv ty))
 rtAliasP f bodyP
   = do pos  <- getSourcePos
        name <- upperIdP
+       posNE <- getSourcePos
        args <- many aliasIdP
        reservedOp "="
        body <- bodyP
        posE <- getSourcePos
        let (tArgs, vArgs) = partition (isSmall . headSym) args
        -- TEMP-NOTE: Parsing produces un-resolved names.
-       return $ Loc pos posE (RTA (makeUnresolvedLHName LHLogicNameBinder name) (f <$> tArgs) vArgs body)
+       return $ Loc pos posE (RTA (Loc pos posNE $ makeUnresolvedLHName LHLogicNameBinder name) (f <$> tArgs) vArgs body)
 
 logDefineP :: Parser BPspec
 logDefineP =

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -1303,8 +1303,8 @@ ealiasP = try (rtAliasP symbol predP)
       <?> "ealiasP"
 
 -- | Parser for a LH type synonym.
-rtAliasP :: GHC.Module -> (Symbol -> tv) -> Parser ty -> Parser (Located (RTAlias tv ty))
-rtAliasP m f bodyP
+rtAliasP :: (Symbol -> tv) -> Parser ty -> Parser (Located (RTAlias tv ty))
+rtAliasP f bodyP
   = do pos  <- getSourcePos
        name <- upperIdP
        args <- many aliasIdP
@@ -1312,7 +1312,7 @@ rtAliasP m f bodyP
        body <- bodyP
        posE <- getSourcePos
        let (tArgs, vArgs) = partition (isSmall . headSym) args
-       return $ Loc pos posE (RTA (makeLogicLHName name m Nothing) (f <$> tArgs) vArgs body)
+       return $ Loc pos posE (RTA (makeUnresolvedLHName LHLogicName name) (f <$> tArgs) vArgs body)
 
 logDefineP :: Parser BPspec
 logDefineP =

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -1303,8 +1303,8 @@ ealiasP = try (rtAliasP symbol predP)
       <?> "ealiasP"
 
 -- | Parser for a LH type synonym.
-rtAliasP :: (Symbol -> tv) -> Parser ty -> Parser (Located (RTAlias tv ty))
-rtAliasP f bodyP
+rtAliasP :: GHC.Module -> (Symbol -> tv) -> Parser ty -> Parser (Located (RTAlias tv ty))
+rtAliasP m f bodyP
   = do pos  <- getSourcePos
        name <- upperIdP
        args <- many aliasIdP
@@ -1312,7 +1312,7 @@ rtAliasP f bodyP
        body <- bodyP
        posE <- getSourcePos
        let (tArgs, vArgs) = partition (isSmall . headSym) args
-       return $ Loc pos posE (RTA name (f <$> tArgs) vArgs body)
+       return $ Loc pos posE (RTA (makeLogicLHName name m Nothing) (f <$> tArgs) vArgs body)
 
 logDefineP :: Parser BPspec
 logDefineP =

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
@@ -117,11 +117,11 @@ instance Hashable LHName where
   hashWithSalt s (LHNUnresolved ns sym) = s `hashWithSalt` ns `hashWithSalt` sym
 
 data LHNameSpace
-    = LHTcName
-    | LHDataConName LHThisModuleNameFlag
-    | LHVarName LHThisModuleNameFlag
-    | LHLogicNameBinder
-    | LHLogicName
+    = LHTcName                            -- ^ Type constructors
+    | LHDataConName LHThisModuleNameFlag  -- ^ Data constructors with procedence
+    | LHVarName LHThisModuleNameFlag      -- ^ Variables with procedence
+    | LHLogicNameBinder                   -- ^ Logic names (LHS)
+    | LHLogicName                         -- ^ Logic names (RHS)
   deriving (Data, Eq, Generic, Ord, Show)
 
 instance B.Binary LHNameSpace

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -1583,7 +1583,7 @@ shiftVV t _
 -- MOVE TO TYPES
 instance (Show tv, Show ty) => Show (RTAlias tv ty) where
   show (RTA n as xs t) =
-    printf "type %s %s %s = %s" (symbolString n)
+    printf "type %s %s %s = %s" (symbolString . getLHNameSymbol $ n)
       (unwords (show <$> as))
       (unwords (show <$> xs))
       (show t)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -1583,7 +1583,7 @@ shiftVV t _
 -- MOVE TO TYPES
 instance (Show tv, Show ty) => Show (RTAlias tv ty) where
   show (RTA n as xs t) =
-    printf "type %s %s %s = %s" (symbolString . getLHNameSymbol $ n)
+    printf "type %s %s %s = %s" (symbolString . getLHNameSymbol . val $ n)
       (unwords (show <$> as))
       (unwords (show <$> xs))
       (show t)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -387,6 +387,7 @@ data Spec lname ty = Spec
   , ialiases   :: ![(F.Located ty, F.Located ty)]                     -- ^ Data type invariants to be checked
   , dataDecls  :: ![DataDeclP lname ty]                               -- ^ Predicated data definitions
   , newtyDecls :: ![DataDeclP lname ty]                               -- ^ Predicated new type definitions
+  -- TEMP-NOTE: fields for the relevant aliases
   , aliases    :: ![F.Located (RTAlias F.Symbol (BareTypeV lname))]   -- ^ RefType aliases
   , ealiases   :: ![F.Located (RTAlias F.Symbol (F.ExprV lname))]     -- ^ Expression aliases
   , embeds     :: !(F.TCEmb (F.Located LHName))                       -- ^ GHC-Tycon-to-fixpoint Tycon map

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -729,6 +729,7 @@ data LiftedSpec = LiftedSpec
     -- ^ Predicated data definitions
   , liftedNewtyDecls :: HashSet DataDeclLHName
     -- ^ Predicated new type definitions
+    -- TEMP-NOTE: The lifted aliases values
   , liftedAliases    :: HashSet (F.Located (RTAlias F.Symbol BareTypeLHName))
     -- ^ RefType aliases
   , liftedEaliases   :: HashSet (F.Located (RTAlias F.Symbol (F.ExprV LHName)))

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -372,7 +372,7 @@ instance Show (Axiom Var Type CoreExpr) where
 --------------------------------------------------------------------------------
 -- TEMP-NOTE: Data type for type aliases
 data RTAlias x a = RTA
-  { rtName  :: LHName             -- ^ name of the alias
+  { rtName  :: F.Located LHName   -- ^ name of the alias
   , rtTArgs :: [x]                -- ^ type parameters
   , rtVArgs :: [Symbol]           -- ^ value parameters
   , rtBody  :: a                  -- ^ what the alias expands to
@@ -389,7 +389,7 @@ mapRTAVars f rt = rt { rtTArgs = f <$> rtTArgs rt }
 -- 'TargetSpec' (actually, the 'GhcSpec' it is derived from), so it needs to
 -- /generate/ resolved names.
 lmapEAlias :: LMap -> F.Located (RTAlias Symbol Expr)
-lmapEAlias (LMap v ys e) = F.atLoc v (RTA (makeGeneratedLogicLHName (F.val v)) [] ys e) -- (F.loc v) (F.loc v)
+lmapEAlias (LMap v ys e) = F.atLoc v (RTA (F.dummyLoc $ makeGeneratedLogicLHName (F.val v)) [] ys e) -- (F.loc v) (F.loc v)
 
 
 -- | The type used during constraint generation, used

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -370,8 +370,9 @@ instance Show (Axiom Var Type CoreExpr) where
 --------------------------------------------------------------------------------
 -- | Refinement Type Aliases
 --------------------------------------------------------------------------------
+-- TEMP-NOTE: Data type for type aliases
 data RTAlias x a = RTA
-  { rtName  :: Symbol             -- ^ name of the alias
+  { rtName  :: LHName             -- ^ name of the alias
   , rtTArgs :: [x]                -- ^ type parameters
   , rtVArgs :: [Symbol]           -- ^ value parameters
   , rtBody  :: a                  -- ^ what the alias expands to
@@ -384,8 +385,8 @@ data RTAlias x a = RTA
 mapRTAVars :: (a -> b) -> RTAlias a ty -> RTAlias b ty
 mapRTAVars f rt = rt { rtTArgs = f <$> rtTArgs rt }
 
-lmapEAlias :: LMap -> F.Located (RTAlias Symbol Expr)
-lmapEAlias (LMap v ys e) = F.atLoc v (RTA (F.val v) [] ys e) -- (F.loc v) (F.loc v)
+lmapEAlias :: LMap -> Ghc.Module -> F.Located (RTAlias Symbol Expr)
+lmapEAlias (LMap v ys e) m = F.atLoc v (RTA (makeLogicLHName (F.val v) m Nothing) [] ys e) -- (F.loc v) (F.loc v)
 
 
 -- | The type used during constraint generation, used

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -385,8 +385,11 @@ data RTAlias x a = RTA
 mapRTAVars :: (a -> b) -> RTAlias a ty -> RTAlias b ty
 mapRTAVars f rt = rt { rtTArgs = f <$> rtTArgs rt }
 
+-- TEMP-NOTE: This function is only (implicitly) used during the making of the
+-- 'TargetSpec' (actually, the 'GhcSpec' it is derived from), so it needs to
+-- /generate/ resolved names.
 lmapEAlias :: LMap -> F.Located (RTAlias Symbol Expr)
-lmapEAlias (LMap v ys e) = F.atLoc v (RTA (makeUnresolvedLHName LHLogicName (F.val v)) [] ys e) -- (F.loc v) (F.loc v)
+lmapEAlias (LMap v ys e) = F.atLoc v (RTA (makeGeneratedLogicLHName (F.val v)) [] ys e) -- (F.loc v) (F.loc v)
 
 
 -- | The type used during constraint generation, used

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -385,8 +385,8 @@ data RTAlias x a = RTA
 mapRTAVars :: (a -> b) -> RTAlias a ty -> RTAlias b ty
 mapRTAVars f rt = rt { rtTArgs = f <$> rtTArgs rt }
 
-lmapEAlias :: LMap -> Ghc.Module -> F.Located (RTAlias Symbol Expr)
-lmapEAlias (LMap v ys e) m = F.atLoc v (RTA (makeLogicLHName (F.val v) m Nothing) [] ys e) -- (F.loc v) (F.loc v)
+lmapEAlias :: LMap -> F.Located (RTAlias Symbol Expr)
+lmapEAlias (LMap v ys e) = F.atLoc v (RTA (makeUnresolvedLHName LHLogicName (F.val v)) [] ys e) -- (F.loc v) (F.loc v)
 
 
 -- | The type used during constraint generation, used
@@ -561,6 +561,7 @@ getModString = moduleNameString . getModName
 --------------------------------------------------------------------------------
 -- | Refinement Type Aliases ---------------------------------------------------
 --------------------------------------------------------------------------------
+-- TEMP-NOTE: should I change this Symbol to LHName?
 data RTEnv tv t = RTE
   { typeAliases :: M.HashMap Symbol (F.Located (RTAlias tv t))
   , exprAliases :: M.HashMap Symbol (F.Located (RTAlias Symbol Expr))

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/QuasiQuoter.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/QuasiQuoter.hs
@@ -93,7 +93,7 @@ mkSpecDecs (Alias rta) =
   return . TySynD name tvs <$> simplifyBareType parsedToBareType lsym (rtBody (val rta))
   where
     lsym = F.atLoc rta n
-    name = symbolName n
+    name = symbolName $ getLHNameSymbol n
     n    = rtName (val rta)
     tvs  = (\a -> PlainTV (symbolName a) BndrReq) <$> rtTArgs (val rta)
 mkSpecDecs _ =

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/QuasiQuoter.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/QuasiQuoter.hs
@@ -93,7 +93,7 @@ mkSpecDecs (Alias rta) =
   return . TySynD name tvs <$> simplifyBareType parsedToBareType lsym (rtBody (val rta))
   where
     lsym = F.atLoc rta n
-    name = symbolName $ getLHNameSymbol n
+    name = symbolName $ getLHNameSymbol $ val n
     n    = rtName (val rta)
     tvs  = (\a -> PlainTV (symbolName a) BndrReq) <$> rtTArgs (val rta)
 mkSpecDecs _ =

--- a/tests/names/neg/QualifiedAliases.hs
+++ b/tests/names/neg/QualifiedAliases.hs
@@ -1,14 +1,20 @@
-{-@ LIQUID "--expect-error-containing=Multiple definitions of Type Alias" @-}
+{-@ LIQUID "--expect-any-error" @-}
 
 -- | This is an instance of LiquidHaskell having a flat import namespace
--- for logic names. Here, both Nat modules export the same type alias 'INat',
--- producing an error even though we explicitly qualify it to avoid ambiguity.
+-- for logic names. Here, both @Nat@ modules export a type alias with
+-- the same name @INat@. With current behavior this module produces a
+-- _Multiple definition of Type Alias_ error when using the alias unqualified,
+-- and an _Unknown type constructor_ error with the qualified alias.
+-- NOTE: This test will be moved to @names-pos@ after fixing issue #2841
 module QualifiedAliases where
 
 import qualified Nat1 as N
 import Nat2
 
 {-@ llength :: [a] -> Nat @-}
-llength :: [a] -> Int
 llength [] = 0
 llength (x : xs) = 1 + length xs
+
+{-@ llength' :: [a] -> N.Nat @-}
+llength' [] = 0
+llength' (x : xs) = 1 + length xs

--- a/tests/names/neg/QualifiedAliases.hs
+++ b/tests/names/neg/QualifiedAliases.hs
@@ -11,10 +11,10 @@ module QualifiedAliases where
 import qualified Nat1 as N
 import Nat2
 
-{-@ llength :: [a] -> Nat @-}
+{-@ llength :: [a] -> INat @-}
 llength [] = 0
 llength (x : xs) = 1 + length xs
 
-{-@ llength' :: [a] -> N.Nat @-}
+{-@ llength' :: [a] -> N.INat @-}
 llength' [] = 0
 llength' (x : xs) = 1 + length xs


### PR DESCRIPTION
For #2481 
I paremeterized `InScopeNonReflectedEnv` to create an environment for qualified type aliases names, this is based on #2550 . For this, I refactored `makeLogicEnvs` by moving some of its local functions to the top-level.

