### PR TITLE
liquidhaskell-boot.cabal: relax upper bounds on Diff and optparse-applicative

### DIFF
--- a/liquidhaskell-boot/liquidhaskell-boot.cabal
+++ b/liquidhaskell-boot/liquidhaskell-boot.cabal
@@ -122,7 +122,7 @@ library
   hs-source-dirs:     src src-ghc src-ghc-9.10
 
   build-depends:      base                 >= 4.11.1.0 && < 5
-                    , Diff                 >= 0.3 && < 0.6
+                    , Diff                 >= 0.3 && < 1.1
                     , array
                     , aeson
                     , binary
@@ -144,7 +144,7 @@ library
                     , hscolour             >= 1.22
                     , liquid-fixpoint      == 0.9.6.3.3
                     , mtl                  >= 2.1
-                    , optparse-applicative < 0.19
+                    , optparse-applicative < 0.20
                     , githash
                     , megaparsec           >= 8
                     , pretty               >= 1.1


### PR DESCRIPTION
I checked that it builds with the latest versions.

I'd appreciate it if you could revise on hackage both 0.9.12.2 and 0.9.10.1.2.