### PR TITLE
Preserve dead bindings when desugaring

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,51 @@
+name: "Copilot Setup Steps"
+
+on:
+    workflow_dispatch:
+    push:
+        paths:
+            - .github/workflows/copilot-setup-steps.yml
+    pull_request:
+        paths:
+            - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+    copilot-setup-steps:
+        runs-on: ubuntu-latest
+
+        permissions:
+            contents: read
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  submodules: recursive
+
+            - name: Setup z3
+              uses: pavpanchekha/setup-z3@6b2d476d7a9227e0d8d2b94f73cd9fcba91b5e98
+              with:
+                  version: "4.15.1"
+                  distribution: glibc-2.39
+
+            - name: Workaround runner image issue
+              # https://github.com/actions/runner-images/issues/7061
+              run: sudo chown -R $USER /usr/local/.ghcup
+
+            - name: Setup GHC and cabal-install
+              uses: haskell-actions/setup@v2
+              with:
+                  ghc-version: "9.14.1"
+                  cabal-version: "3.16.0.0"
+
+            - name: Cache cabal store
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ~/.cabal/packages
+                      ~/.cabal/store
+                      dist-newstyle
+                  key: ${{ runner.os }}-9.14.1-cabal-${{ hashFiles('cabal.project', '**/*.cabal') }}
+
+            - name: Build liquidhaskell
+              run: cabal build liquidhaskell liquid-prelude liquid-vector

--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ You can directly extend and run the tests by modifying the files in
 
 Tests run in parallel, unless the flag `--measure-timings` is specified to `test_plugin.sh`.
 
+### How to add a new test
+
+Select a folder where to add the test, for instance `tests/ple/pos` and add a
+new file `MyTest.hs` with the test module. Then add the module to the
+corresponding executable in `tests/tests.cabal`.
+
 ## How to create performance comparison charts
 
 Firstly, make sure to remove previous compilation artifacts of tests before measuring performance,

--- a/liquidhaskell-boot/ghc-api-tests/GhcApiTests.hs
+++ b/liquidhaskell-boot/ghc-api-tests/GhcApiTests.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ViewPatterns #-}
 
 import           Control.Monad
+import           Control.Monad.IO.Class (liftIO)
 import           Data.List (find)
 import           Data.Time (getCurrentTime)
 import           Liquid.GHC.API
@@ -11,13 +12,13 @@ import           Liquid.GHC.API
     , LitNumType(..)
     , Literal(..)
     , apiCommentsParsedSource
-    , gopt_set
     , occNameString
     , pAT_ERROR_ID
     , showPprQualified
     , splitDollarApp
     , untick
     )
+import           Liquid.GHC.API.Extra (addNoInlinePragmasToBinds)
 import           Test.Tasty
 import           Test.Tasty.HUnit
 import           Test.Tasty.Runners.AntXML
@@ -29,6 +30,7 @@ import qualified GHC.Core as GHC
 import qualified GHC.Data.EnumSet as EnumSet
 import qualified GHC.Data.FastString as GHC
 import qualified GHC.Data.StringBuffer as GHC
+import qualified GHC.Driver.Main as GHC (hscDesugar)
 import qualified GHC.Parser as Parser
 import qualified GHC.Parser.Lexer as GHC
 import qualified GHC.Types.Id as GHC
@@ -52,7 +54,8 @@ testTree =
       , testCase "caseDesugaring" testCaseDesugaring
       , testCase "numericLiteralDesugaring" testNumLitDesugaring
       , testCase "dollarDesugaring" testDollarDesugaring
-      , testCase "localBindingsDesugaring" testLocalBindingsDesugaring
+      , testCase "deadBindingPreservation" testDeadBindingPreservation
+      , testCase "exportedBindingNotInlined" testExportedBindingNotInlined
       ]
 
 -- Tests that Liquid.GHC.API.Extra.apiComments can retrieve the comments in
@@ -204,49 +207,104 @@ findExpr name (p:ps) = case p of
   _ -> findExpr name ps
 
 
--- | Test that local bindings are preserved.
-testLocalBindingsDesugaring :: IO ()
-testLocalBindingsDesugaring = do
-    let inputSource = unlines
-          [ "module LocalBindingsDesugaring where"
-          , "f :: ()"
-          , "f = z"
-          , "  where"
-          , "    z = ()"
-          ]
-
-        isExpectedDesugaring p = case findExpr "f" p of
-          Just (Let (GHC.NonRec b _) _)
-            -> occNameString (GHC.occName b) == "z"
-          _ -> False
-
-    coreProgram <- compileToCore "LocalBindingsDesugaring" inputSource
-    unless (isExpectedDesugaring coreProgram) $
-      fail $ unlines $
-        "Unexpected desugaring:" : map showPprQualified coreProgram
-
-
 compileToCore :: String -> String -> IO [GHC.CoreBind]
 compileToCore modName inputSource = do
-    now <- getCurrentTime
     GHC.runGhc (Just libdir) $ do
-      df1 <- GHC.getSessionDynFlags
-      GHC.setSessionDynFlags $ df1
-        { GHC.backend = GHC.interpreterBackend
-        }
-         `gopt_set` GHC.Opt_InsertBreakpoints
-      let target = GHC.Target {
-                   GHC.targetId           = GHC.TargetFile (modName ++ ".hs") Nothing
-                 , GHC.targetUnitId       = GHC.homeUnitId_ df1
-                 , GHC.targetAllowObjCode = False
-                 , GHC.targetContents     = Just (GHC.stringToStringBuffer inputSource, now)
-                 }
-      GHC.setTargets [target]
-      void $ GHC.load GHC.LoadAllTargets
-
-      dsMod <- GHC.getModSummary
-                 (GHC.mkModule GHC.mainUnit (GHC.mkModuleName modName))
-             >>= GHC.parseModule
-             >>= GHC.typecheckModule
-             >>= GHC.desugarModule
+      (_, tcMod) <- typecheckSourceCode modName inputSource
+      dsMod <- GHC.desugarModule tcMod
       return $ GHC.mg_binds $ GHC.dm_core_module dsMod
+
+typecheckSourceCode
+  :: GHC.GhcMonad m => String -> String -> m (GHC.ModSummary, GHC.TypecheckedModule)
+typecheckSourceCode modName inputSource = do
+    now <- liftIO getCurrentTime
+    df1 <- GHC.getSessionDynFlags
+    GHC.setSessionDynFlags $ df1 { GHC.backend = GHC.interpreterBackend }
+    let target = GHC.Target
+               { GHC.targetId           = GHC.TargetFile (modName ++ ".hs") Nothing
+               , GHC.targetUnitId       = GHC.homeUnitId_ df1
+               , GHC.targetAllowObjCode = False
+               , GHC.targetContents     = Just (GHC.stringToStringBuffer inputSource, now)
+               }
+    GHC.setTargets [target]
+    void $ GHC.depanal [] False
+
+    ms <- GHC.getModSummary
+            (GHC.mkModule GHC.mainUnit (GHC.mkModuleName modName))
+    tm <- GHC.parseModule ms >>= GHC.typecheckModule
+    return (ms, tm)
+
+-- | Like 'compileToCore' but applies 'addNoInlinePragmasToBinds' before
+-- desugaring, simulating what LH's plugin does to preserve bindings that
+-- would otherwise be inlined away.
+compileToCoreWithLH :: String -> String -> IO [GHC.CoreBind]
+compileToCoreWithLH modName inputSource = do
+    GHC.runGhc (Just libdir) $ do
+      (ms, tcMod) <- typecheckSourceCode modName inputSource
+      let (tcg, _) = GHC.tm_internals_ tcMod
+          tcg' = addNoInlinePragmasToBinds tcg
+      hsc_env <- GHC.getSession
+      guts <- liftIO $ GHC.hscDesugar hsc_env ms tcg'
+      return $ GHC.mg_binds guts
+
+-- | Tests that dead bindings (unused where-clause bindings) are preserved
+-- when 'addNoInlinePragmasToBinds' marks Ids as exported.
+testDeadBindingPreservation :: IO ()
+testDeadBindingPreservation = do
+    let inputSource = unlines
+          [ "module DeadBindingPreservation where"
+          , "f :: Int -> ()"
+          , "f x = ()"
+          , "  where"
+          , "    z = x + 1"
+          ]
+
+        -- The dead binding 'z' should still appear in the Core output.
+        hasDeadBinding p = case findExpr "f" p of
+          Just e -> hasLetNamed "z" e
+          _      -> False
+
+    coreProgram <- compileToCoreWithLH "DeadBindingPreservation" inputSource
+    unless (hasDeadBinding coreProgram) $
+      fail $ unlines $
+        "Dead binding 'z' was eliminated:" : map showPprQualified coreProgram
+
+-- | Tests that a binding marked as exported is not inlined even when it
+-- occurs exactly once (i.e. it would normally be inlined by the simple
+-- optimizer).
+testExportedBindingNotInlined :: IO ()
+testExportedBindingNotInlined = do
+    let inputSource = unlines
+          [ "module ExportedBindingNotInlined where"
+          , "f :: Int -> Int"
+          , "f x = z"
+          , "  where"
+          , "    z = x + 1"
+          ]
+
+        -- The binding 'z' is used exactly once. Without the exported
+        -- marking, the simple optimizer would inline it. With it,
+        -- 'z' should still appear as a let-binding.
+        hasBinding p = case findExpr "f" p of
+          Just e -> hasLetNamed "z" e
+          _      -> False
+
+    coreProgram <- compileToCoreWithLH "ExportedBindingNotInlined" inputSource
+    unless (hasBinding coreProgram) $
+      fail $ unlines $
+        "Binding 'z' was inlined:" : map showPprQualified coreProgram
+
+-- | Check if an expression contains a let-binding with the given name.
+hasLetNamed :: String -> GHC.CoreExpr -> Bool
+hasLetNamed name = go
+  where
+    go (Let (GHC.NonRec b _) body) =
+      occNameString (GHC.occName b) == name || go body
+    go (Let (GHC.Rec pairs) body) =
+      any (\(b, _) -> occNameString (GHC.occName b) == name) pairs || go body
+    go (Lam _ e) = go e
+    go (App e1 e2) = go e1 || go e2
+    go (GHC.Case _ _ _ alts) = any (\(Alt _ _ rhs) -> go rhs) alts
+    go (GHC.Cast e _) = go e
+    go (GHC.Tick _ e) = go e
+    go _ = False

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API/Extra.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API/Extra.hs
@@ -122,10 +122,17 @@ apiCommentsParsedSource ps =
     spanToLineColumn =
       fmap (\s -> (srcSpanStartLine s, srcSpanStartCol s)) . srcSpanToRealSrcSpan
 
--- | Adds NOINLINE pragmas to all bindings in the module.
+-- | Adds NOINLINE pragmas to all bindings in the module and sets them as
+-- exported identifiers.
 --
 -- This prevents the simple optimizer from inlining such bindings which might
 -- have specs that would otherwise be left dangling.
+--
+-- Setting the exported flag prevents both inlining and removal of dead bindings
+-- in the simple optimizer. NOINLINE is redundant with this, but it expresseses
+-- the intent more clearly. Note also that Language.Haskell.Liquid.Transform.Rewrite.inlineLoopBreaker
+-- depends at the moment on NOINLINE being inserted to tell appart bindings in
+-- the original program from generated bindings.
 --
 -- https://gitlab.haskell.org/ghc/ghc/-/issues/24386
 --
@@ -150,7 +157,7 @@ addNoInlinePragmasToBinds tcg = tcg{ tcg_binds = go (tcg_binds tcg) }
         pat -> gmapT (id `extT` markPat) pat
 
     markId :: Id -> Id
-    markId var = var `setInlinePragma` neverInlinePragma
+    markId var = setIdExported (var `setInlinePragma` neverInlinePragma)
 
     -- The AbsBinds come from the GHC typechecker to handle polymorphism,
     -- overloading, and recursion, so those don't correspond directly to
@@ -160,6 +167,10 @@ addNoInlinePragmasToBinds tcg = tcg{ tcg_binds = go (tcg_binds tcg) }
     -- See
     -- https://github.com/ucsd-progsys/liquidhaskell/issues/2257 for more
     -- context.
+    --
+    -- The first binding inside abs_binds is not given NOINLINE (to avoid
+    -- interfering with the polymorphism wrapper), but nested where-clause
+    -- bindings inside it are still marked via the generic traversal.
     markAbsBinds :: AbsBinds -> AbsBinds
     markAbsBinds absBinds0@AbsBinds{ abs_binds = binds, abs_exports = exports }  =
         absBinds0

--- a/tests/basic/pos/DeadBind00.hs
+++ b/tests/basic/pos/DeadBind00.hs
@@ -1,0 +1,18 @@
+-- | Regression test: dead bindings in where-clauses should be preserved
+-- so that LH can analyze them. GHC's simple optimizer normally removes
+-- dead bindings via occurrence analysis; our modification to
+-- 'addNoInlinePragmasToBinds' marks binder Ids as exported to prevent this.
+
+module DeadBind00 where
+
+{-@ reflect length' @-}
+{-@ length' :: xs:[a] -> Nat @-}
+length' :: [a] -> Int
+length' [] = 0
+length' (_:xs) = 1 + length' xs
+
+{-@ f :: xs:[a] -> { length' xs >= 0 } @-}
+f :: [a] -> ()
+f xs = ()
+  where
+    zs = length' xs

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2229,6 +2229,7 @@ executable basic-pos
                     , AssmRefl02D
                     , AssmRefl03
                     , AssmReflFilter
+                    , DeadBind00
                     , Float
                     , Inc00
                     , Inc01


### PR DESCRIPTION
By marking all identifiers in the user program as exported, we can stop ghc from removing dead bindings. This allows to insert hypothesis in a direct way.

Instead of 
```
f x = () ? lemma x
```
we can say
```
f x = ()
  where
   lem1 = lemma x
```

Improves situation for #2544.
