### PR TITLE
Stop shadowing reflected signatures with assumed signatures

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Init.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Init.hs
@@ -82,7 +82,10 @@ initEnv info
        let tcb   = fmap (rTypeSort tce) <$> concat bs
        let cbs   = giCbs . giSrc $ info
        rTrue   <- mapM (traverse (true allowTC)) f6
-       let γ0    = measEnv sp (head bs) cbs tcb lt1s lt2s (f6 ++ bs!!3) (bs!!5) hs info
+       -- Issue #2537: reflected sigs (f6) must come AFTER assumed sigs (bs!!3) so that
+       -- when both exist for the same symbol (e.g., assume-reflect actual functions),
+       -- the strengthened reflected sig wins in M.fromList (which keeps the last entry).
+       let γ0    = measEnv sp (head bs) cbs tcb lt1s lt2s (bs!!3 ++ f6) (bs!!5) hs info
        γ  <- globalize <$> foldM (+=) γ0 ( [("initEnv", x, y) | (x, y) <- concat (rTrue:tail bs)])
        return γ {invs = is (invs1 ++ invs2)}
   where

--- a/tests/basic/pos/AssmRefl04.hs
+++ b/tests/basic/pos/AssmRefl04.hs
@@ -1,0 +1,26 @@
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--ple" @-}
+
+-- Test for issue #2537: assume-reflected definitions should not lose
+-- measure information when the actual function already has an assumed spec.
+
+module AssmRefl04 where
+
+import Data.Set as Set
+
+{-@ infixr ++ @-}
+
+test :: Int -> ()
+test x = lemma ([x] ++ [x]) (Set.singleton x)
+
+{-@ lemma :: x:[Int] -> {y:_ | Set.isSubsetOf y (Set.listElts x) } -> { Set.isSubsetOf y (Set.listElts x) } @-}
+lemma :: [Int] -> Set Int -> ()
+lemma _ _ = ()
+
+{-@ reflect append @-}
+{-@ assume append :: xs:[a] -> ys:[a] -> {v:[a] | len v = len xs + len ys} @-}
+append :: [a] -> [a] -> [a]
+append [] ys = ys
+append (x:xs) ys = x : append xs ys
+
+{-@ assume reflect ++ as append @-}

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2232,6 +2232,7 @@ executable basic-pos
                     , AssmRefl02C
                     , AssmRefl02D
                     , AssmRefl03
+                    , AssmRefl04
                     , AssmReflFilter
                     , DeadBind00
                     , Float
@@ -2284,6 +2285,7 @@ executable basic-pos
                     , TestAdmit
 
     build-depends:    base
+                    , containers
                     , liquid-prelude
                     , liquidhaskell
 


### PR DESCRIPTION
Reflected signatures were shadowed by assumed signatures in the environment prepared for constraint generation. This was not an issue until assumed-reflected functions came, since they can show in both forms.

The signature of the reflected signature should be stronger than the assumed signature, so it is made to prevail in the commit.

Fixes #2537 