### PR TITLE
Make assume reflect error sensitive to dflags

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -45,6 +45,7 @@ import Control.Arrow (second)
 import Data.Function (on)
 import qualified Data.Map as Map
 import qualified Data.HashMap.Strict as M
+import System.IO.Unsafe (unsafePerformIO)
 
 findDuplicatePair :: Ord k => (a -> k) -> [a] -> Maybe (a, a)
 findDuplicatePair key xs =
@@ -113,8 +114,11 @@ makeAssumeReflectAxiom sig env tce (actual, pretended) =
   else
     Ex.throw $ mkError actual $
       show qPretended ++ " and " ++ show qActual ++ " should have the same type. But " ++
-      "types " ++ F.showpp pretendedTy ++ " and " ++ F.showpp actualTy  ++ " do not match."
+      "types\n\n" ++ showType pretendedTy ++ "\n\n and\n\n" ++ showType actualTy  ++ "\n\ndo not match."
   where
+    showType = Ghc.showPpr
+      (unsafePerformIO $ Ghc.reflectGhc Ghc.getDynFlags $ gtleSession $ reTyLookupEnv env)
+
     at = val $ strengthenSpecWithMeasure sig env actualV pretended{val=qPretended}
 
     -- Get the Ghc.Var's of the actual and pretended function names

--- a/tests/basic/neg/AssmRefl03.hs
+++ b/tests/basic/neg/AssmRefl03.hs
@@ -1,5 +1,5 @@
 -- | Type mismatch
-{-@ LIQUID "--expect-error-containing=\"AssmRefl03.myfoobar\" and \"AssmRefl03.foobar\" should have the same type. But types GHC.Types.Bool -> GHC.Types.Bool and GHC.Types.Int -> GHC.Types.Bool do not match." @-}
+{-@ LIQUID "--expect-error-containing=\"AssmRefl03.myfoobar\" and \"AssmRefl03.foobar\" should have the same type." @-}
 {-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--ple"        @-}
 


### PR DESCRIPTION
This makes possible to pass `-fprint-explicit-...` flags to improve the error message which compares types. For instance:

```
    Cannot lift Haskell function `$` to logic                                                      
    "SKIIdx.myD" and "GHC.Internal.Base.$" should have the same type. But types
                                                                                                   
forall a b -> (a -> b) -> a -> b                                                                   
                                                                                                   
 and                                                                                               
                                                                                                   
forall (repa :: RuntimeRep) (repb :: RuntimeRep) (a :: TYPE repa)                                  
       (b :: TYPE repb).                 
(a -> b) -> a -> b                                                                                                                                                                                    
                                                                                                   
do not match.                                                                                      
   |                                             
15 | {-@ assume reflect $ as myD @-}                                                               
   |
```