### PR TITLE
Refactor name resolution and simplify name lookup of let-bound variables

### DIFF
--- a/liquidhaskell-boot/ghc-api-tests/GhcApiTests.hs
+++ b/liquidhaskell-boot/ghc-api-tests/GhcApiTests.hs
@@ -108,10 +108,6 @@ testCaseDesugaring = do
           , "        True -> ()"
           ]
 
-        fBind (GHC.NonRec b _e) =
-          occNameString (GHC.occName b) == "f"
-        fBind _ = False
-
         -- Expected desugaring:
         --
         -- CaseDesugaring.f
@@ -124,8 +120,8 @@ testCaseDesugaring = do
         --            GHC.Types.True -> GHC.Tuple.()
         --          }
         --
-        isExpectedDesugaring p = case find fBind p of
-          Just (GHC.NonRec _ e0)
+        isExpectedDesugaring p = case findExpr "f" p of
+          Just e0
             | Lam x (untick -> Case (Var x') _ _ [alt0, _alt1]) <- e0
             , x == x'
             , Alt DEFAULT [] e1 <- alt0
@@ -150,18 +146,14 @@ testNumLitDesugaring = do
           , "f = 1"
           ]
 
-        fBind (GHC.NonRec b _e) =
-          occNameString (GHC.occName b) == "f"
-        fBind _ = False
-
         -- Expected desugaring:
         --
         -- NumLitDesugaring.f
         --      = \@a dict -> fromInteger @a dict (GHC.Num.Integer.IS 1#)
         --
-        isExpectedDesugaring p = case find fBind p of
-          Just (GHC.NonRec _ e0)
-            | Lam _a (Lam _dict (untick -> App fromIntegerApp (App (Var vIS) lit))) <- e0
+        isExpectedDesugaring p = case findExpr "f" p of
+          Just e0
+            | Lam _a (Lam _dict (untick . dropLets -> App fromIntegerApp (App (Var vIS) lit))) <- e0
             , App (App (Var vFromInteger) _aty) _numDict <- fromIntegerApp
             , GHC.idName vFromInteger  == GHC.fromIntegerName
             , GHC.nameStableString (GHC.idName vIS) == GHC.nameStableString GHC.integerISDataConName
@@ -174,6 +166,10 @@ testNumLitDesugaring = do
       fail $ unlines $
         "Unexpected desugaring:" : map showPprQualified coreProgram
 
+dropLets :: GHC.CoreExpr -> GHC.CoreExpr
+dropLets (Let _ e) = dropLets e
+dropLets e         = e
+
 -- | Tests that dollar sign desugars as Liquid Haskell expects.
 testDollarDesugaring :: IO ()
 testDollarDesugaring = do
@@ -183,12 +179,8 @@ testDollarDesugaring = do
           , "f = (\\_ -> ()) $ 'a'"
           ]
 
-        fBind (GHC.NonRec b _e) =
-          occNameString (GHC.occName b) == "f"
-        fBind _ = False
-
-        isExpectedDesugaring p = case find fBind p of
-          Just (GHC.NonRec _ e0)
+        isExpectedDesugaring p = case findExpr "f" p of
+          Just e0
             | Just (Lam _ _, App _ (Lit (LitChar 'a'))) <- splitDollarApp e0
             -> True
           _ -> False
@@ -197,6 +189,20 @@ testDollarDesugaring = do
     unless (isExpectedDesugaring coreProgram) $
       fail $ unlines $
         "Unexpected desugaring:" : map showPprQualified coreProgram
+
+-- | Find the Core expression bound to the given name.
+findExpr :: String -> GHC.CoreProgram -> Maybe GHC.CoreExpr
+findExpr _ [] =
+  Nothing
+findExpr name (p:ps) = case p of
+  GHC.NonRec b e
+    | occNameString (GHC.occName b) == name
+    -> Just e
+  GHC.Rec binds
+    | Just (_, e) <- find (\(b, _e) -> occNameString (GHC.occName b) == name) binds
+    -> Just e
+  _ -> findExpr name ps
+
 
 -- | Test that local bindings are preserved.
 testLocalBindingsDesugaring :: IO ()
@@ -209,12 +215,8 @@ testLocalBindingsDesugaring = do
           , "    z = ()"
           ]
 
-        fBind (GHC.NonRec b _e) =
-          occNameString (GHC.occName b) == "f"
-        fBind _ = False
-
-        isExpectedDesugaring p = case find fBind p of
-          Just (GHC.NonRec _ (Let (GHC.NonRec b _) _))
+        isExpectedDesugaring p = case findExpr "f" p of
+          Just (Let (GHC.NonRec b _) _)
             -> occNameString (GHC.occName b) == "z"
           _ -> False
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -380,7 +380,10 @@ makeAssumeType cfg tce lmap dm sym mbT v def
     -- Negative Debruijn indices (levels :^)) are safer
     freeSort    = [-1, -2 ..]
 
-    (xs, def') = GM.notracePpr "grabBody" $ grabBody allowTC (Ghc.expandTypeSynonyms τ) $ normalize allowTC def
+    (xs, def') =
+      GM.notracePpr "grabBody" $
+      grabBody allowTC (Ghc.expandTypeSynonyms τ) $
+      normalizeCoreExpr allowTC def
     su         = F.mkSubst  $ zip (F.symbol     <$> xs) xArgs
                            ++ zip (simplesymbol <$> xs) xArgs
     xts        = [(F.symbol x, rTypeSortExp tce t) | (x, t) <- aargs at]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -24,7 +24,7 @@ module Language.Haskell.Liquid.Bare.Resolve
   , lookupGhcDataConLHName
   , lookupGhcDnTyCon
   , lookupGhcIdLHName
-  , lookupLocalVar
+  , lookupLetBoundVar
   , lookupGhcTyConLHName
   , lookupGhcTyThingFromName
   , lookupGhcId
@@ -59,7 +59,6 @@ import qualified Data.HashSet                      as S
 import qualified Data.Maybe                        as Mb
 import qualified Data.HashMap.Strict               as M
 import           GHC.Stack
-import           Text.Megaparsec.Pos (sourceColumn, sourceLine)
 import qualified Text.PrettyPrint.HughesPJ         as PJ
 
 import qualified Language.Fixpoint.Types               as F
@@ -121,15 +120,14 @@ getGlobalSyms (_, spec)
 makeLocalVars :: [Ghc.CoreBind] -> LocalVars
 makeLocalVars = localVarMap . localBinds
 
--- TODO: rewrite using CoreVisitor
 localBinds :: [Ghc.CoreBind] -> [LocalVarDetails]
 localBinds                    = concatMap (bgoT [])
   where
-    bgoT g (Ghc.NonRec _ e) = go g e
-    bgoT g (Ghc.Rec xes)    = concatMap (go g . snd) xes
-    pgo g isRec (x, e)      = mkLocalVarDetails g isRec x : go g e
-    bgo g (Ghc.NonRec x e)  = pgo g False (x, e)
-    bgo g (Ghc.Rec xes)     = concatMap (pgo g True) xes
+    bgoT g (Ghc.NonRec x e) = pgo g True False (x, e)
+    bgoT g (Ghc.Rec xes)    = concatMap (pgo g True True) xes
+    pgo g isTopLevel isRec (x, e) = mkLocalVarDetails g isTopLevel isRec x : go g e
+    bgo g (Ghc.NonRec x e)  = pgo g False False (x, e)
+    bgo g (Ghc.Rec xes)     = concatMap (pgo g False True) xes
     go g (Ghc.App e a)       = concatMap (go g) [e, a]
     go g (Ghc.Lam x e)       = go (x:g) e
     go g (Ghc.Let b e)       = bgo g b ++ go (Ghc.bindersOf b ++ g) e
@@ -139,10 +137,11 @@ localBinds                    = concatMap (bgoT [])
     go _ (Ghc.Var _)         = []
     go _ _                   = []
 
-    mkLocalVarDetails g isRec v = LocalVarDetails
+    mkLocalVarDetails g isTopLevel isRec v = LocalVarDetails
       { lvdSourcePos = F.sp_start $ F.srcSpan v
       , lvdVar = v
       , lvdLclEnv = g
+      , lvdIsTopLevel = isTopLevel
       , lvdIsRec = isRec
       }
 
@@ -186,39 +185,41 @@ isLocal = isEmptySymbol
 isEmptySymbol :: F.Symbol -> Bool
 isEmptySymbol x = F.lengthSym x == 0
 
--- | @lookupLocalVar@ takes as input the list of "global" (top-level) vars
---   that also match the name @lx@; we then pick the "closest" definition.
+-- | @lookupLetBoundVar@ yields the name of the closes let bound definition.
 --   See tests/names/pos/LocalSpec.hs for a motivating example.
-
-lookupLocalVar :: F.Loc a => LocalVars -> LocSymbol -> [a] -> Maybe (Either a Ghc.Var)
-lookupLocalVar localVars lx gvs = findNearest lxn kvs
+--
+-- This function never returns a top-level variable.
+--
+-- PRECONDITION: the input symbol is not qualified.
+--
+lookupLetBoundVar :: LocalVars -> LocSymbol -> Maybe Ghc.Var
+lookupLetBoundVar localVars lx
+   | GM.isQualifiedSym x = error $ "lookupLetBoundVar: called on a qualified symbol: " ++ show lx
+   | otherwise = findNearest lxn kvs
   where
-    kvs                   = prioritizeRecBinds (M.lookupDefault [] x (lvSymbols localVars)) ++ gs
-    gs                    = [(F.sp_start $ F.srcSpan v, Left v) | v <- gvs]
-    lxn                   = F.sp_start $ F.srcSpan lx
-    (_, x)                = unQualifySymbol (F.val lx)
+    x = F.val lx
+    kvs = prioritizeRecBinds (M.lookupDefault [] x (lvSymbols localVars))
+    lxn = F.sp_start $ F.srcSpan lx
 
     -- Sometimes GHC produces multiple bindings that have the same source
     -- location. To select among these, we give preference to the recursive
     -- bindings which might need termination metrics.
     prioritizeRecBinds lvds =
       let (recs, nrecs) = L.partition lvdIsRec lvds
-       in map lvdToPair (recs ++ nrecs)
-    lvdToPair lvd = (lvdSourcePos lvd, Right (lvdVar lvd))
+       in recs ++ nrecs
 
-    findNearest :: F.SourcePos -> [(F.SourcePos, b)] -> Maybe b
-    findNearest key kvs1 = argMin [ (posDistance key k, v) | (k, v) <- kvs1 ]
+    findNearest :: F.SourcePos -> [LocalVarDetails] -> Maybe Ghc.Var
+    findNearest key = pickByLocation key .  L.sortBy (compare `on` lvdSourcePos)
 
-    -- We prefer the var with the smaller distance, or equal distance
-    -- but left of the spec, or not left of the spec but below it.
-    posDistance a b =
-      ( abs (F.unPos (sourceLine a) - F.unPos (sourceLine b))
-      , sourceColumn a < sourceColumn b -- Note: False is prefered/smaller to True
-      , sourceLine a > sourceLine b
-      )
-
-    argMin :: (Ord k) => [(k, v)] -> Maybe v
-    argMin = Mb.listToMaybe . map snd . L.sortBy (compare `on` fst)
+    pickByLocation :: F.SourcePos -> [LocalVarDetails] -> Maybe Ghc.Var
+    pickByLocation _ [] = Nothing
+    pickByLocation _ [lvd]
+      | lvdIsTopLevel lvd = Nothing
+      | otherwise = Just $ lvdVar lvd
+    pickByLocation key (lvd0 : xs@(lvd1 : _))
+      | lvdSourcePos lvd1 < key  = pickByLocation key xs
+      | lvdSourcePos lvd0 < key  = pickByLocation key [lvd1]
+      | otherwise = pickByLocation key [lvd0]
 
 
 lookupGhcDnTyCon :: Env -> ModName -> DataName -> Lookup (Maybe Ghc.TyCon)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -185,7 +185,7 @@ isLocal = isEmptySymbol
 isEmptySymbol :: F.Symbol -> Bool
 isEmptySymbol x = F.lengthSym x == 0
 
--- | @lookupLetBoundVar@ yields the name of the closes let bound definition.
+-- | @lookupLetBoundVar@ yields the name of the closest let-bound definition.
 --   See tests/names/pos/LocalSpec.hs for a motivating example.
 --
 -- This function never returns a top-level variable.

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Types.hs
@@ -104,6 +104,7 @@ data LocalVarDetails = LocalVarDetails
   { lvdSourcePos :: F.SourcePos
   , lvdVar :: Ghc.Var
   , lvdLclEnv :: [Ghc.Var]
+  , lvdIsTopLevel :: Bool  -- ^ Is the variable defined at the top-level?
   , lvdIsRec :: Bool  -- ^ Is the variable defined in a letrec?
   } deriving Show
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -79,7 +79,7 @@ import qualified Data.HashMap.Strict                     as HM
 import           Data.List (find, isSuffixOf, nubBy, partition)
 import           Data.List.Extra (dropEnd)
 import qualified Data.Map as Map
-import           Data.Maybe (fromMaybe, listToMaybe, mapMaybe, maybeToList)
+import           Data.Maybe (mapMaybe, maybeToList)
 import qualified Data.Text                               as Text
 import qualified GHC.Types.Name.Occurrence
 
@@ -259,49 +259,42 @@ resolveLHNames cfg thisModule localVars impMods globalRdrEnv bareSpec0 dependenc
               -- If multiple matches are found, report the ambiguous name and return it.
               tar@(FoundTypeAliases { }) -> do addError $ errResolveTypeAlias (s <$ lname) tar
                                                pure $ val lname
-              NoSuchTypeAlias alts -> lookupGRELHName alts (LHTcName lcl) lname s listToMaybe
+              NoSuchTypeAlias alts -> lookupGRELHName alts (LHTcName lcl) lname s
         LHNUnresolved ns@(LHVarName lcl) s
           | isDataCon s ->
-              lookupGRELHName [] (LHDataConName lcl) lname s listToMaybe
+              lookupGRELHName [] (LHDataConName lcl) lname s
+          | not (LH.isQualifiedSym s)
+          , Just n <- (fmap GHC.getName $ Resolve.lookupLetBoundVar localVars (atLoc lname s))
+          ->
+              pure $ LHNResolved (LHRGHC n) s
           | otherwise ->
               lookupGRELHName [] ns lname s
-                (fmap (either id GHC.getName) . Resolve.lookupLocalVar localVars (atLoc lname s))
         LHNUnresolved LHLogicNameBinder s ->
           pure $ makeLogicLHName s thisModule Nothing
         n@(LHNUnresolved LHLogicName _) ->
           -- This one will be resolved by resolveLogicNames
           pure n
-        LHNUnresolved ns@(LHDataConName _) s -> lookupGRELHName [] ns lname s listToMaybe
+        LHNUnresolved ns@(LHDataConName _) s -> lookupGRELHName [] ns lname s
         n@LHNResolved { } -> pure n
 
-    lookupGRELHName alts ns lname s localNameLookup =
+    lookupGRELHName alts ns lname s =
       case maybeDropImported ns $ GHC.lookupGRE globalRdrEnv (mkLookupGRE ns s) of
         [e] -> do
           let n = GHC.greName e
-              n' = fromMaybe n $ localNameLookup [n]
-          pure $ LHNResolved (LHRGHC n') s
+          pure $ LHNResolved (LHRGHC n) s
         es@(_:_) -> do
-          let topLevelNames = map GHC.greName es
-          case localNameLookup topLevelNames of
-            Just n | notElem n topLevelNames ->
-              pure $ LHNResolved (LHRGHC n) s
-            _ -> do
-              addError
-                (ErrDupNames
-                   (LH.fSrcSpan lname)
-                   "variable"
-                   (pprint s)
-                   (map (PJ.text . GHC.showPprUnsafe) es)
-                )
-              pure $ val lname
-        [] ->
-          case localNameLookup [] of
-            Just n' ->
-              pure $ LHNResolved (LHRGHC n') s
-            Nothing -> do
-              addError
-                (errResolve alts (nameSpaceKind ns) "Cannot resolve name" (s <$ lname))
-              pure $ val lname
+          addError
+            (ErrDupNames
+               (LH.fSrcSpan lname)
+               "variable"
+               (pprint s)
+               (map (PJ.text . GHC.showPprUnsafe) es)
+            )
+          pure $ val lname
+        [] -> do
+          addError
+            (errResolve alts (nameSpaceKind ns) "Cannot resolve name" (s <$ lname))
+          pure $ val lname
 
     maybeDropImported ns es
       | localNameSpace ns = filter GHC.isLocalGRE es

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -286,7 +286,7 @@ resolveLHNames cfg thisModule localVars impMods globalRdrEnv bareSpec0 dependenc
           addError
             (ErrDupNames
                (LH.fSrcSpan lname)
-               "variable"
+               (nameSpaceKind ns)
                (pprint s)
                (map (PJ.text . GHC.showPprUnsafe) es)
             )

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -264,9 +264,9 @@ resolveLHNames cfg thisModule localVars impMods globalRdrEnv bareSpec0 dependenc
           | isDataCon s ->
               lookupGRELHName [] (LHDataConName lcl) lname s
           | not (LH.isQualifiedSym s)
-          , Just n <- (fmap GHC.getName $ Resolve.lookupLetBoundVar localVars (atLoc lname s))
+          , Just v <- Resolve.lookupLetBoundVar localVars (atLoc lname s)
           ->
-              pure $ LHNResolved (LHRGHC n) s
+              pure $ LHNResolved (LHRGHC (GHC.getName v)) s
           | otherwise ->
               lookupGRELHName [] ns lname s
         LHNUnresolved LHLogicNameBinder s ->

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -19,7 +19,7 @@ module Language.Haskell.Liquid.Transforms.CoreToLogic
   , inlineSpecType
   , measureSpecType
   , weakenResult
-  , normalize
+  , normalizeCoreExpr
   ) where
 
 import           Data.Bifunctor (first)
@@ -223,7 +223,7 @@ coreToDef :: Reftable r => Located LHName -> Var -> C.CoreExpr
           -> LogicM [Def (Located (RRType r)) DataCon]
 coreToDef locSym _ s              = do 
     allowTC <- reader $ typeclass . lsConfig
-    go [] $ inlinePreds $ simplify allowTC s
+    go [] $ inlinePreds $ simplifyCoreExpr allowTC s
   where
     go args   (C.Lam  x e)        = go (x:args) e
     go args   (C.Tick _ e)        = go args e
@@ -232,7 +232,7 @@ coreToDef locSym _ s              = do
       | Just t <- isMeasureArg z  = coreAltToDef locSym z zs z t [Alt C.DEFAULT [] e]
     go _ _                        = measureFail locSym "Does not have a case-of at the top-level"
 
-    inlinePreds   = inline (eqType boolTy . GM.expandVarType)
+    inlinePreds   = inlineCoreExpr (eqType boolTy . GM.expandVarType)
 
 measureFail       :: Located LHName -> String -> a
 measureFail x msg = panic sp e
@@ -258,7 +258,7 @@ varRType = GM.varLocInfo ofType
 coreToFun :: LocSymbol -> Var -> C.CoreExpr ->  LogicM ([Var], Either Expr Expr)
 coreToFun _ _v s = do 
   allowTC <- reader $ typeclass . lsConfig
-  go [] $ normalize allowTC s
+  go [] $ normalizeCoreExpr allowTC s
   where
     go acc (C.Lam x e)  | isTyVar x = go acc e
     go acc (C.Lam x e)  = do 
@@ -275,7 +275,7 @@ instance Show C.CoreExpr where
 coreToLogic :: C.CoreExpr -> LogicM Expr
 coreToLogic cb = do
   allowTC <- reader $ typeclass . lsConfig
-  coreToLg $ normalize allowTC cb
+  coreToLg $ normalizeCoreExpr allowTC cb
 
 
 coreToLg :: C.CoreExpr -> LogicM Expr
@@ -597,79 +597,80 @@ isANF      v = isPrefixOfSym (symbol ("lq_anf" :: String)) (simpleSymbolVar v)
 isDead :: Id -> Bool
 isDead     = isDeadOcc . occInfo . Ghc.idInfo
 
-class Simplify a where
-  simplify :: Bool -> a -> a
-  inline   :: (Id -> Bool) -> a -> a
+normalizeCoreExpr :: Bool -> CoreExpr -> CoreExpr
+normalizeCoreExpr allowTC = inline_preds . inline_anf . simplifyCoreExpr allowTC
+  where
+    inline_preds = inlineCoreExpr (eqType boolTy . GM.expandVarType)
+    inline_anf   = inlineCoreExpr isANF
 
-  normalize :: Bool -> a -> a
-  normalize allowTC = inline_preds . inline_anf . simplify allowTC
-   where
-    inline_preds = inline (eqType boolTy . GM.expandVarType)
-    inline_anf   = inline isANF
+simplifyCoreExpr :: Bool -> CoreExpr -> CoreExpr
+simplifyCoreExpr allowTC = go
+  where
+    isDictOrErasable = if allowTC then GM.isEmbeddedDictVar else isErasable
 
-instance Simplify C.CoreExpr where
-  simplify _ e@(C.Var _)
-    = e
-  simplify _ e@(C.Lit _)
-    = e
-  simplify allowTC (C.App e (C.Type _))
-    = simplify allowTC e
-  simplify allowTC (C.App e (C.Var dict))  | (if allowTC then GM.isEmbeddedDictVar else isErasable) dict
-    = simplify allowTC e
-  simplify allowTC (C.App (C.Lam x e) _)   | isDead x
-    = simplify allowTC e
-  simplify allowTC (C.App e1 e2)
-    = C.App (simplify allowTC e1) (simplify allowTC e2)
-  simplify allowTC (C.Lam x e) | isTyVar x
-    = simplify allowTC e
-  simplify allowTC (C.Lam x e) | (if allowTC then GM.isEmbeddedDictVar else isErasable) x
-    = simplify allowTC e
-  simplify allowTC (C.Lam x e)
-    = C.Lam x (simplify allowTC e)
-  simplify allowTC (C.Let (C.NonRec x _) e) | (if allowTC then GM.isEmbeddedDictVar else isErasable) x
-    = simplify allowTC e
-  simplify allowTC (C.Let (C.Rec xes) e)    | all ((if allowTC then GM.isEmbeddedDictVar else isErasable) . fst) xes
-    = simplify allowTC e
-  simplify allowTC (C.Let xes e)
-    = C.Let (simplify allowTC xes) (simplify allowTC e)
-  simplify allowTC (C.Case e x _t alts@[Alt _ _ ee,_,_]) | isBangInteger alts
-  -- XXX(matt): seems to be for debugging?
-    = -- Misc.traceShow ("To simplify allowTC case") $
-       sub (M.singleton x (simplify allowTC e)) (simplify allowTC ee)
-  simplify allowTC (C.Case e x t alts)
-    = C.Case (simplify allowTC e) x t (filter (not . isPatErrorAlt) (simplify allowTC <$> alts))
-  simplify allowTC (C.Cast e c)
-    = C.Cast (simplify allowTC e) c
-  simplify allowTC (C.Tick _ e)
-    = simplify allowTC e
-  simplify _ (C.Coercion c)
-    = C.Coercion c
-  simplify _ (C.Type t)
-    = C.Type t
+    go :: CoreExpr -> CoreExpr
+    go e@(C.Var _)
+      = e
+    go e@(C.Lit _)
+      = e
+    go (C.App e1 (C.Type _))
+      = go e1
+    go (C.App e1 (C.Var v))
+      | isDictOrErasable v
+      = go e1
+    go (C.App (C.Lam x e) _)
+      | isDead x
+      = go e
+    go (C.App e1 e2)
+      = C.App (go e1) (go e2)
+    go (C.Lam x e)
+      | isTyVar x
+      = go e
+    go (C.Lam x e)
+      | isDictOrErasable x
+      = go e
+    go (C.Lam x e)
+      = C.Lam x (go e)
+    go (C.Let (C.NonRec x eb) e)
+      | isDictOrErasable x
+      = go e
+      | otherwise
+      = C.Let (C.NonRec x (go eb)) (go e)
+    go (C.Let (C.Rec xes) e)
+      | all (isDictOrErasable . fst) xes
+      = go e
+      | otherwise
+      = C.Let (C.Rec (map (fmap go) xes)) (go e)
+    go (C.Case e x _t alts@[Alt _ _ ee,_,_])
+      | isBangInteger alts
+      = sub (M.singleton x (go e)) (go ee)
+    go (C.Case e x t alts)
+      = C.Case (go e) x t $
+         filter
+           (not . isPatErrorAlt)
+           [ Alt c xs (go ealt) | Alt c xs ealt <- alts ]
+    go (C.Cast e c)
+      = C.Cast (go e) c
+    go (C.Tick _ e)
+      = go e
+    go (C.Coercion c)
+      = C.Coercion c
+    go (C.Type t)
+      = C.Type t
 
-  inline p (C.Let (C.NonRec x ex) e) | p x
-                               = sub (M.singleton x (inline p ex)) (inline p e)
-  inline p (C.Let xes e)       = C.Let (inline p xes) (inline p e)
-  inline p (C.App e1 e2)       = C.App (inline p e1) (inline p e2)
-  inline p (C.Lam x e)         = C.Lam x (inline p e)
-  inline p (C.Case e x t alts) = C.Case (inline p e) x t (inline p <$> alts)
-  inline p (C.Cast e c)        = C.Cast (inline p e) c
-  inline p (C.Tick t e)        = C.Tick t (inline p e)
-  inline _ (C.Var x)           = C.Var x
-  inline _ (C.Lit l)           = C.Lit l
-  inline _ (C.Coercion c)      = C.Coercion c
-  inline _ (C.Type t)          = C.Type t
-
-
-instance Simplify C.CoreBind where
-  simplify allowTC (C.NonRec x e) = C.NonRec x (simplify allowTC e)
-  simplify allowTC (C.Rec xes)    = C.Rec (fmap (simplify allowTC) <$> xes )
-
-  inline p (C.NonRec x e) = C.NonRec x (inline p e)
-  inline p (C.Rec xes)    = C.Rec (fmap (inline p) <$> xes)
-
-instance Simplify C.CoreAlt where
-  simplify allowTC (Alt c xs e) = Alt c xs (simplify allowTC e)
-    -- where xs   = F.tracepp _msg xs0
-    --      _msg = "isCoVars? " ++ F.showpp [(x, isCoVar x, varType x) | x <- xs0]
-  inline p (Alt c xs e) = Alt c xs (inline p e)
+inlineCoreExpr :: (Id -> Bool) -> CoreExpr -> CoreExpr
+inlineCoreExpr p (C.Let (C.NonRec x ex) e)
+  | p x = sub (M.singleton x (inlineCoreExpr p ex)) (inlineCoreExpr p e)
+  | otherwise = C.Let (C.NonRec x (inlineCoreExpr p ex)) (inlineCoreExpr p e)
+inlineCoreExpr p (C.Let (C.Rec xes) e) = C.Let (C.Rec (map (fmap (inlineCoreExpr p)) xes)) (inlineCoreExpr p e)
+inlineCoreExpr p (C.App e1 e2)       = C.App (inlineCoreExpr p e1) (inlineCoreExpr p e2)
+inlineCoreExpr p (C.Lam x e)         = C.Lam x (inlineCoreExpr p e)
+inlineCoreExpr p (C.Case e x t alts) =
+  C.Case (inlineCoreExpr p e) x t
+    [ Alt c xs (inlineCoreExpr p ealt) | Alt c xs ealt <- alts ]
+inlineCoreExpr p (C.Cast e c)        = C.Cast (inlineCoreExpr p e) c
+inlineCoreExpr p (C.Tick t e)        = C.Tick t (inlineCoreExpr p e)
+inlineCoreExpr _ (C.Var x)           = C.Var x
+inlineCoreExpr _ (C.Lit l)           = C.Lit l
+inlineCoreExpr _ (C.Coercion c)      = C.Coercion c
+inlineCoreExpr _ (C.Type t)          = C.Type t


### PR DESCRIPTION
This PR shares some simplifications I did while wrestling with GHC HEAD.

They make it easier to follow the code in name resolution of assertions for let-bound variables, and also made a function to retrieve a particular top-level bind in tests of the GHC API. Previously, the code to resolve top-level names and let-bound names was entangled.

The Simplify class is eliminated and replaced with simplification functions that work on concrete types.