### PR TITLE
Yield a LogicMap with resolved names from name resolution

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -209,8 +209,17 @@ resolveLHNames cfg thisModule localVars impMods globalRdrEnv bareSpec0 dependenc
 
       checkErrors
 
+      -- Rebuild the logic map with fully-resolved define bodies from sp3.
+      -- lmap1 was built before resolveLogicNames, so body symbols (e.g. "len")
+      -- are bare/unresolved.  sp3 has gone through logic name resolution and
+      -- fromBareSpecLHName, so its defines carry properly qualified symbols.
+      let lmap2 = lmap <> mkLogicMap (HM.fromList
+                   [ (F.val $ lhNameToResolvedSymbol <$> k,
+                      v { lmVar = lhNameToResolvedSymbol <$> k })
+                   | (k, v) <- defines sp3 ])
+
       dcs <- gets roUsedDataCons
-      return (sp3 { usedDataCons = dcs }, logicNameEnv0, lmap1)
+      return (sp3 { usedDataCons = dcs }, logicNameEnv0, lmap2)
   where
     -- Early exit name resolution if errors are found and pass them to the output.
     checkErrors :: ExceptT [Error] (StateT RenameOutput Identity) ()

--- a/tests/names/pos/DefineLenResolve.hs
+++ b/tests/names/pos/DefineLenResolve.hs
@@ -1,0 +1,22 @@
+-- | Regression test: user-written `define length x = len x` must resolve
+-- the bare `len` symbol to the qualified class measure, so reflected
+-- functions that use `length` in their body (and metric) pass sort-checking.
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple" @-}
+
+module DefineLenResolve where
+
+{-@ reflect ms @-}
+{-@ ms :: [[Int]] -> Nat @-}
+ms :: [[Int]] -> Int
+ms [] = 0
+ms (x:xs) = 1 + length x + ms xs
+
+{-@
+define length x = len x
+@-}
+
+{-@ f :: xs:[[Int]] -> Int / [ms xs] @-}
+f :: [[Int]] -> Int
+f [] = 0
+f (x:xs) = 1 + f xs

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -747,6 +747,7 @@ executable names-pos
                     , Capture02
                     , ClojurVector
                     , DataFields
+                    , DefineLenResolve
                     , ExpandsDependentPairs
                     , ExprAliases
                     , ExprAliasesCopycat


### PR DESCRIPTION
In `LHNameResolution.hs`, the logic map returned from `resolveLHNames` was constructed **before** the logic name resolution pass.

This commit rebuilds the logic map from the defines in the spec resulting from logic name resolution.

The previous logic map is still used as input to `resolveLogicNames` since it only needs correct **keys** (not bodies) to detect undefined names.

This issue caused undefined symbol errors in sort checking sometimes, as in the provided regression test.