### PR TITLE
Document alias naming convention

### DIFF
--- a/docs/mkDocs/docs/specifications.md
+++ b/docs/mkDocs/docs/specifications.md
@@ -333,7 +333,8 @@ and compelling example.
 
 **Syntax:** The key requirements for type aliases are:
 
-- Value parameters are specified in **upper**case: `X`, `Y`, `Z` etc.
+1. It's name can start with either an upper or lower case letter.
+2. Value parameters are specified in **upper**case: `X`, `Y`, `Z` etc.
 
 ### Type Aliases
 
@@ -380,8 +381,10 @@ see [tests/pos/Map.hs](https://github.com/ucsd-progsys/liquidhaskell/blob/develo
 
 **Syntax:** The key requirements for type aliases are:
 
-1. Type parameters go first and are specified in **lower**case: `a`, `b`, `c` etc.
-2. Value parameters are specified in **upper**case: `X`, `Y`, `Z` etc.
+1. It's name must follow the convention of regular Haskell types. Note they can override existing
+   Haskell type names within annotations.
+2. Type parameters go first and are specified in **lower**case: `a`, `b`, `c` etc.
+3. Value parameters are specified in **upper**case: `X`, `Y`, `Z` etc.
 
 ### Import/Export of aliases
 


### PR DESCRIPTION
Closes #2673

Adds a couple of lines to the specification page on allowed names for both type and predicate aliases.

Namely:

- Type aliases names should follow the same convention as regular Haskell types (haven't checked if this is actually enforced by the parser, but some experiments point in that direction).
- Predicate aliases can start start either with lower or upper case.