### PR TITLE
docs: updata mkdocs build and migrate to built-in tags plugin

### DIFF
--- a/.github/workflows/docs-ci-cd.yml
+++ b/.github/workflows/docs-ci-cd.yml
@@ -1,8 +1,6 @@
 # Build the docs on every commit
 # Also deploy when pushed to 'develop' (if they built OK)
 
-# Based off
-# https://squidfunk.github.io/mkdocs-material/publishing-your-site/?h=deploy#with-github-actions
 name: Documentation CI/CD
 on:
   push:
@@ -14,28 +12,25 @@ jobs:
   build-docs-job:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v30
         with:
-          python-version: 3.x
-      - run: pip install \
-              mkdocs-material \
-              mkdocs-awesome-pages-plugin \
-              git+https://github.com/jldiaz/mkdocs-plugin-tags.git
-      - run: cd docs/mkDocs && mkdocs build -s
+          nix_path: nixpkgs=channel:nixos-unstable
+      - run: nix-shell nix-shells/mkdocs.nix --run "cd docs/mkDocs && mkdocs build -s"
   deploy-docs-job:
     runs-on: ubuntu-latest
     needs: build-docs-job
     # Only deploy docs from 'develop' branch (and if they built OK).
     if: success() && github.ref == 'refs/heads/develop'
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
         with:
-          python-version: 3.x
-      - run: pip install \
-              mkdocs-material \
-              mkdocs-awesome-pages-plugin \
-              git+https://github.com/jldiaz/mkdocs-plugin-tags.git
-      - run: cd docs/mkDocs && mkdocs gh-deploy --force
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@v30
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          nix-shell nix-shells/mkdocs.nix --run "cd docs/mkDocs && mkdocs gh-deploy --force"
 

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ tests/synthesis/logs/*
 /.vagrant/
 TAGS
 tags*
+!docs/mkDocs/docs/tags.md
 a.out
 *.json
 js/

--- a/docs/mkDocs/docs/.nav.yml
+++ b/docs/mkDocs/docs/.nav.yml
@@ -1,0 +1,10 @@
+nav:
+  - "<div id='demo'><i aria-hidden=true class='mdi mdi-cloud-braces'></i> Try Online</div>": https://liquidhaskell.goto.ucsd.edu/index.html
+  - "<i aria-hidden=true class='mdi mdi-human-greeting'></i> Tutorial": http://ucsd-progsys.github.io/liquidhaskell-tutorial/
+  - "<i aria-hidden=true class='mdi mdi-download'></i> Installation": install.md
+  - "<i aria-hidden=true class='mdi mdi-script'></i> Spec Reference": specifications.md
+  - "<i aria-hidden=true class='mdi mdi-flag'></i> Flag Reference": options.md
+  - "<i aria-hidden=true class='mdi mdi-school'></i> Papers": papers.md
+  - "<i aria-hidden=true class='mdi mdi-bullhorn'></i> Blog":
+      - blogposts
+      - tags.md

--- a/docs/mkDocs/docs/blogposts/.nav.yml
+++ b/docs/mkDocs/docs/blogposts/.nav.yml
@@ -1,0 +1,2 @@
+sort:
+  direction: desc

--- a/docs/mkDocs/docs/blogposts/.pages
+++ b/docs/mkDocs/docs/blogposts/.pages
@@ -1,4 +1,0 @@
-
-# This file forces mkdocs-awesome-pages to show new blogposts first
-
-order: desc

--- a/docs/mkDocs/docs/blogposts/2013-01-27-refinements101-reax.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2013-01-27-refinements101-reax.lhs.md
@@ -272,9 +272,9 @@ There are several things to take away.
    [counterexamples][icse04] that illustrate when a specification
    [fails][dsd].
 
-[qblog101]: /blog/2013/01/01/refinement-types-101.lhs/#comment-772807850
+[qblog101]: 2013-01-01-refinement-types-101.lhs.md
 [qreddit101]: http://www.reddit.com/r/haskell/comments/16w3hp/liquidhaskell_refinement_types_in_haskell_via_smt/c809160
-[ref101]:  /blog/2013/01/01/refinement-types-101.lhs/ 
+[ref101]:  2013-01-01-refinement-types-101.lhs.md
 [concolic]: http://en.wikipedia.org/wiki/Concolic_testing
 [icse04]: http://goto.ucsd.edu/~rjhala/papers/generating_tests_from_counterexamples.html
 [dsd]: http://dl.acm.org/citation.cfm?doid=1348250.1348254

--- a/docs/mkDocs/docs/blogposts/2013-01-28-bounding-vectors.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2013-01-28-bounding-vectors.lhs.md
@@ -679,8 +679,8 @@ like lists and trees.
 [vec]:     http://hackage.haskell.org/package/vector
 [dml]:     http://www.cs.bu.edu/~hwxi/DML/DML.html
 [agdavec]: http://code.haskell.org/Agda/examples/Vec.agda
-[ref101]:  /blog/2013/01/01/refinement-types-101.lhs/ 
-[ref102]:  /blog/2013/01/27/refinements-101-reax.lhs/ 
+[ref101]:  2013-01-01-refinement-types-101.lhs.md
+[ref102]:  2013-01-27-refinements101-reax.lhs.md
 [foldl]:   http://hackage.haskell.org/packages/archive/base/latest/doc/html/src/Data-List.html
 
 [dmlarray]:http://www.cs.bu.edu/~hwxi/academic/papers/pldi98.pdf

--- a/docs/mkDocs/docs/blogposts/2013-01-31-safely-catching-a-list-by-its-tail.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2013-01-31-safely-catching-a-list-by-its-tail.lhs.md
@@ -524,11 +524,11 @@ Well folks, thats all for now. I trust this article gave you a sense of
    functions) in order to enforce special invariants.
 
 
-[vecbounds]:  /blog/2013/01/05/bounding-vectors.lhs/ 
+[vecbounds]:  /blog/2013/01/05/bounding-vectors.lhs/
 [ghclist]:    https://github.com/ucsd-progsys/liquidhaskell/blob/master/include/GHC/List.lhs#L125
 [foldl1]:     http://hackage.haskell.org/packages/archive/base/latest/doc/html/src/Data-List.html#foldl1
 [risersMitchell]: http://neilmitchell.blogspot.com/2008/03/sorting-at-speed.html
 [risersApple]: http://blog.jbapple.com/2008/01/extra-type-safety-using-polymorphic.html
-[ref101]:  /blog/2013/01/01/refinement-types-101.lhs/ 
-[ref102]:  /blog/2013/01/27/refinements101-reax.lhs/ 
+[ref101]:  2013-01-01-refinement-types-101.lhs.md
+[ref102]:  2013-01-27-refinements101-reax.lhs.md
 

--- a/docs/mkDocs/docs/blogposts/2013-02-16-kmeans-clustering-I.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2013-02-16-kmeans-clustering-I.lhs.md
@@ -370,9 +370,9 @@ legs, and return post-haste for the [next installment][kmeansII], in which
 we will use the types and functions described above, to develop the clustering
 algorithm.
 
-[safeList]:      /blog/2013/01/31/safely-catching-a-list-by-its-tail.lhs/
-[kmeansI]:       /blog/2013/02/16/kmeans-clustering-I.lhs/
-[kmeansII]:      /blog/2013/02/17/kmeans-clustering-II.lhs/
+[safeList]:      2013-01-31-safely-catching-a-list-by-its-tail.lhs.md
+[kmeansI]:       2013-02-16-kmeans-clustering-I.lhs.md
+[kmeansII]:      2013-02-17-kmeans-clustering-II.lhs.md
 [URL-take]:      https://github.com/ucsd-progsys/liquidhaskell/blob/master/include/GHC/List.lhs#L334
 [URL-groupBy]:   http://hackage.haskell.org/packages/archive/base/latest/doc/html/Data-List.html#v:groupBy
 [URL-transpose]: http://hackage.haskell.org/packages/archive/base/latest/doc/html/src/Data-List.html#transpose

--- a/docs/mkDocs/docs/blogposts/2013-02-17-kmeans-clustering-II.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2013-02-17-kmeans-clustering-II.lhs.md
@@ -806,10 +806,10 @@ at all.
 encourage you to ponder about how you might modify the types (and
 implementation) to verify that KMeans indeed produces at most `k` clusters...
 
-[ref101]:        /blog/2013/01/01/refinement-types-101.lhs/
-[safeList]:      /blog/2013/01/31/safely-catching-a-list-by-its-tail.lhs/
-[kmeansI]:       /blog/2013/02/16/kmeans-clustering-I.lhs/
-[kmeansII]:      /blog/2013/02/17/kmeans-clustering-II.lhs/
+[ref101]:        2013-01-01-refinement-types-101.lhs.md
+[safeList]:      2013-01-31-safely-catching-a-list-by-its-tail.lhs.md
+[kmeansI]:       2013-02-16-kmeans-clustering-I.lhs.md
+[kmeansII]:      2013-02-17-kmeans-clustering-II.lhs.md
 [URL-take]:      https://github.com/ucsd-progsys/liquidhaskell/blob/master/include/GHC/List.lhs#L334
 [URL-groupBy]:   http://hackage.haskell.org/packages/archive/base/latest/doc/html/Data-List.html#v:groupBy
 [URL-transpose]: http://hackage.haskell.org/packages/archive/base/latest/doc/html/src/Data-List.html#transpose

--- a/docs/mkDocs/docs/blogposts/2013-03-04-bounding-vectors.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2013-03-04-bounding-vectors.lhs.md
@@ -721,9 +721,9 @@ like lists and trees.
 [vec]:      http://hackage.haskell.org/package/vector
 [dml]:      http://www.cs.bu.edu/~hwxi/DML/DML.html
 [agdavec]:  http://code.haskell.org/Agda/examples/Vec.agda
-[ref101]:   /blog/2013/01/01/refinement-types-101.lhs/ 
-[ref102]:   /blog/2013/01/27/refinements-101-reax.lhs/ 
+[ref101]:   2013-01-01-refinement-types-101.lhs.md
+[ref102]:   2013-01-27-refinements101-reax.lhs.md
 [foldl]:    http://hackage.haskell.org/packages/archive/base/latest/doc/html/src/Data-List.html
-[listtail]: /blog/2013/01/31/safely-catching-a-list-by-its-tail.lhs/
+[listtail]: 2013-01-31-safely-catching-a-list-by-its-tail.lhs.md
 [dmlarray]: http://www.cs.bu.edu/~hwxi/academic/papers/pldi98.pdf
 

--- a/docs/mkDocs/docs/blogposts/2013-05-24-unique-zipper.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2013-05-24-unique-zipper.lhs.md
@@ -498,7 +498,7 @@ That's all for now! This post illustrated
 
 
 [wiki-zipper]: http://en.wikipedia.org/wiki/Zipper_(data_structure)
-[about-sets]:  blog/2013/03/26/talking-about-sets.lhs/
+[about-sets]:  2013-03-26-talking-about-sets.lhs.md
 [setspec]:     https://github.com/ucsd-progsys/liquidhaskell/blob/master/include/Data/Set.spec
 
 

--- a/docs/mkDocs/docs/blogposts/2013-06-03-abstracting-over-refinements.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2013-06-03-abstracting-over-refinements.lhs.md
@@ -350,8 +350,8 @@ and hold on tight, because we're going to see some rather nifty things that
 this new technique makes possible, including induction, reasoning about
 memoizing functions, and *ordering* and *sorting* data. Stay tuned.
 
-[blog-dbz]:     /blog/2013/01/01/refinement-types-101.lhs/ 
-[blog-len]:     /blog/2013/01/31/safely-catching-a-list-by-its-tail.lhs/ 
-[blog-vec]:     /blog/2013/03/04/bounding-vectors.lhs/
-[blog-set]:     /blog/2013/03/26/talking/about/sets.lhs/
-[blog-zip]:     /blog/2013/05/16/unique-zipper.lhs/
+[blog-dbz]:     2013-01-01-refinement-types-101.lhs.md
+[blog-len]:     2013-01-31-safely-catching-a-list-by-its-tail.lhs.md
+[blog-vec]:     2013-03-04-bounding-vectors.lhs.md
+[blog-set]:     2013-03-26-talking-about-sets.lhs.md
+[blog-zip]:     2013-05-24-unique-zipper.lhs.md

--- a/docs/mkDocs/docs/blogposts/2013-07-29-putting-things-in-order.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2013-07-29-putting-things-in-order.lhs.md
@@ -779,7 +779,7 @@ LiquidHaskell we need merely write:
 
 
 
-[blog-absref]:     /blog/2013/06/3/abstracting-over-refinements.lhs/
+[blog-absref]:     2013-06-03-abstracting-over-refinements.lhs.md
 [blog-absref-vec]: http://goto.ucsd.edu/~rjhala/liquid/abstract_refinement_types.pdf
 [data-list]:        http://www.haskell.org/ghc/docs/latest/html/libraries/base/src/Data-List.html#sort
 [omega-sort]:      http://web.cecs.pdx.edu/~sheard/Code/InsertMergeSort.html

--- a/docs/mkDocs/docs/blogposts/2013-10-10-csv-tables.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2013-10-10-csv-tables.lhs.md
@@ -169,4 +169,4 @@ like this one?
 </pre>
 
 [shapeless-csv]: http://www.reddit.com/r/scala/comments/1nhzi2/using_shapelesss_sized_type_to_eliminate_real/
-[list-measure]:  /blog/2013/01/31/safely-catching-a-list-by-its-tail.lhs/ 
+[list-measure]:  2013-01-31-safely-catching-a-list-by-its-tail.lhs.md

--- a/docs/mkDocs/docs/blogposts/2013-12-02-getting-to-the-bottom.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2013-12-02-getting-to-the-bottom.lhs.md
@@ -100,4 +100,4 @@ is *definitely* not bottom.
 In other words, we need to teach LiquidHaskell how to prove that a computation 
 definitely terminates.
 
-[ref-lies]:  /blog/2013/11/23/telling_lies.lhs/ 
+[ref-lies]:  2013-11-23-telling_lies.lhs.md

--- a/docs/mkDocs/docs/blogposts/2013-12-09-checking-termination.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2013-12-09-checking-termination.lhs.md
@@ -190,5 +190,5 @@ With this hint, liquidHaskell will happily verify that `sum'` is indeed a termin
 Thats all for now, next time we'll see how the basic technique can be extended
 to a variety of real-world settings.
 
-[ref-lies]:  /blog/2013/11/23/telling-lies.lhs/ 
-[ref-bottom]: /blog/2013/12/01/getting-to-the-bottom.lhs/
+[ref-lies]:  2013-11-23-telling_lies.lhs.md
+[ref-bottom]: 2013-12-02-getting-to-the-bottom.lhs.md

--- a/docs/mkDocs/docs/blogposts/2013-12-14-gcd.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2013-12-14-gcd.lhs.md
@@ -117,7 +117,7 @@ prove it terminates. Stay tuned!
 
 
 [ref-euclidean]:    http://en.wikipedia.org/wiki/Euclidean_algorithm
-[ref-termination]:  /blog/2013/12/09/checking-termination.lhs/ 
-[ref-lies]:  /blog/2013/11/23/telling_lies.lhs/ 
-[ref-bottom]: /blog/2013/12/02/getting-to-the-bottom.lhs/
-[comment-elias]: http://goto.ucsd.edu/~rjhala/liquid/haskell/blog/blog/2013/12/09/checking-termination.lhs/#comment-1159606500
+[ref-termination]:  2013-12-09-checking-termination.lhs.md
+[ref-lies]:  2013-11-23-telling_lies.lhs.md
+[ref-bottom]: 2013-12-02-getting-to-the-bottom.lhs.md
+[comment-elias]: http://goto.ucsd.edu/~rjhala/liquid/haskell/blog2013-12-09-checking-termination.lhs.md#comment-1159606500

--- a/docs/mkDocs/docs/blogposts/2014-02-11-the-advantage-of-measures.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2014-02-11-the-advantage-of-measures.lhs.md
@@ -467,4 +467,4 @@ type-signature.
 [GADT]: http://www.reddit.com/r/haskell/comments/1xiurm/how_to_define_append_for_ordlist_defined_as_gadt/cfbrinr
 [Reddit]: http://www.reddit.com/r/haskell/comments/1xiurm/how_to_define_append_for_ordlist_defined_as_gadt/
 [OrdList]: http://www.haskell.org/platform/doc/2013.2.0.0/ghc-api/OrdList.html
-[measure]: http://goto.ucsd.edu/~rjhala/liquid/haskell/blog/blog/2013/01/31/safely-catching-a-list-by-its-tail.lhs/
+[measure]: http://goto.ucsd.edu/~rjhala/liquid/haskell/blog2013-01-31-safely-catching-a-list-by-its-tail.lhs.md

--- a/docs/mkDocs/docs/blogposts/2014-08-15-a-finer-filter.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2014-08-15-a-finer-filter.lhs.md
@@ -383,7 +383,7 @@ school `Boolean` approach has its merits. Take a look at the clever
 or this lovely new paper by [Kaki and Jagannathan][catalyst] which
 shows how refinements can be further generalized to make Boolean filters fine.
 
-[sets]:   /blog/2013/03/26/talking-about-sets.lhs/ 
-[absref]:   /blog/2013/06/03/abstracting-over-refinements.lhs/ 
+[sets]:   2013-03-26-talking-about-sets.lhs.md
+[absref]:   2013-06-03-abstracting-over-refinements.lhs.md
 [racket]:   http://www.ccs.neu.edu/racket/pubs/popl08-thf.pdf
 [catalyst]: http://gowthamk.github.io/docs/icfp77-kaki.pdf

--- a/docs/mkDocs/docs/blogposts/2017-12-15-splitting-and-splicing-intervals-I.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2017-12-15-splitting-and-splicing-intervals-I.lhs.md
@@ -397,6 +397,6 @@ Is it even _possible_, let alone _easier_ to do that with LH?
 [intersect-good]:    https://github.com/antalsz/hs-to-coq/blob/8f84d61093b7be36190142c795d6cd4496ef5aed/examples/intervals/Proofs.v#L370-L439
 [union-good]:        https://github.com/antalsz/hs-to-coq/blob/b7efc7a8dbacca384596fc0caf65e62e87ef2768/examples/intervals/Proofs_Function.v#L319-L382
 [subtract-good]:     https://github.com/antalsz/hs-to-coq/blob/8f84d61093b7be36190142c795d6cd4496ef5aed/examples/intervals/Proofs.v#L565-L648
-[abs-ref]:           /tags/abstract-refinements.html
+[abs-ref]:           ../tags.md#tag:abstract-refinements
 [hs-to-coq]:         https://github.com/antalsz/hs-to-coq
 [nomeata-intervals]: https://www.joachim-breitner.de/blog/734-Finding_bugs_in_Haskell_code_by_proving_it

--- a/docs/mkDocs/docs/blogposts/2017-12-24-splitting-and-splicing-intervals-II.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2017-12-24-splitting-and-splicing-intervals-II.lhs.md
@@ -633,7 +633,7 @@ x2:a -&gt; x3:a -&gt; {VV : a | VV == RangeSet.max x2 x3
 </pre>
 </div>
 
-[splicing-1]:        2017-12-15-splitting-and-splicing-intervals-I.lhs/
+[splicing-1]:        2017-12-15-splitting-and-splicing-intervals-I.lhs.md
 [lh-termination]:    https://github.com/ucsd-progsys/liquidhaskell/blob/develop/README.md#explicit-termination-metrics
 [lh-qed]:            https://github.com/ucsd-progsys/liquidhaskell/blob/develop/include/Language/Haskell/Liquid/NewProofCombinators.hs#L65-L69
 [lh-imp-eq]:         https://github.com/ucsd-progsys/liquidhaskell/blob/develop/include/Language/Haskell/Liquid/NewProofCombinators.hs#L87-L96
@@ -643,8 +643,8 @@ x2:a -&gt; x3:a -&gt; {VV : a | VV == RangeSet.max x2 x3
 [intersect-good]:    https://github.com/antalsz/hs-to-coq/blob/8f84d61093b7be36190142c795d6cd4496ef5aed/examples/intervals/Proofs.v#L370-L439
 [union-good]:        https://github.com/antalsz/hs-to-coq/blob/b7efc7a8dbacca384596fc0caf65e62e87ei2768/examples/intervals/Proofs_Function.v#L319-L382
 [subtract-good]:     https://github.com/antalsz/hs-to-coq/blob/8f84d61093b7be36190142c795d6cd4496ef5aed/examples/intervals/Proofs.v#L565-L648
-[tag-abs-ref]:       /tags/abstract-refinements.html
-[tag-induction]:     /tags/induction.html
-[tag-reflection]:    /tags/reflection.html
+[tag-abs-ref]:       ../tags.md#tag:abstract-refinements
+[tag-induction]:     ../tags.md#tag:induction
+[tag-reflection]:    ../tags.md#tag:reflection
 [hs-to-coq]:         https://github.com/antalsz/hs-to-coq
 [nomeata-intervals]: https://www.joachim-breitner.de/blog/734-Finding_bugs_in_Haskell_code_by_proving_it

--- a/docs/mkDocs/docs/blogposts/2018-05-17-hillel-verifier-rodeo-I-leftpad.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2018-05-17-hillel-verifier-rodeo-I-leftpad.lhs.md
@@ -424,6 +424,6 @@ That concludes part I of the rodeo. What did I learn from this exercise?
 [fstar-leftpad]:    https://gist.github.com/graydon/901f98049d05db65d9a50f741c7f7626
 [idris-leftpad]:    https://github.com/hwayne/lets-prove-leftpad/blob/master/idris/Leftpad.idr
 [dafny-seq-axioms]: https://github.com/Microsoft/dafny/blob/master/Binaries/DafnyPrelude.bpl#L898-L1110
-[tag-reflection]:   /tags/reflection.html
-[tag-ple]:          /tags/ple.html
+[tag-reflection]:   ../tags.md#tag:reflection
+[tag-ple]:          ../tags.md
 [regehr-tweet]:     https://twitter.com/johnregehr/status/996901816842440704

--- a/docs/mkDocs/docs/blogposts/2019-10-20-why-types.lhs.md
+++ b/docs/mkDocs/docs/blogposts/2019-10-20-why-types.lhs.md
@@ -454,6 +454,6 @@ for patiently answering my many questions about Dafny!
 
 [ex1-dafny]: https://rise4fun.com/Dafny/tkfQ
 [ex2-dafny]: https://rise4fun.com/Dafny/nphIv
-[ex1-lh]: FIXME
-[ex2-lh]: FIXME
+[ex1-lh]: #
+[ex2-lh]: #
 

--- a/docs/mkDocs/docs/index.md
+++ b/docs/mkDocs/docs/index.md
@@ -42,7 +42,7 @@ Dependent contracts let you specify, e.g. that <code>dotProduct</code> requires 
 <div class="example-row">
 <p>
 LH checks that functions terminate and so warns about the infinite recursion due to the missing case in <code>fib</code>.
-<a href="tags.html#termination">(more...)</a>
+<a href="tags/#tag:termination">(more...)</a>
 </p>
 <img src="static/img/splash-fib.gif">
 </div>

--- a/docs/mkDocs/docs/options.md
+++ b/docs/mkDocs/docs/options.md
@@ -28,7 +28,7 @@ The options are descibed below (and by the legacy executable: `liquid --help`)
 
 **Directives:** `automatic-instances`
 
-To enable theorem proving, e.g. as [described here](tags.html#reflection)
+To enable theorem proving, e.g. as [described here](tags.md#tag:reflection)
 use the option
 
 ```haskell

--- a/docs/mkDocs/docs/specifications.md
+++ b/docs/mkDocs/docs/specifications.md
@@ -535,7 +535,7 @@ However, as they are *expanded* at compile time, `inline` functions
 **cannot be recursive**. The can call _other_ (non-recursive) inline functions.
 
 If you want to talk about arbitrary (recursive) functions inside your types, 
-then you need to use `reflect` described [in the blog](tags.html#reflection).
+then you need to use `reflect` described [in the blog](tags.md#tag:reflection).
 
 ## Self-Invariants
 

--- a/docs/mkDocs/docs/static/misc.css
+++ b/docs/mkDocs/docs/static/misc.css
@@ -32,8 +32,18 @@
 .md-tabs__list {
     display:grid;
     grid-auto-flow:column;
-    grid-auto-columns:1fr;
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
 }
+
+/* Place the 7 tab items into columns 1,2,4,5,6,8,9 — leaving columns 3 and 7
+   empty to reproduce the visual spacers from the original nav. */
+.md-tabs__list > .md-tabs__item:nth-child(1) { grid-column: 1; }
+.md-tabs__list > .md-tabs__item:nth-child(2) { grid-column: 2; }
+.md-tabs__list > .md-tabs__item:nth-child(3) { grid-column: 4; }
+.md-tabs__list > .md-tabs__item:nth-child(4) { grid-column: 5; }
+.md-tabs__list > .md-tabs__item:nth-child(5) { grid-column: 6; }
+.md-tabs__list > .md-tabs__item:nth-child(6) { grid-column: 8; }
+.md-tabs__list > .md-tabs__item:nth-child(7) { grid-column: 9; }
 
 .md-tabs__list > .md-tabs__item > * > * {
     padding: 0.3rem;

--- a/docs/mkDocs/docs/tags.html
+++ b/docs/mkDocs/docs/tags.html
@@ -1,3 +1,0 @@
-
-This file gets overwritten by the plugin which generates the "tags" page.
-It's just here as a workaround to prevent `mkdocs build -s` from complaining.

--- a/docs/mkDocs/docs/tags.md
+++ b/docs/mkDocs/docs/tags.md
@@ -1,0 +1,3 @@
+# Tags
+
+<!-- material/tags -->

--- a/docs/mkDocs/mkdocs.yml
+++ b/docs/mkDocs/mkdocs.yml
@@ -4,19 +4,6 @@ site_url: https://ucsd-progsys.github.io/liquidhaskell/
 repo_url: https://github.com/ucsd-progsys/liquidhaskell
 edit_uri: edit/develop/docs/mkDocs/docs
 
-nav:
-  - "<div id='demo'><i aria-hidden=true class='mdi mdi-cloud-braces'></i> Try Online</div>": https://liquidhaskell.goto.ucsd.edu/index.html
-  - "<i aria-hidden=true class='mdi mdi-human-greeting'></i> Tutorial": http://ucsd-progsys.github.io/liquidhaskell-tutorial/
-  - "": index.md #spacer
-  - "<i aria-hidden=true class='mdi mdi-download'></i> Installation": install.md
-  - "<i aria-hidden=true class='mdi mdi-script'></i> Spec Reference": specifications.md
-  - "<i aria-hidden=true class='mdi mdi-flag'></i> Flag Reference": options.md
-  - "": index.md #spacer
-  - "<i aria-hidden=true class='mdi mdi-school'></i> Papers": papers.md
-  - "<i aria-hidden=true class='mdi mdi-bullhorn'></i> Blog":
-      - ... | blogposts/*
-      - Tags: tags.html
-
 theme:
   name: material
   features:
@@ -30,8 +17,8 @@ theme:
 
 plugins:
   - search
-  - tags
-  - awesome-pages
+  - material/tags
+  - awesome-nav
 
 markdown_extensions:
   - toc:

--- a/docs/mkDocs/theme-overrides/main.html
+++ b/docs/mkDocs/theme-overrides/main.html
@@ -30,7 +30,7 @@
   {% if page.meta.tags %}
   <div class="blogpost-meta-tags">
     {% for tag in page.meta.tags %}          
-      <a href="../../tags.html#{{ tag }}" class="tag-button">{% include ".icons/material/tag.svg" %}{{ tag }}</a>
+      <a href="../../tags/#tag:{{ tag }}" class="tag-button">{% include ".icons/material/tag.svg" %}{{ tag }}</a>
     {% endfor %}
   </div>
   {% endif %}

--- a/nix-shells/mkdocs.nix
+++ b/nix-shells/mkdocs.nix
@@ -1,0 +1,21 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  python = pkgs.python314;
+  pythonPackages = pkgs.python314Packages;
+  mkdocs = pythonPackages.mkdocs;
+  mkdocsMaterial = pythonPackages.mkdocs-material;
+  awesomePages = pythonPackages.mkdocs-awesome-nav;
+in pkgs.mkShell {
+  buildInputs = [
+    pkgs.git
+    mkdocs
+    mkdocsMaterial
+    awesomePages
+  ];
+
+  shellHook = ''
+    echo "Shell with mkdocs and plugins available (mkdocs --version: $(mkdocs --version 2>/dev/null || true))"
+  '';
+}
+


### PR DESCRIPTION
Updates the configuration of mkdocs and provides a way to provision mkdocs to build the site locally via `nix-shells/mkdocs.nix`.

Notes:

- provide a nix file to provision mkdocs
- fixed broken links
- fixed tags generation
- provide a nix file to provision mkdocs
- mkdocs.yml: rename plugin 'awesome-pages' → 'awesome-nav' (the entry-point name registered by mkdocs-awesome-nav 3.x in nixpkgs); rename plugin 'tags' → 'material/tags' (the correct entry-point in mkdocs-material 9.x); remove deprecated 'tags_file' option
- mkdocs.yml: remove 'nav:' block entirely — awesome-nav replaces the whole nav from mkdocs.yml with one generated from the filesystem anyway, causing strict-mode warnings; nav is now defined in docs/.nav.yml
- docs/.nav.yml: new file with the full nav structure (external links, Material icon titles, Blog section with descending blogpost glob)
- docs/blogposts/.nav.yml implied by glob sort in .nav.yml; old docs/blogposts/.pages (awesome-pages format) removed
- docs/tags.html: remove stub file left over from the old third-party jldiaz/mkdocs-plugin-tags plugin
- docs/tags.md: new file with the [TAGS] macro so the built-in material/tags plugin renders the tags index page
- docs/options.md, docs/specifications.md: fix broken 'tags.html#reflection' links → 'tags.md#reflection'