### PR TITLE
Do not introduce visible foralls in the anf transformation

### DIFF
--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -404,6 +404,7 @@ import GHC.Core.Type                  as Ghc
     , newTyConInstRhs
     , piResultTys
     , splitAppTys
+    , splitForAllForAllTyBinders
     , splitFunTy_maybe
     , splitFunTys
     , splitTyConApp

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/TypeRep.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/TypeRep.hs
@@ -9,8 +9,6 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Language.Haskell.Liquid.GHC.TypeRep (
-  mkTyArg, 
-
   showTy
   ) where
 
@@ -19,9 +17,6 @@ import           Liquid.GHC.API as Ghc hiding (mkTyArg, showPpr, panic)
 import           Language.Fixpoint.Types (symbol)
 
 -- e368f3265b80aeb337fbac3f6a70ee54ab14edfd
-
-mkTyArg :: TyVar -> TyVarBinder
-mkTyArg v = Bndr v Required
 
 instance Eq Type where
   t1 == t2 = eqType' t1 t2

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/ANF.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/ANF.hs
@@ -13,7 +13,6 @@ module Language.Haskell.Liquid.Transforms.ANF (anormalize) where
 
 import           Debug.Trace (trace)
 import           Prelude                          hiding (error)
-import           Language.Haskell.Liquid.GHC.TypeRep
 import           Liquid.GHC.API  as Ghc hiding ( get, mkTyArg
                                                                 , showPpr
                                                                 , DsM
@@ -36,6 +35,7 @@ import qualified Text.Printf as Printf
 import           Data.Hashable
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HM
+import GHC.Core.Type (ForAllTyBinder)
 
 --------------------------------------------------------------------------------
 -- | A-Normalize a module ------------------------------------------------------
@@ -70,20 +70,20 @@ normalizeTyVars (NonRec x e) = NonRec (setVarType x t') $ normalizeForAllTys e
   where
     t'       = subst msg as as' bt
     msg      = "WARNING: unable to renameVars on " ++ GM.showPpr x
-    as'      = fst $ splitForAllTyCoVars $ exprType e
-    (as, bt) = splitForAllTyCoVars (varType x)
+    as'      = fst $ splitForAllForAllTyBinders $ exprType e
+    (as, bt) = splitForAllForAllTyBinders (varType x)
 normalizeTyVars (Rec xes)    = Rec xes'
   where
     nrec     = normalizeTyVars <$> (uncurry NonRec <$> xes)
     xes'     = (\case NonRec x e -> (x, e); _ -> impossible Nothing "This cannot happen") <$> nrec
 
-subst :: String -> [TyVar] -> [TyVar] -> Type -> Type
+subst :: String -> [ForAllTyBinder] -> [ForAllTyBinder] -> Type -> Type
 subst msg as as' bt
   | length as == length as'
-  = mkForAllTys (mkTyArg <$> as') $ substTy su bt
+  = mkForAllTys as' $ substTy su bt
   | otherwise
-  = trace msg $ mkForAllTys (mkTyArg <$> as) bt
-  where su = mkTvSubstPrs $ zip as (mkTyVarTys as')
+  = trace msg $ mkForAllTys as bt
+  where su = mkTvSubstPrs $ zip (map binderVar as) (mkTyVarTys (map binderVar as'))
 
 -- | eta-expand CoreBinds with quantified types
 normalizeForAllTys :: CoreExpr -> CoreExpr


### PR DESCRIPTION
The anf transformation was changing the foralls in types to visible. This has no consequence because the "Eq Type" instance ignores the visibility attribute, but it was still surprising and unnecessary behavior.