### PR TITLE
Let LiquidHaskell work with -plugin-package

### DIFF
--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -786,6 +786,7 @@ import GHC.Unit.Finder                as Ghc
     ( FindResult(Found, NoPackage, FoundMultiple, NotFound)
     , findExposedPackageModule
     , findImportedModule
+    , findPluginModule
     )
 import GHC.Unit.Home.ModInfo          as Ghc
     ( HomeModInfo(hm_iface) )

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/SpecFinder.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/SpecFinder.hs
@@ -2,6 +2,23 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE RankNTypes   #-}
 
+{-
+Note [Module Visibility and Lookup in GHC]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+GHC distinguishes between two module visibility namespaces:
+
+- **Regular packages** (`-package`): modules are found by `findImportedModule`,
+  which searches `findExposedPackageModule`.
+- **Plugin packages** (`-plugin-package`): modules are found by
+  `findPluginModule`, which searches `findExposedPluginPackageModule`.
+
+Whenever a module is looked up, we start with `findImportedModule` to check
+regular packages, and if that fails, we fall back to `findPluginModule` to check
+plugin packages. This allows us to support both visibility namespaces without
+requiring users to mind how they specify dependencies.
+
+-}
+
 module Language.Haskell.Liquid.GHC.Plugin.SpecFinder
     ( findRelevantSpecs
     , SpecFinderResult(..)
@@ -63,8 +80,16 @@ findRelevantSpecs lhAssmPkgExcludes hscEnv mods = do
                                    | otherwise = do
       let assumptionsModName = assumptionsModuleName m
       -- loadInterface might mutate the EPS if the module is
-      -- not already loaded
-      res <- liftIO $ findImportedModule hscEnv assumptionsModName NoPkgQual
+      -- not already loaded.
+      --
+      -- Try findImportedModule first (for -package), then fall back to
+      -- findPluginModule (for -plugin-package).
+      -- See Note [Module Visibility and Lookup in GHC] for details.
+      res <- liftIO $ do
+        r <- findImportedModule hscEnv assumptionsModName NoPkgQual
+        case r of
+          Found{} -> pure r
+          _       -> findPluginModule hscEnv assumptionsModName
       case res of
         Found _ assumptionsMod -> do
           _ <- initIfaceTcRn $ loadInterface "liquidhaskell assumptions" assumptionsMod ImportBySystem
@@ -112,7 +137,13 @@ configToRedundantDependencies env cfg = do
       res <- findImportedModule env mn (renamePkgQual (hsc_unit_env env) mn (Just "liquidhaskell"))
       case res of
         Found _ mdl -> pure $ Just (toStableModule mdl)
-        _           -> pure Nothing
+        _ -> do
+          -- Fall back to plugin package visibility
+          -- See Note [Module Visibility and Lookup in GHC] for details.
+          res2 <- findPluginModule env mn
+          case res2 of
+            Found _ mdl -> pure $ Just (toStableModule mdl)
+            _           -> pure Nothing
 
 -- | Static associative map of the 'ModuleName' that needs to be filtered from the final 'TargetDependencies'
 -- due to some particular configuration options.

--- a/tests/harness/Test/Groups.hs
+++ b/tests/harness/Test/Groups.hs
@@ -38,6 +38,7 @@ microTestGroups =
   , "pattern-pos"
   , "typeclass-pos"
   , "typed-holes"
+  , "plugin-package-pos"
   ]
 
 benchmarkTestGroups :: [Text]

--- a/tests/plugin-package/PluginPackageTest.hs
+++ b/tests/plugin-package/PluginPackageTest.hs
@@ -1,0 +1,9 @@
+-- | Test that LiquidHaskell works when loaded via -plugin-package
+-- rather than -package. This verifies that LHAssumptions modules
+-- are found through the plugin module search path.
+module PluginPackageTest where
+
+{-@ safeHead :: {v:[a] | len v > 0} -> a @-}
+safeHead :: [a] -> a
+safeHead (x:_) = x
+safeHead []    = error "impossible"

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2674,7 +2674,6 @@ executable typed-holes
     if !flag(typed-holes) && flag(stack)
       buildable:      False
 
-    ghc-options:      -fplugin=LiquidHaskell
     other-modules:    Example0
                     , Example1
                     , Example2

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2715,3 +2715,25 @@ test-suite liquidhaskell-test
                   , QuickCheck
                   , tasty
                   , tasty-quickcheck
+
+flag plugin-package-pos
+     default: False
+
+executable plugin-package-pos
+    import:           common-ghc-options
+    main-is:          Main.hs
+    if !flag(plugin-package-pos) && flag(stack)
+      buildable:      False
+
+    hs-source-dirs:   app
+                    , plugin-package
+
+    other-modules:    PluginPackageTest
+
+    build-depends:    base
+                    , liquid-prelude
+                    , liquidhaskell
+
+    -- Hide liquidhaskell from regular imports and expose only as plugin package.
+    -- This tests that LHAssumptions modules are found via findPluginModule.
+    ghc-options:      -hide-package liquidhaskell -plugin-package liquidhaskell


### PR DESCRIPTION
`-plugin-package` is not yet supported by cabal, but it is going to be needed by `buck2_haskell` and `rules_haskell`.

[1] https://downloads.haskell.org/ghc/9.14.1/docs/users_guide/extending_ghc.html#ghc-flag-plugin-package-pkg
[2] https://github.com/MercuryTechnologies/buck2-haskell
[3] https://github.com/tweag/rules_haskell