### PR TITLE
Add constraint IDs to termination check (ErrAssType) errors

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Split.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Split.hs
@@ -276,7 +276,7 @@ splitC _ (SubR γ o r)
     r2  = F.RR F.boolSort $ F.Reft (vv, F.EVar vv)
     vv  = "vvRec"
     ci  = Ci src err (cgVar γ)
-    err = Just $ ErrAssType src o (text $ show o ++ "type error") g (rHole rr)
+    err = Just $ ErrAssType src o (text $ show o ++ "type error") Nothing g (rHole rr)
     rr  = toReft r
     tag = getTag γ
     src = getLocation γ

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Liquid.hs
@@ -161,6 +161,7 @@ cidE2u cfg (subcId, e) =
   where
     attachSubcId es@ErrSubType{}      = es { cid = Just subcId }
     attachSubcId es@ErrSubTypeModel{} = es { cid = Just subcId }
+    attachSubcId es@ErrAssType{}      = es { cid = Just subcId }
     attachSubcId es = es
 
 -- writeCGI tgt cgi = {-# SCC "ConsWrite" #-} writeFile (extFileName Cgi tgt) str

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Errors.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Errors.hs
@@ -259,6 +259,7 @@ data TError t =
   | ErrAssType { pos  :: !SrcSpan
                , obl  :: !Oblig
                , msg  :: !Doc
+               , cid  :: Maybe SubcId
                , ctx  :: !(M.HashMap Symbol t)
                , cond :: t
                } -- ^ condition failure error
@@ -801,10 +802,11 @@ hint e = maybe empty (\d -> "" $+$ ("HINT:" <+> d)) (go e)
 --------------------------------------------------------------------------------
 ppError' :: (PPrint a, Show a) => Tidy -> Doc -> TError a -> Doc
 --------------------------------------------------------------------------------
-ppError' td dCtx (ErrAssType _ o _ c p)
+ppError' td dCtx (ErrAssType _ o _ cid c p)
   = pprintTidy td o
         $+$ dCtx
         $+$ ppFull td (ppPropInContext td p c)
+        $+$ maybe mempty (\i -> text "Constraint id" <+> text (show i)) cid
 
 ppError' td dCtx err@(ErrSubType _ _ _ _ _ tE)
   | totalityType td tE


### PR DESCRIPTION
The ErrAssType error type, used for termination check failures reported by the fixpoint solver, was missing the constraint ID that ErrSubType and ErrSubTypeModel already had. This made it difficult to cross-reference termination errors with constraints in LH dumps.

Changes:
- Add cid :: Maybe SubcId field to ErrAssType in Types/Errors.hs
- Handle ErrAssType in attachSubcId (Liquid.hs) to propagate solver IDs
- Display constraint ID in ppError' for ErrAssType
- Pass Nothing for cid at the ErrAssType construction site in Split.hs

Fixes #2658