### PR TITLE
Fix name resolution of tuple expressions in type alias applications

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -513,7 +513,13 @@ mapMBareTypes f  = go
 --   the string `Prop (Ev (plus n n))` where `Prop` is the alias:
 --     {-@ type Prop E = {v:_ | prop v = E} @-}
 --   the parser will chomp in `Ev (plus n n)` as a `BareType` and so
---   `exprArg` converts that `BareType` into an `Expr`.
+-- | @exprArg@ converts a type to a value.
+--   
+--   At parse time the arguments of type aliases are all treated as types.
+--   This needs fixing before verification because some arguments are
+--   meant to be values. Hence, this function to correct the
+--   arguments in question. See the documentation of
+--   @fixExpressionArgsOfTypeAliases@ for some more context.
 exprArg :: SourcePos -> String -> BareTypeParsed -> ExprV LocSymbol
 exprArg l msg = notracepp ("exprArg: " ++ msg) . go
   where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -457,7 +457,21 @@ resolveBoundVarsInTypeAliases = updateAliases resolveBoundVars
 -- > {-@ type Prop E = {v:_ | prop v = E} @-}
 --
 -- the parser builds a type for @Ev (plus n n)@.
+-- | @fixExpressionArgsOfTypeAliases taliases spec@ converts types to
+-- values when they appear in value positions of type aliases according
+-- to @taliases@.
 --
+-- The expression arguments of type aliases are initially parsed as
+-- types. This function converts them to expressions.
+--
+-- For instance, in @Prop (Ev (plus n n))@ where `Prop` is the alias
+--
+-- > {-@ type Prop E = {v:_ | prop v = E} @-}
+--
+-- the parser builds a type for @Ev (plus n n)@, making a type
+-- constructor of @Ev@ and type variables of @plus@ and @n@. But
+-- @Ev@ is really a data constructor, @plus@ is a function, and @n@
+-- is a value. 
 fixExpressionArgsOfTypeAliases
   :: InScopeEnv (RTAlias Symbol ())
   -> BareSpecParsed

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -519,12 +519,17 @@ exprArg l msg = notracepp ("exprArg: " ++ msg) . go
   where
     go :: BareTypeParsed -> ExprV LocSymbol
     go (RExprArg e)     = val e
-    go (RVar (BTV x) _)       = EVar x
+    go (RVar (BTV x) _) = EVar x
     go (RApp x [] [] _) = EVar (getLHNameSymbol <$> btc_tc x)
-    go (RApp f ts [] _) = eApps (EVar (getLHNameSymbol <$> btc_tc f)) (go <$> ts)
+    go (RApp f ts [] _) = eApps (EVar (renameAmbiguousCtor . getLHNameSymbol <$> btc_tc f)) (go <$> ts)
     go (RAppTy t1 t2 _) = EApp (go t1) (go t2)
     go z                = panic sp $ Printf.printf "Unexpected expression parameter: %s in %s" (show $ parsedToBareType z) msg
     sp                  = Just (LH.sourcePosSrcSpan l)
+
+renameAmbiguousCtor :: Symbol -> Symbol
+renameAmbiguousCtor x
+  | Just n <- isTyTupleSizedSymbol x = tmTupleSizedSymbol n
+  | otherwise = x
 
 -- | A type alias 'lookupInScopeEnv' that distinguishes locally defined names
 -- from imported ones based on their resolution status:

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -783,11 +783,11 @@ bTup [(_,t)] _ r
 bTup ts rs r
   | all (Mb.isNothing . fst) ts || length ts < 2
   = RApp
-      (mkBTyCon $ dummyLoc $ makeUnresolvedLHName (LHTcName LHAnyModuleNameF) $ fromString $ "Tuple" ++ show (length ts))
+      (mkBTyCon $ dummyLoc $ makeUnresolvedLHName (LHTcName LHAnyModuleNameF) $ tyTupleSizedSymbol (length ts))
       (snd <$> ts) rs (reftUReft r)
   | otherwise
   = RApp
-      (mkBTyCon $ dummyLoc $ makeUnresolvedLHName (LHTcName LHAnyModuleNameF) $ fromString $ "Tuple" ++ show (length ts))
+      (mkBTyCon $ dummyLoc $ makeUnresolvedLHName (LHTcName LHAnyModuleNameF) $ tyTupleSizedSymbol (length ts))
       (mapReft (const trueURef) . snd <$> ts)
       rs'
       (reftUReft r)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
@@ -56,6 +56,7 @@ import GHC.Show
 import GHC.Stack
 import Language.Fixpoint.Types
 import Language.Haskell.Liquid.GHC.Misc ( locNamedThing ) -- Symbolic GHC.Name
+import Text.Read (readMaybe)
 import qualified Liquid.GHC.API as GHC
 
 import GHC.Types (Any)
@@ -81,19 +82,17 @@ selfSymbol :: Symbol
 selfSymbol = symbol ("liquid_internal_this" :: String)
 
 tyTupleSizedSymbol :: Int -> Symbol
-tyTupleSizedSymbol n = symbol $ "Tuple" ++ show n
+tyTupleSizedSymbol n | n < 0     = error "tyTupleSizedSymbol: negative arity"
+                     | otherwise = symbol $ "Tuple" ++ show n
 
 isTyTupleSizedSymbol :: Symbol -> Maybe Int
-isTyTupleSizedSymbol s =
-  case Text.stripPrefix "Tuple" (symbolText s) of
-    Just rest
-      | all (`elem` ['0'..'9']) $ Text.unpack rest
-      , not $ Text.null rest
-      -> Just $ read $ Text.unpack rest
-    _ -> Nothing
+isTyTupleSizedSymbol s = Text.stripPrefix "Tuple" (symbolText s)
+                     >>= readMaybe . Text.unpack
 
 tmTupleSizedSymbol :: Int -> Symbol
-tmTupleSizedSymbol n | n == 1    = "MkSolo"
+tmTupleSizedSymbol n | n < 0     = error "tmTupleSizedSymbol: negative arity"
+                     | n == 0    = "()"
+                     | n == 1    = "MkSolo"
                      | otherwise = symbol $ "(" <> replicate (n - 1) ',' <> ")"
 
 -- | A name for an entity that does not exist in Haskell

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
@@ -9,6 +9,9 @@ module Language.Haskell.Liquid.Types.Names
   , propSymbol
   , getPropIndex
   , selfSymbol
+  , tyTupleSizedSymbol
+  , isTyTupleSizedSymbol
+  , tmTupleSizedSymbol
   , LogicName (..)
   , LHResolvedName (..)
   , LHName (..)
@@ -76,6 +79,22 @@ anyTypeSymbol = symbol (show ''Any)
 
 selfSymbol :: Symbol
 selfSymbol = symbol ("liquid_internal_this" :: String)
+
+tyTupleSizedSymbol :: Int -> Symbol
+tyTupleSizedSymbol n = symbol $ "Tuple" ++ show n
+
+isTyTupleSizedSymbol :: Symbol -> Maybe Int
+isTyTupleSizedSymbol s =
+  case Text.stripPrefix "Tuple" (symbolText s) of
+    Just rest
+      | all (`elem` ['0'..'9']) $ Text.unpack rest
+      , not $ Text.null rest
+      -> Just $ read $ Text.unpack rest
+    _ -> Nothing
+
+tmTupleSizedSymbol :: Int -> Symbol
+tmTupleSizedSymbol n | n == 1    = "MkSolo"
+                     | otherwise = symbol $ "(" <> replicate (n - 1) ',' <> ")"
 
 -- | A name for an entity that does not exist in Haskell
 --

--- a/tests/names/pos/TupleParse.hs
+++ b/tests/names/pos/TupleParse.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE GADTs #-}
+
+module TupleParse where
+
+import Language.Haskell.Liquid.ProofCombinators
+
+{-@ type Ix typ E = {v:typ | prop v = E} @-}
+
+data Foo where
+  {-@ MkFoo :: x:Int -> Ix Foo (x, x) @-}
+  MkFoo :: Int -> Foo

--- a/tests/names/pos/TupleParse.hs
+++ b/tests/names/pos/TupleParse.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE GADTs #-}
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple"        @-}
 
 module TupleParse where
 
@@ -9,3 +11,13 @@ import Language.Haskell.Liquid.ProofCombinators
 data Foo where
   {-@ MkFoo :: x:Int -> Ix Foo (x, x) @-}
   MkFoo :: Int -> Foo
+
+
+{-@ type Alias a B = { v:a | B = B } @-}
+{-@ tuples :: Alias (a, b) 1 -> Alias (b, a) 1 @-}
+tuples :: (a, b) -> (b, a)
+tuples (x, y) = (y, x)
+
+{-@ goldbachsconjecture  :: { (1, 2) /= (2, 1) } @-}
+goldbachsconjecture :: Proof
+goldbachsconjecture = trivial

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -767,6 +767,7 @@ executable names-pos
                     , T1521
                     , T675
                     , TransitivePredAliases
+                    , TupleParse
                     , TypeAliasShadowing
                     , Uniques
                     , Vector04


### PR DESCRIPTION
This PR fixes name resolution so the following example stops failing.

```haskell
module Minimal where

import Language.Haskell.Liquid.ProofCombinators

{-@ type Ix typ E = {v:typ | prop v = E} @-}

data Foo where
  {-@ MkFoo :: x:Int -> Ix Foo (x, x) @-}
  MkFoo :: Int -> Foo
```

This was the error produced:
```
[1 of 1] Compiling Minimal          ( Minimal.hs, Minimal.o )
Fixpoint.Types.dummyLoc:1:1: error:
    Unknown logic name `Tuple2`
    Cannot resolve name
    Maybe you meant one of: len autolen
```