### PR TITLE
Optimize and document (?)

### DIFF
--- a/liquid-prelude/src/Language/Haskell/Liquid/ProofCombinators.hs
+++ b/liquid-prelude/src/Language/Haskell/Liquid/ProofCombinators.hs
@@ -115,13 +115,37 @@ infixl 3 =>=
 _ =>= y  = y
 
 -------------------------------------------------------------------------------
--- | `?` is basically Haskell's $ and is used for the right precedence
--- | `?` lets you "add" some fact into a proof term
+-- | @e ? lemma@ lets you use the type of @lemma@ when checking that @e@ haskell
+-- has some expected refinement type.
+--
+-- Schematically, @?@ allows to use @q x@ to check that @e@ satisfies @p x e@
+-- in the following function.
+--
+-- > f :: x:t0 -> {v:t1 | p x v}
+-- > f x = e ? lemma x
+-- >   where
+-- >     lemma :: y:t0 -> { q y }
+-- >     lemma = ...
+--
+-- While @?@ is defined as Haskell's 'const', @?@ is optimized by Liquid
+-- Haskell. The 'const' function, on the other hand, would incur some extra
+-- verification overhead because Liquid Haskell needs to go through the trouble
+-- of checking that @const e lemma@ is actually @e@.
+--
+-- === At a lower level
+--
+-- Liquid Haskell treats @e ? lemma@ as
+--
+-- > let fresh0 = e
+-- >  in let fresh1 = lemma
+-- >      in fresh0
+--
+-- Which makes the @fresh1@ binding available in the environment of whatever
+-- constraints arise in the inner occurrence of @fresh0@.
 -------------------------------------------------------------------------------
 
 infixl 3 ?
 
-{-@ (?) :: forall a b <pa :: a -> Bool, pb :: b -> Bool>. a<pa> -> b<pb> -> a<pa> @-}
 (?) :: a -> b -> a
 x ? _ = x
 {-# INLINE (?)   #-}

--- a/liquidhaskell-boot/liquidhaskell-boot.cabal
+++ b/liquidhaskell-boot/liquidhaskell-boot.cabal
@@ -80,6 +80,7 @@ library
                       Language.Haskell.Liquid.Termination.Structural
                       Language.Haskell.Liquid.Transforms.ANF
                       Language.Haskell.Liquid.Transforms.CoreToLogic
+                      Language.Haskell.Liquid.Transforms.QuestionMark
                       Language.Haskell.Liquid.Transforms.RefSplit
                       Language.Haskell.Liquid.Transforms.Rewrite
                       Language.Haskell.Liquid.Transforms.Simplify

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -244,6 +244,7 @@ import GHC.Core                       as Ghc
     , bindersOfBinds
     , cmpAlt
     , collectArgs
+    , collectArgsTicks
     , collectBinders
     , collectTyAndValBinders
     , collectTyBinders

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -65,6 +65,7 @@ import           Language.Fixpoint.Types           hiding ( errs
 import qualified Language.Haskell.Liquid.Measure         as Ms
 import           Language.Haskell.Liquid.Parse
 import           Language.Haskell.Liquid.Transforms.ANF
+import           Language.Haskell.Liquid.Transforms.QuestionMark
 import           Language.Haskell.Liquid.Types.Errors
 import           Language.Haskell.Liquid.Types.PrettyPrint
 import           Language.Haskell.Liquid.Types.Specs
@@ -525,17 +526,17 @@ processModule LiquidHaskellContext{..} = do
     debugLog $ "mg_tcs => " ++ O.showSDocUnsafe (O.ppr $ mg_tcs modGuts0)
 
     hscEnv <- getTopEnv
+    tcg <- getGblEnv
     let preNormalizedCore = preNormalizeCore moduleCfg modGuts0
         modGuts = modGuts0 { mg_binds = preNormalizedCore }
         file = LH.modSummaryHsFile lhModuleSummary
-    targetSrc  <- liftIO $ makeTargetSrc moduleCfg file modGuts hscEnv
+    targetSrc  <- liftIO $ makeTargetSrc moduleCfg file modGuts hscEnv (tcg_rdr_env tcg)
     logger <- getLogger
 
     -- See https://github.com/ucsd-progsys/liquidhaskell/issues/1711
     -- Due to the fact the internals can throw exceptions from pure code at any point, we need to
     -- call 'evaluate' to force any exception and catch it, if we can.
 
-    tcg <- getGblEnv
     let localVars = Resolve.makeLocalVars preNormalizedCore
         eBareSpec = resolveLHNames
           moduleCfg
@@ -591,12 +592,14 @@ makeTargetSrc :: Config
               -> FilePath
               -> ModGuts
               -> HscEnv
+              -> GlobalRdrEnv
               -> IO TargetSrc
-makeTargetSrc cfg file modGuts hscEnv = do
+makeTargetSrc cfg file modGuts hscEnv rdrEnv = do
   when (dumpPreNormalizedCore cfg) $ do
     putStrLn "\n*************** Pre-normalized CoreBinds *****************\n"
     putStrLn $ unlines $ L.intersperse "" $ map (GHC.showPpr (GHC.hsc_dflags hscEnv)) (mg_binds modGuts)
-  coreBinds <- anormalize cfg hscEnv modGuts
+  coreBindsANF <- anormalize cfg hscEnv modGuts
+  let coreBinds = eliminateQuestionMark rdrEnv coreBindsANF
   when (dumpNormalizedCore cfg) $ do
     putStrLn "\n*************** normalized CoreBinds *****************\n"
     putStrLn $ unlines $ L.intersperse "" $ map (GHC.showPpr (GHC.hsc_dflags hscEnv)) coreBinds

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/QuestionMark.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/QuestionMark.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE PatternGuards #-}
+-- | Eliminate applications of the '?' operator from Core after ANF.
+--
+-- After ANF, @e ? s@ becomes:
+--
+-- @
+-- let a1 = e
+-- let a2 = s
+-- ... (?) \@A \@B a1 a2
+-- @
+--
+-- This pass replaces @(?) \@A \@B a1 a2@ with just @a1@, so that no KVars
+-- are introduced in the signature of @?@. The binding @a2 = s@ remains in
+-- scope, so the lemma's postcondition still enters the environment during
+-- constraint generation.
+
+module Language.Haskell.Liquid.Transforms.QuestionMark (eliminateQuestionMark) where
+
+import Liquid.GHC.API as Ghc
+
+-- | Look up the '?' operator in the 'GlobalRdrEnv'. If found, eliminate all
+-- its applications from the Core program. If not found (module doesn't import
+-- ProofCombinators), return the bindings unchanged.
+eliminateQuestionMark :: GlobalRdrEnv -> [CoreBind] -> [CoreBind]
+eliminateQuestionMark rdrEnv cbs =
+  case lookupQuestionMark rdrEnv of
+    Nothing   -> cbs
+    Just name -> map (goBind name) cbs
+
+-- | Find the 'Name' of '?' from @Language.Haskell.Liquid.ProofCombinators@
+-- in the renamer environment.
+lookupQuestionMark :: GlobalRdrEnv -> Maybe Name
+lookupQuestionMark rdrEnv =
+  case lookupGRE rdrEnv (LookupRdrName rdrName SameNameSpace) of
+    [gre] -> Just (greName gre)
+    _     -> Nothing
+  where
+    rdrName = mkRdrQual (mkModuleName "Language.Haskell.Liquid.ProofCombinators")
+                        (mkVarOcc "?")
+
+goBind :: Name -> CoreBind -> CoreBind
+goBind n (NonRec x e) = NonRec x (goExpr n e)
+goBind n (Rec xes)    = Rec [(x, goExpr n e) | (x, e) <- xes]
+
+goExpr :: Name -> CoreExpr -> CoreExpr
+goExpr n e
+  | Just firstArg <- isQuestionMarkApp n e = goExpr n firstArg
+goExpr n (Lam x e)         = Lam x (goExpr n e)
+goExpr n (Let b e)          = Let (goBind n b) (goExpr n e)
+goExpr n (Case s x t alts) = Case (goExpr n s) x t [goAlt n a | a <- alts]
+goExpr n (Cast e co)        = Cast (goExpr n e) co
+goExpr n (Tick t e)         = Tick t (goExpr n e)
+goExpr n (App f a)          = App (goExpr n f) (goExpr n a)
+goExpr _ e                  = e -- Var, Lit, Type, Coercion
+
+goAlt :: Name -> CoreAlt -> CoreAlt
+goAlt n (Alt con bs e) = Alt con bs (goExpr n e)
+
+-- | Detect a fully-saturated application of '?': four arguments total
+-- (two types + two values), possibly wrapped in ticks.
+-- Returns @Just arg1@ (the first value argument).
+isQuestionMarkApp :: Name -> CoreExpr -> Maybe CoreExpr
+isQuestionMarkApp name expr =
+  case collectArgsTicks (const True) expr of
+    (Var v, args, _ticks)
+      | varName v == name
+      , [_tA, _tB, a, _b] <- args
+      -> Just a
+    _ -> Nothing
+


### PR DESCRIPTION
This PR introduces a core pass which runs after ANF normalization and before constraint generation. It replaces fully-applied `(?) @A @b e1 e2` expressions with just `e1`.

The pass looks up (?) in the GlobalRdrEnv (tcg_rdr_env) to obtain its Name, then uses Name equality for fast identification in Core. If the module does not have (?) in scope, the pass is skipped entirely.

This avoids introducing KVars for the applications of (?), while the lemma argument (e2) remains as an ANF binding so its postcondition still enters the verification environment.

This eliminates the growth of queries for the SMT solver with each (?) application without --reflection and makes T1660 independent of (?)'s LH signature.

A second commit documents (?) and eliminates the now redundant refinement type signature.

Fixes #2544.
Fixes #2617.