### PR TITLE
feat: add pkgconfig-depends z3

### DIFF
--- a/liquidhaskell.cabal
+++ b/liquidhaskell.cabal
@@ -85,6 +85,7 @@ library
                       ghc-prim
   default-language:   Haskell98
   ghc-options:        -Wall
+  pkgconfig-depends:  z3
 
   if flag(devel)
     ghc-options:      -Werror


### PR DESCRIPTION
this fixes compatibility issues with Nix and allows discovery of the `z3` dependency needed for Liquid Haskell to work
originally patched by @youwen5