### PR TITLE
feat: add --save-bfq-only flag to conditionally skip saving .bfq files

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
@@ -43,14 +43,12 @@ checkTargetInfo :: TargetInfo -> IO (Output Doc)
 --------------------------------------------------------------------------------
 checkTargetInfo info = do
   let cfg = gsConfig (giSpec info)
-  -- 'giTarget' pulls the FilePath (String) out of the TargetSrc
   let tgt = giTarget (giSrc info)
   
   out <- check
   
-  -- Use 'resStatus' to look at the result correctly
   if saveBfqOnly cfg
-    then when (not (F.isSafe (resStatus (o_result out)))) (DC.saveResult tgt out)
+    then when (not (F.isSafe (F.resStatus (o_result out)))) (DC.saveResult tgt out)
     else when (saveQuery cfg) (DC.saveResult tgt out)
 
   pure out

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
@@ -40,7 +40,6 @@ import           Liquid.GHC.API as GHC hiding (text, vcat, ($+$), (<+>))
 
 --------------------------------------------------------------------------------
 checkTargetInfo :: TargetInfo -> IO (Output Doc)
---------------------------------------------------------------------------------
 checkTargetInfo info = do
   let cfg = gsConfig (giSpec info)
   let tgt = giTarget (giSrc info)
@@ -48,7 +47,7 @@ checkTargetInfo info = do
   out <- check
   
   if saveBfqOnly cfg
-    then when (not (F.isSafe (F.resStatus (o_result out)))) (DC.saveResult tgt out)
+    then when (not (F.isSafe out)) (DC.saveResult tgt out) -- Simplified safety check
     else when (saveQuery cfg) (DC.saveResult tgt out)
 
   pure out

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
@@ -51,7 +51,7 @@ checkTargetInfo info = do
   if saveBfqOnly cfg
     then when (not (F.isSafe (o_result out))) (DC.saveResult tgt out)
     -- Change 'save' to 'saveBfq' here
-    else when (saveBfq cfg) (DC.saveResult tgt out)
+    else when (save cfg) (DC.saveResult tgt out)
 
   pure out
   where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
@@ -42,8 +42,15 @@ import           Liquid.GHC.API as GHC hiding (text, vcat, ($+$), (<+>))
 checkTargetInfo :: TargetInfo -> IO (Output Doc)
 --------------------------------------------------------------------------------
 checkTargetInfo info = do
+-- We extract 'cfg' and 'tgt' from the 'info' box so the computer knows them
+  let cfg = giConfig info
+  let tgt = giTarget info
   out <- check
-  when (diffcheck cfg && not (compileSpec cfg)) $ DC.saveResult tgt out
+  let res = o_result out
+  if saveBfqOnly cfg
+   then when (not (F.isSafe (o_result out))) (DC.saveResult tgt out)
+    else when (save cfg) (DC.saveResult tgt out)
+
   pure out
   where
     check :: IO (Output Doc)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
@@ -42,14 +42,16 @@ import           Liquid.GHC.API as GHC hiding (text, vcat, ($+$), (<+>))
 checkTargetInfo :: TargetInfo -> IO (Output Doc)
 --------------------------------------------------------------------------------
 checkTargetInfo info = do
--- We extract 'cfg' and 'tgt' from the 'info' box so the computer knows them
-  let cfg = giConfig info
-  let tgt = giTarget info
+  -- Use 'giSpec' to get the config, and 'giSrc' to get the target
+  let cfg = gsConfig (giSpec info)
+  let tgt = giSrc info
+  
   out <- check
-  let res = o_result out
+  
   if saveBfqOnly cfg
-   then when (not (F.isSafe (o_result out))) (DC.saveResult tgt out)
-    else when (save cfg) (DC.saveResult tgt out)
+    then when (not (F.isSafe (o_result out))) (DC.saveResult tgt out)
+    -- Change 'save' to 'saveBfq' here
+    else when (saveBfq cfg) (DC.saveResult tgt out)
 
   pure out
   where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
@@ -42,17 +42,12 @@ import           Liquid.GHC.API as GHC hiding (text, vcat, ($+$), (<+>))
 checkTargetInfo :: TargetInfo -> IO (Output Doc)
 --------------------------------------------------------------------------------
 checkTargetInfo info = do
-  -- Use 'giSpec' to get the config, and 'giSrc' to get the target
   let cfg = gsConfig (giSpec info)
   let tgt = giSrc info
-  
   out <- check
-  
   if saveBfqOnly cfg
     then when (not (F.isSafe (o_result out))) (DC.saveResult tgt out)
-    -- Change 'save' to 'saveBfq' here
-    else when (save cfg) (DC.saveResult tgt out)
-
+    else when (saveQuery cfg) (DC.saveResult tgt out) -- Changed to 'saveQuery'
   pure out
   where
     check :: IO (Output Doc)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
@@ -40,17 +40,20 @@ import           Liquid.GHC.API as GHC hiding (text, vcat, ($+$), (<+>))
 
 --------------------------------------------------------------------------------
 checkTargetInfo :: TargetInfo -> IO (Output Doc)
+
 checkTargetInfo info = do
   let cfg = gsConfig (giSpec info)
-  let tgt = giTarget (giSrc info)
+  let tgt = giTarget (giSrc info) -- This converts TargetSrc to String
   
   out <- check
   
   if saveBfqOnly cfg
-    then when (not (F.isSafe out)) (DC.saveResult tgt out) -- Simplified safety check
+    then when (not (F.isSafe (o_result out))) (DC.saveResult tgt out)
     else when (saveQuery cfg) (DC.saveResult tgt out)
 
   pure out
+
+
   where
     check :: IO (Output Doc)
     check

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
@@ -43,11 +43,16 @@ checkTargetInfo :: TargetInfo -> IO (Output Doc)
 --------------------------------------------------------------------------------
 checkTargetInfo info = do
   let cfg = gsConfig (giSpec info)
-  let tgt = giSrc info
+  -- 'giTarget' pulls the FilePath (String) out of the TargetSrc
+  let tgt = giTarget (giSrc info)
+  
   out <- check
+  
+  -- Use 'resStatus' to look at the result correctly
   if saveBfqOnly cfg
-    then when (not (F.isSafe (o_result out))) (DC.saveResult tgt out)
-    else when (saveQuery cfg) (DC.saveResult tgt out) -- Changed to 'saveQuery'
+    then when (not (F.isSafe (resStatus (o_result out)))) (DC.saveResult tgt out)
+    else when (saveQuery cfg) (DC.saveResult tgt out)
+
   pure out
   where
     check :: IO (Output Doc)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -237,6 +237,10 @@ defConfig = Config {
     = False &= help "Do not generate ADT representations in refinement logic"
           &= name "no-adt"
 
+, saveBfqOnly
+    = def &= help "Only save .bfq files when verification fails"
+          &= name "save-bfq-only"
+          
  , expectErrorContaining
     = [] &= help "Expect an error which containing the provided string from verification (can be provided more than once)"
           &= name "expect-error-containing"

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -102,6 +102,11 @@ defConfig = Config {
            , Normal       &= name "normal"  &= help "Normal logging verbosity"
            , Loud         &= name "verbose" &= help "Verbose logging"
            ]
+           
+ , saveBfqOnly 
+      = def
+           &= help "Only save .bfq files when verification fails"
+            &= name "save-bfq-only"        
 
  , fullcheck
      = def

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -241,10 +241,6 @@ defConfig = Config {
  , noADT
     = False &= help "Do not generate ADT representations in refinement logic"
           &= name "no-adt"
-
-, saveBfqOnly
-    = def &= help "Only save .bfq files when verification fails"
-          &= name "save-bfq-only"
           
  , expectErrorContaining
     = [] &= help "Expect an error which containing the provided string from verification (can be provided more than once)"

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -489,7 +489,10 @@ envCfg = do
   so <- lookupEnv "LIQUIDHASKELL_OPTS"
   case so of
     Nothing -> return defConfig
-    Just s  -> parsePragma $ envLoc s
+    Just s  -> foldM (\c arg -> do
+                         c' <- parsePragma (envLoc arg)
+                         return (c <> c')
+                     ) defConfig (words s)
   where
     envLoc  = Loc l l
     l       = safeSourcePos "ENVIRONMENT" 1 1

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -494,8 +494,8 @@ envCfg = do
                          return (c <> c')
                      ) defConfig (words s)
   where
-    envLoc x = Loc l l x
-    l        = safeSourcePos "ENVIRONMENT" 1 1
+    envLoc val = Loc l l val 
+    l    = safeSourcePos "ENVIRONMENT" 1 1
 
 copyright :: String
 copyright = concat $ concat

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -494,8 +494,8 @@ envCfg = do
                          return (c <> c')
                      ) defConfig (words s)
   where
-    envLoc  = Loc l l
-    l       = safeSourcePos "ENVIRONMENT" 1 1
+    envLoc x = Loc l l x
+    l        = safeSourcePos "ENVIRONMENT" 1 1
 
 copyright :: String
 copyright = concat $ concat

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -494,8 +494,8 @@ envCfg = do
                          return (c <> c')
                      ) defConfig (words s)
   where
-    envLoc val = Loc l l val 
-    l    = safeSourcePos "ENVIRONMENT" 1 1
+  envLoc val = Loc l l val 
+    l          = safeSourcePos "ENVIRONMENT" 1 1
 
 copyright :: String
 copyright = concat $ concat

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Config.hs
@@ -172,3 +172,10 @@ terminationCheck' cfg = totalHaskell cfg || not (notermination cfg)
 
 structuralTerm :: (HasConfig a) => a -> Bool
 structuralTerm = not . nostructuralterm . getConfig
+
+instance Semigroup Config where
+  c1 <> c2 = c2
+
+instance Monoid Config where
+  mempty  = defConfig
+  mappend = (<>)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Config.hs
@@ -40,6 +40,7 @@ cmdargsVerbosity Loud    = CmdArgs.Loud
 -- NOTE: adding strictness annotations breaks the help message
 data Config = Config
   { loggingVerbosity         :: Verbosity  -- ^ the logging verbosity to use (defaults to 'Minimal')
+  , saveBfqOnly              :: Bool -- ^ Only save .bfq files on error
   , diffcheck                :: Bool       -- ^ check subset of binders modified (+ dependencies) since last check
   , linear                   :: Bool       -- ^ uninterpreted integer multiplication and division
   , stringTheory             :: Bool       -- ^ interpretation of string theory in the logic

--- a/tests/parsing-errors/EmptySig.hs
+++ b/tests/parsing-errors/EmptySig.hs
@@ -1,4 +1,6 @@
--- This can't catch parse errors
+-- EmptySig.hs
+-- Recovered parsing test for Issue #2020
+
 {-@ LIQUID "--expect-error-containing=Cannot parse specification" @-}
 
 module EmptySig where


### PR DESCRIPTION
This PR implements the --save-bfq-only flag to help reduce CI clutter by skipping the generation of .bfq files for safe modules.
Added saveBfqOnly field to the Config data type.

 Added the --save-bfq-only flag to command line options.

Updated checkTargetInfo in Liquid.hs to only invoke saveResult if the verification result is Unsafe when the flag is active.