### PR TITLE
Type alias tweaks

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -1317,17 +1317,20 @@ embedP = do
 
 
 aliasP :: Parser (RTAlias Symbol BareTypeParsed)
-aliasP  = rtAliasP id     bareTypeP <?> "aliasP"
+aliasP =
+  rtAliasP id (locUpperIdLHNameP LHLogicNameBinder) bareTypeP <?> "aliasP"
 
 ealiasP :: Parser (RTAlias Symbol (ExprV LocSymbol))
-ealiasP = try (rtAliasP symbol predP)
-      <|> rtAliasP symbol exprP
-      <?> "ealiasP"
+ealiasP = rtAliasP symbol locBinderLogicNameP exprP <?> "ealiasP"
 
 -- | Parser for a LH type synonym.
-rtAliasP :: (Symbol -> tv) -> Parser ty -> Parser (RTAlias tv ty)
-rtAliasP f bodyP
-  = do lname <- locBinderLogicNameP
+rtAliasP
+  :: (Symbol -> tv)
+  -> Parser (Located LHName)
+  -> Parser ty
+  -> Parser (RTAlias tv ty)
+rtAliasP f nameP bodyP
+  = do lname <- nameP
        args <- many aliasIdP
        reservedOp "="
        body <- bodyP

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -494,6 +494,7 @@ bareTyArgP
  <|> try (braces $ RExprArg <$> located exprP)
  <|> try bareAtomNoAppP
  <|> try (parens bareTypeP)
+ <|> try (parens $ RExprArg <$> located exprP)
  <?> "bareTyArgP"
 
 bareAtomNoAppP :: Parser BareTypeParsed

--- a/liquidhaskell-boot/tests/Parser.hs
+++ b/liquidhaskell-boot/tests/Parser.hs
@@ -260,6 +260,10 @@ testSucceeds =
        parseSingleSpec "x :: k:Int -> Int" @?==
           "x :: k:Int -> Int"
 
+    , testCase "k:Int -> B (k + 1)" $
+       parseSingleSpec "x :: k:Int -> B (k + 1)" @?==
+          "x :: k:Int -> (B {k + 1})"
+
     , testCase "type spec 1 " $
        parseSingleSpec "type IncrListD a D = [a]<{\\x y -> (x+D) <= y}>" @?==
           "type IncrListD a D  =  [a]<\\x##2 _ -> {y##3 : LIQUID$dummy | x##2 + D <= y##3}>"

--- a/liquidhaskell-boot/tests/Parser.hs
+++ b/liquidhaskell-boot/tests/Parser.hs
@@ -489,6 +489,18 @@ testFails =
               , "unexpected ':'"
               , "expecting \"->\", \"=>\", '/', bareTyArgP, end of input, mmonoPredicateP, or monoPredicateP"
               ]
+
+    , testCase "type t = Nat (type aliases should start with upper case)" $
+          parseSingleSpec "type t = Nat" @?==
+            unlines
+              [ "<test>:1:6:"
+              , "  |"
+              , "1 | type t = Nat"
+              , "  |      ^"
+              , "unexpected 't'"
+              , "expecting aliasP"
+              ]
+
     ]
 
 


### PR DESCRIPTION
* Type aliases only can start with an uppercase letter now
* Allow applications of type aliases to use parenthesis for expression arguments

Addresses #2673