### PR TITLE
Show solutions of non-cut kvars in error messages

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
@@ -135,29 +135,29 @@ solveCs cfg tgt cgi info names = do
   finfo            <- cgInfoFInfo info cgi
   let fcfg          = fixConfig tgt cfg
   F.Result {resStatus=r0, resSolution=solCuts, resNonCutsSolution=solNonCuts} <- solve fcfg finfo
-  let sol           = HashMap.union solCuts solNonCuts
+  let sol           = HashMap.union (HashMap.map F.Delayed solCuts) solNonCuts
   let failBs        = gsFail $ gsTerm $ giSpec info
   let (r,rf)        = splitFails (S.map val failBs) r0 
   let resErr        = second (applySolution finfo sol . cinfoError) <$> r
   -- resModel_        <- fmap (e2u cfg sol) <$> getModels info cfg resErr
-  let resModel_     = cidE2u cfg sol <$> resErr
-  let resModel'     = resModel_  `addErrors` (e2u cfg sol <$> logErrors cgi)
+  let resModel_     = cidE2u cfg <$> resErr
+  let resModel'     = resModel_  `addErrors` (e2u cfg <$> logErrors cgi)
                                  `addErrors` makeFailErrors (S.toList failBs) rf 
                                  `addErrors` makeFailUseErrors (S.toList failBs) (giCbs $ giSrc info)
   let lErrors       = applySolution finfo sol <$> logErrors cgi
-  let resModel      = resModel' `addErrors` (e2u cfg sol <$> lErrors)
+  let resModel      = resModel' `addErrors` (e2u cfg <$> lErrors)
   let out0          = mkOutput cfg resModel finfo sol (annotMap cgi)
   return            $ out0 { o_vars    = names    }
                            { o_result  = resModel }
 
 
-e2u :: Config -> F.FixSolution -> Error -> UserError
-e2u cfg s = fmap F.pprint . tidyError cfg s
+e2u :: Config -> Error -> UserError
+e2u cfg = fmap F.pprint . tidyError cfg
 
-cidE2u :: Config -> F.FixSolution -> (Integer, Error) -> UserError
-cidE2u cfg s (subcId, e) =
+cidE2u :: Config -> (Integer, Error) -> UserError
+cidE2u cfg (subcId, e) =
   let e' = attachSubcId e
-   in fmap F.pprint (tidyError cfg s e')
+   in fmap F.pprint (tidyError cfg e')
   where
     attachSubcId es@ErrSubType{}      = es { cid = Just subcId }
     attachSubcId es@ErrSubTypeModel{} = es { cid = Just subcId }

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
@@ -12,6 +12,7 @@ import           Data.Bifunctor
 import qualified Data.HashSet as S 
 import           Text.PrettyPrint.HughesPJ
 import           Control.Monad (when)
+import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Maybe as Mb
 import qualified Data.List  as L 
 import qualified Language.Haskell.Liquid.UX.DiffCheck as DC
@@ -133,18 +134,19 @@ solveCs :: Config -> FilePath -> CGInfo -> TargetInfo -> Maybe [String] -> IO (O
 solveCs cfg tgt cgi info names = do
   finfo            <- cgInfoFInfo info cgi
   let fcfg          = fixConfig tgt cfg
-  F.Result {resStatus=r0, resSolution=sol} <- solve fcfg finfo
+  F.Result {resStatus=r0, resSolution=solCuts, resNonCutsSolution=solNonCuts} <- solve fcfg finfo
+  let sol           = HashMap.union solCuts solNonCuts
   let failBs        = gsFail $ gsTerm $ giSpec info
   let (r,rf)        = splitFails (S.map val failBs) r0 
-  let resErr        = second (applySolution sol . cinfoError) <$> r
+  let resErr        = second (applySolution finfo sol . cinfoError) <$> r
   -- resModel_        <- fmap (e2u cfg sol) <$> getModels info cfg resErr
   let resModel_     = cidE2u cfg sol <$> resErr
   let resModel'     = resModel_  `addErrors` (e2u cfg sol <$> logErrors cgi)
                                  `addErrors` makeFailErrors (S.toList failBs) rf 
                                  `addErrors` makeFailUseErrors (S.toList failBs) (giCbs $ giSrc info)
-  let lErrors       = applySolution sol <$> logErrors cgi
+  let lErrors       = applySolution finfo sol <$> logErrors cgi
   let resModel      = resModel' `addErrors` (e2u cfg sol <$> lErrors)
-  let out0          = mkOutput cfg resModel sol (annotMap cgi)
+  let out0          = mkOutput cfg resModel finfo sol (annotMap cgi)
   return            $ out0 { o_vars    = names    }
                            { o_result  = resModel }
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -1541,17 +1541,19 @@ rTypeSort     ::  (PPrint r, Reftable r, SubsTy RTyVar (RType RTyCon RTyVar ()) 
 rTypeSort tce = typeSort tce . toType True
 
 --------------------------------------------------------------------------------
-applySolution :: (Functor f) => FInfo a -> FixSolution -> f SpecType -> f SpecType
+applySolution
+  :: (Functor f)
+  => FInfo a -> M.HashMap KVar (Delayed Expr) -> f SpecType -> f SpecType
 --------------------------------------------------------------------------------
 applySolution si = fmap . fmap . mapReft' . appSolRefa si
   where
     mapReft' f (MkUReft (Reft (x, z)) p) = MkUReft (Reft (x, f z)) p
 
 appSolRefa :: Visitable t
-           => GInfo c a -> M.HashMap KVar Expr -> t -> t
+           => GInfo c a -> M.HashMap KVar (Delayed Expr) -> t -> t
 appSolRefa si s = mapKVars f0
   where
-    f0 k        = Just $ M.lookupDefault PTop k s
+    f0 k        = Just $ forceDelayed $ M.lookupDefault (Delayed PTop) k s
 
     mapKVars :: Visitable t => (KVar -> Maybe Expr) -> t -> t
     mapKVars f = trans txK

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -107,7 +107,7 @@ import           Text.Printf
 import           Text.PrettyPrint.HughesPJ hiding ((<>), first)
 import           Language.Fixpoint.Misc
 import           Language.Fixpoint.Types hiding (DataDecl (..), DataCtor (..), panic, shiftVV, Predicate, isNumeric)
-import           Language.Fixpoint.Types.Visitor (mapKVars, Visitable)
+import           Language.Fixpoint.Types.Visitor (trans, Visitable)
 import qualified Language.Fixpoint.Types as F
 import           Language.Haskell.Liquid.Types.Errors
 import           Language.Haskell.Liquid.Types.PrettyPrint
@@ -1541,17 +1541,34 @@ rTypeSort     ::  (PPrint r, Reftable r, SubsTy RTyVar (RType RTyCon RTyVar ()) 
 rTypeSort tce = typeSort tce . toType True
 
 --------------------------------------------------------------------------------
-applySolution :: (Functor f) => FixSolution -> f SpecType -> f SpecType
+applySolution :: (Functor f) => FInfo a -> FixSolution -> f SpecType -> f SpecType
 --------------------------------------------------------------------------------
-applySolution = fmap . fmap . mapReft' . appSolRefa
+applySolution si = fmap . fmap . mapReft' . appSolRefa si
   where
     mapReft' f (MkUReft (Reft (x, z)) p) = MkUReft (Reft (x, f z)) p
 
 appSolRefa :: Visitable t
-           => M.HashMap KVar Expr -> t -> t
-appSolRefa s p = mapKVars f p
+           => GInfo c a -> M.HashMap KVar Expr -> t -> t
+appSolRefa si s = mapKVars f0
   where
-    f k        = Just $ M.lookupDefault PTop k s
+    f0 k        = Just $ M.lookupDefault PTop k s
+
+    mapKVars :: Visitable t => (KVar -> Maybe Expr) -> t -> t
+    mapKVars f = trans txK
+      where
+        txK (PKVar k su)
+          | Just p' <- f k =
+              rapierSubstExpr (substSymbolsSet su) (renameDomain k su) p'
+        txK p = p
+
+        -- The parameters of kvars all seem to have prefix $ and suffix ##k_
+        -- at the point where mapKVars is used. We compensate for that here.
+        renameDomain k (Su m) =
+          Su $ M.fromList
+            [ (consSym '$' (suffixSymbol v "k_"), e)
+            | v <- kvarDomain si k
+            , let e = M.lookupDefault (EVar v) v m
+            ]
 
 --------------------------------------------------------------------------------
 -- shiftVV :: Int -- SpecType -> Symbol -> SpecType

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Annotate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Annotate.hs
@@ -78,9 +78,9 @@ import           Language.Haskell.Liquid.Types.Types
 
 -- | @output@ creates the pretty printed output
 --------------------------------------------------------------------------------------------
-mkOutput :: Config -> ErrorResult -> FixSolution -> AnnInfo (Annot SpecType) -> Output Doc
+mkOutput :: Config -> ErrorResult -> FInfo a -> FixSolution -> AnnInfo (Annot SpecType) -> Output Doc
 --------------------------------------------------------------------------------------------
-mkOutput cfg res sol anna
+mkOutput cfg res si sol anna
   = O { o_vars   = Nothing
       -- , o_errors = []
       , o_types  = toDoc <$> annTy
@@ -90,7 +90,7 @@ mkOutput cfg res sol anna
       }
   where
     annTmpl      = closeAnnots anna
-    annTy        = tidySpecType Lossy <$> applySolution sol annTmpl
+    annTy        = tidySpecType Lossy <$> applySolution si sol annTmpl
     toDoc        = rtypeDoc tidy
     tidy         = if shortNames cfg then Lossy else Full
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Annotate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Annotate.hs
@@ -78,7 +78,7 @@ import           Language.Haskell.Liquid.Types.Types
 
 -- | @output@ creates the pretty printed output
 --------------------------------------------------------------------------------------------
-mkOutput :: Config -> ErrorResult -> FInfo a -> FixSolution -> AnnInfo (Annot SpecType) -> Output Doc
+mkOutput :: Config -> ErrorResult -> FInfo a -> FixDelayedSolution -> AnnInfo (Annot SpecType) -> Output Doc
 --------------------------------------------------------------------------------------------
 mkOutput cfg res si sol anna
   = O { o_vars   = Nothing

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Errors.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Errors.hs
@@ -34,11 +34,11 @@ type Ctx  = M.HashMap F.Symbol SpecType
 type CtxM = M.HashMap F.Symbol (WithModel SpecType)
 
 ------------------------------------------------------------------------
-tidyError :: Config -> F.FixSolution -> Error -> Error
+tidyError :: Config -> Error -> Error
 ------------------------------------------------------------------------
-tidyError cfg sol
+tidyError cfg
   = fmap (tidySpecType tidy)
-  . tidyErrContext tidy sol
+  . tidyErrContext tidy
   where
     tidy = configTidy cfg
 
@@ -47,8 +47,8 @@ configTidy cfg
   | shortNames cfg = F.Lossy
   | otherwise      = F.Full
 
-tidyErrContext :: F.Tidy -> F.FixSolution -> Error -> Error
-tidyErrContext k _ e@(ErrSubType {})
+tidyErrContext :: F.Tidy -> Error -> Error
+tidyErrContext k e@(ErrSubType {})
   = e { ctx = c', tact = F.subst θ tA, texp = F.subst θ tE }
     where
       (θ, c') = tidyCtx k xs (ctx e)
@@ -56,7 +56,7 @@ tidyErrContext k _ e@(ErrSubType {})
       tA      = tact e
       tE      = texp e
 
-tidyErrContext _ _ e@(ErrSubTypeModel {})
+tidyErrContext _ e@(ErrSubTypeModel {})
   = e { ctxM = c', tactM = fmap (F.subst θ) tA, texp = fmap (F.subst θ) tE }
     where
       (θ, c') = tidyCtxM xs $ ctxM e
@@ -64,7 +64,7 @@ tidyErrContext _ _ e@(ErrSubTypeModel {})
       tA      = tactM e
       tE      = texp e
 
-tidyErrContext k _ e@(ErrAssType {})
+tidyErrContext k e@(ErrAssType {})
   = e { ctx = c', cond = F.subst θ p }
     where
       m       = ctx e
@@ -72,7 +72,7 @@ tidyErrContext k _ e@(ErrAssType {})
       xs      = F.syms p
       p       = cond e
 
-tidyErrContext _ _ e
+tidyErrContext _ e
   = e
 
 --------------------------------------------------------------------------------

--- a/tests/errors/KVars.hs
+++ b/tests/errors/KVars.hs
@@ -1,0 +1,12 @@
+{-@ LIQUID "--expect-error-containing=v < 0" @-}
+-- | Tests that KVar solutions show in error messages
+module KVars where
+
+
+{-@ intId :: forall <p :: Int -> Bool> . Int<p> -> Int<p> @-}
+intId :: Int -> Int
+intId x = x
+
+{-@ test :: {x:Int | x < 0} -> {v:Int | v > 0} @-}
+test :: Int -> Int
+test x = intId x

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -641,6 +641,7 @@ executable errors
                     , InlineSubExp0
                     , InlineSubExp1
                     , IrregularData
+                    , KVars
                     , LiftMeasureCase
                     , LocalHole
                     , MissingAssume


### PR DESCRIPTION
Follow up to https://github.com/ucsd-progsys/liquid-fixpoint/pull/810

This PR shows kvar solutions in error messages. As an example, where an error message used to show:
```
KVars.hs:10:1: error:
    Liquid Type Mismatch
    .
    The inferred type
      VV : GHC.Types.Int
    .
    is not a subtype of the required type
      VV : {VV##579 : GHC.Types.Int | VV##579 > 0}
    .
    Constraint id 2
   |
10 | test x = intId x
   | ^^^^^^^^^^^^^^^^
```
With this PR it says
```
KVars.hs:10:1: error:
    Liquid Type Mismatch
    .
    The inferred type
      VV : {v : GHC.Types.Int | v == x##aDm
                                && v < 0}
    .
    is not a subtype of the required type
      VV : {VV##579 : GHC.Types.Int | VV##579 > 0}
    .
    in the context
      x##aDm : {v : GHC.Types.Int | v < 0}
    Constraint id 2
   |
10 | test x = intId x
   | ^^^^^^^^^^^^^^^^
```
See the test `tests/errors/KVars.hs` added in this PR.

Modules that produce large kvar solutions are a bit slower to verify now. This is noticeable in only 5 of our benchmarks. This is because simplifying the solutions (as in `simplifyKVars`) adds a few seconds. The simplification is forced when writing `.vim.annot`, `.json`, and `.html` files in the `.liquid` folder (currently controlled by the `--no-annotations` flag). I'm guessing that these files should be stopped from being written by default.

The simplification of a kvar solution is also forced when rendering an error message where the kvar solution is needed. If no such error is shown, there is no performance overhead. 

Here are the worsening benchmarks:

* `tests/neg/StateConstraints0.hs` 7s +8s
* `tests/benchmarks/icfp15/pos/IfM.hs` 2s +5s
* `tests/benchmarks/esop2013-submission/Base.hs` 30s + 3s
* `tests/benchmarks/bytestring-0.9.2.1/Data/ByteString/LazyZip.hs` 2s + 3s
* `tests/pos/StateConstraints.hs` 2s +2s