### PR TITLE
Replace two implementations of substitution with GHC's

### DIFF
--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -369,7 +369,12 @@ import GHC.Core.TyCo.Rep              as Ghc
     , mkTyVarTys
     )
 import GHC.Core.TyCo.Compare          as Ghc (eqType, nonDetCmpType)
-import GHC.Core.TyCo.Subst            as Ghc (extendSubstInScopeSet, substCo, zipTvSubst)
+import GHC.Core.TyCo.Subst            as Ghc
+    ( extendSubstInScope
+    , extendSubstInScopeSet
+    , substCo
+    , zipTvSubst
+    )
 import GHC.Core.TyCon                 as Ghc
     ( TyConBinder
     , TyConBndrVis(AnonTCB)
@@ -470,6 +475,7 @@ import GHC.Plugins                    as Ghc ( Serialized(Serialized)
                                              , purePlugin
                                              , extendIdSubst
                                              , substExpr
+                                             , Subst
                                              )
 import GHC.Core.FVs                   as Ghc
     ( exprFreeVars

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -464,19 +464,26 @@ import GHC.HsToCore.Monad             as Ghc
     ( DsM, initDsTc, initDsWithModGuts, newUnique )
 import GHC.Iface.Syntax               as Ghc
     ( IfaceAnnotation(ifAnnotatedValue) )
-import GHC.Plugins                    as Ghc ( Serialized(Serialized)
-                                             , deserializeWithData
-                                             , fromSerialized
-                                             , toSerialized
-                                             , defaultPlugin
-                                             , emptyPlugins
-                                             , Plugin(..)
-                                             , CommandLineOption
-                                             , purePlugin
-                                             , extendIdSubst
-                                             , substExpr
-                                             , Subst
-                                             )
+import GHC.Plugins                    as Ghc
+    ( Serialized(Serialized)
+    , deserializeWithData
+    , fromSerialized
+    , toSerialized
+    , defaultPlugin
+    , emptyPlugins
+    , Plugin(..)
+    , CommandLineOption
+    , purePlugin
+    , extendIdSubst
+    , extendIdSubstList
+    , extendSubst
+    , extendSubstList
+    , extendTvSubst
+    , extendTvSubstList
+    , mkEmptySubst
+    , substExpr
+    , Subst
+    )
 import GHC.Core.FVs                   as Ghc
     ( exprFreeVars
     , exprFreeVarsList
@@ -773,13 +780,14 @@ import GHC.Types.Var                  as Ghc
     , varUnique
     )
 import GHC.Types.Var.Env              as Ghc
-    ( emptyInScopeSet, mkRnEnv2 )
+    ( emptyInScopeSet, mkInScopeSet, mkRnEnv2 )
 import GHC.Types.Var.Set              as Ghc
     ( VarSet
     , elemVarSet
     , emptyVarSet
     , extendVarSet
     , extendVarSetList
+    , unionVarSet
     , unitVarSet
     )
 import GHC.Unit.Env                   as Ghc

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -380,10 +380,12 @@ makeAssumeType cfg tce lmap dm sym mbT v def
     -- Negative Debruijn indices (levels :^)) are safer
     freeSort    = [-1, -2 ..]
 
+    normalizedExpr = normalizeCoreExpr allowTC def
+    inScopeSubst =
+      Ghc.emptySubst `Ghc.extendSubstInScopeSet` Ghc.exprFreeVars normalizedExpr
     (xs, def') =
       GM.notracePpr "grabBody" $
-      grabBody allowTC (Ghc.expandTypeSynonyms τ) $
-      normalizeCoreExpr allowTC def
+      grabBody allowTC inScopeSubst (Ghc.expandTypeSynonyms τ) normalizedExpr
     su         = F.mkSubst  $ zip (F.symbol     <$> xs) xArgs
                            ++ zip (simplesymbol <$> xs) xArgs
     xts        = [(F.symbol x, rTypeSortExp tce t) | (x, t) <- aargs at]
@@ -392,25 +394,27 @@ rTypeSortExp :: F.TCEmb Ghc.TyCon -> SpecType -> F.Sort
 rTypeSortExp tce = typeSort tce . Ghc.expandTypeSynonyms . toType False
 
 grabBody :: Bool -- ^ typeclass enabled
+         -> Ghc.Subst -- ^ in-scope set for capture-avoiding substitution
          -> Ghc.Type -> Ghc.CoreExpr -> ([Ghc.Var], Ghc.CoreExpr)
-grabBody allowTC (Ghc.ForAllTy _ ty) e
-  = grabBody allowTC ty e
-grabBody allowTC@False Ghc.FunTy{ Ghc.ft_arg = tx, Ghc.ft_res = t} e | Ghc.isClassPred tx
-  = grabBody allowTC t e
-grabBody allowTC@True Ghc.FunTy{ Ghc.ft_arg = tx, Ghc.ft_res = t} e | isEmbeddedDictType tx
-  = grabBody allowTC t e
-grabBody allowTC torig@Ghc.FunTy {} (Ghc.Let (Ghc.NonRec x e) body)
-  = grabBody allowTC torig (subst (x,e) body)
-grabBody allowTC Ghc.FunTy{ Ghc.ft_res = t} (Ghc.Lam x e)
-  = (x:xs, e') where (xs, e') = grabBody allowTC t e
-grabBody allowTC t (Ghc.Tick _ e)
-  = grabBody allowTC t e
-grabBody allowTC ty@Ghc.FunTy{} e
+grabBody allowTC inScope (Ghc.ForAllTy _ ty) e
+  = grabBody allowTC inScope ty e
+grabBody allowTC@False inScope Ghc.FunTy{ Ghc.ft_arg = tx, Ghc.ft_res = t} e | Ghc.isClassPred tx
+  = grabBody allowTC inScope t e
+grabBody allowTC@True inScope Ghc.FunTy{ Ghc.ft_arg = tx, Ghc.ft_res = t} e | isEmbeddedDictType tx
+  = grabBody allowTC inScope t e
+grabBody allowTC inScope torig@Ghc.FunTy {} (Ghc.Let (Ghc.NonRec x e) body)
+  = grabBody allowTC inScope torig (Ghc.substExpr (Ghc.extendIdSubst inScope x e) body)
+grabBody allowTC inScope Ghc.FunTy{ Ghc.ft_res = t} (Ghc.Lam x e)
+  = (x:xs, e')
+   where (xs, e') = grabBody allowTC (Ghc.extendSubstInScope inScope x) t e
+grabBody allowTC inScope t (Ghc.Tick _ e)
+  = grabBody allowTC inScope t e
+grabBody allowTC inScope ty@Ghc.FunTy{} e
   = (txs++xs, e')
    where (ts,tr)  = splitFun ty
-         (xs, e') = grabBody allowTC tr (foldl Ghc.App e (Ghc.Var <$> txs))
+         (xs, e') = grabBody allowTC inScope tr (foldl Ghc.App e (Ghc.Var <$> txs))
          txs      = [ stringVar ("ls" ++ show i) t |  (t,i) <- zip ts [(1::Int)..]]
-grabBody _ _ e
+grabBody _ _ _ e
   = ([], e)
 
 splitFun :: Ghc.Type -> ([Ghc.Type], Ghc.Type)
@@ -429,38 +433,6 @@ strengthenRes st rf = go st
     go (RAllP p t)     = RAllP p $ go t
     go (RFun x i tx t r) = RFun x i tx (go t) r
     go t               =  t `strengthen` ofReft rf
-
-class Subable a where
-  subst :: (Ghc.Var, Ghc.CoreExpr) -> a -> a
-
-instance Subable Ghc.Var where
-  subst (x, ex) z
-    | x == z, Ghc.Var y <- ex = y
-    | otherwise           = z
-
-instance Subable Ghc.CoreExpr where
-  subst (x, ex) (Ghc.Var y)
-    | x == y    = ex
-    | otherwise = Ghc.Var y
-  subst su (Ghc.App f e)
-    = Ghc.App (subst su f) (subst su e)
-  subst su (Ghc.Lam x e)
-    = Ghc.Lam x (subst su e)
-  subst su (Ghc.Case e x t alts)
-    = Ghc.Case (subst su e) x t (subst su <$> alts)
-  subst su (Ghc.Let (Ghc.Rec xes) e)
-    = Ghc.Let (Ghc.Rec (fmap (subst su) <$> xes)) (subst su e)
-  subst su (Ghc.Let (Ghc.NonRec x ex) e)
-    = Ghc.Let (Ghc.NonRec x (subst su ex)) (subst su e)
-  subst su (Ghc.Cast e t)
-    = Ghc.Cast (subst su e) t
-  subst su (Ghc.Tick t e)
-    = Ghc.Tick t (subst su e)
-  subst _ e
-    = e
-
-instance Subable Ghc.CoreAlt where
-  subst su (Ghc.Alt c xs e) = Ghc.Alt c xs (subst su e)
 
 data AxiomType = AT { aty :: SpecType, aargs :: [(F.Symbol, SpecType)], ares :: SpecType }
   deriving Show

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Relational.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Relational.hs
@@ -15,7 +15,6 @@ module Language.Haskell.Liquid.Constraint.Relational (consAssmRel, consRelTop) w
 
 import           Control.Monad (foldM, forM_)
 import           Data.Bifunctor                                 ( Bifunctor(bimap) )
-import qualified Data.HashMap.Strict                            as M
 import qualified Data.List                                      as L
 import           Data.String                                    ( IsString(..) )
 import qualified Language.Fixpoint.Types                        as F
@@ -31,12 +30,11 @@ import           Liquid.GHC.API                 ( Alt
                                                 , CoreBndr
                                                 , CoreExpr
                                                 , Expr(..)
-                                                , Type(..)
+                                                , Type
                                                 , TyVar
                                                 , Var(..))
 import qualified Liquid.GHC.API                as Ghc
 import qualified Language.Haskell.Liquid.GHC.Misc               as GM
-import           Language.Haskell.Liquid.GHC.Play               (Subable(sub, subTy))
 import qualified Language.Haskell.Liquid.GHC.SpanStack          as Sp
 import           Language.Haskell.Liquid.GHC.TypeRep            ()
 import           Language.Haskell.Liquid.Misc
@@ -163,7 +161,9 @@ consRelCheckBind γ ψ b1@(Rec [(f1, e1)]) b2@(Rec [(f2, e2)]) t1 t2 ra rp
     forM_ (refts t1 ++ refts t2) (\r -> entlFunReft γ r "consRelCheckBind Rec")
     let xs' = zipWith mkRelCopies xs1 xs2
     let (xs1', xs2') = unzip xs'
-    let (e1'', e2'') = L.foldl' subRel (e1', e2') (zip xs1 xs2)
+    -- Strip lambdas first, then substitute in the bodies where xs are free
+    let body1 = subVars xs1 xs1' (xbody e1')
+        body2 = subVars xs2 xs2' (xbody e2')
     γ' <- γ += ("Bind Rec f1", F.symbol f1', t1) >>= (+= ("Bind Rec f2", F.symbol f2', t2))
     γ'' <- foldM (\γγ (x, t) -> γγ += ("Bind Rec x1", F.symbol x, t)) γ' (zip (xs1' ++ xs2') (ts1 ++ ts2))
     let vs2xs =  F.subst $ F.mkSubst $ zip (vs1 ++ vs2) $ map (F.EVar . F.symbol) (xs1' ++ xs2')
@@ -173,7 +173,7 @@ consRelCheckBind γ ψ b1@(Rec [(f1, e1)]) b2@(Rec [(f2, e2)]) t1 t2 ra rp
                               map vs2xs [F.PAnd fo, a]
     let p' = unapp rp (zip vs1 vs2)
     let ψ' = ho ++ ψ
-    consRelCheck γ''' ψ' (xbody e1'') (xbody e2'') (vs2xs $ ret t1) (vs2xs $ ret t2) (vs2xs $ concl (fromRelExpr p'))
+    consRelCheck γ''' ψ' body1 body2 (vs2xs $ ret t1) (vs2xs $ ret t2) (vs2xs $ concl (fromRelExpr p'))
   where
     a = fromRelExpr ra
     p = fromRelExpr rp
@@ -181,7 +181,6 @@ consRelCheckBind γ ψ b1@(Rec [(f1, e1)]) b2@(Rec [(f2, e2)]) t1 t2 ra rp
     (e1', e2') = subRelCopies e1 f1 e2 f2
     unapp :: RelExpr -> [(F.Symbol, F.Symbol)] -> RelExpr
     unapp = L.foldl' (\p' (v1, v2) -> unapplyRelArgsR v1 v2 p')
-    subRel (e1'', e2'') (x1, x2) = subRelCopies e1'' x1 e2'' x2
 
 consRelCheckBind _ _ (Rec [(_, e1)]) (Rec [(_, e2)]) t1 t2 _ rp
   = F.panic $ "consRelCheckBind Rec: exprs, types, and pred should have same number of args " ++
@@ -694,8 +693,22 @@ subRelCopies :: CoreExpr -> Var -> CoreExpr -> Var -> (CoreExpr, CoreExpr)
 subRelCopies e1 x1 e2 x2 = (subVarAndTy x1 evar1 e1, subVarAndTy x2 evar2 e2)
   where (evar1, evar2) = mkRelCopies x1 x2
 
+-- | Rename a variable in a CoreExpr.
 subVarAndTy :: Var -> Var -> CoreExpr -> CoreExpr
-subVarAndTy x v = subTy (M.singleton x $ TyVarTy v) . sub (M.singleton x $ Var v)
+subVarAndTy x v e = Ghc.substExpr subst e
+  where
+    inScope = Ghc.mkInScopeSet (Ghc.exprFreeVars e `Ghc.extendVarSet` v)
+    vE = if Ghc.isTyVar x then Type (Ghc.TyVarTy v) else Var v
+    subst = Ghc.extendSubst (Ghc.mkEmptySubst inScope) x vE
+
+-- | Rename multiple variables in a CoreExpr at once.
+subVars :: [Var] -> [Var] -> CoreExpr -> CoreExpr
+subVars xs vs e = Ghc.substExpr subst e -- (M.fromList (zip xs (Var <$> vs)))
+  where
+    fvs     = Ghc.exprFreeVars e `Ghc.extendVarSetList` vs
+    inScope = Ghc.mkInScopeSet fvs
+    subst   = Ghc.extendIdSubstList (Ghc.mkEmptySubst inScope)
+                [ (x, Var v) | (x, v) <- zip xs vs ]
 
 mkRelCopies :: Var -> Var -> (Var, Var)
 mkRelCopies x1 x2 = (mkCopyWithSuffix relSuffixL x1, mkCopyWithSuffix relSuffixR x2)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Play.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Play.hs
@@ -7,14 +7,12 @@ module Language.Haskell.Liquid.GHC.Play where
 
 import Prelude hiding (error)
 
-import           Control.Arrow       ((***))
 import qualified Data.HashMap.Strict as M
 import qualified Data.List           as L
 import qualified Data.Maybe          as Mb
 
-import Liquid.GHC.API as Ghc hiding (panic, showPpr)
+import Liquid.GHC.API as Ghc
 import Language.Haskell.Liquid.GHC.Misc ()
-import Language.Haskell.Liquid.Types.Errors
 import Language.Haskell.Liquid.Types.Variance
 
 -------------------------------------------------------------------------------
@@ -146,88 +144,6 @@ isRecursivenewTyCon c
 
 dataConImplicitIds :: DataCon -> [Id]
 dataConImplicitIds dc = [ x | AnId x <- dataConImplicitTyThings dc]
-
-class Subable a where
-  sub   :: M.HashMap CoreBndr CoreExpr -> a -> a
-  subTy :: M.HashMap TyVar Type -> a -> a
-
-instance Subable CoreExpr where
-  sub s (Var v)        = M.lookupDefault (Var v) v s
-  sub _ (Lit l)        = Lit l
-  sub s (App e1 e2)    = App (sub s e1) (sub s e2)
-  sub s (Lam b e)      = Lam b (sub s e)
-  sub s (Let b e)      = Let (sub s b) (sub s e)
-  sub s (Case e b t a) = Case (sub s e) (sub s b) t (map (sub s) a)
-  sub s (Cast e c)     = Cast (sub s e) c
-  sub s (Tick t e)     = Tick t (sub s e)
-  sub _ (Type t)       = Type t
-  sub _ (Coercion c)   = Coercion c
-
-  subTy s (Var v)      = Var (subTy s v)
-  subTy _ (Lit l)      = Lit l
-  subTy s (App e1 e2)  = App (subTy s e1) (subTy s e2)
-  subTy s (Lam b e)    | isTyVar b = Lam v' (subTy s e)
-   where v' = case M.lookup b s of
-               Just (TyVarTy v) -> v
-               _                -> b
-
-  subTy s (Lam b e)      = Lam (subTy s b) (subTy s e)
-  subTy s (Let b e)      = Let (subTy s b) (subTy s e)
-  subTy s (Case e b t a) = Case (subTy s e) (subTy s b) (subTy s t) (map (subTy s) a)
-  subTy s (Cast e _c)    = Cast (subTy s e) $ panic Nothing "subTy Coercion"
-  subTy s (Tick t e)     = Tick t (subTy s e)
-  subTy s (Type t)       = Type (subTy s t)
-  subTy _s (Coercion _c) = Coercion $ panic Nothing "subTy Coercion"
-
-instance Subable (Alt Var) where
- sub s (Alt a b e)   = Alt a (map (sub s) b)   (sub s e)
- subTy s (Alt a b e) = Alt a (map (subTy s) b) (subTy s e)
-
-instance Subable Var where
- sub s v   | M.member v s = subVar $ s M.! v
-           | otherwise    = v
- subTy s v = setVarType v (subTy s (varType v))
-
-subVar :: Expr t -> Id
-subVar (Var x) = x
-subVar  _      = panic Nothing "sub Var"
-
-instance Subable (Bind Var) where
- sub s (NonRec x e)   = NonRec (sub s x) (sub s e)
- sub s (Rec xes)      = Rec ((sub s *** sub s) <$> xes)
-
- subTy s (NonRec x e) = NonRec (subTy s x) (subTy s e)
- subTy s (Rec xes)    = Rec ((subTy s  *** subTy s) <$> xes)
-
-instance Subable Type where
- sub _ e   = e
- subTy     = substTysWith
-
-substTysWith :: M.HashMap Var Type -> Type -> Type
-substTysWith s tv@(TyVarTy v)      = M.lookupDefault tv v s
-substTysWith s (FunTy aaf m t1 t2) = FunTy aaf m (substTysWith s t1) (substTysWith s t2)
-substTysWith s (ForAllTy v t)      = ForAllTy v (substTysWith (M.delete (binderVar v) s) t)
-substTysWith s (TyConApp c ts)     = TyConApp c (map (substTysWith s) ts)
-substTysWith s (AppTy t1 t2)       = AppTy (substTysWith s t1) (substTysWith s t2)
-substTysWith _ (LitTy t)           = LitTy t
-substTysWith s (CastTy t c)        = CastTy (substTysWith s t) c
-substTysWith _ (CoercionTy c)      = CoercionTy c
-
-substExpr :: M.HashMap Var Var -> CoreExpr -> CoreExpr
-substExpr s = go
-  where
-    subsVar v                = M.lookupDefault v v s
-    go (Var v)               = Var $ subsVar v
-    go (Lit l)               = Lit l
-    go (App e1 e2)           = App (go e1) (go e2)
-    go (Lam x e)             = Lam (subsVar x) (go e)
-    go (Let (NonRec x ex) e) = Let (NonRec (subsVar x) (go ex)) (go e)
-    go (Let (Rec xes) e)     = Let (Rec [(subsVar x', go e') | (x',e') <- xes]) (go e)
-    go (Case e b t alts)     = Case (go e) (subsVar b) t [Alt c (subsVar <$> xs) (go e') | Alt c xs e' <- alts]
-    go (Cast e c)            = Cast (go e) c
-    go (Tick t e)            = Tick t (go e)
-    go (Type t)              = Type t
-    go (Coercion c)          = Coercion c
 
 mapType :: (Type -> Type) -> Type -> Type
 mapType f = go

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Measure.hs
@@ -169,7 +169,7 @@ noDummySyms t
 combineDCTypes :: String -> Type -> [RRType Reft] -> RRType Reft
 combineDCTypes _msg t ts = L.foldl' strengthenRefTypeGen (ofType t) ts
 
-mapArgumens :: Bool -> SourcePos -> RRType Reft -> RRType Reft -> Maybe Subst
+mapArgumens :: Bool -> SourcePos -> RRType Reft -> RRType Reft -> Maybe F.Subst
 mapArgumens allowTC lc t1 t2 = go xts1' xts2'
   where
     xts1 = zip (ty_binds rep1) (ty_args rep1)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -47,7 +47,6 @@ import qualified Language.Haskell.Liquid.GHC.Misc      as GM
 import           Language.Haskell.Liquid.Bare.Types
 import           Language.Haskell.Liquid.Bare.DataType
 import           Language.Haskell.Liquid.Bare.Misc     (simpleSymbolVar)
-import           Language.Haskell.Liquid.GHC.Play
 import           Language.Haskell.Liquid.Types.Errors
 import           Language.Haskell.Liquid.Types.Names
 import           Language.Haskell.Liquid.Types.RefType
@@ -690,7 +689,7 @@ simplifyCoreExpr allowTC = go
       = C.Let (C.Rec (map (fmap go) xes)) (go e)
     go (C.Case e x _t alts@[Alt _ _ ee,_,_])
       | isBangInteger alts
-      = sub (M.singleton x (go e)) (go ee)
+      = sub x (go e) (go ee)
     go (C.Case e x t alts)
       = C.Case (go e) x t $
          filter
@@ -705,9 +704,22 @@ simplifyCoreExpr allowTC = go
     go (C.Type t)
       = C.Type t
 
+-- | Substitute variable bindings in a CoreExpr using GHC's capture-avoiding
+-- substExpr.
+--
+-- TODO: This implementation is a bit wastful since it collects the free
+-- variables of both expressions every time, we could pass a superset of the
+-- free variables instead. But the overhead is not observable in our tests.
+sub :: CoreBndr -> CoreExpr -> CoreExpr -> CoreExpr
+sub x e0 e = Ghc.substExpr su e
+  where
+    fvs     = Ghc.exprFreeVars e `Ghc.unionVarSet` Ghc.exprFreeVars e0
+    inScope = Ghc.mkInScopeSet fvs
+    su   = Ghc.extendIdSubst (Ghc.mkEmptySubst inScope) x e0
+
 inlineCoreExpr :: (Id -> Bool) -> CoreExpr -> CoreExpr
 inlineCoreExpr p (C.Let (C.NonRec x ex) e)
-  | p x = sub (M.singleton x (inlineCoreExpr p ex)) (inlineCoreExpr p e)
+  | p x = sub x (inlineCoreExpr p ex) (inlineCoreExpr p e)
   | otherwise = C.Let (C.NonRec x (inlineCoreExpr p ex)) (inlineCoreExpr p e)
 inlineCoreExpr p (C.Let (C.Rec xes) e) = C.Let (C.Rec (map (fmap (inlineCoreExpr p)) xes)) (inlineCoreExpr p e)
 inlineCoreExpr p (C.App e1 e2)       = C.App (inlineCoreExpr p e1) (inlineCoreExpr p e2)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Rewrite.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/Rewrite.hs
@@ -24,17 +24,15 @@ module Language.Haskell.Liquid.Transforms.Rewrite
 
   ) where
 
-import           Liquid.GHC.API as Ghc hiding (get, showPpr, substExpr)
+import           Liquid.GHC.API as Ghc hiding (get, showPpr)
 import           Language.Haskell.Liquid.GHC.TypeRep ()
 import           Data.Maybe     (fromMaybe, isJust, mapMaybe)
 import           Control.Monad.State hiding (lift)
 import           Language.Haskell.Liquid.Misc (Nat)
-import           Language.Haskell.Liquid.GHC.Play (sub, substExpr)
 import           Language.Haskell.Liquid.GHC.Misc (unTickExpr, isTupleId, mkAlive)
 import           Language.Haskell.Liquid.Types.Errors (impossible)
 import           Language.Haskell.Liquid.UX.Config  (Config, noSimplifyCore)
 import qualified Data.List as L
-import qualified Data.HashMap.Strict as M
 
 --------------------------------------------------------------------------------
 -- | Top-level rewriter --------------------------------------------------------
@@ -283,7 +281,11 @@ isProjectionOf _ _ = Nothing
 -- | `substTuple xs ys e'` returns e' [y1 := x1,...,yn := xn]
 --------------------------------------------------------------------------------
 substTuple :: [Var] -> [Var] -> CoreExpr -> CoreExpr
-substTuple xs ys = substExpr (M.fromList $ zip ys xs)
+substTuple xs ys e = Ghc.substExpr subst e
+  where
+    inScope = Ghc.mkInScopeSet (Ghc.exprFreeVars e `extendVarSetList` xs)
+    subst   = Ghc.extendIdSubstList (Ghc.mkEmptySubst inScope)
+                [ (v, Var v') | (v, v') <- zip ys xs ]
 
 -- | Yields the tuple of variables at the end of nested cases with
 -- a single alternative each.
@@ -339,7 +341,11 @@ inlineLoopBreaker :: Bind Id -> Bind Id
 inlineLoopBreaker (NonRec x e)
     | Just (lbx, lbe, lbargs) <- hasLoopBreaker be =
        let asPrefix = take (length as - length lbargs) as
-           lbe' = sub (M.singleton lbx (ecall asPrefix)) lbe
+           inScope =
+             Ghc.mkInScopeSet $
+               Ghc.exprFreeVars (ecall asPrefix) `unionVarSet` Ghc.exprFreeVars lbe
+           subst = Ghc.extendIdSubst (Ghc.mkEmptySubst inScope) lbx (ecall asPrefix)
+           lbe' = Ghc.substExpr subst lbe
         in Rec [(x, mkLams (αs ++ asPrefix) (mkLets nrbinds lbe'))]
   where
     (αs, as, e') = collectTyAndValBinders e

--- a/scripts/benchmark-comparison.sh
+++ b/scripts/benchmark-comparison.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# benchmark-comparison.sh $1
+#
+# Builds benchmark comparison charts for $1 vs the current branch.
+
+set -euo pipefail
+
+BEFORE_BRANCH=$1
+AFTER_BRANCH=$(git rev-parse HEAD)
+
+clean_run_collect() {
+    local run_label="$1"  # "before" or "after"
+    echo "Running benchmarks for $run_label branch..."
+    find dist-newstyle -name "tests-*" -o -name "prover-ple-lib-*" | xargs rm -rf
+    ./scripts/test/test_plugin.sh --measure-timings-j1
+    rm -rf tmp tmp-${run_label}
+    cabal build ghc-timings
+    cabal exec ghc-timings dist-newstyle
+    mv tmp tmp-${run_label}
+    cabal run benchmark-timings -- tmp-${run_label}/*.json --phase LiquidHaskellCPU -o summary-${run_label}.csv
+}
+
+clean_run_collect after
+
+echo "Checking out BEFORE branch: $BEFORE_BRANCH"
+git checkout "$BEFORE_BRANCH"
+git submodule update --init --recursive
+clean_run_collect before
+echo "Checking out AFTER branch: $AFTER_BRANCH"
+git checkout "$AFTER_BRANCH"
+git submodule update --init --recursive
+
+cabal run plot-performance -- -b summary-before.csv -a summary-after.csv -s 50


### PR DESCRIPTION
Addresses part of #2676

This removes the implementations at Language.Haskell.Liquid.GHC.Play.Subable and Language.Haskell.Liquid.Bare.Axiom.Subable.

