### PR TITLE
Tweaks to make abstract predicates less surprising

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Expand.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Expand.hs
@@ -515,6 +515,7 @@ cookSpecTypeE env sigEnv name@(ModName _ _) x bt
     f =   (if doplug || not allowTC then plugHoles allowTC sigEnv name x else id)
         . fmap (RT.addTyConInfo embs tyi)
         . Bare.txRefSort tyi embs
+        . checkExtraAbsRef embs tyi
         . fmap txExpToBind -- What does this function DO
         . (specExpandType rtEnv . fmap (generalizeWith x))
         . (if doplug || not allowTC then maybePlug allowTC sigEnv name x else id)
@@ -540,6 +541,42 @@ generalizeWith :: Bare.PlugTV Ghc.Var -> SpecType -> SpecType
 generalizeWith (Bare.HsTV v) t = generalizeVar v t
 generalizeWith  Bare.RawTV   t = t
 generalizeWith _             t = RT.generalize t
+
+-- | Check for extra abstract refinement arguments (lambda-form) on type
+--   constructors that don't declare enough PVar parameters.  This must run
+--   BEFORE 'txRefSort' and 'addTyConInfo' so that only user-written RProps
+--   are present (system-generated default RProps from 'rtPropTop' have not
+--   been added yet).  See GitHub issue #2603.
+checkExtraAbsRef :: F.TCEmb Ghc.TyCon -> Bare.TyConMap -> LocSpecType -> LocSpecType
+checkExtraAbsRef embs tyi lt = walkCheck (GM.fSrcSpan lt) (val lt) `seq` lt
+  where
+    walkCheck sp (RAllT _ t _)      = walkCheck sp t
+    walkCheck sp (RAllP _ t)        = walkCheck sp t
+    walkCheck sp (RFun _ _ t1 t2 _) = walkCheck sp t1 `seq` walkCheck sp t2
+    walkCheck sp (RApp rc ts rs _)
+      | not (null lambdaRest)
+      = uError $ ErrOther sp $ PJ.vcat
+          [ PJ.text "Type constructor" PJ.<+> PJ.text (GM.showPpr (rtc_tc rc))
+              PJ.<+> if nExpected == 0
+                       then PJ.text "does not accept abstract refinement arguments,"
+                       else PJ.text "expects" PJ.<+> PJ.int nExpected
+                         PJ.<+> PJ.text "abstract refinement argument(s),"
+          , PJ.text "but was given" PJ.<+> PJ.int nGiven PJ.<> PJ.text "."
+          ]
+      | otherwise = foldWalk sp ts
+      where
+        (_, pvs)    = RT.appRTyCon embs tyi rc ts
+        nExpected   = length pvs
+        nGiven      = length rs
+        (_, rrest)  = splitAt nExpected rs
+        lambdaRest  = [r | r@(RProp binds _) <- rrest, not (null binds)]
+    walkCheck sp (RAllE _ t1 t2)    = walkCheck sp t1 `seq` walkCheck sp t2
+    walkCheck sp (REx _ t1 t2)      = walkCheck sp t1 `seq` walkCheck sp t2
+    walkCheck sp (RAppTy t1 t2 _)   = walkCheck sp t1 `seq` walkCheck sp t2
+    walkCheck sp (RRTy xts _ _ t)   = foldWalk sp (snd <$> xts) `seq` walkCheck sp t
+    walkCheck _  _                   = ()
+
+    foldWalk sp = L.foldl' (\acc t -> acc `seq` walkCheck sp t) ()
 
 generalizeVar :: Ghc.Var -> SpecType -> SpecType
 generalizeVar v t = mkUnivs [(a, mempty) | a <- as] [] t

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -512,8 +512,10 @@ addSymSortRef :: (PPrint s) => Ghc.SrcSpan -> s -> RPVar -> SpecProp -> Int -> S
 addSymSortRef sp rc p r i = addSymSortRef' sp rc i p r
 
 addSymSortRef' :: (PPrint s) => Ghc.SrcSpan -> s -> Int -> RPVar -> SpecProp -> SpecProp
-addSymSortRef' _ _ _ p (RProp s (RVar v r)) | isDummy v
-  = RProp xs t
+addSymSortRef' sp rc i p (RProp s (RVar v r)) | isDummy v
+  = if length s > length (pargs p)
+    then uError $ ErrPartPred sp (pprint rc) (pprint $ pname p) i (length (pargs p) + 1) (length s + 1)
+    else RProp xs t
     where
       t  = ofRSort (pvType p) `RT.strengthen` r
       xs = spliceArgs "addSymSortRef 1" s p
@@ -532,8 +534,10 @@ addSymSortRef' sp rc i p (RProp _ (RHole r@(MkUReft _ (Pr [up]))))
 addSymSortRef' _ _ _ _ (RProp s (RHole r))
   = RProp s (RHole r)
 
-addSymSortRef' _ _ _ p (RProp s t)
-  = RProp xs t
+addSymSortRef' sp rc i p (RProp s t)
+  = if length s > length (pargs p)
+    then uError $ ErrPartPred sp (pprint rc) (pprint $ pname p) i (length (pargs p) + 1) (length s + 1)
+    else RProp xs t
     where
       xs = spliceArgs "addSymSortRef 2" s p
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -517,8 +517,27 @@ addSymSortRef' sp rc i p (RProp s (RVar v r)) | isDummy v
     then uError $ ErrPartPred sp (pprint rc) (pprint $ pname p) i (length (pargs p) + 1) (length s + 1)
     else RProp xs t
     where
-      t  = ofRSort (pvType p) `RT.strengthen` r
-      xs = spliceArgs "addSymSortRef 1" s p
+      -- When the lambda provides fewer args than the PVar expects,
+      -- the lambda's refinement variable (last lambda arg) should bind
+      -- to the next PVar parameter position, not to the value type.
+      -- e.g. for p :: a -> a -> b -> Bool, {\x y -> x >= y} should
+      -- bind x→arg1, y→arg2 (not y→value).
+      nLambdaArgs = length s + 1  -- s bindings + 1 refvar
+      nPVarArgs   = length (pargs p) + 1  -- pargs + 1 value
+      (s', r')
+        | nLambdaArgs < nPVarArgs
+        , MkUReft (F.Reft (rv, body)) prd <- r
+        = -- Promote the refvar to a regular binding; the body still refers
+          -- to rv which now names the (length s + 1)th PVar arg.
+          -- Use a fresh vv as the Reft binder (value variable).
+          let vv    = F.vv (Just 0)
+              -- Sort placeholder; spliceArgs replaces it with the PVar's sort
+              dSort = Misc.fst3 (last (pargs p))
+          in (s ++ [(rv, dSort)], MkUReft (F.Reft (vv, body)) prd)
+        | otherwise
+        = (s, r)
+      t  = ofRSort (pvType p) `RT.strengthen` r'
+      xs = spliceArgs "addSymSortRef 1" s' p
 
 addSymSortRef' sp rc i p (RProp _ (RHole r@(MkUReft _ (Pr [up]))))
   | length xs == length ts

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -1311,7 +1311,7 @@ freshPredRef γ e (PV _ rsort _ as)
 --------------------------------------------------------------------------------
 argType :: Type -> Maybe F.Expr
 argType (LitTy (NumTyLit i)) = mkI i
-argType (LitTy (StrTyLit s)) = mkS $ bytesFS s
+argType (LitTy (StrTyLit s)) = Just $ mkS $ bytesFS s
 argType (TyVarTy x)          = Just $ F.EVar $ F.symbol $ varName x
 argType t
   | F.symbol (GM.showPpr t) == anyTypeSymbol

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -780,7 +780,16 @@ bTup :: [(Maybe Symbol, BareTypeParsed)]
      -> [RTPropV LocSymbol BTyCon BTyVar (UReftV LocSymbol (ReftV LocSymbol))]
      -> ReftV LocSymbol
      -> BareTypeParsed
-bTup [(_,t)] _ r
+bTup [(_,t)] rs r
+  | not (null rs)
+  = case appendRProps t rs of
+      Just t' | isTauto (fmap val r) -> t'
+              | otherwise            -> t' `strengthenUReft` reftUReft r
+      Nothing -> uError $ ErrOther GHC.noSrcSpan $ PJ.vcat
+        [ PJ.text "Cannot apply abstract refinement arguments to a non-constructor type."
+        , PJ.text "Abstract refinements can only be applied to type constructors, e.g."
+        , PJ.text "    (T a b) <p>"
+        ]
   | isTauto (fmap val r)  = t
   | otherwise  = t `strengthenUReft` reftUReft r
 bTup ts rs r
@@ -798,6 +807,14 @@ bTup ts rs r
     args       = [(Mb.fromMaybe dummySymbol x, mapReft mempty t) | (x,t) <- ts]
     makeProp i = RProp (reverse $ take i args) ((snd <$> ts)!!i)
     rs'        = makeProp <$> [1..(length ts-1)]
+
+-- | Append abstract refinement predicates to the RProp list of an RApp.
+-- Returns Nothing if the type is not an RApp (predicates can't be attached).
+appendRProps :: RTypeV v c tv r
+             -> [RTPropV v c tv r]
+             -> Maybe (RTypeV v c tv r)
+appendRProps (RApp c ts rs r0) rs' = Just (RApp c ts (rs ++ rs') r0)
+appendRProps _                _   = Nothing
 
 
 -- Temporarily restore this hack benchmarks/esop2013-submission/Array.hs fails

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -342,6 +342,9 @@ checkBoolAlts [Alt (C.DataAlt true) [] etrue, Alt (C.DataAlt false) [] efalse]
 checkBoolAlts alts
   = throw ("checkBoolAlts failed on " ++ GM.showPpr alts)
 
+-- @casesToLg v e alts@ transforms a case expression with scrutinee @e@ and
+-- alternatives @alts@ into a logic expression. The variable @v@ is the binder
+-- for the scrutinee in the case alternatives.
 casesToLg :: Var -> Expr -> [C.CoreAlt] -> LogicM Expr
 casesToLg v e alts = mapM (altToLg e) normAlts >>= go
   where
@@ -594,12 +597,59 @@ isANF      v = isPrefixOfSym (symbol ("lq_anf" :: String)) (simpleSymbolVar v)
 isDead :: Id -> Bool
 isDead     = isDeadOcc . occInfo . Ghc.idInfo
 
+-- | 'normalizeCoreExpr allowTC e' simplifies the Core expression 'e' by:
+--   1. inlining predicates (i.e. applications of measures that return Bool)
+--   2. inlining ANF variables (i.e. variables that are introduced by the ANF transformation)
+--   3. simplifying the expression by removing dead binders and applications of
+--      type arguments and dictionaries.
+--
+-- The 'allowTC' flag controls whether type class dictionaries are considered erasable
+-- and will be removed from the expression.
+--
 normalizeCoreExpr :: Bool -> CoreExpr -> CoreExpr
 normalizeCoreExpr allowTC = inline_preds . inline_anf . simplifyCoreExpr allowTC
   where
     inline_preds = inlineCoreExpr (eqType boolTy . GM.expandVarType)
     inline_anf   = inlineCoreExpr isANF
 
+-- | 'simplifyCoreExpr allowTC e' simplifies the Core expression 'e' by removing
+-- applications of type arguments and dictionaries, and by removing dead
+-- binders.
+--
+-- The 'allowTC' flag controls whether type class dictionaries are considered
+-- erasable.
+--
+-- If 'allowTC' is 'True', then type class dictionaries are considered erasable
+-- and will be removed from the expression. If 'allowTC' is 'False', then type
+-- class dictionaries are not considered erasable and will not be removed.
+--
+-- This function is used in 'normalizeCoreExpr' to simplify the Core expression
+-- before inlining predicates and ANF variables.
+--
+-- The 'simplifyCoreExpr' function recursively traverses the Core expression and
+-- applies the following simplifications:
+--   1. It removes applications of type arguments (i.e. 'C.App e1 (C.Type _)').
+--   2. It removes applications of variables that are considered erasable
+--      (i.e. 'C.App e1 (C.Var v)' where 'v' is erasable).
+--   3. It removes applications of lambda expressions where the binder is dead
+--      (i.e. 'C.App (C.Lam x e) _' where 'x' is dead).
+--   4. It removes lambda expressions where the binder is a type variable
+--      (i.e. 'C.Lam x e' where 'x' is a type variable).
+--   5. It removes lambda expressions where the binder is considered erasable
+--      (i.e. 'C.Lam x e' where 'x' is erasable).
+--   6. It removes non-recursive let bindings where the binder is considered
+--      erasable (i.e. 'C.Let (C.NonRec x eb) e' where 'x' is erasable).
+--   7. It removes recursive let bindings where all binders are considered
+--      erasable (i.e. 'C.Let (C.Rec xes) e' where all 'x' in 'xes' are
+--      erasable).
+--   8. It simplifies case expressions that match on a boolean by checking if
+--      the alternatives correspond to 'True' and 'False' and then substituting
+--      the scrutinee with the appropriate alternative.
+--   9. It simplifies case expressions by removing alternatives that correspond
+--      to pattern match errors (i.e. 'isPatErrorAlt').
+--   10. It recursively simplifies applications, casts, ticks, coercions, and
+--       type expressions.
+--
 simplifyCoreExpr :: Bool -> CoreExpr -> CoreExpr
 simplifyCoreExpr allowTC = go
   where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -545,7 +545,7 @@ mkLit (LitNumber _ n) = mkI n
 -- mkLit (LitInteger n _)  = mkI n
 mkLit (LitFloat  n)    = mkR n
 mkLit (LitDouble n)    = mkR n
-mkLit (LitString    s)    = mkS s
+mkLit (LitString    s) = Just (mkS s)
 mkLit (LitChar   c)    = mkC c
 mkLit _                 = Nothing -- ELit sym sort
 
@@ -555,8 +555,8 @@ mkI = Just . ECon . I
 mkR :: Rational -> Maybe Expr
 mkR                    = Just . ECon . F.R . fromRational
 
-mkS :: ByteString -> Maybe Expr
-mkS                    = Just . ESym . SL  . decodeUtf8With lenientDecode
+mkS :: ByteString -> Expr
+mkS = ESym . SL  . decodeUtf8With lenientDecode
 
 mkC :: Char -> Maybe Expr
 mkC                    = Just . ECon . (`F.L` F.charSort)  . repr

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Errors.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Errors.hs
@@ -990,11 +990,14 @@ ppError' _ dCtx (ErrPartPred _ c p i eN aN)
         $+$ dCtx
         $+$ nest 4 (vcat
                         [ "The" <+> text (Misc.intToString i) <+> "argument of" <+> c <+> "is predicate" <+> ppTicks p
-                        , "which expects" <+> pprint eN <+> "arguments" <+> "but is given only" <+> pprint aN
+                        , "which expects" <+> pprint eN <+> "arguments" <+> "but is given" <+> pprint aN
                         , " "
-                        , "Abstract predicates cannot be partially applied; for a possible fix see:"
-                        , " "
-                        , nest 4 "https://github.com/ucsd-progsys/liquidhaskell/issues/594"
+                        , if eN > aN
+                          then vcat [ "Abstract predicates cannot be partially applied; for a possible fix see:"
+                                    , " "
+                                    , nest 4 "https://github.com/ucsd-progsys/liquidhaskell/issues/594"
+                                    ]
+                          else "The provided predicate has too many arguments."
                         ])
 
 ppError' _ dCtx e@(ErrMismatch _ x msg τ t cause hsSp)

--- a/tests/absref/pos/ParenAbsRef.hs
+++ b/tests/absref/pos/ParenAbsRef.hs
@@ -1,0 +1,15 @@
+{- | Test that abstract refinement predicates on parenthesized types
+     are correctly propagated. (Pair Int Int)<p> should behave the same
+     as Pair<p> Int Int.
+-}
+module ParenAbsRef where
+
+{-@ data Pair a b <p :: a -> b -> Bool> = Pair { pFst :: a, pSnd :: b<p pFst> } @-}
+data Pair a b = Pair a b
+
+-- Parenthesized form: the predicate applies to the Pair type constructor
+{-@ type OrdPair = (Pair Int Int) <{\x y -> x <= y}> @-}
+
+{-@ mkGood :: OrdPair @-}
+mkGood :: Pair Int Int
+mkGood = Pair 3 5

--- a/tests/absref/pos/PartialPredArgs.hs
+++ b/tests/absref/pos/PartialPredArgs.hs
@@ -1,0 +1,21 @@
+{- | Regression test: when a lambda predicate has fewer arguments than
+     the formal abstract predicate, arguments must bind left-to-right
+     to the formal parameters (not shift to the value position).
+
+     Here p :: a -> a -> b -> Bool has 3 args, but the lambda {\x y -> x >= y}
+     has only 2. The correct binding is x→1st arg, y→2nd arg. With the data
+     declaration p pfst pfst, the constraint becomes pfst >= pfst which is
+     trivially true (SAFE).
+
+     If arguments were shifted (old bug), y would bind to the value type
+     (psnd), giving pfst >= psnd = 1 >= 2 = UNSAFE.
+-}
+module PartialPredArgs where
+
+{-@ data Pair a b <p :: a -> a -> b -> Bool>
+      = MkPair { pfst :: a, psnd :: b<p pfst pfst> } @-}
+data Pair a b = MkPair { pfst :: a, psnd :: b }
+
+{-@ foo :: Pair <{\x y -> x >= y}> Int Int @-}
+foo :: Pair Int Int
+foo = MkPair 1 2

--- a/tests/errors/ExtraAbsRefArgs.hs
+++ b/tests/errors/ExtraAbsRefArgs.hs
@@ -1,0 +1,16 @@
+{-@ LIQUID "--expect-error-containing=does not accept abstract refinement arguments" @-}
+
+-- Test for issue #2603: abstract refinement predicate applied to a type
+-- constructor that doesn't declare any abstract refinement parameters.
+-- Without parentheses around (Pair ...), the parser attaches <{...}> to Int
+-- which has no abstract refinement parameters.
+
+module ExtraAbsRefArgs where
+
+{-@ data Pair a b <p :: a -> b -> Bool> = MkPair { pfst :: a, psnd :: b<p pfst> } @-}
+data Pair a b = MkPair { pfst :: a, psnd :: b }
+
+-- The <{...}> gets attached to Int, not to Pair
+{-@ foo :: Pair Int Int <{\x y -> x <= y}> @-}
+foo :: Pair Int Int
+foo = MkPair 1 2

--- a/tests/errors/ExtraAbsRefArgs.hs
+++ b/tests/errors/ExtraAbsRefArgs.hs
@@ -10,7 +10,7 @@ module ExtraAbsRefArgs where
 {-@ data Pair a b <p :: a -> b -> Bool> = MkPair { pfst :: a, psnd :: b<p pfst> } @-}
 data Pair a b = MkPair { pfst :: a, psnd :: b }
 
--- The <{...}> gets attached to Int, not to Pair
+-- The <{...}> gets attached to Int (no pvars), not to Pair
 {-@ foo :: Pair Int Int <{\x y -> x <= y}> @-}
 foo :: Pair Int Int
 foo = MkPair 1 2

--- a/tests/errors/PredArityMismatch.hs
+++ b/tests/errors/PredArityMismatch.hs
@@ -1,0 +1,13 @@
+{-@ LIQUID "--expect-error-containing=Malformed predicate application" @-}
+
+-- Test for arity mismatch: predicate expects 2 arguments (a -> b -> Bool)
+-- but is given a 3-argument lambda.
+
+module PredArityMismatch where
+
+{-@ data Pair a b <p :: a -> b -> Bool> = MkPair { pfst :: a, psnd :: b<p pfst> } @-}
+data Pair a b = MkPair { pfst :: a, psnd :: b }
+
+{-@ foo :: Pair <{\x y z -> x <= y}> Int Int @-}
+foo :: Pair Int Int
+foo = MkPair 1 2

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -625,6 +625,7 @@ executable errors
                     , EmptyData
                     , ErrLocation
                     , ErrLocation2
+                    , ExtraAbsRefArgs
                     -- , ExportMeasure0
                     -- , ExportReflect0
                     , Fractional

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2075,6 +2075,7 @@ executable absref-pos
                     , ListQSort
                     , Papp00
                     , ParenAbsRef
+                    , PartialPredArgs
                     , State00
                     , VectorLoop
 

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2073,6 +2073,7 @@ executable absref-pos
                     , ListISort_LType
                     , ListQSort
                     , Papp00
+                    , ParenAbsRef
                     , State00
                     , VectorLoop
 

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -596,6 +596,7 @@ executable errors
                     , BadDataDeclTyVars
                     , BadGADT
                     , BadPredApp
+                    , PredArityMismatch
                     -- , BadQualifier
                     , BadSig0
                     , BadSig1


### PR DESCRIPTION
* `(T a b c)<p>` is not ignored anymore. Now it has the same meaning as T <p> a b c
* `T <{\a b -> e}>` produces an error message if `T` does not expect a predicate. When the predicate has a single argument `T <{\a -> e}>` and T does not expect a predicate, this is still taken as `{v:T | e}`.
* In `T` predicate expects three arguments, `T <{\a b -> e}>` binds `a` and `b` to the first two arguments of the predicate. Before, `b` was bound to the last argument instead.
* If the arity of the actual parameter is too large, an error is produced.

Fixes #2603.