### PR TITLE
Adapt to liquid-fixpoint's syms returning HashSet instead of list 

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -741,7 +741,7 @@ consE γ (Var x) | GM.isDataConId x
   = do t0 <- varRefType γ x
        -- NV: The check is expected to fail most times, so
        --     it is cheaper than direclty fmap ignoreSelf.
-       let hasSelf = selfSymbol `elem` F.syms t0
+       let hasSelf = selfSymbol `S.member` F.syms t0
        let t = if hasSelf
                 then fmap ignoreSelf <$> t0
                 else t0
@@ -1134,7 +1134,7 @@ cconsFreshE kvkind γ e = do
 checkUnbound :: (PPrint a, Show a2, F.Subable a, F.Variable a ~ F.Symbol)
              => CGEnv -> CoreExpr -> F.Symbol -> a -> a2 -> a
 checkUnbound γ e x t a
-  | x `notElem` F.syms t = t
+  | not (x `S.member` F.syms t) = t
   | otherwise            = panic (Just $ getLocation γ) msg
   where
     msg = unlines [ "checkUnbound: " ++ show x ++ " is elem of syms of " ++ showpp t
@@ -1221,7 +1221,7 @@ substSelfReft :: F.Reft -> F.Reft
 substSelfReft (F.Reft (v, e)) = F.Reft (v, F.subst1 e (selfSymbol, F.EVar v))
 
 ignoreSelf :: F.Reft -> F.Reft
-ignoreSelf = F.mapExpr (\r -> if selfSymbol `elem` F.syms r then F.PTrue else r)
+ignoreSelf = F.mapExpr (\r -> if selfSymbol `S.member` F.syms r then F.PTrue else r)
 
 --------------------------------------------------------------------------------
 -- | `projectTypes` masks (i.e. true's out) all types EXCEPT those

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Qualifier.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Qualifier.hs
@@ -10,7 +10,7 @@ module Language.Haskell.Liquid.Constraint.Qualifier
   where
 
 import           Prelude hiding (error)
-import           Data.List                (delete, nub, partition)
+import           Data.List                (partition)
 import           Data.Maybe               (isJust, catMaybes, fromMaybe, isNothing)
 import qualified Data.HashSet        as S
 import qualified Data.HashMap.Strict as M
@@ -239,7 +239,7 @@ mkQual :: SEnv Sort
        -> Qualifier
 mkQual lEnv l _ γ v so p   = mkQ "Auto" ((v, so) : xts) p l
   where
-    xs   = delete v $ nub $ syms p
+    xs   = S.toList (S.delete v $ syms p)
     xts  = catMaybes $ zipWith (envSort l lEnv γ) xs [0..]
 
 envSort :: SourcePos -> SEnv Sort -> SEnv Sort -> Symbol -> Integer -> Maybe (Symbol, Sort)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
@@ -148,8 +148,8 @@ makeRewrites info sub = concatMap (makeRewriteOne tce) $ filter ((`S.member` rws
 canRewrite :: S.HashSet F.Symbol -> F.Expr -> F.Expr -> Bool
 canRewrite freeVars' from to = noFreeSyms && doesNotDiverge
   where
-    fromSyms           = S.intersection freeVars' (S.fromList $ F.syms from)
-    toSyms             = S.intersection freeVars' (S.fromList $ F.syms to)
+    fromSyms           = S.intersection freeVars' (F.syms from)
+    toSyms             = S.intersection freeVars' (F.syms to)
     noFreeSyms         = S.null $ S.difference toSyms fromSyms
     doesNotDiverge     = Mb.isNothing (unify (S.toList freeVars') from to)
                       || Mb.isJust (unify (S.toList freeVars') to from)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -463,7 +463,7 @@ instance Hashable v => F.Subable (UsedPVarBV v v) where
 
 instance Hashable v => F.Subable (PredicateBV v v) where
   type Variable (PredicateBV v v) = v
-  syms     (Pr pvs) = S.unions (map F.syms pvs)
+  syms (Pr pvs) = F.syms pvs
   subst  s (Pr pvs) = Pr (F.subst s  <$> pvs)
   substf f (Pr pvs) = Pr (F.substf f <$> pvs)
   substa f (Pr pvs) = Pr (F.substa f <$> pvs)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -160,6 +160,7 @@ import qualified Data.HashMap.Strict                    as M
 import qualified Data.List                              as L
 import           Data.Maybe                             (mapMaybe)
 import           Data.List                              as L (nub)
+import qualified Data.HashSet                           as S
 import           Data.Proxy                             (Proxy(..))
 import           Text.PrettyPrint.HughesPJ              hiding (first, (<>))
 import           Language.Fixpoint.Misc
@@ -454,7 +455,7 @@ pvars (Pr pvs) = pvs
 
 instance Hashable v => F.Subable (UsedPVarBV v v) where
   type Variable (UsedPVarBV v v) = v
-  syms pv         = [ y | (_, x, F.EVar y) <- pargs pv, x /= y ]
+  syms pv         = S.fromList [ y | (_, x, F.EVar y) <- pargs pv, x /= y ]
   subst s pv      = pv { pargs = mapThd3 (F.subst s)  <$> pargs pv }
   substf f pv     = pv { pargs = mapThd3 (F.substf f) <$> pargs pv }
   substa f pv     = pv { pargs = mapThd3 (F.substa f) <$> pargs pv }
@@ -462,7 +463,7 @@ instance Hashable v => F.Subable (UsedPVarBV v v) where
 
 instance Hashable v => F.Subable (PredicateBV v v) where
   type Variable (PredicateBV v v) = v
-  syms     (Pr pvs) = concatMap F.syms   pvs
+  syms     (Pr pvs) = S.unions (map F.syms pvs)
   subst  s (Pr pvs) = Pr (F.subst s  <$> pvs)
   substf f (Pr pvs) = Pr (F.substf f <$> pvs)
   substa f (Pr pvs) = Pr (F.substa f <$> pvs)
@@ -1142,7 +1143,7 @@ instance F.PPrint (NoReftB b) where
 
 instance Hashable b => F.Subable (NoReftB b) where
   type Variable (NoReftB b) = b
-  syms _   = []
+  syms _   = S.empty
   substa _ = id
   substf _ = id
   subst _  = id
@@ -1345,7 +1346,7 @@ instance (Meet r, Eq v) => Meet (UReftBV v v r)
 
 instance (F.Subable r, F.Variable r ~ v) => F.Subable (UReftBV v v r) where
   type Variable (UReftBV v v r) = v
-  syms (MkUReft r p)     = F.syms r ++ F.syms p
+  syms (MkUReft r p)     = F.syms r `S.union` F.syms p
   subst s (MkUReft r z)  = MkUReft (F.subst s r)  (F.subst s z)
   substf f (MkUReft r z) = MkUReft (F.substf f r) (F.substf f z)
   substa f (MkUReft r z) = MkUReft (F.substa f r) (F.substa f z)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
@@ -72,6 +72,7 @@ import qualified Prelude
 import           Control.Monad                          (liftM2, liftM3, liftM4)
 import           Data.Bifunctor (bimap)
 import           Data.Hashable (Hashable)
+import qualified Data.HashSet as S
 
 import qualified Language.Fixpoint.Types as F
 import           Language.Fixpoint.Types (ExprBV, Symbol)
@@ -247,7 +248,7 @@ addInvCond t r'
 
 instance (IsReft r, F.Subable r, TyConable c, F.Binder v, F.Variable r ~ v, ReftBind r ~ v) => F.Subable (RTPropBV v v c tv r) where
   type Variable (RTPropBV v v c tv r) = v
-  syms (RProp  ss r)     = (fst <$> ss) ++ F.syms r
+  syms (RProp  ss r)     = S.fromList (fst <$> ss) `S.union` F.syms r
 
   subst su (RProp ss (RHole r)) = RProp ss (RHole (F.subst su r))
   subst su (RProp  ss t) = RProp ss (F.subst su <$> t)
@@ -261,7 +262,7 @@ instance (IsReft r, F.Subable r, TyConable c, F.Binder v, F.Variable r ~ v, Reft
 
 instance (F.Subable r, IsReft r, TyConable c, F.Binder v, F.Variable r ~ v, ReftBind r ~ v) => F.Subable (RTypeBV v v c tv r) where
   type Variable (RTypeBV v v c tv r) = v
-  syms        = foldReft False (\_ r acc -> F.syms r ++ acc) []
+  syms        = foldReft False (\_ r acc -> F.syms r `S.union` acc) S.empty
   -- 'substa' will substitute bound vars
   substa f    = emapExprArg (\_ -> F.substa f) []      . mapReft  (F.substa f)
   -- 'substf' will NOT substitute bound vars

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
@@ -246,18 +246,24 @@ addInvCond t r'
     F.Reft(v, rv) = ur_reft r'
 
 
-instance (IsReft r, F.Subable r, TyConable c, F.Binder v, F.Variable r ~ v, ReftBind r ~ v) => F.Subable (RTPropBV v v c tv r) where
-  type Variable (RTPropBV v v c tv r) = v
+instance ( IsReft r
+         , F.Subable r
+         , F.Subable t
+         , TyConable c
+         , F.Binder v
+         , F.Variable r ~ v
+         , F.Variable t ~ v
+         , ReftBind r ~ v
+         ) =>
+         F.Subable (RefB v (RTypeBV v v c tv r) t) where
+  type Variable (RefB v (RTypeBV v v c tv r) t) = v
   syms (RProp  ss r)     = S.fromList (fst <$> ss) `S.union` F.syms r
 
-  subst su (RProp ss (RHole r)) = RProp ss (RHole (F.subst su r))
-  subst su (RProp  ss t) = RProp ss (F.subst su <$> t)
+  subst su (RProp  ss t) = RProp ss (F.subst su t)
 
-  substf f (RProp ss (RHole r)) = RProp ss (RHole (F.substf f r))
-  substf f (RProp  ss t) = RProp ss (F.substf f <$> t)
+  substf f (RProp  ss t) = RProp ss (F.substf f t)
 
-  substa f (RProp ss (RHole r)) = RProp ss (RHole (F.substa f r))
-  substa f (RProp  ss t) = RProp ss (F.substa f <$> t)
+  substa f (RProp  ss t) = RProp ss (F.substa f t)
 
 
 instance (F.Subable r, IsReft r, TyConable c, F.Binder v, F.Variable r ~ v, ReftBind r ~ v) => F.Subable (RTypeBV v v c tv r) where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -299,25 +299,6 @@ instance Meet (RTProp RTyCon RTyVar Reft)
 instance Semigroup (RType RTyCon RTyVar r) => Meet (RType RTyCon RTyVar r) where
 instance Meet (RType BTyCon BTyVar (UReft Reft))
 
-----------------------------------------------------------------------------
--- | Subable Instances -----------------------------------------------------
-----------------------------------------------------------------------------
-
-instance Subable (RRProp Reft) where
-  syms (RProp ss (RHole r)) = S.fromList (fst <$> ss) `S.union` syms r
-  syms (RProp ss t)      = S.fromList (fst <$> ss) `S.union` syms t
-
-
-  subst su (RProp ss (RHole r)) = RProp (fmap (subst su) <$> ss) $ RHole $ subst su r
-  subst su (RProp ss r)  = RProp  (fmap (subst su) <$> ss) $ subst su r
-
-
-  substf f (RProp ss (RHole r)) = RProp (fmap (substf f) <$> ss) $ RHole $ substf f r
-  substf f (RProp ss r) = RProp  (fmap (substf f) <$> ss) $ substf f r
-
-  substa f (RProp ss (RHole r)) = RProp (fmap (substa f) <$> ss) $ RHole $ substa f r
-  substa f (RProp ss r) = RProp  (fmap (substa f) <$> ss) $ substa f r
-
 -- MOVE TO TYPES
 instance Fixpoint String where
   toFix = text

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -304,8 +304,8 @@ instance Meet (RType BTyCon BTyVar (UReft Reft))
 ----------------------------------------------------------------------------
 
 instance Subable (RRProp Reft) where
-  syms (RProp ss (RHole r)) = (fst <$> ss) ++ syms r
-  syms (RProp ss t)      = (fst <$> ss) ++ syms t
+  syms (RProp ss (RHole r)) = S.fromList (fst <$> ss) `S.union` syms r
+  syms (RProp ss t)      = S.fromList (fst <$> ss) `S.union` syms t
 
 
   subst su (RProp ss (RHole r)) = RProp (fmap (subst su) <$> ss) $ RHole $ subst su r

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -791,7 +791,7 @@ instance F.PPrint (CMeasure t) => Show (CMeasure t) where
 
 
 instance F.Subable (Measure ty ctor) where
-  syms  m     = concatMap F.syms (msEqns m)
+  syms  m     = S.unions (map F.syms (msEqns m))
   substa f m  = m { msEqns = F.substa f  <$> msEqns m }
   substf f m  = m { msEqns = F.substf f  <$> msEqns m }
   subst  su m = m { msEqns = F.subst  su <$> msEqns m }
@@ -800,7 +800,7 @@ instance F.Subable (Measure ty ctor) where
   -- subst  su (M n s es _) = M n s $ F.subst  su <$> es
 
 instance F.Subable (Def ty ctor) where
-  syms (Def _ _ _ sb bd)  = (fst <$> sb) ++ F.syms bd
+  syms (Def _ _ _ sb bd)  = S.fromList (fst <$> sb) `S.union` F.syms bd
   substa f  (Def m c t b bd) = Def m c t b $ F.substa f  bd
   substf f  (Def m c t b bd) = Def m c t b $ F.substf f  bd
   subst  su (Def m c t b bd) = Def m c t b $ F.subst  su bd
@@ -808,7 +808,7 @@ instance F.Subable (Def ty ctor) where
 instance F.Subable Body where
   syms (E e)       = F.syms e
   syms (P e)       = F.syms e
-  syms (R s e)     = s : F.syms e
+  syms (R s e)     = S.insert s (F.syms e)
 
   substa f (E e)   = E   (F.substa f e)
   substa f (P e)   = P   (F.substa f e)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -791,7 +791,7 @@ instance F.PPrint (CMeasure t) => Show (CMeasure t) where
 
 
 instance F.Subable (Measure ty ctor) where
-  syms  m     = S.unions (map F.syms (msEqns m))
+  syms m = F.syms (msEqns m)
   substa f m  = m { msEqns = F.substa f  <$> msEqns m }
   substf f m  = m { msEqns = F.substf f  <$> msEqns m }
   subst  su m = m { msEqns = F.subst  su <$> msEqns m }

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Errors.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Errors.hs
@@ -54,7 +54,7 @@ tidyErrContext k e@(ErrSubType {})
   = e { ctx = c', tact = F.subst θ tA, texp = F.subst θ tE }
     where
       (θ, c') = tidyCtx k xs (ctx e)
-      xs      = F.syms tA ++ F.syms tE
+      xs      = S.toList (F.syms tA `S.union` F.syms tE)
       tA      = tact e
       tE      = texp e
 
@@ -62,7 +62,7 @@ tidyErrContext _ e@(ErrSubTypeModel {})
   = e { ctxM = c', tactM = fmap (F.subst θ) tA, texp = fmap (F.subst θ) tE }
     where
       (θ, c') = tidyCtxM xs $ ctxM e
-      xs      = F.syms tA ++ F.syms tE
+      xs      = S.toList (F.syms tA `S.union` F.syms tE)
       tA      = tactM e
       tE      = texp e
 
@@ -71,7 +71,7 @@ tidyErrContext k e@(ErrAssType {})
     where
       m       = ctx e
       (θ, c') = tidyCtx k xs m
-      xs      = F.syms p
+      xs      = S.toList (F.syms p)
       p       = cond e
 
 tidyErrContext _ e
@@ -166,7 +166,7 @@ tidyREnvM      :: [F.Symbol] -> CtxM -> [(F.Symbol, WithModel SpecType)]
 tidyREnvM xs m = [(x, t) | x <- xs', t <- maybeToList (M.lookup x m), ok t]
   where
     xs'       = expandFix deps xs
-    deps y    = maybe [] (F.syms . rTypeReft . dropModel) (M.lookup y m)
+    deps y    = maybe [] (S.toList . F.syms . rTypeReft . dropModel) (M.lookup y m)
     ok        = not . isFunTy . dropModel
 
 expandFix :: (Eq a, Hashable a) => (a -> [a]) -> [a] -> [a]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Tidy.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Tidy.hs
@@ -98,7 +98,7 @@ tidyVV r@(Reft (va,_))
   | isJunk va = shiftVV r v'
   | otherwise = r
   where
-    v'        = if v `elem` xs then symbol ("v'" :: T.Text) else v
+    v'        = if v `S.member` xs then symbol ("v'" :: T.Text) else v
     v         = symbol ("v" :: T.Text)
     xs        = syms r
     isJunk    = isPrefixOfSym "x"
@@ -106,7 +106,7 @@ tidyVV r@(Reft (va,_))
 tidySymbols :: Tidy -> SpecType -> SpecType
 tidySymbols k t = substa (shortSymbol k . tidySymbol) $ mapBind dropBind t
   where
-    xs          = S.fromList (syms t)
+    xs          = syms t
     dropBind x  = if x `S.member` xs then tidySymbol x else nonSymbol
 
 shortSymbol :: Tidy -> Symbol -> Symbol
@@ -141,7 +141,7 @@ tidyInternalRefas = mapReft txReft
 tidyDSymbols :: SpecType -> SpecType
 tidyDSymbols t = mapBind tx $ substa tx t
   where
-    tx         = bindersTx [x | x <- syms t, isTmp x]
+    tx         = bindersTx (S.toList $ S.filter isTmp $ syms t)
     isTmp      = (tempPrefix `isPrefixOfSym`)
 
 tidyFunBinds :: SpecType -> SpecType


### PR DESCRIPTION
We adapt to syms returning a HashSet in Liquid Fixpoint (https://github.com/ucsd-progsys/liquid-fixpoint/pull/845).

There is another commit in this PR to remove a redundant instance of Subable.