### PR TITLE
add --save-bfq-on-error flag for liquidhaskell and include it in CI

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -75,3 +75,9 @@ jobs:
           cabal test tests:tasty --test-show-details=streaming
           cabal test tests:liquidhaskell-test --test-show-details=streaming
           cabal test -j1 liquidhaskell-boot --test-show-details=streaming
+      - name: Upload bfq artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bfq-files
+          path: '**/*.bfq'

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
@@ -43,6 +43,7 @@ fixConfig tgt cfg = FC.defConfig
   , FC.eliminate      = eliminate         cfg
   , FC.nonLinCuts     = not (higherOrderFlag cfg) -- eliminate cfg /= FC.All
   , FC.save           = saveQuery         cfg
+  , FC.saveBfqOnError = saveBfqOnError    cfg
   , FC.srcFile        = tgt
   , FC.cores          = cores             cfg
   , FC.minPartSize    = minPartSize       cfg

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -102,6 +102,7 @@ defConfig = Config
   , linear                        = False
   , stringTheory                  = False
   , saveQuery                     = False
+  , saveBfqOnError                = False
   , checks                        = []
   , pruneUnsorted                 = False
   , notermination                 = False
@@ -204,6 +205,8 @@ lhOptions =
       "Interpretation of Strings by z3"
   , opt [] ["save-query", "save"] (NoArg $ fm $ \c -> c { saveQuery = True })
       "Save fixpoint query to file (slow)"
+  , opt [] ["save-bfq-on-error"] (NoArg $ fm $ \c -> c { saveBfqOnError = True })
+      "Save fixpoint query as .bfq only when verification fails"
 
   -- SMT
   , opt [] ["smt-timeout"] (ReqArg (fm . setSmtTimeout) "MSEC")

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Config.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Config.hs
@@ -37,6 +37,7 @@ data Config = Config
   , smtTimeout               :: Maybe Int  -- ^ smt timeout
   , fullcheck                :: Bool       -- ^ check all binders (overrides diffcheck)
   , saveQuery                :: Bool       -- ^ save fixpoint query
+  , saveBfqOnError           :: Bool       -- ^ save fixpoint query as .bfq only on verification failure
   , checks                   :: [String]   -- ^ set of binders to check
   , noCheckUnknown           :: Bool       -- ^ whether to complain about specifications for unexported and unused values
   , notermination            :: Bool       -- ^ disable termination check

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -61,6 +61,9 @@ common common-ghc-options
 
     default-language: Haskell2010
 
+common ghc-options-for-negated-tests
+    ghc-options: -fplugin-opt=LiquidHaskell:--save-bfq-on-error
+
 flag benchmark-stitch-lh
      default: False
 
@@ -288,7 +291,7 @@ flag benchmark-icfp15-neg
      default: False
 
 executable benchmark-icfp15-neg
-  import:             common-ghc-options
+  import:             common-ghc-options, ghc-options-for-negated-tests
   main-is:            Main.hs
   if !flag(benchmark-icfp15-neg) && flag(stack)
     buildable:        False
@@ -388,7 +391,7 @@ flag prover-nople-neg
      default: False
 
 executable prover-nople-neg
-  import:             common-ghc-options
+  import:             common-ghc-options, ghc-options-for-negated-tests
   main-is:            Main.hs
   if !flag(prover-nople-neg) && flag(stack)
     buildable:        False
@@ -571,7 +574,7 @@ flag errors
      default: False
 
 executable errors
-    import:           common-ghc-options
+    import:           common-ghc-options, ghc-options-for-negated-tests
     main-is:          Main.hs
     if !flag(errors) && flag(stack)
       buildable:      False
@@ -797,7 +800,7 @@ flag names-neg
      default: False
 
 executable names-neg
-    import:           common-ghc-options
+    import:           common-ghc-options, ghc-options-for-negated-tests
     main-is:          Main.hs
     if !flag(names-neg) && flag(stack)
       buildable:      False
@@ -909,7 +912,7 @@ flag class-neg
       default: False
 
 executable class-neg
-    import:           common-ghc-options
+    import:           common-ghc-options, ghc-options-for-negated-tests
     main-is:          Main.hs
     if !flag(class-neg) && flag(stack)
       buildable:      False
@@ -931,7 +934,7 @@ flag reflect-neg
      default: False
 
 executable reflect-neg
-    import:           common-ghc-options
+    import:           common-ghc-options, ghc-options-for-negated-tests
     main-is:          Main.hs
     if !flag(reflect-neg) && flag(stack)
       buildable:      False
@@ -995,7 +998,7 @@ flag measure-neg
      default: False
 
 executable measure-neg
-    import:           common-ghc-options
+    import:           common-ghc-options, ghc-options-for-negated-tests
     main-is:          Main.hs
     if !flag(measure-neg) && flag(stack)
       buildable:      False
@@ -1087,7 +1090,7 @@ flag unit-neg
      default: False
 
 executable unit-neg
-    import:           common-ghc-options
+    import:           common-ghc-options, ghc-options-for-negated-tests
     main-is:          Main.hs
     if !flag(unit-neg) && flag(stack)
       buildable:      False
@@ -2092,7 +2095,7 @@ flag absref-neg
      default: False
 
 executable absref-neg
-    import:           common-ghc-options
+    import:           common-ghc-options, ghc-options-for-negated-tests
     main-is:          Main.hs
     if !flag(absref-neg) && flag(stack)
       buildable:      False
@@ -2147,7 +2150,7 @@ flag relational-neg
      default: False
 
 executable relational-neg
-    import:           common-ghc-options
+    import:           common-ghc-options, ghc-options-for-negated-tests
     main-is:          Main.hs
     if !flag(relational-neg) && flag(stack)
       buildable:      False
@@ -2174,7 +2177,7 @@ flag basic-neg
      default: False
 
 executable basic-neg
-    import:           common-ghc-options
+    import:           common-ghc-options, ghc-options-for-negated-tests
     main-is:          Main.hs
     if !flag(basic-neg) && flag(stack)
       buildable:      False
@@ -2478,7 +2481,7 @@ flag ple-neg
      default: False
 
 executable ple-neg
-    import:           common-ghc-options
+    import:           common-ghc-options, ghc-options-for-negated-tests
     main-is:          Main.hs
     if !flag(ple-neg) && flag(stack)
       buildable:      False
@@ -2577,7 +2580,7 @@ flag terminate-neg
      default: False
 
 executable terminate-neg
-    import:           common-ghc-options
+    import:           common-ghc-options, ghc-options-for-negated-tests
     main-is:          Main.hs
     if !flag(terminate-neg) && flag(stack)
       buildable:      False


### PR DESCRIPTION
i'm not sure how to pass the `--save-bfq-on-error` through the LH plugin test pipeline like you (@facundominguez) did in the previous PR. the `extraOpts` in `Build.hs` goes to cabal build, not to individual test executables.