### PR TITLE
Make explicit in types that r can have only three instances

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -424,7 +424,7 @@ splitFun = go []
 
 
 isBoolBind :: Ghc.Var -> Bool
-isBoolBind v = isBool (ty_res $ toRTypeRep ((ofType $ Ghc.varType v) :: RRType ()))
+isBoolBind v = isBool (ty_res $ toRTypeRep ((ofType $ Ghc.varType v) :: RRType NoReft))
 
 strengthenRes :: SpecType -> F.Reft -> SpecType
 strengthenRes st rf = go st

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Axiom.hs
@@ -467,7 +467,7 @@ unDummy x i
   | x /= F.dummySymbol = x
   | otherwise          = F.symbol ("lq" ++ show i)
 
-singletonApp :: F.Symbolic a => F.Symbol -> [a] -> UReft F.Reft
+singletonApp :: F.Symbolic a => F.Symbol -> [a] -> UReft
 singletonApp s ys = MkUReft r mempty
   where
     r             = F.exprReft (F.eApps (F.EVar s) (F.eVar <$> ys))

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -794,12 +794,12 @@ getRewriteErrors (rw, t)
           ++ " contains an inner refinement."
 
 
-isRefined :: (ToReft r, Eq (ReftVar r)) => RType c tv r -> Bool
+isRefined :: (IsReft r, Eq (ReftVar r)) => RType c tv r -> Bool
 isRefined ty
   | Just r <- stripRTypeBase ty = not $ isTauto r
   | otherwise = False
 
-hasInnerRefinement :: (ToReft r, Eq (ReftVar r)) => RType c tv r -> Bool
+hasInnerRefinement :: (IsReft r, Eq (ReftVar r)) => RType c tv r -> Bool
 hasInnerRefinement (RFun _ _ rIn rOut _) =
   isRefined rIn || isRefined rOut
 hasInnerRefinement (RAllT _ ty  _) =

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -794,12 +794,12 @@ getRewriteErrors (rw, t)
           ++ " contains an inner refinement."
 
 
-isRefined :: ToReft r => RType c tv r -> Bool
+isRefined :: (ToReft r, Eq (ReftVar r)) => RType c tv r -> Bool
 isRefined ty
   | Just r <- stripRTypeBase ty = not $ isTauto r
   | otherwise = False
 
-hasInnerRefinement :: ToReft r => RType c tv r -> Bool
+hasInnerRefinement :: (ToReft r, Eq (ReftVar r)) => RType c tv r -> Bool
 hasInnerRefinement (RFun _ _ rIn rOut _) =
   isRefined rIn || isRefined rOut
 hasInnerRefinement (RAllT _ ty  _) =

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -270,7 +270,7 @@ checkTargetSpec specs src env cbs tsp
     -- allowTC          = typeclass (getConfig sp)
     bsc              = bscope (getConfig tsp)
     noPrune          = not (pruneFlag tsp)
-    txCtors ts       = [(v, fmap (fmap (fmap (F.filterUnMatched temps))) t) | (v, t) <- ts]
+    txCtors ts       = [(v, fmap (mapReft (mapReftField (F.filterUnMatched temps))) t) | (v, t) <- ts]
     temps            = F.makeTemplates $ gsUnsorted $ gsData tsp
     ef               = mkElabFlags (smtsolver $ getConfig tsp)
 
@@ -616,9 +616,7 @@ checkTcArity RTyCon{ rtc_tc = tc } givenArity
     expectedArity = tyConRealArity tc
 
 
-checkAbstractRefs
-  :: (PPrint t, IsReft t, ReftBind t ~ F.Symbol, ReftVar t ~ F.Symbol, SubsTy RTyVar RSort t) =>
-     RType RTyCon RTyVar (UReft t) -> Maybe Doc
+checkAbstractRefs :: SpecType -> Maybe Doc
 checkAbstractRefs rt = go rt
   where
     penv = mkPEnv rt
@@ -675,7 +673,7 @@ checkAbstractRefs rt = go rt
 
 -- TODO remove the unused UReft arg
 checkReft                    :: (PPrint r, IsReft r, ReftBind r ~ F.Symbol, ReftVar r ~ F.Symbol, SubsTy RTyVar (RType RTyCon RTyVar NoReft) r)
-                             => F.SrcSpan -> F.SEnv F.SortedReft -> F.TCEmb TyCon -> Maybe (RRType (UReft r)) -> UReft r -> ElabM (Maybe Doc)
+                             => F.SrcSpan -> F.SEnv F.SortedReft -> F.TCEmb TyCon -> Maybe (RRType r) -> r -> ElabM (Maybe Doc)
 checkReft _  _   _   Nothing  _ = pure Nothing -- TODO:RPropP/Ref case, not sure how to check these yet.
 checkReft sp env emb (Just t) _ = do me <- checkSortedReftFull sp env r
                                      pure $ (\z -> dr $+$ z) <$> me

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/DataType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/DataType.hs
@@ -738,7 +738,7 @@ getPsSigPs :: [(UsedPVar, a)] -> Bool -> SpecProp -> [(a, Bool)]
 getPsSigPs m pos (RProp _ (RHole r)) = addps m pos r
 getPsSigPs m pos (RProp _ t) = getPsSig m pos t
 
-addps :: [(UsedPVar, a)] -> b -> UReft t -> [(a, b)]
+addps :: [(UsedPVar, a)] -> b -> UReft -> [(a, b)]
 addps m pos (MkUReft _ ps) = (, pos) . f  <$> pvars ps
   where
     f = Mb.fromMaybe (panic Nothing "Bare.addPs: notfound") . (`L.lookup` m) . RT.uPVar
@@ -804,7 +804,7 @@ strengthenClassSel v lt = lt { val = st }
     RFun x' i tx <$> local (extend x') (go t) <*> pure (meet r r')
   go t = RT.strengthen t . singletonApp s . L.reverse <$> reader snd
 
-singletonApp :: F.Symbolic a => F.LocSymbol -> [a] -> UReft F.Reft
+singletonApp :: F.Symbolic a => F.LocSymbol -> [a] -> UReft
 singletonApp s ys = MkUReft r mempty
   where r = F.exprReft (F.mkEApp s (F.eVar <$> ys))
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Expand.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Expand.hs
@@ -815,7 +815,7 @@ expToBind p = do
       pargs' <- mapM expToBindParg pargs0
       return $ p { pargs = pargs' }
 
-expToBindParg :: (((), F.Symbol, F.Expr), RSort) -> State ExSt ((), F.Symbol, F.Expr)
+expToBindParg :: ((NoReft, F.Symbol, F.Expr), RSort) -> State ExSt (NoReft, F.Symbol, F.Expr)
 expToBindParg ((t, s, e), s') = fmap ((,,) t s) (expToBindExpr e s')
 
 expToBindExpr :: F.Expr ->  RSort -> State ExSt F.Expr

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Expand.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Expand.hs
@@ -310,7 +310,7 @@ instance Expand F.Reft where
   expand rtEnv l (F.Reft (v, ra)) = F.Reft (v, expand rtEnv l ra)
 
 instance Expand RReft where
-  expand rtEnv l = fmap (expand rtEnv l)
+  expand rtEnv l (MkUReft r p) = MkUReft (expand rtEnv l r) p
 
 expandReft :: (Expand r) => BareRTEnv -> F.SourcePos -> RType c tv r -> RType c tv r
 expandReft rtEnv l = fmap (expand rtEnv l)
@@ -800,7 +800,7 @@ addExist t x (tx, e) = REx x t' t
     t'               = ofRSort tx `RT.strengthen` RT.uTop r
     r                = F.exprReft e
 
-expToBindRef :: UReft r -> State ExSt (UReft r)
+expToBindRef :: UReft -> State ExSt UReft
 expToBindRef (MkUReft r (Pr p))
   = mapM expToBind p <&> (MkUReft r . Pr)
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -590,8 +590,8 @@ varLocSym v = F.symbol <$> GM.locNamedThing v
 isSimpleType :: Ghc.Type -> Bool
 isSimpleType = isFirstOrder . RT.typeSort mempty
 
-makeClassMeasureSpec :: MSpec (RType c tv (UReft r2)) t
-                     -> [(Located LHName, CMeasure (RType c tv r2))]
+makeClassMeasureSpec :: MSpec (RType c tv UReft) t
+                     -> [(Located LHName, CMeasure (RType c tv F.Reft))]
 makeClassMeasureSpec Ms.MSpec{..} = tx <$> M.elems cmeasMap
   where
     tx (M n s _ _ _) = (n, CM n (mapReft ur_reft s))

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -366,6 +366,7 @@ rtypePredBinds = map RT.uPVar . ty_preds . toRTypeRep
 --------------------------------------------------------------------------------
 type Expandable r = ( PPrint r
                     , IsReft r
+                    , Meet r
                     , ReftBind r ~ F.Symbol
                     , ReftVar r ~ F.Symbol
                     , F.Subable r

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/ToBare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/ToBare.hs
@@ -77,7 +77,7 @@ txRTV :: (c1 -> c2) -> (tv1 -> tv2) -> RTVU c1 tv1 -> RTVU c2 tv2
 txRTV cF vF (RTVar α z) = RTVar (vF α) (txRType cF vF <$> z)
 
 txPV :: (c1 -> c2) -> (tv1 -> tv2) -> PVU c1 tv1 -> PVU c2 tv2
-txPV cF vF (PV sym k y txes) = PV sym k' y txes'
+txPV cF vF (PV sym k txes) = PV sym k' txes'
   where
     txes'                  = [ (tx t, x, e) | (t, x, e) <- txes]
     k'                     = tx k

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -1298,7 +1298,7 @@ varAnn γ x t
 -- | Helpers: Creating Fresh Refinement -------------------------------
 -----------------------------------------------------------------------
 freshPredRef :: CGEnv -> CoreExpr -> PVar RSort -> CG SpecProp
-freshPredRef γ e (PV _ rsort _ as)
+freshPredRef γ e (PV _ rsort as)
   = do t    <- freshTyType (typeclass (getConfig γ))  PredInstE e (toType False rsort)
        args <- mapM (const fresh) as
        let targs = [(x, s) | (x, (s, y, z)) <- zip args as, F.EVar y == z ]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Generate.hs
@@ -471,7 +471,7 @@ consBind isRec' γ (x, e, Unknown)
        return $ Asserted t
 
 killSubst :: RReft -> RReft
-killSubst = fmap killSubstReft
+killSubst = mapReftField killSubstReft
 
 killSubstReft :: F.Reft -> F.Reft
 killSubstReft = trans ks
@@ -483,7 +483,7 @@ killSubstReft = trans ks
 -- Used during type application to record how type variables are instantiated,
 -- so the solver can apply the correct sort substitution to qualifier solutions.
 addTyVarSubToKVars :: F.Symbol -> F.Sort -> SpecType -> SpecType
-addTyVarSubToKVars sym sort = fmap (fmap (trans addSub))
+addTyVarSubToKVars sym sort = mapReft (mapReftField (trans addSub))
   where
     addSub (F.PKVar k tsu su) =
       let tsu' = M.map (F.applyCoercion sym sort) tsu
@@ -635,7 +635,7 @@ cconsE' γ e t
           addHole (RealSrcSpan srcSpan Strict.Nothing) x t γ
         _ -> return ()
 
-lambdaSingleton :: CGEnv -> F.TCEmb TyCon -> Var -> CoreExpr -> CG (UReft F.Reft)
+lambdaSingleton :: CGEnv -> F.TCEmb TyCon -> Var -> CoreExpr -> CG UReft
 lambdaSingleton γ tce x e
   | higherOrderFlag γ
   = do expr <- lamExpr γ e
@@ -743,7 +743,7 @@ consE γ (Var x) | GM.isDataConId x
        --     it is cheaper than direclty fmap ignoreSelf.
        let hasSelf = selfSymbol `S.member` F.syms t0
        let t = if hasSelf
-                then fmap ignoreSelf <$> t0
+                then mapReft (mapReftField ignoreSelf) t0
                 else t0
        addLocA (Just x) (getLocation γ) (varAnn γ x t)
        return t
@@ -1214,7 +1214,7 @@ caseEnv γ x acs a _ _ = do
 -- SELF special substitutions
 ------------------------------------------------------
 
-substSelf :: UReft F.Reft -> UReft F.Reft
+substSelf :: UReft -> UReft
 substSelf (MkUReft r p) = MkUReft (substSelfReft r) p
 
 substSelfReft :: F.Reft -> F.Reft
@@ -1416,7 +1416,7 @@ simplify (Lam x e) | isTyVar x = simplify e
 simplify e                     = e
 
 
-singletonReft :: (F.Symbolic a) => a -> UReft F.Reft
+singletonReft :: (F.Symbolic a) => a -> UReft
 singletonReft = uTop . F.symbolReft . F.symbol
 
 -- | RJ: `nomeet` replaces `strengthenS` for `strengthen` in the definition

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Qualifier.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Qualifier.hs
@@ -186,14 +186,13 @@ refTypeQuals lEnv ef l tce t0    = go emptySEnv t0
     insertsSEnv'              = foldr (\(x, t) γ -> insertSEnv x (rTypeSort tce t) γ)
 
 
-refTopQuals :: (PPrint t, IsReft t,  ReftBind t ~ Symbol, ReftVar t ~ Symbol, SubsTy RTyVar RSort t)
-            => SEnv Sort
+refTopQuals :: SEnv Sort
             -> ElabFlags
             -> SourcePos
             -> TCEmb TyCon
             -> RType RTyCon RTyVar r
             -> SEnv Sort
-            -> RRType (UReft t)
+            -> SpecType
             -> [Qualifier]
 refTopQuals lEnv ef l tce t0 γ rrt
   = [ mkQ' v so pa  | let (RR so (Reft (v, ra))) = rTypeSortedReft tce rrt

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Split.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Split.hs
@@ -314,7 +314,7 @@ bsplitC γ t1 t2 = do
 addLhsInv :: CGEnv -> SpecType -> SpecType
 addLhsInv γ t = addRTyConInv (invs γ) t `strengthen` r
   where
-    r         = (mempty :: UReft F.Reft) { ur_reft = F.Reft (F.dummySymbol, p) }
+    r         = (mempty :: UReft) { ur_reft = F.Reft (F.dummySymbol, p) }
     p         = constraintToLogic rE' (lcs γ)
     rE'       = insertREnv v t (renv γ)
     v         = rTypeValueVar t

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -515,7 +515,7 @@ constraintP
                                (replicate (length xts + 1) trueURef)
                                ((snd <$> xts) ++ [t1]) <$> bareTypeP
 
-trueURef :: UReftV v (ReftV v)
+trueURef :: UReftV v
 trueURef = MkUReft F.trueReft (Pr [])
 
 constraintEnvP :: Parser [(LocSymbol, BareTypeParsed)]
@@ -752,7 +752,7 @@ maybeDigit
 ------------------------------------------------------------------------
 
 bRProp :: [((Symbol, τ), Symbol)]
-       -> ExprV LocSymbol -> Ref τ (RTypeV LocSymbol c BTyVar (UReftV LocSymbol (ReftV LocSymbol)))
+       -> ExprV LocSymbol -> Ref τ (RTypeV LocSymbol c BTyVar (UReftV LocSymbol))
 bRProp []    _    = panic Nothing "Parse.bRProp empty list"
 bRProp syms' epr  = RProp ss $ bRVar (BTV $ dummyLoc dummyName) (Pr []) r
   where
@@ -767,18 +767,18 @@ mkSubstLocSymbol toB = toKVarSubst . M.fromList . reverse . filter notTrivial
     notTrivial (x, EVar y) = x /= toB y
     notTrivial _           = True
 
-bRVar :: tv -> PredicateV v -> r -> RTypeV v c tv (UReftV v r)
+bRVar :: tv -> PredicateV v -> ReftV v -> RTypeV v c tv (UReftV v)
 bRVar α p r = RVar α (MkUReft r p)
 
-bLst :: Maybe (RTypeV v BTyCon tv (UReftV v r))
-     -> [RTPropV v BTyCon tv (UReftV v r)]
-     -> r
-     -> RTypeV v BTyCon tv (UReftV v r)
+bLst :: Maybe (RTypeV v BTyCon tv (UReftV v))
+     -> [RTPropV v BTyCon tv (UReftV v)]
+     -> ReftV v
+     -> RTypeV v BTyCon tv (UReftV v)
 bLst (Just t) rs r = RApp (mkBTyCon $ dummyLoc $ makeUnresolvedLHName (LHTcName LHAnyModuleNameF) listConName) [t] rs (reftUReft r)
 bLst Nothing  rs r = RApp (mkBTyCon $ dummyLoc $ makeUnresolvedLHName (LHTcName LHAnyModuleNameF) listConName) []  rs (reftUReft r)
 
 bTup :: [(Maybe Symbol, BareTypeParsed)]
-     -> [RTPropV LocSymbol BTyCon BTyVar (UReftV LocSymbol (ReftV LocSymbol))]
+     -> [RTPropV LocSymbol BTyCon BTyVar (UReftV LocSymbol)]
      -> ReftV LocSymbol
      -> BareTypeParsed
 bTup [(_,t)] rs r
@@ -823,11 +823,11 @@ appendRProps _                _   = Nothing
 -- TODO RApp Int [] [p] true should be syntactically different than RApp Int [] [] p
 -- bCon b s [RProp _ (RHole r1)] [] _ r = RApp b [] [] $ r1 `meet` (MkUReft r mempty s)
 bCon :: c
-     -> [RTPropV v c tv (UReftV v r)]
-     -> [RTypeV v c tv (UReftV v r)]
+     -> [RTPropV v c tv (UReftV v)]
+     -> [RTypeV v c tv (UReftV v)]
      -> PredicateV v
-     -> r
-     -> RTypeV v c tv (UReftV v r)
+     -> ReftV v
+     -> RTypeV v c tv (UReftV v)
 bCon b rs ts p r = RApp b ts rs $ MkUReft r p
 
 bAppTy :: Foldable t => BTyVar -> t BareTypeParsed -> ReftV LocSymbol -> BareTypeParsed
@@ -836,7 +836,7 @@ bAppTy v ts r  = strengthenUReft ts' (reftUReft r)
     ts'        = foldl' (\a b -> RAppTy a b (uTop F.trueReft)) (RVar v (uTop F.trueReft)) ts
 
 strengthenUReft
-  :: BareTypeParsed -> UReftV LocSymbol (ReftV LocSymbol) -> BareTypeParsed
+  :: BareTypeParsed -> UReftV LocSymbol -> BareTypeParsed
 strengthenUReft = strengthenWith meetUReft
   where
     meetUReft (MkUReft r0 (Pr p0)) (MkUReft r1 (Pr p1)) =
@@ -880,10 +880,10 @@ substExprV toB su0 = go
         s2' = fromKVarSubst s2
 
 
-reftUReft :: r -> UReftV v r
+reftUReft :: ReftV v -> UReftV v
 reftUReft r    = MkUReft r (Pr [])
 
-predUReft :: PredicateV v -> UReftV v (ReftV v)
+predUReft :: PredicateV v -> UReftV v
 predUReft = MkUReft F.trueReft
 
 dummyTyId :: String

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Parse.hs
@@ -587,7 +587,7 @@ predVarIdP
   = symbol <$> tyVarIdP
 
 bPVar :: Symbol -> t -> [(Symbol, t1)] -> PVarV LocSymbol t1
-bPVar p _ xts  = PV p τ dummySymbol τxs
+bPVar p _ xts  = PV p τ τxs
   where
     (_, τ) = safeLast "bPVar last" xts
     τxs    = [ (τ', x, EVar (dummyLoc x)) | (x, τ') <- init xts ]
@@ -692,7 +692,7 @@ monoPredicate1P
 predVarUseP :: Parser (PVarV LocSymbol String)
 predVarUseP
   = do (p, xs) <- funArgsP
-       return   $ PV p dummyTyId dummySymbol [ (dummyTyId, dummySymbol, x) | x <- xs ]
+       return   $ PV p dummyTyId [ (dummyTyId, dummySymbol, x) | x <- xs ]
 
 funArgsP :: Parser (Symbol, [ExprV LocSymbol])
 funArgsP  = try realP <|> empP <?> "funArgsP"

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Equality.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Equality.hs
@@ -67,7 +67,7 @@ class REq a where
 instance REq t2 => REq (Ref t1 t2) where
     (RProp _ t1) =*= (RProp _ t2) = t1 =*= t2
 
-instance REq (UReft F.Reft) where
+instance REq UReft where
   (MkUReft r1 p1) =*= (MkUReft r2 p2)
      = r1 =*= r2 && p1 == p2
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PredType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PredType.hs
@@ -220,7 +220,7 @@ dataConTy _ _
 -- | Interface: Replace Predicate With Uninterpreted Function Symbol -------
 ----------------------------------------------------------------------------
 replacePredsWithRefs :: (UsedPVar, (F.Symbol, [(NoReft, F.Symbol, F.Expr)]) -> F.Expr)
-                     -> UReft F.Reft -> UReft F.Reft
+                     -> UReft -> UReft
 replacePredsWithRefs (p, r) (MkUReft (F.Reft(v, rs)) (Pr ps))
   = MkUReft (F.Reft (v, rs'')) (Pr ps2)
   where
@@ -415,13 +415,13 @@ substPredP msg (p, RProp ss prop) (RProp s t)
    -- su  = mkSubst (zip (fst <$> ss) (EVar . fst <$> ss'))
 
 
-splitRPvar :: PVar t -> UReft r -> (UReft r, [UsedPVar])
+splitRPvar :: PVar t -> UReft -> (UReft, [UsedPVar])
 splitRPvar pv (MkUReft x (Pr pvs)) = (MkUReft x (Pr pvs'), epvs)
   where
     (epvs, pvs')               = L.partition (uPVar pv ==) pvs
 
 -- TODO: rewrite using foldReft
-freeArgsPs :: PVar (RType t t1 NoReft) -> RType t t1 (UReft t2) -> [F.Symbol]
+freeArgsPs :: PVar (RType t t1 NoReft) -> RType t t1 UReft -> [F.Symbol]
 freeArgsPs p (RVar _ r)
   = freeArgsPsRef p r
 freeArgsPs p (RFun _ _ t1 t2 r)
@@ -444,7 +444,7 @@ freeArgsPs p (RHole r)
 freeArgsPs p (RRTy env r _ t)
   = L.nub $ concatMap (freeArgsPs p . snd) env ++ freeArgsPsRef p r ++ freeArgsPs p t
 
-freeArgsPsRef :: PVar t1 -> UReft t -> [F.Symbol]
+freeArgsPsRef :: PVar t1 -> UReft -> [F.Symbol]
 freeArgsPsRef p (MkUReft _ (Pr ps)) = [x | (_, x, w) <- concatMap pargs ps', F.EVar x == w]
   where
    ps' = f <$> filter (uPVar p ==) ps

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PredType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PredType.hs
@@ -246,7 +246,7 @@ pVartoRConc p (v, args)
 -----------------------------------------------------------------------
 pvarRType :: (PPrint r, IsReft r) => PVar RSort -> RRType r
 -----------------------------------------------------------------------
-pvarRType (PV _ k {- (PVProp τ) -} _ args) = rpredType k (fst3 <$> args) -- (ty:tys)
+pvarRType (PV _ k {- (PVProp τ) -} args) = rpredType k (fst3 <$> args) -- (ty:tys)
   -- where
   --   ty  = uRTypeGen τ
   --   tys = uRTypeGen . fst3 <$> args

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PredType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PredType.hs
@@ -368,6 +368,7 @@ substRCon
       SubsTy tv (RType RTyCon tv NoReft) tv,
       SubsTy tv (RType RTyCon tv NoReft) (RTVar tv (RType RTyCon tv NoReft)),
       FreeVar RTyCon tv,
+      Meet r,
       Meet (RType RTyCon tv r))
   => [Char]
   -> (t, Ref RSort (RType RTyCon tv r))

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PredType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PredType.hs
@@ -219,7 +219,7 @@ dataConTy _ _
 ----------------------------------------------------------------------------
 -- | Interface: Replace Predicate With Uninterpreted Function Symbol -------
 ----------------------------------------------------------------------------
-replacePredsWithRefs :: (UsedPVar, (F.Symbol, [((), F.Symbol, F.Expr)]) -> F.Expr)
+replacePredsWithRefs :: (UsedPVar, (F.Symbol, [(NoReft, F.Symbol, F.Expr)]) -> F.Expr)
                      -> UReft F.Reft -> UReft F.Reft
 replacePredsWithRefs (p, r) (MkUReft (F.Reft(v, rs)) (Pr ps))
   = MkUReft (F.Reft (v, rs'')) (Pr ps2)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
@@ -389,7 +389,7 @@ pprCls bb p c ts
 
 
 pprPvarDef :: (OkRTBV b v c tv (NoReftB b)) => PPEnv -> Prec -> PVarBV b v (RTypeBV b v c tv (NoReftB b)) -> Doc
-pprPvarDef bb p (PV s t _ xts)
+pprPvarDef bb p (PV s t xts)
   = pprint s <+> dcolon <+> intersperse arrow dargs <+> pprPvarKind bb p t
   where
     dargs = [pprPvarSort bb p xt | (xt,_,_) <- xts]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
@@ -436,7 +436,7 @@ ppTy bb r0 t = doc
     | not (ppPs bb) = t
     | otherwise     = t <-> angleBrackets (pprint p)
 
-instance (PPrint (PredicateBV b v), ToReft (PredicateBV b v), PPrint r, ToReft r) => PPrint (UReftBV b v r) where
+instance (PPrint (PredicateBV b v), ToReft (PredicateBV b v), PPrint (F.ReftBV b v)) => PPrint (UReftBV b v) where
   pprintTidy k (MkUReft r p)
     | isTauto r  = pprintTidy k p
     | isTauto p  = pprintTidy k r

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
@@ -436,10 +436,10 @@ ppTy bb r0 t = doc
     | not (ppPs bb) = t
     | otherwise     = t <-> angleBrackets (pprint p)
 
-instance (PPrint (PredicateBV b v), ToReft (PredicateBV b v), PPrint (F.ReftBV b v)) => PPrint (UReftBV b v) where
+instance (ToReft (F.ReftBV b v), PPrint (PredicateBV b v), PPrint (F.ReftBV b v)) => PPrint (UReftBV b v) where
   pprintTidy k (MkUReft r p)
     | isTauto r  = pprintTidy k p
-    | isTauto p  = pprintTidy k r
+    | null (pvars p) = pprintTidy k r
     | otherwise  = pprintTidy k p <-> text " & " <-> pprintTidy k r
 
 --------------------------------------------------------------------------------

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
@@ -422,7 +422,7 @@ dot                = char '.'
 ppTy ::
   ( Ord (ReftBind r), F.Fixpoint (ReftBind r), PPrint (ReftBind r)
   , Ord (ReftVar r), F.Fixpoint (ReftVar r), PPrint (ReftVar r)
-  , ToReft r
+  , IsReft r
   ) => PPEnv -> r -> Doc -> Doc
 ppTy bb r0 t = doc
  where
@@ -436,7 +436,7 @@ ppTy bb r0 t = doc
     | not (ppPs bb) = t
     | otherwise     = t <-> angleBrackets (pprint p)
 
-instance (ToReft (F.ReftBV b v), Eq v, PPrint (PredicateBV b v), PPrint (F.ReftBV b v)) => PPrint (UReftBV b v) where
+instance (IsReft (F.ReftBV b v), Eq v, PPrint (PredicateBV b v), PPrint (F.ReftBV b v)) => PPrint (UReftBV b v) where
   pprintTidy k (MkUReft r p)
     | isTauto r  = pprintTidy k p
     | null (pvars p) = pprintTidy k r

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
@@ -436,7 +436,7 @@ ppTy bb r0 t = doc
     | not (ppPs bb) = t
     | otherwise     = t <-> angleBrackets (pprint p)
 
-instance (ToReft (F.ReftBV b v), PPrint (PredicateBV b v), PPrint (F.ReftBV b v)) => PPrint (UReftBV b v) where
+instance (ToReft (F.ReftBV b v), Eq v, PPrint (PredicateBV b v), PPrint (F.ReftBV b v)) => PPrint (UReftBV b v) where
   pprintTidy k (MkUReft r p)
     | isTauto r  = pprintTidy k p
     | null (pvars p) = pprintTidy k r

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE TupleSections              #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE RoleAnnotations            #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 
@@ -79,7 +80,8 @@ module Language.Haskell.Liquid.Types.RType (
   , mapUReftV
   , emapUReftVM
   , NoReft
-  , NoReftB(..)
+  , NoReftB
+  , NoReftBV(..)
 
   -- * Parse-time entities describing refined data types
   , SizeFun, SizeFunV (..), szFun
@@ -393,7 +395,7 @@ emapSubstVM f m = F.toKVarSubst . M.fromList <$> mapM (traverse (emapExprVM f)) 
 
 type UsedPVar    = UsedPVarV Symbol
 type UsedPVarV v = UsedPVarBV Symbol v
-type UsedPVarBV b v = PVarBV b v (NoReftB b)
+type UsedPVarBV b v = PVarBV b v (NoReftBV b v)
 
 type Predicate = PredicateV Symbol
 type PredicateV v = PredicateBV Symbol v
@@ -738,10 +740,10 @@ instance NFData TyConInfo
 
 type RTVU c tv = RTVUV Symbol c tv
 type RTVUV v c tv = RTVUBV Symbol v c tv
-type RTVUBV b v c tv = RTVar tv (RTypeBV b v c tv (NoReftB b))
+type RTVUBV b v c tv = RTVar tv (RTypeBV b v c tv (NoReftBV b v))
 type PVU c tv = PVUV Symbol c tv
 type PVUV v c tv = PVarV v (RTypeV v c tv NoReft)
-type PVUBV b v c tv = PVarBV b v (RTypeBV b v c tv (NoReftB b))
+type PVUBV b v c tv = PVarBV b v (RTypeBV b v c tv (NoReftBV b v))
 
 type RType c tv r = RTypeV Symbol c tv r
 type RTypeV v c tv = RTypeBV Symbol v c tv
@@ -1061,7 +1063,7 @@ rPropP τ r = RProp τ (RHole r)
 --   In general, perhaps we need not expose @Ref@ directly at all.
 type RTProp c tv r = RTPropV Symbol c tv r
 type RTPropV v c tv r = RTPropBV Symbol v c tv r
-type RTPropBV b v c tv r = RefB b (RTypeBV b v c tv (NoReftB b)) (RTypeBV b v c tv r)
+type RTPropBV b v c tv r = RefB b (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv r)
 
 type UReft = UReftV F.Symbol
 type UReftV v = UReftBV F.Symbol v
@@ -1124,35 +1126,37 @@ emapUReftVM
   => ([Symbol] -> v -> m v') -> (F.ReftV v -> m (F.ReftV v')) -> UReftV v -> m (UReftV v')
 emapUReftVM f g (MkUReft r p) = MkUReft <$> g r <*> emapPredicateVM f p
 
+type role NoReftBV phantom phantom
 type NoReft = NoReftB Symbol
-data NoReftB b = NoReft
+type NoReftB b = NoReftBV b Symbol
+data NoReftBV b v = NoReft
   deriving (Eq, Generic, Data, Functor, Foldable, Show, Traversable)
-  deriving (B.Binary, Hashable) via Generically (NoReftB b)
+  deriving (B.Binary, Hashable) via Generically (NoReftBV b v)
 
-instance NFData (NoReftB b)
+instance NFData (NoReftBV b v)
 
-instance F.PPrint (NoReftB b) where
+instance F.PPrint (NoReftBV b v) where
   pprintTidy _ _ = text $ show ()
 
-instance Hashable b => F.Subable (NoReftB b) where
-  type Variable (NoReftB b) = b
+instance Hashable b => F.Subable (NoReftBV b v) where
+  type Variable (NoReftBV b v) = b
   syms _   = S.empty
   substa _ = id
   substf _ = id
   subst _  = id
   subst1 r = const r
 
-instance Semigroup (NoReftB b) where
+instance Semigroup (NoReftBV b v) where
   _ <> _ = NoReft
 
-instance Monoid (NoReftB b) where
+instance Monoid (NoReftBV b v) where
   mempty = NoReft
 
 type BRType      = RTypeV Symbol BTyCon BTyVar    -- ^ "Bare" parsed version
 type BRTypeV v   = RTypeV v      BTyCon BTyVar    -- ^ "Bare" parsed version
 type RRType      = RTypeV Symbol RTyCon RTyVar    -- ^ "Resolved" version
 type BSort       = BRType    NoReft
-type BSortV v    = BRTypeV v NoReft
+type BSortV v    = BRTypeV v (NoReftBV Symbol v)
 type RSort       = RRType    NoReft
 type BPVar       = PVar      BSort
 type RPVar       = PVar      RSort
@@ -1226,12 +1230,13 @@ type OkRTBV b v c tv r =
   , F.Binder b
   , IsReft r
   , ReftBind r ~ b
+  , v ~ F.Symbol
   , Eq c, Eq tv, Ord b, Ord v, Ord (ReftVar r)
   , Hashable tv
   )
 
 -- | Types that have one associated refinement representible by a 'F.ReftBV'
-class (F.Binder (ReftBind r), Eq (ReftVar r)) => ToReft r where
+class F.Binder (ReftBind r) => ToReft r where
   type ReftVar r
   type ReftBind r
   type ReftBind r = Symbol
@@ -1249,7 +1254,7 @@ class Top r where
   top :: r -> r
 
 -- | Types that can be constructed from a 'F.ReftBV'
-class (ToReft r, Meet r, Top r) => IsReft r where
+class (ToReft r, Meet r, Top r, Eq (ReftVar r)) => IsReft r where
   ofReft :: F.ReftBV (ReftBind r) (ReftVar r) -> r
   -- | Apply a function to the underlying 'F.ReftBV' without discarding predicates.
   mapReftField :: (F.ReftBV (ReftBind r) (ReftVar r) -> F.ReftBV (ReftBind r) (ReftVar r)) -> r -> r
@@ -1257,7 +1262,7 @@ class (ToReft r, Meet r, Top r) => IsReft r where
 trueReft :: IsReft r => r
 trueReft = ofReft F.trueReft
 
-isTauto :: ToReft r => r -> Bool
+isTauto :: (ToReft r, Eq (ReftVar r)) => r -> Bool
 isTauto r0 = F.isTautoReft r && null ps
  where
   MkUReft r (Pr ps) = toUReft r0
@@ -1289,15 +1294,15 @@ instance (F.Binder v, F.Fixpoint v, Eq v) => IsReft (F.ReftBV v v) where
   ofReft = id
   mapReftField f = f
 
-instance F.Binder b => ToReft (NoReftB b) where
-  type ReftVar (NoReftB b) = Symbol
-  type ReftBind (NoReftB b) = b
+instance (F.Binder b) => ToReft (NoReftBV b v) where
+  type ReftVar (NoReftBV b v) = v
+  type ReftBind (NoReftBV b v) = b
   toReft _ = F.trueReft
 
-instance Top (NoReftB b) where
+instance Top (NoReftBV b v) where
   top _ = NoReft
 
-instance F.Binder b => IsReft (NoReftB b) where
+instance (F.Binder b, Eq v) => IsReft (NoReftBV b v) where
   ofReft _ = NoReft
   mapReftField _ = id
 
@@ -1314,7 +1319,7 @@ instance Monoid F.Reft where
   mempty  = F.trueReft
   mappend = (<>)
 
-instance Meet (NoReftB b)
+instance Meet (NoReftBV b v)
 
 instance (Semigroup (F.ReftBV b v), Eq b, Eq v) => Meet (UReftBV b v)
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -58,7 +58,7 @@ module Language.Haskell.Liquid.Types.RType (
   , Predicate
   , PredicateV
   , PredicateBV(..)
-  , PredicateCompat(..)
+  , pappV
 
   -- * Expression Arguments
   , notExprArg
@@ -162,7 +162,6 @@ import qualified Data.List                              as L
 import           Data.Maybe                             (mapMaybe)
 import           Data.List                              as L (nub)
 import qualified Data.HashSet                           as S
-import           Data.Proxy                             (Proxy(..))
 import           Text.PrettyPrint.HughesPJ              hiding (first, (<>))
 import           Language.Fixpoint.Misc
 
@@ -1337,26 +1336,11 @@ instance (F.Refreshable v, Hashable v) => F.Subable (UReftBV v v) where
 
 instance Meet Predicate
 
-pToRef :: PredicateCompat b v => PVarBV b v a -> F.ExprBV b v
-pToRef p = pApp (pnameV p) $ F.EVar (pargV p) : (thd3 <$> pargs p)
-
-pApp      :: forall b v . PredicateCompat b v => v -> [ExprBV b v] -> ExprBV b v
+pApp :: Symbol -> [Expr] -> Expr
 pApp p es = F.mkEApp fn (F.EVar p:es)
   where
-    fn    = F.dummyLoc (pappV (Proxy :: Proxy b) n)
+    fn    = F.dummyLoc $ F.symbol (pappV n)
     n     = length es
 
-class PredicateCompat b v where
-  pappV :: Proxy b -> Int -> v
-  pnameV :: PVarBV b v a -> v
-  pargV :: PVarBV b v a -> v
-
-instance PredicateCompat Symbol Symbol where
-  pappV _ n = F.symbol $ "papp" ++ show n
-  pnameV p = pname p
-  pargV p = parg p
-
-instance PredicateCompat Symbol F.LocSymbol where
-  pappV _ n = F.dummyLoc $ F.symbol $ "papp" ++ show n
-  pnameV p = F.dummyLoc $ pname p
-  pargV p = F.dummyLoc $ parg p
+pappV :: Int -> Symbol
+pappV n = F.symbol $ "papp" ++ show n

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE UndecidableInstances       #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE RecordWildCards            #-}
@@ -12,6 +13,7 @@
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE TupleSections              #-}
+{-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE RoleAnnotations            #-}
@@ -117,10 +119,15 @@ module Language.Haskell.Liquid.Types.RType (
   , RFInfo(..), defRFInfo, mkRFInfo, classRFInfo
 
   -- * Converting to and from refinements
+  , ConcreteReft(..)
   , Meet(..)
   , Top(..)
   , IsReft(..)
   , isTauto
+  , mapReftField
+  , ofReft
+  , toReft
+  , toUReft
   , trueReft
   )
   where
@@ -151,7 +158,6 @@ import           Liquid.GHC.API as Ghc hiding ( Expr
                                                                )
 import           Data.String
 import           GHC.Generics
-import           Prelude                          hiding  (error)
 
 import           Control.DeepSeq
 import           Data.Traversable                       (forAccumM)
@@ -746,13 +752,15 @@ type PVUBV b v c tv = PVarBV b v (RTypeBV b v c tv (NoReftBV b v))
 
 type RType c tv r = RTypeV Symbol c tv r
 type RTypeV v c tv = RTypeBV Symbol v c tv
+
 -- | A refinement type
 --
 -- * @b@ is the type of bindings
 -- * @v@ is the type of variables appearing in expressions
 -- * @c@ is the type of type constructors
 -- * @tv@ is the type of type variables
--- * @r@ is the type of refinements
+-- * @r@ is the type of refinements. Must instance the 'IsReft' class. There are
+--   only three instances of 'IsReft': 'ReftBV', 'NoReftBV', and 'UReftBV'.
 --
 -- A refinement might be missing (e.g. @r@ is @NoReft@), if the RTypeBV is used to
 -- represent the type of an entity that can't use refinements, e.g. the type of
@@ -1243,58 +1251,89 @@ class Semigroup r => Meet r where
 class Top r where
   top :: r -> r
 
--- | Types that can be constructed from a 'F.ReftBV'
+-- | The universe of refinement types that can be used in RTypes.
+data ConcreteReft r b v where
+  ConcreteNoReft :: ConcreteReft (NoReftBV b v) b v
+  ConcreteReft :: F.ReftBV b v -> ConcreteReft (F.ReftBV b v) b v
+  ConcreteUReft :: UReftBV b v -> ConcreteReft (UReftBV b v) b v
+
+-- | Types that can be constructed from a 'F.ReftBV'.
+--
+-- Only three types can be 'IsReft': 'NoReftBV', 'F.ReftBV', and 'UReftBV'.
+--
+-- 'ofConcreteReft' and 'toConcreteReft' must be inverses of each other.
+--
+-- In order to allow distinguishing the @r@ type when no value is present
+-- (e.g. in @ofReft@ or @trueReft@), 'toConcreteReft' must be non-strict.
+--
 class (F.Binder (ReftBind r), Top r) => IsReft r where
   type ReftVar r
   type ReftBind r
-  type ReftBind r = Symbol
-  toReft :: r -> F.ReftBV (ReftBind r) (ReftVar r)
-  toUReft :: r -> UReftBV (ReftBind r) (ReftVar r)
-  toUReft r = MkUReft (toReft r) pdTrue
-  ofReft :: F.ReftBV (ReftBind r) (ReftVar r) -> r
-  -- | Apply a function to the underlying 'F.ReftBV' without discarding predicates.
-  mapReftField :: (F.ReftBV (ReftBind r) (ReftVar r) -> F.ReftBV (ReftBind r) (ReftVar r)) -> r -> r
+  ofConcreteReft :: ConcreteReft r (ReftBind r) (ReftVar r) -> r
+  toConcreteReft :: r -> ConcreteReft r (ReftBind r) (ReftVar r)
 
-trueReft :: IsReft r => r
-trueReft = ofReft F.trueReft
+ofReft :: forall r. IsReft r => F.ReftBV (ReftBind r) (ReftVar r) -> r
+ofReft r = case toConcreteReft @r (error "ofReft") of
+  ConcreteNoReft -> NoReft
+  ConcreteReft _ -> r
+  ConcreteUReft _ -> MkUReft r pdTrue
+
+toReft :: IsReft r => r -> F.ReftBV (ReftBind r) (ReftVar r)
+toReft r0 = case toConcreteReft r0 of
+   ConcreteNoReft -> F.trueReft
+   ConcreteReft r -> r
+   ConcreteUReft (MkUReft r _) -> r
+
+toUReft :: IsReft r => r -> UReftBV (ReftBind r) (ReftVar r)
+toUReft r0 = case toConcreteReft r0 of
+   ConcreteNoReft -> MkUReft F.trueReft pdTrue
+   ConcreteReft r -> MkUReft r pdTrue
+   ConcreteUReft r -> r
+
+instance Top (NoReftBV b v) where
+  top _ = NoReft
+instance F.Binder b => Top (F.ReftBV b v) where
+  top _ = F.trueReft
+instance F.Binder b => Top (UReftBV b v) where
+  top _ = MkUReft F.trueReft pdTrue
+
+trueReft :: forall r. IsReft r => r
+trueReft = case toConcreteReft @r (error "trueReft") of
+  ConcreteNoReft -> top (error "trueReft: ConcreteNoReft")
+  ConcreteReft _ -> top (error "trueReft: ConcreteReft")
+  ConcreteUReft _ -> top (error "trueReft: ConcreteUReft")
 
 isTauto :: (IsReft r, Eq (ReftVar r)) => r -> Bool
-isTauto r0 = F.isTautoReft r && null ps
- where
-  MkUReft r (Pr ps) = toUReft r0
+isTauto r0 = case toConcreteReft r0 of
+  ConcreteNoReft -> True
+  ConcreteReft r -> F.isTautoReft r
+  ConcreteUReft (MkUReft r (Pr ps)) -> F.isTautoReft r && null ps
+
+mapReftField :: IsReft r => (F.ReftBV (ReftBind r) (ReftVar r) -> F.ReftBV (ReftBind r) (ReftVar r)) -> r -> r
+mapReftField f r0 = case toConcreteReft r0 of
+  ConcreteNoReft -> ofConcreteReft ConcreteNoReft
+  ConcreteReft r -> ofConcreteReft (ConcreteReft (f r))
+  ConcreteUReft (MkUReft r p) -> ofConcreteReft (ConcreteUReft (MkUReft (f r) p))
 
 instance (IsReft (F.ReftBV b v), F.Binder b) => IsReft (UReftBV b v) where
   type ReftVar (UReftBV b v) = v
   type ReftBind (UReftBV b v) = b
-  toReft = toReft . ur_reft
-  toUReft (MkUReft r p) = MkUReft (toReft r) p
-  ofReft r = MkUReft (ofReft r) pdTrue
-  mapReftField f u = u { ur_reft = f (ur_reft u) }
-
-instance Top (F.ReftBV b v) => Top (UReftBV b v) where
-  top (MkUReft r _) = MkUReft (top r) pdTrue
-
-instance F.Binder b => Top (F.ReftBV b v) where
-  top _ = F.trueReft
+  ofConcreteReft (ConcreteUReft r) = r
+  toConcreteReft = ConcreteUReft
 
 instance (F.Binder v, F.Fixpoint v) => Meet (F.ReftBV v v) where
 
 instance (F.Binder b, F.Fixpoint v) => IsReft (F.ReftBV b v) where
   type ReftVar (F.ReftBV b v) = v
   type ReftBind (F.ReftBV b v) = b
-  toReft = id
-  ofReft = id
-  mapReftField f = f
+  toConcreteReft = ConcreteReft
+  ofConcreteReft (ConcreteReft r) = r
 
 instance F.Binder b => IsReft (NoReftBV b v) where
   type ReftVar (NoReftBV b v) = v
   type ReftBind (NoReftBV b v) = b
-  toReft _ = F.trueReft
-  ofReft _ = NoReft
-  mapReftField _ = id
-
-instance Top (NoReftBV b v) where
-  top _ = NoReft
+  toConcreteReft _ = ConcreteNoReft
+  ofConcreteReft ConcreteNoReft = NoReft
 
 instance Top t => Top (RefB b τ t) where
   top (RProp args t) = RProp args (top t)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -117,7 +117,6 @@ module Language.Haskell.Liquid.Types.RType (
   , RFInfo(..), defRFInfo, mkRFInfo, classRFInfo
 
   -- * Converting to and from refinements
-  , ToReft(..)
   , Meet(..)
   , Top(..)
   , IsReft(..)
@@ -1235,15 +1234,6 @@ type OkRTBV b v c tv r =
   , Hashable tv
   )
 
--- | Types that have one associated refinement representible by a 'F.ReftBV'
-class F.Binder (ReftBind r) => ToReft r where
-  type ReftVar r
-  type ReftBind r
-  type ReftBind r = Symbol
-  toReft :: r -> F.ReftBV (ReftBind r) (ReftVar r)
-  toUReft :: r -> UReftBV (ReftBind r) (ReftVar r)
-  toUReft r = MkUReft (toReft r) pdTrue
-
 -- | Types that can be combined conjunctively in some sense
 class Semigroup r => Meet r where
   meet :: r -> r -> r
@@ -1254,7 +1244,13 @@ class Top r where
   top :: r -> r
 
 -- | Types that can be constructed from a 'F.ReftBV'
-class (ToReft r, Top r) => IsReft r where
+class (F.Binder (ReftBind r), Top r) => IsReft r where
+  type ReftVar r
+  type ReftBind r
+  type ReftBind r = Symbol
+  toReft :: r -> F.ReftBV (ReftBind r) (ReftVar r)
+  toUReft :: r -> UReftBV (ReftBind r) (ReftVar r)
+  toUReft r = MkUReft (toReft r) pdTrue
   ofReft :: F.ReftBV (ReftBind r) (ReftVar r) -> r
   -- | Apply a function to the underlying 'F.ReftBV' without discarding predicates.
   mapReftField :: (F.ReftBV (ReftBind r) (ReftVar r) -> F.ReftBV (ReftBind r) (ReftVar r)) -> r -> r
@@ -1262,49 +1258,43 @@ class (ToReft r, Top r) => IsReft r where
 trueReft :: IsReft r => r
 trueReft = ofReft F.trueReft
 
-isTauto :: (ToReft r, Eq (ReftVar r)) => r -> Bool
+isTauto :: (IsReft r, Eq (ReftVar r)) => r -> Bool
 isTauto r0 = F.isTautoReft r && null ps
  where
   MkUReft r (Pr ps) = toUReft r0
 
-instance (F.Binder b, ToReft (F.ReftBV b v)) => ToReft (UReftBV b v) where
+instance (IsReft (F.ReftBV b v), F.Binder b) => IsReft (UReftBV b v) where
   type ReftVar (UReftBV b v) = v
   type ReftBind (UReftBV b v) = b
   toReft = toReft . ur_reft
   toUReft (MkUReft r p) = MkUReft (toReft r) p
+  ofReft r = MkUReft (ofReft r) pdTrue
+  mapReftField f u = u { ur_reft = f (ur_reft u) }
 
 instance Top (F.ReftBV b v) => Top (UReftBV b v) where
   top (MkUReft r _) = MkUReft (top r) pdTrue
 
-instance (IsReft (F.ReftBV b v), F.Binder b) => IsReft (UReftBV b v) where
-  ofReft r = MkUReft (ofReft r) pdTrue
-  mapReftField f u = u { ur_reft = f (ur_reft u) }
-
-instance F.Binder b => ToReft (F.ReftBV b v) where
-  type ReftVar (F.ReftBV b v) = v
-  type ReftBind (F.ReftBV b v) = b
-  toReft = id
-
-instance (F.Binder b) => Top (F.ReftBV b v) where
+instance F.Binder b => Top (F.ReftBV b v) where
   top _ = F.trueReft
 
 instance (F.Binder v, F.Fixpoint v) => Meet (F.ReftBV v v) where
 
 instance (F.Binder b, F.Fixpoint v) => IsReft (F.ReftBV b v) where
+  type ReftVar (F.ReftBV b v) = v
+  type ReftBind (F.ReftBV b v) = b
+  toReft = id
   ofReft = id
   mapReftField f = f
 
-instance (F.Binder b) => ToReft (NoReftBV b v) where
+instance F.Binder b => IsReft (NoReftBV b v) where
   type ReftVar (NoReftBV b v) = v
   type ReftBind (NoReftBV b v) = b
   toReft _ = F.trueReft
+  ofReft _ = NoReft
+  mapReftField _ = id
 
 instance Top (NoReftBV b v) where
   top _ = NoReft
-
-instance F.Binder b => IsReft (NoReftBV b v) where
-  ofReft _ = NoReft
-  mapReftField _ = id
 
 instance Top t => Top (RefB b τ t) where
   top (RProp args t) = RProp args (top t)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -1254,7 +1254,7 @@ class Top r where
   top :: r -> r
 
 -- | Types that can be constructed from a 'F.ReftBV'
-class (ToReft r, Top r, Eq (ReftVar r)) => IsReft r where
+class (ToReft r, Top r) => IsReft r where
   ofReft :: F.ReftBV (ReftBind r) (ReftVar r) -> r
   -- | Apply a function to the underlying 'F.ReftBV' without discarding predicates.
   mapReftField :: (F.ReftBV (ReftBind r) (ReftVar r) -> F.ReftBV (ReftBind r) (ReftVar r)) -> r -> r
@@ -1267,7 +1267,7 @@ isTauto r0 = F.isTautoReft r && null ps
  where
   MkUReft r (Pr ps) = toUReft r0
 
-instance (F.Binder b, ToReft (F.ReftBV b v), Eq v) => ToReft (UReftBV b v) where
+instance (F.Binder b, ToReft (F.ReftBV b v)) => ToReft (UReftBV b v) where
   type ReftVar (UReftBV b v) = v
   type ReftBind (UReftBV b v) = b
   toReft = toReft . ur_reft
@@ -1276,11 +1276,11 @@ instance (F.Binder b, ToReft (F.ReftBV b v), Eq v) => ToReft (UReftBV b v) where
 instance Top (F.ReftBV b v) => Top (UReftBV b v) where
   top (MkUReft r _) = MkUReft (top r) pdTrue
 
-instance (IsReft (F.ReftBV b v),  F.Binder v) => IsReft (UReftBV b v) where
+instance (IsReft (F.ReftBV b v), F.Binder b) => IsReft (UReftBV b v) where
   ofReft r = MkUReft (ofReft r) pdTrue
   mapReftField f u = u { ur_reft = f (ur_reft u) }
 
-instance (F.Binder b, Eq v) => ToReft (F.ReftBV b v) where
+instance F.Binder b => ToReft (F.ReftBV b v) where
   type ReftVar (F.ReftBV b v) = v
   type ReftBind (F.ReftBV b v) = b
   toReft = id
@@ -1290,7 +1290,7 @@ instance (F.Binder b) => Top (F.ReftBV b v) where
 
 instance (F.Binder v, F.Fixpoint v) => Meet (F.ReftBV v v) where
 
-instance (F.Binder b, F.Fixpoint v, Eq v) => IsReft (F.ReftBV b v) where
+instance (F.Binder b, F.Fixpoint v) => IsReft (F.ReftBV b v) where
   ofReft = id
   mapReftField f = f
 
@@ -1302,7 +1302,7 @@ instance (F.Binder b) => ToReft (NoReftBV b v) where
 instance Top (NoReftBV b v) where
   top _ = NoReft
 
-instance (F.Binder b, Eq v) => IsReft (NoReftBV b v) where
+instance F.Binder b => IsReft (NoReftBV b v) where
   ofReft _ = NoReft
   mapReftField _ = id
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -1213,7 +1213,7 @@ type OkRT c tv r =
   ( TyConable c
   , F.PPrint tv, F.PPrint c, F.PPrint r, F.PPrint (ReftVar r)
   , F.Fixpoint (ReftVar r)
-  , ToReft r
+  , IsReft r
   , ReftBind r ~ F.Symbol
   , Eq c, Eq tv, Ord (ReftVar r)
   , Hashable tv
@@ -1224,7 +1224,7 @@ type OkRTBV b v c tv r =
   , F.PPrint b, F.PPrint v, F.PPrint tv, F.PPrint c, F.PPrint r, F.PPrint (ReftVar r)
   , F.Fixpoint b, F.Fixpoint v, F.Fixpoint (ReftVar r)
   , F.Binder b
-  , ToReft r
+  , IsReft r
   , ReftBind r ~ b
   , Eq c, Eq tv, Ord b, Ord v, Ord (ReftVar r)
   , Hashable tv
@@ -1271,7 +1271,7 @@ instance (F.Binder b, ToReft (F.ReftBV b v), Eq v) => ToReft (UReftBV b v) where
 instance Top (F.ReftBV b v) => Top (UReftBV b v) where
   top (MkUReft r _) = MkUReft (top r) pdTrue
 
-instance (IsReft (F.ReftBV v v),  F.Binder v) => IsReft (UReftBV v v) where
+instance (IsReft (F.ReftBV b v),  F.Binder v) => IsReft (UReftBV b v) where
   ofReft r = MkUReft (ofReft r) pdTrue
   mapReftField f u = u { ur_reft = f (ur_reft u) }
 
@@ -1316,7 +1316,7 @@ instance Monoid F.Reft where
 
 instance Meet (NoReftB b)
 
-instance (Semigroup (F.ReftBV v v), Eq v) => Meet (UReftBV v v)
+instance (Semigroup (F.ReftBV b v), Eq b, Eq v) => Meet (UReftBV b v)
 
 instance (F.Refreshable v, Hashable v) => F.Subable (UReftBV v v) where
   type Variable (UReftBV v v) = v

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -1319,7 +1319,7 @@ mapReftField f r0 = case toConcreteReft r0 of
   ConcreteReft r -> ofConcreteReft (ConcreteReft (f r))
   ConcreteUReft (MkUReft r p) -> ofConcreteReft (ConcreteUReft (MkUReft (f r) p))
 
-instance (IsReft (F.ReftBV b v), F.Binder b) => IsReft (UReftBV b v) where
+instance F.Binder b => IsReft (UReftBV b v) where
   type ReftVar (UReftBV b v) = v
   type ReftBind (UReftBV b v) = b
   ofConcreteReft (ConcreteUReft r) = r
@@ -1327,7 +1327,7 @@ instance (IsReft (F.ReftBV b v), F.Binder b) => IsReft (UReftBV b v) where
 
 instance (F.Binder v, F.Fixpoint v) => Meet (F.ReftBV v v) where
 
-instance (F.Binder b, F.Fixpoint v) => IsReft (F.ReftBV b v) where
+instance F.Binder b => IsReft (F.ReftBV b v) where
   type ReftVar (F.ReftBV b v) = v
   type ReftBind (F.ReftBV b v) = b
   toConcreteReft = ConcreteReft

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -1311,20 +1311,8 @@ instance F.Binder b => IsReft (NoReftB b) where
   ofReft _ = NoReft
   mapReftField _ = id
 
-instance ToReft t => ToReft (RefB b τ t) where
-  type ReftVar (RefB b τ t) = ReftVar t
-  type ReftBind (RefB b τ t) = ReftBind t
-  toReft (RProp _ t) = toReft t
-
 instance Top t => Top (RefB b τ t) where
   top (RProp args t) = RProp args (top t)
-
-instance (F.Binder b, Ord v, PredicateCompat b v) => ToReft (PredicateBV b v) where
-  type ReftVar (PredicateBV b v) = v
-  type ReftBind (PredicateBV b v) = b
-  toReft (Pr [])       = F.trueReft
-  toReft (Pr ps@(p:_)) = F.Reft (parg p, F.pAnd $ pToRef <$> ps)
-  toUReft p = MkUReft F.trueReft p
 
 instance Top (PredicateBV b v) where
   top _ = pdTrue

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -54,7 +54,7 @@ module Language.Haskell.Liquid.Types.RType (
   -- * Predicate Variables
   , PVar
   , PVarV
-  , PVarBV (PV, pname, parg, ptype, pargs), pvType
+  , PVarBV (PV, pname, ptype, pargs), pvType
   , Predicate
   , PredicateV
   , PredicateBV(..)
@@ -291,19 +291,13 @@ type PVarV v t = PVarBV Symbol v t
 -- @{-\@ foo :: forall a \<p :: x:a -> z:a -> Bool\>. y:a -> a\<p y\> \@-}@
 --
 -- * At the __binder__ (inside 'RAllP'):
---   @PV{pname="p", ptype=a, parg="LIQUID$dummy", pargs=[(a, "x", EVar "x")]}@
+--   @PV{pname="p", ptype=a, pargs=[(a, "x", EVar "x")]}@
 -- * At the __use site__ @a\<p y\>@ (inside 'ur_pred'):
---   @PV{pname="p", ptype=a, parg="LIQUID$dummy", pargs=[(a, "x", EVar "y")]}@
+--   @PV{pname="p", ptype=a, pargs=[(a, "x", EVar "y")]}@
 --
 -- * @pname@ is the name of the predicate variable, e.g. @p@
 -- * @ptype@ is the type of the last (value) argument, i.e. the type being
 --   constrained, e.g. @a@
--- * @parg@ is an internal dummy binder — always @"LIQUID$dummy"@. It is used
---   by 'pToRef' as the value-position variable in the uninterpreted function
---   call @papp_n(p, parg, e1, ..., en)@ when converting a standalone
---   'PredicateBV' to a 'F.Reft' via 'toReft'. In the main constraint
---   generation path ('replacePredsWithRefs' / 'pVartoRConc'), the @ur_reft@
---   binder is used instead.
 -- * @pargs@ is the list of non-value arguments (excluding the last one).
 --   Each triple is @(type, formal-binder, actual-expr)@.
 --   The __formal-binder__ always comes from the predicate declaration site
@@ -318,7 +312,6 @@ type PVarV v t = PVarBV Symbol v t
 data PVarBV b v t = PV
   { pname :: !b
   , ptype :: !t
-  , parg  :: !b
   , pargs :: ![(t, b, F.ExprBV b v)]
   } deriving (Generic, Data, Show, Functor)
   deriving B.Binary via Generically (PVarBV b v t)
@@ -345,12 +338,12 @@ instance Eq b => Eq (PVarBV b v t) where
   pv == pv' = pname pv == pname pv' {- UNIFY: What about: && eqArgs pv pv' -}
 
 instance Ord b => Ord (PVarBV b v t) where
-  compare (PV n _ _ _)  (PV n' _ _ _) = compare n n'
+  compare (PV n _ _)  (PV n' _ _) = compare n n'
 
 instance (NFData b, NFData v, NFData t) => NFData (PVarBV b v t)
 
 instance Hashable b => Hashable (PVarBV b v a) where
-  hashWithSalt i (PV n _ _ _) = hashWithSalt i n
+  hashWithSalt i (PV n _ _) = hashWithSalt i n
 
 pvType :: PVarBV b v t -> t
 pvType = ptype
@@ -359,7 +352,7 @@ instance (Ord b, F.Fixpoint b, Hashable b, F.PPrint b, Ord v, F.Fixpoint v, F.PP
   pprintTidy _ = pprPvar
 
 pprPvar :: (Ord b, F.Fixpoint b, Hashable b, F.PPrint b, Ord v, F.Fixpoint v, F.PPrint v) => PVarBV b v a -> Doc
-pprPvar (PV s _ _ xts) = F.pprint s <+> hsep (F.pprint . thd3 <$> xts)
+pprPvar (PV s _ xts) = F.pprint s <+> hsep (F.pprint . thd3 <$> xts)
 
 -- | A map traversal that collects the local variables in scope
 emapExprVM :: (Monad m, Hashable b) => ([b] -> v -> m v') -> ExprBV b v -> m (ExprBV b v')
@@ -1088,7 +1081,6 @@ type UReftV v = UReftBV F.Symbol v
 --   { ur_reft = F.Reft ("VV", PTrue)          -- no first-order constraint
 --   , ur_pred = Pr [ PV { pname = "p"
 --                       , ptype = intSort
---                       , parg  = "LIQUID$dummy"
 --                       , pargs = [(intSort, "x", EVar "m")] } ]
 --   }
 -- @
@@ -1103,13 +1095,12 @@ type UReftV v = UReftBV F.Symbol v
 -- * @ur_pred@ is the abstract-refinement part: a 'PredicateBV' (= @Pr [UsedPVarBV]@),
 --   i.e. a conjunction of predicate-variable applications.
 --   Each 'UsedPVarBV' records which predicate variable is used (via @pname@),
---   the internal dummy binder (@parg = "LIQUID$dummy"@), and the actual
---   argument expressions (@pargs@) at this use site (see 'PVarBV').
+--   and the actual argument expressions (@pargs@) at this use site (see 'PVarBV').
 --
 -- During constraint generation, @ur_pred@ is eliminated by
 -- 'replacePredsWithRefs': each predicate-variable application is converted
 -- to an uninterpreted function call @papp_n(p, VV, e1, ..., en)@ via
--- 'pVartoRConc' (using the @ur_reft@ binder @VV@, __not__ @parg@) and
+-- 'pVartoRConc' (using the @ur_reft@ binder @VV@) and
 -- conjoined into @ur_reft@, producing a pure 'F.Reft' understood by the SMT
 -- solver.  After this step, @ur_pred@ becomes @Pr []@.
 --

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE TupleSections              #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -436,10 +437,10 @@ instance (Ord b, F.Fixpoint b, Hashable b, F.PPrint b, Ord v, F.Fixpoint v, F.PP
   pprintTidy _ (Pr [])  = text "True"
   pprintTidy k (Pr pvs) = hsep $ punctuate (text "&") (F.pprintTidy k <$> pvs)
 
-instance (Semigroup a, Eq b) => Semigroup (UReftBV b v a) where
+instance (Semigroup (F.ReftBV b v), Eq b) => Semigroup (UReftBV b v) where
   MkUReft x y <> MkUReft x' y' = MkUReft (x <> x') (y <> y')
 
-instance (Monoid a) => Monoid (UReft a) where
+instance Monoid UReft where
   mempty  = MkUReft mempty mempty
   mappend = (<>)
 
@@ -468,7 +469,7 @@ instance Hashable v => F.Subable (PredicateBV v v) where
   substf f (Pr pvs) = Pr (F.substf f <$> pvs)
   substa f (Pr pvs) = Pr (F.substa f <$> pvs)
 
-instance NFData r => NFData (UReft r)
+instance NFData UReft
 
 newtype BTyVar = BTV F.LocSymbol
   deriving (Show, Generic, Data)
@@ -1070,8 +1071,8 @@ type RTProp c tv r = RTPropV Symbol c tv r
 type RTPropV v c tv r = RTPropBV Symbol v c tv r
 type RTPropBV b v c tv r = RefB b (RTypeBV b v c tv (NoReftB b)) (RTypeBV b v c tv r)
 
-type UReft r = UReftV F.Symbol r
-type UReftV v r = UReftBV F.Symbol v r
+type UReft = UReftV F.Symbol
+type UReftV v = UReftBV F.Symbol v
 
 -- | A combined refinement carrying both a first-order predicate and a
 -- conjunction of abstract-refinement (predicate-variable) applications.
@@ -1116,19 +1117,21 @@ type UReftV v r = UReftBV F.Symbol v r
 -- 'toReft' on a 'UReftBV' discards @ur_pred@ entirely and returns only
 -- @ur_reft@; it must therefore be called only after predicate-replacement.
 --
-data UReftBV b v r = MkUReft
-  { ur_reft   :: !r
+data UReftBV b v = MkUReft
+  { ur_reft   :: !(F.ReftBV b v)
   , ur_pred   :: !(PredicateBV b v)
   }
-  deriving (Eq, Generic, Data, Functor, Foldable, Show, Traversable)
-  deriving (B.Binary, Hashable) via Generically (UReftBV b v r)
+  deriving (Eq, Generic, Data)
+  deriving (B.Binary, Hashable) via Generically (UReftBV b v)
 
-mapUReftV :: (v -> v') -> (r -> r') -> UReftV v r -> UReftV v' r'
+deriving instance (Show (F.ReftBV b v), Show (PredicateBV b v)) => Show (UReftBV b v)
+
+mapUReftV :: (v -> v') -> (F.ReftV v -> F.ReftV v') -> UReftV v -> UReftV v'
 mapUReftV f g (MkUReft r p) = MkUReft (g r) (mapPredicateV f p)
 
 emapUReftVM
   :: Monad m
-  => ([Symbol] -> v -> m v') -> (r -> m r') -> UReftV v r -> m (UReftV v' r')
+  => ([Symbol] -> v -> m v') -> (F.ReftV v -> m (F.ReftV v')) -> UReftV v -> m (UReftV v')
 emapUReftVM f g (MkUReft r p) = MkUReft <$> g r <*> emapPredicateVM f p
 
 type NoReft = NoReftB Symbol
@@ -1165,7 +1168,7 @@ type BPVar       = PVar      BSort
 type RPVar       = PVar      RSort
 type RReft       = RReftV    F.Symbol
 type RReftV v    = RReftBV Symbol v
-type RReftBV b v = UReftBV b v (F.ReftBV b v)
+type RReftBV b v = UReftBV b v
 type BareType    = BareTypeV F.Symbol
 type BareTypeParsed = BareTypeV F.LocSymbol
 type BareTypeLHName = BareTypeV LHName
@@ -1243,7 +1246,7 @@ class (F.Binder (ReftBind r), Eq (ReftVar r)) => ToReft r where
   type ReftBind r
   type ReftBind r = Symbol
   toReft :: r -> F.ReftBV (ReftBind r) (ReftVar r)
-  toUReft :: r -> UReftBV (ReftBind r) (ReftVar r) (F.ReftBV (ReftBind r) (ReftVar r))
+  toUReft :: r -> UReftBV (ReftBind r) (ReftVar r)
   toUReft r = MkUReft (toReft r) pdTrue
 
 -- | Types that can be combined conjunctively in some sense
@@ -1258,6 +1261,8 @@ class Top r where
 -- | Types that can be constructed from a 'F.ReftBV'
 class (ToReft r, Meet r, Top r) => IsReft r where
   ofReft :: F.ReftBV (ReftBind r) (ReftVar r) -> r
+  -- | Apply a function to the underlying 'F.ReftBV' without discarding predicates.
+  mapReftField :: (F.ReftBV (ReftBind r) (ReftVar r) -> F.ReftBV (ReftBind r) (ReftVar r)) -> r -> r
 
 trueReft :: IsReft r => r
 trueReft = ofReft F.trueReft
@@ -1267,17 +1272,18 @@ isTauto r0 = F.isTautoReft r && null ps
  where
   MkUReft r (Pr ps) = toUReft r0
 
-instance (ToReft r, ReftBind r ~ b, ReftVar r ~ v) => ToReft (UReftBV b v r) where
-  type ReftVar (UReftBV b v r) = ReftVar r
-  type ReftBind (UReftBV b v r) = ReftBind r
+instance (F.Binder b, ToReft (F.ReftBV b v), Eq v) => ToReft (UReftBV b v) where
+  type ReftVar (UReftBV b v) = v
+  type ReftBind (UReftBV b v) = b
   toReft = toReft . ur_reft
   toUReft (MkUReft r p) = MkUReft (toReft r) p
 
-instance Top r => Top (UReftBV b v r) where
+instance Top (F.ReftBV b v) => Top (UReftBV b v) where
   top (MkUReft r _) = MkUReft (top r) pdTrue
 
-instance (IsReft r, F.Binder v, ReftBind r ~ v, ReftVar r ~ v) => IsReft (UReftBV v v r) where
+instance (IsReft (F.ReftBV v v),  F.Binder v) => IsReft (UReftBV v v) where
   ofReft r = MkUReft (ofReft r) pdTrue
+  mapReftField f u = u { ur_reft = f (ur_reft u) }
 
 instance (F.Binder b, Eq v) => ToReft (F.ReftBV b v) where
   type ReftVar (F.ReftBV b v) = v
@@ -1291,6 +1297,7 @@ instance (F.Binder v, F.Fixpoint v) => Meet (F.ReftBV v v) where
 
 instance (F.Binder v, F.Fixpoint v, Eq v) => IsReft (F.ReftBV v v) where
   ofReft = id
+  mapReftField f = f
 
 instance F.Binder b => ToReft (NoReftB b) where
   type ReftVar (NoReftB b) = Symbol
@@ -1302,6 +1309,7 @@ instance Top (NoReftB b) where
 
 instance F.Binder b => IsReft (NoReftB b) where
   ofReft _ = NoReft
+  mapReftField _ = id
 
 instance ToReft t => ToReft (RefB b τ t) where
   type ReftVar (RefB b τ t) = ReftVar t
@@ -1330,10 +1338,10 @@ instance Monoid F.Reft where
 
 instance Meet (NoReftB b)
 
-instance (Meet r, Eq v) => Meet (UReftBV v v r)
+instance (Semigroup (F.ReftBV v v), Eq v) => Meet (UReftBV v v)
 
-instance (F.Subable r, F.Variable r ~ v) => F.Subable (UReftBV v v r) where
-  type Variable (UReftBV v v r) = v
+instance (F.Refreshable v, Hashable v) => F.Subable (UReftBV v v) where
+  type Variable (UReftBV v v) = v
   syms (MkUReft r p)     = F.syms r `S.union` F.syms p
   subst s (MkUReft r z)  = MkUReft (F.subst s r)  (F.subst s z)
   substf f (MkUReft r z) = MkUReft (F.substf f r) (F.substf f z)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -400,7 +400,7 @@ emapSubstVM f m = F.toKVarSubst . M.fromList <$> mapM (traverse (emapExprVM f)) 
 
 type UsedPVar    = UsedPVarV Symbol
 type UsedPVarV v = UsedPVarBV Symbol v
-type UsedPVarBV b v = PVarBV b v ()
+type UsedPVarBV b v = PVarBV b v (NoReftB b)
 
 type Predicate = PredicateV Symbol
 type PredicateV v = PredicateBV Symbol v
@@ -409,11 +409,11 @@ newtype PredicateBV b v = Pr [UsedPVarBV b v]
   deriving (B.Binary, Hashable) via Generically (PredicateBV b v)
 
 mapPredicateV :: (v -> v') -> PredicateV v -> PredicateV v'
-mapPredicateV f (Pr xs) = Pr (map (mapPVarV f (const ())) xs)
+mapPredicateV f (Pr xs) = Pr (map (mapPVarV f (const NoReft)) xs)
 
 -- | A map traversal that collects the local variables in scope
 emapPredicateVM :: Monad m => ([Symbol] -> v -> m v') -> PredicateV v -> m (PredicateV v')
-emapPredicateVM f (Pr xs) = Pr <$> mapM (emapPVarVM f (\_ _ -> pure ())) xs
+emapPredicateVM f (Pr xs) = Pr <$> mapM (emapPVarVM f (\_ _ -> pure NoReft)) xs
 
 instance (Ord b, Ord v) => Eq (PredicateBV b v) where
   (Pr vs) == (Pr ws)
@@ -760,7 +760,7 @@ type RTypeV v c tv = RTypeBV Symbol v c tv
 -- * @tv@ is the type of type variables
 -- * @r@ is the type of refinements
 --
--- A refinement might be missing (e.g. @r@ is @()@), if the RTypeBV is used to
+-- A refinement might be missing (e.g. @r@ is @NoReft@), if the RTypeBV is used to
 -- represent the type of an entity that can't use refinements, e.g. the type of
 -- an abstract predicate.
 data RTypeBV b v c tv r
@@ -1292,16 +1292,6 @@ instance (F.Binder v, F.Fixpoint v) => Meet (F.ReftBV v v) where
 instance (F.Binder v, F.Fixpoint v, Eq v) => IsReft (F.ReftBV v v) where
   ofReft = id
 
-instance ToReft () where
-  type ReftVar () = Symbol
-  toReft _ = F.trueReft
-
-instance Top () where
-  top _ = ()
-
-instance IsReft () where
-  ofReft _ = ()
-
 instance F.Binder b => ToReft (NoReftB b) where
   type ReftVar (NoReftB b) = Symbol
   type ReftBind (NoReftB b) = b
@@ -1338,8 +1328,6 @@ instance Monoid F.Reft where
   mempty  = F.trueReft
   mappend = (<>)
 
-instance Meet ()
-
 instance Meet (NoReftB b)
 
 instance (Meet r, Eq v) => Meet (UReftBV v v r)
@@ -1350,9 +1338,6 @@ instance (F.Subable r, F.Variable r ~ v) => F.Subable (UReftBV v v r) where
   subst s (MkUReft r z)  = MkUReft (F.subst s r)  (F.subst s z)
   substf f (MkUReft r z) = MkUReft (F.substf f r) (F.substf f z)
   substa f (MkUReft r z) = MkUReft (F.substa f r) (F.substa f z)
-
-instance F.Expression (UReft ()) where
-  expr = F.expr . toReft
 
 instance Meet Predicate
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -1254,7 +1254,7 @@ class Top r where
   top :: r -> r
 
 -- | Types that can be constructed from a 'F.ReftBV'
-class (ToReft r, Meet r, Top r, Eq (ReftVar r)) => IsReft r where
+class (ToReft r, Top r, Eq (ReftVar r)) => IsReft r where
   ofReft :: F.ReftBV (ReftBind r) (ReftVar r) -> r
   -- | Apply a function to the underlying 'F.ReftBV' without discarding predicates.
   mapReftField :: (F.ReftBV (ReftBind r) (ReftVar r) -> F.ReftBV (ReftBind r) (ReftVar r)) -> r -> r

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -1290,7 +1290,7 @@ instance (F.Binder b) => Top (F.ReftBV b v) where
 
 instance (F.Binder v, F.Fixpoint v) => Meet (F.ReftBV v v) where
 
-instance (F.Binder v, F.Fixpoint v, Eq v) => IsReft (F.ReftBV v v) where
+instance (F.Binder b, F.Fixpoint v, Eq v) => IsReft (F.ReftBV b v) where
   ofReft = id
   mapReftField f = f
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -1297,6 +1297,10 @@ instance F.Binder b => Top (F.ReftBV b v) where
 instance F.Binder b => Top (UReftBV b v) where
   top _ = MkUReft F.trueReft pdTrue
 
+-- | A refinement type that accepts all elements of its base type.
+--
+-- This is a generalization of 'F.trueReft' for the other types that instantiate
+-- 'IsReft'.
 trueReft :: forall r. IsReft r => r
 trueReft = case toConcreteReft @r (error "trueReft") of
   ConcreteNoReft -> top (error "trueReft: ConcreteNoReft")

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
@@ -285,29 +285,8 @@ mapExprReft f = mapReft g
   where
     g (MkUReft (F.Reft (x, e)) p) = MkUReft (F.Reft (x, f x e)) p
 
-data OrReftBV r = LeftReftBV (F.ReftBV (ReftBind r) (ReftVar r)) | RightR r
-
-instance ToReft r => ToReft (OrReftBV r) where
-  type ReftBind (OrReftBV r) = ReftBind r
-  type ReftVar (OrReftBV r) = ReftVar r
-  toReft (LeftReftBV r) = r
-  toReft (RightR r) = toReft r
-  toUReft (LeftReftBV r) = MkUReft r (Pr [])
-  toUReft (RightR r) = toUReft r
-
-instance ToReft r => Semigroup (OrReftBV r) where
-  _ <> _ = Prelude.error "Meet OrReftBV"
-
-instance ToReft r => Meet (OrReftBV r) where
-
-instance F.Binder (ReftBind r) => Top (OrReftBV r) where
-  top _ = LeftReftBV F.trueReft
-
-instance ToReft r => IsReft (OrReftBV r) where
-  ofReft r = LeftReftBV r
-
-isTrivial :: (ToReft r, TyConable c, F.Binder b, ReftBind r ~ b) => RTypeBV b v c tv r -> Bool
-isTrivial = foldReft False (\_ r b -> isTauto r && b) True . fmap RightR
+isTrivial :: (ToReft r, IsReft r, TyConable c, F.Binder b, ReftBind r ~ b) => RTypeBV b v c tv r -> Bool
+isTrivial = foldReft False (\_ r b -> isTauto r && b) True
 
 mapReft ::  (r1 -> r2) -> RTypeBV b v c tv r1 -> RTypeBV b v c tv r2
 mapReft f = emapReft (const f) []

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
@@ -678,7 +678,7 @@ mapBind f = go
     mapS                  = mapReft (\NoReft -> NoReft) . mapBind f
     mapI RTVNoInfo{..}    = RTVNoInfo{..}
     mapI RTVInfo{..}      = RTVInfo { rtv_kind = mapS rtv_kind, .. }
-    mapP (PV n τ a as)    = PV (f n) (mapS τ) (f a) (mapA <$> as)
+    mapP (PV n τ as)    = PV (f n) (mapS τ) (mapA <$> as)
     mapA (τ, b, e)        = (mapS τ, f b, F.mapBindExpr f e)
     mapR (RProp as t)     = RProp (bimap f mapS <$> as) (go t)
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
@@ -286,7 +286,7 @@ mapExprReft f = mapReft g
   where
     g (MkUReft (F.Reft (x, e)) p) = MkUReft (F.Reft (x, f x e)) p
 
-isTrivial :: (ToReft r, IsReft r, TyConable c, F.Binder b, ReftBind r ~ b, Eq (ReftVar r)) => RTypeBV b v c tv r -> Bool
+isTrivial :: (IsReft r, IsReft r, TyConable c, F.Binder b, ReftBind r ~ b, Eq (ReftVar r)) => RTypeBV b v c tv r -> Bool
 isTrivial = foldReft False (\_ r b -> isTauto r && b) True
 
 mapReft ::  (r1 -> r2) -> RTypeBV b v c tv r1 -> RTypeBV b v c tv r2
@@ -345,7 +345,7 @@ emapFReftM f (F.Reft (v, e)) = F.reft v <$> emapExprVM (f . (v:)) e
 
 -- The first parameter corresponds to the bscope config setting
 emapReftM
-  :: (Monad m, ToReft r1, F.Binder b, CompatibleBinder b tv, ReftBind r1 ~ b)
+  :: (Monad m, IsReft r1, F.Binder b, CompatibleBinder b tv, ReftBind r1 ~ b)
   => Bool
   -> ([b] -> v1 -> m v2)
   -> ([b] -> r1 -> m r2)
@@ -369,7 +369,7 @@ emapReftM bscp vf f = go
     go γ (RHole r)         = RHole <$> f γ r
 
 emapRefM
-  :: (Monad m, ToReft t, F.Binder b, CompatibleBinder b tv, ReftBind t ~ b)
+  :: (Monad m, IsReft t, F.Binder b, CompatibleBinder b tv, ReftBind t ~ b)
   => Bool
   -> ([b] -> v -> m v')
   -> ([b] -> t -> m s)
@@ -385,7 +385,7 @@ emapRefM bscp vf f γ0 (RProp ss t0) =
       <*> emapReftM bscp vf f (map fst ss ++ γ0) t0
 
 emapBareTypeVM
-  :: (Monad m, Ord v1)
+  :: (Monad m, F.Fixpoint v1)
   => Bool
   -> ([Symbol] -> v1 -> m v2)
   -> [Symbol]
@@ -689,10 +689,10 @@ insertSEnv = F.insertSEnv
 insertsSEnv :: (Eq b, Hashable b) => F.SEnvB b a -> [(b, a)] -> F.SEnvB b a
 insertsSEnv  = foldr (\(x, t) γ -> insertSEnv x t γ)
 
-rTypeValueVar :: (ToReft r, F.Binder (ReftBind r)) => RTypeBV b v c tv r -> ReftBind r
+rTypeValueVar :: (IsReft r, F.Binder (ReftBind r)) => RTypeBV b v c tv r -> ReftBind r
 rTypeValueVar t = vv where F.Reft (vv,_) =  rTypeReft t
 
-rTypeReft :: (ToReft r, F.Binder (ReftBind r)) => RTypeBV b v c tv r -> F.ReftBV (ReftBind r) (ReftVar r)
+rTypeReft :: (IsReft r, F.Binder (ReftBind r)) => RTypeBV b v c tv r -> F.ReftBV (ReftBind r) (ReftVar r)
 rTypeReft = maybe F.trueReft toReft . stripRTypeBase
 
 -- stripRTypeBase ::  RType a -> Maybe a

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
@@ -71,6 +71,7 @@ import qualified Prelude
 
 import           Control.Monad                          (liftM2, liftM3, liftM4)
 import           Data.Bifunctor (bimap)
+import           Data.Coerce (coerce)
 import           Data.Hashable (Hashable)
 import qualified Data.HashSet as S
 
@@ -103,8 +104,8 @@ type SpecRep     = RRep      RReft
 type RTypeRep = RTypeRepV Symbol
 type RTypeRepV = RTypeRepBV Symbol
 data RTypeRepBV b v c tv r = RTypeRep
-  { ty_vars   :: [(RTVar tv (RTypeBV b v c tv (NoReftB b)), r)]
-  , ty_preds  :: [PVarBV b v (RTypeBV b v c tv (NoReftB b))]
+  { ty_vars   :: [(RTVar tv (RTypeBV b v c tv (NoReftBV b v)), r)]
+  , ty_preds  :: [PVarBV b v (RTypeBV b v c tv (NoReftBV b v))]
   , ty_binds  :: [b]
   , ty_info   :: [RFInfo]
   , ty_refts  :: [r]
@@ -131,8 +132,8 @@ toRTypeRep t         = RTypeRep αs πs xs is rs ts t''
     (αs, πs, t') = bkUniv t
     ((xs, is, ts, rs), t'') = bkArrow t'
 
-mkArrow :: [(RTVar tv (RTypeBV b v c tv (NoReftB b)), r)]
-        -> [PVarBV b v (RTypeBV b v c tv (NoReftB b))]
+mkArrow :: [(RTVar tv (RTypeBV b v c tv (NoReftBV b v)), r)]
+        -> [PVarBV b v (RTypeBV b v c tv (NoReftBV b v))]
         -> [(b, RFInfo, RTypeBV b v c tv r, r)]
         -> RTypeBV b v c tv r
         -> RTypeBV b v c tv r
@@ -167,8 +168,8 @@ safeBkArrow (RAllP _ _)     = Prelude.error {- panic Nothing -} "safeBkArrow on 
 safeBkArrow t               = bkArrow t
 
 mkUnivs :: (Foldable t, Foldable t1)
-        => t  (RTVar tv (RTypeBV b v c tv (NoReftB b)), r)
-        -> t1 (PVarBV b v (RTypeBV b v c tv (NoReftB b)))
+        => t  (RTVar tv (RTypeBV b v c tv (NoReftBV b v)), r)
+        -> t1 (PVarBV b v (RTypeBV b v c tv (NoReftBV b v)))
         -> RTypeBV b v c tv r
         -> RTypeBV b v c tv r
 mkUnivs αs πs rt = foldr (\(a,r) t -> RAllT a t r) (foldr RAllP rt πs) αs
@@ -180,7 +181,7 @@ bkUnivClass t        = (as, ps, cs, t2)
     (cs, t2)     = bkClass t1
 
 
-bkUniv :: RTypeBV b v tv c r -> ([(RTVar c (RTypeBV b v tv c (NoReftB b)), r)], [PVarBV b v (RTypeBV b v tv c (NoReftB b))], RTypeBV b v tv c r)
+bkUniv :: RTypeBV b v tv c r -> ([(RTVar c (RTypeBV b v tv c (NoReftBV b v)), r)], [PVarBV b v (RTypeBV b v tv c (NoReftBV b v))], RTypeBV b v tv c r)
 bkUniv (RAllT α t r) = let (αs, πs, t') = bkUniv t in ((α, r):αs, πs, t')
 bkUniv (RAllP π t)   = let (αs, πs, t') = bkUniv t in (αs, π:πs, t')
 bkUniv t             = ([], [], t)
@@ -285,7 +286,7 @@ mapExprReft f = mapReft g
   where
     g (MkUReft (F.Reft (x, e)) p) = MkUReft (F.Reft (x, f x e)) p
 
-isTrivial :: (ToReft r, IsReft r, TyConable c, F.Binder b, ReftBind r ~ b) => RTypeBV b v c tv r -> Bool
+isTrivial :: (ToReft r, IsReft r, TyConable c, F.Binder b, ReftBind r ~ b, Eq (ReftVar r)) => RTypeBV b v c tv r -> Bool
 isTrivial = foldReft False (\_ r b -> isTauto r && b) True
 
 mapReft ::  (r1 -> r2) -> RTypeBV b v c tv r1 -> RTypeBV b v c tv r2
@@ -313,10 +314,10 @@ emapRef  f γ (RProp s t)         = RProp s $ emapReft f γ t
 
 mapRTypeV ::  (v -> v') -> RTypeBV b v c tv r -> RTypeBV b v' c tv r
 mapRTypeV _ (RVar α r)        = RVar α r
-mapRTypeV f (RAllT α t r)     = RAllT (fmap (mapRTypeV f) α) (mapRTypeV f t) r
-mapRTypeV f (RAllP π t)       = RAllP (mapPVarV f (mapRTypeV f) π) (mapRTypeV f t)
+mapRTypeV f (RAllT α t r)     = RAllT (mapRTypeV f <$> coerce α) (mapRTypeV f t) r
+mapRTypeV f (RAllP π t)       = RAllP (mapPVarV f (mapRTypeV f) $ coerce π) (mapRTypeV f t)
 mapRTypeV f (RFun x i t t' r) = RFun x i (mapRTypeV f t) (mapRTypeV f t') r
-mapRTypeV f (RApp c ts rs r)  = RApp c (mapRTypeV f <$> ts) (mapRefV <$> rs) r
+mapRTypeV f (RApp c ts rs r)  = RApp c (mapRTypeV f <$> ts) (mapRefV <$> coerce rs) r
   where
     mapRefV (RProp ss t) = RProp (map (fmap (mapRTypeV f)) ss) (mapRTypeV f t)
 mapRTypeV f (REx z t t')      = REx z (mapRTypeV f t) (mapRTypeV f t')
@@ -327,10 +328,10 @@ mapRTypeV _ (RHole r)         = RHole r
 
 mapRTypeVM :: (Hashable b, Monad m) => (v -> m v') -> RTypeBV b v c tv r -> m (RTypeBV b v' c tv r)
 mapRTypeVM _ (RVar α r)        = return $ RVar α r
-mapRTypeVM f (RAllT α t r)     = RAllT <$> traverse (mapRTypeVM f) α <*> mapRTypeVM f t <*> pure r
-mapRTypeVM f (RAllP π t)       = RAllP <$> emapPVarVM (const f) (const (mapRTypeVM f)) π <*> mapRTypeVM f t
+mapRTypeVM f (RAllT α t r)     = RAllT <$> traverse (mapRTypeVM f) (coerce α) <*> mapRTypeVM f t <*> pure r
+mapRTypeVM f (RAllP π t)       = RAllP <$> emapPVarVM (const f) (const (mapRTypeVM f)) (coerce π) <*> mapRTypeVM f t
 mapRTypeVM f (RFun x i t t' r) = RFun x i <$> mapRTypeVM f t <*> mapRTypeVM f t' <*> pure r
-mapRTypeVM f (RApp c ts rs r)  = RApp c <$> mapM (mapRTypeVM f) ts <*> mapM mapRefVM rs <*> pure r
+mapRTypeVM f (RApp c ts rs r)  = RApp c <$> mapM (mapRTypeVM f) ts <*> mapM mapRefVM (coerce rs) <*> pure r
   where
     mapRefVM (RProp ss t) = RProp <$> mapM (traverse (mapRTypeVM f)) ss <*> mapRTypeVM f t
 mapRTypeVM f (REx z t t')      = REx z <$> mapRTypeVM f t <*> mapRTypeVM f t'
@@ -354,8 +355,8 @@ emapReftM
 emapReftM bscp vf f = go
   where
     go γ (RVar α r)        = RVar  α <$> f γ r
-    go γ (RAllT α t r)     = RAllT <$> traverse (emapReftM bscp vf (const pure) γ) α <*> go (coerceBinder (ty_var_value α) : γ) t <*> f γ r
-    go γ (RAllP π t)       = RAllP <$> emapPVarVM vf (emapReftM bscp vf (const pure)) π <*> go γ t
+    go γ (RAllT α t r)     = RAllT <$> traverse (emapReftM bscp vf (const pure) γ) (coerce α) <*> go (coerceBinder (ty_var_value α) : γ) t <*> f γ r
+    go γ (RAllP π t)       = RAllP <$> emapPVarVM vf (emapReftM bscp vf (const pure)) (coerce π) <*> go γ t
     go γ (RFun x i t t' r) = RFun  x i <$> go (x:γ) t <*> go (x:γ) t' <*> f (x:γ) r
     go γ (RApp c ts rs r)  =
       let γ' = if bscp then F.reftBind (toReft r) : γ  else γ
@@ -380,7 +381,7 @@ emapRefM bscp vf f γ0 (RProp ss t0) =
       mapAccumM
         (\γ (s, t) -> (s:γ,) . (s,) <$> emapReftM bscp vf (const pure) γ t)
         γ0
-        ss
+        (coerce ss)
       <*> emapReftM bscp vf f (map fst ss ++ γ0) t0
 
 emapBareTypeVM
@@ -399,7 +400,7 @@ emapBareTypeVM bscp f =
 mapDataDeclV :: (v -> v') -> DataDeclP v ty -> DataDeclP v' ty
 mapDataDeclV f DataDecl {..} =
     DataDecl
-      { tycPVars = map (mapPVarV f (mapRTypeV f)) tycPVars
+      { tycPVars = map (mapPVarV f (mapRTypeV f)) (coerce tycPVars)
       , tycSFun = fmap (fmap f) tycSFun
       , ..
       }
@@ -419,7 +420,7 @@ emapDataDeclM bscp vf f d = do
     tycDCons <- traverse (mapM (emapDataCtorTyM f)) (tycDCons d)
     tycSFun <- traverse (traverse (vf [])) (tycSFun d)
     tycPropTy <- traverse (f []) $ tycPropTy d
-    return d{tycDCons, tycPVars, tycSFun, tycPropTy}
+    return d{tycDCons, tycPVars = coerce tycPVars, tycSFun, tycPropTy}
 
 emapDataCtorTyM
   :: Monad m
@@ -566,10 +567,10 @@ rtvinfoIsVal RTVInfo{..} = rtv_is_val
 efoldReft :: (IsReft r, TyConable c, F.Binder b, ReftBind r ~ b)
           => BScope
           -> (c  -> [RTypeBV b v c tv r] -> [(b, a)])
-          -> (RTVar tv (RTypeBV b v c tv (NoReftB b)) -> [(b, a)])
+          -> (RTVar tv (RTypeBV b v c tv (NoReftBV b v)) -> [(b, a)])
           -> (RTypeBV b v c tv r -> a)
           -> (F.SEnvB b a -> Maybe (RTypeBV b v c tv r) -> r -> z -> z)
-          -> (PVarBV b v (RTypeBV b v c tv (NoReftB b)) -> F.SEnvB b a -> F.SEnvB b a)
+          -> (PVarBV b v (RTypeBV b v c tv (NoReftBV b v)) -> F.SEnvB b a -> F.SEnvB b a)
           -> F.SEnvB b a
           -> z
           -> RTypeBV b v c tv r
@@ -662,10 +663,10 @@ mapBind f = go
     mapR (RProp as t)     = RProp (bimap f mapS <$> as) (go t)
 
 --------------------------------------------------
-ofRSort ::  IsReft r => RTypeBV b v c tv (NoReftB b) -> RTypeBV b v c tv r
+ofRSort ::  IsReft r => RTypeBV b v c tv (NoReftBV b v) -> RTypeBV b v c tv r
 ofRSort = fmap (const trueReft)
 
-toRSort :: F.Binder b => RTypeBV b v c tv r -> RTypeBV b v c tv (NoReftB b)
+toRSort :: F.Binder b => RTypeBV b v c tv r -> RTypeBV b v c tv (NoReftBV b v)
 toRSort = stripAnnotations . mapBind (const F.wildcard) . (NoReft <$)
 
 stripAnnotations :: RTypeBV b v c tv r -> RTypeBV b v c tv r

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
@@ -385,7 +385,7 @@ emapRefM bscp vf f γ0 (RProp ss t0) =
       <*> emapReftM bscp vf f (map fst ss ++ γ0) t0
 
 emapBareTypeVM
-  :: (Monad m, F.Fixpoint v1)
+  :: Monad m
   => Bool
   -> ([Symbol] -> v1 -> m v2)
   -> [Symbol]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -647,7 +647,7 @@ strengthenWith mt = go
     go t                  _  = t
 
 
-quantifyRTy :: (Monoid r, Eq tv) => [RTVar tv (RTypeV v c tv NoReft)] -> RTypeV v c tv r -> RTypeV v c tv r
+quantifyRTy :: (Monoid r, Eq tv) => [RTVar tv (RTypeV v c tv (NoReftBV Symbol v))] -> RTypeV v c tv r -> RTypeV v c tv r
 quantifyRTy tvs ty = foldr rAllT ty tvs
   where rAllT a t = RAllT a t mempty
 
@@ -850,7 +850,7 @@ allTyVars' t = fmap ty_var_value $ vs ++ vs'
     vs'     = freeTyVars t
 
 
-freeTyVars :: Eq tv => RTypeV v c tv r -> [RTVar tv (RTypeV v c tv NoReft)]
+freeTyVars :: Eq tv => RTypeV v c tv r -> [RTVar tv (RTypeV v c tv (NoReftBV Symbol v))]
 freeTyVars (RAllP _ t)       = freeTyVars t
 freeTyVars (RAllT α t _)     = freeTyVars t L.\\ [α]
 freeTyVars (RFun _ _ t t' _) = freeTyVars t `L.union` freeTyVars t'
@@ -886,83 +886,83 @@ tyClasses t               = panic Nothing ("RefType.tyClasses cannot handle" ++ 
 
 subsTyVarsMeet
   :: (Eq tv, Foldable t, Hashable tv, IsReft r, TyConable c, Binder b,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) c, SubsTy tv (RTypeBV b v c tv (NoReftB b)) r,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTypeBV b v c tv (NoReftB b)), FreeVar c tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTVar tv (RTypeBV b v c tv (NoReftB b))))
-  => t (tv, RTypeBV b v c tv (NoReftB b), RTypeBV b v c tv r) -> RTypeBV b v c tv r -> RTypeBV b v c tv r
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
+  => t (tv, RTypeBV b v c tv (NoReftBV b v), RTypeBV b v c tv r) -> RTypeBV b v c tv r -> RTypeBV b v c tv r
 subsTyVarsMeet        = subsTyVars True
 
 subsTyVarsNoMeet
   :: (Eq tv, Foldable t, Hashable tv, IsReft r, TyConable c, Binder b,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) c, SubsTy tv (RTypeBV b v c tv (NoReftB b)) r,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTypeBV b v c tv (NoReftB b)), FreeVar c tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTVar tv (RTypeBV b v c tv (NoReftB b))))
-  => t (tv, RTypeBV b v c tv (NoReftB b), RTypeBV b v c tv r) -> RTypeBV b v c tv r -> RTypeBV b v c tv r
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
+  => t (tv, RTypeBV b v c tv (NoReftBV b v), RTypeBV b v c tv r) -> RTypeBV b v c tv r -> RTypeBV b v c tv r
 subsTyVarsNoMeet      = subsTyVars False
 
 subsTyVarNoMeet
   :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) c, SubsTy tv (RTypeBV b v c tv (NoReftB b)) r,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTypeBV b v c tv (NoReftB b)), FreeVar c tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTVar tv (RTypeBV b v c tv (NoReftB b))))
-  => (tv, RTypeBV b v c tv (NoReftB b), RTypeBV b v c tv r) -> RTypeBV b v c tv r -> RTypeBV b v c tv r
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
+  => (tv, RTypeBV b v c tv (NoReftBV b v), RTypeBV b v c tv r) -> RTypeBV b v c tv r -> RTypeBV b v c tv r
 subsTyVarNoMeet       = subsTyVar False
 
 subsTyVarMeet
   :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) c, SubsTy tv (RTypeBV b v c tv (NoReftB b)) r,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTypeBV b v c tv (NoReftB b)), FreeVar c tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTVar tv (RTypeBV b v c tv (NoReftB b))))
-  => (tv, RTypeBV b v c tv (NoReftB b), RTypeBV b v c tv r) -> RTypeBV b v c tv r -> RTypeBV b v c tv r
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
+  => (tv, RTypeBV b v c tv (NoReftBV b v), RTypeBV b v c tv r) -> RTypeBV b v c tv r -> RTypeBV b v c tv r
 subsTyVarMeet         = subsTyVar True
 
 subsTyVarMeet'
   :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) c, SubsTy tv (RTypeBV b v c tv (NoReftB b)) r,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTypeBV b v c tv (NoReftB b)), FreeVar c tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTVar tv (RTypeBV b v c tv (NoReftB b))))
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
   => (tv, RTypeBV b v c tv r) -> RTypeBV b v c tv r -> RTypeBV b v c tv r
 subsTyVarMeet' (α, t) = subsTyVarMeet (α, toRSort t, t)
 
 subsTyVars
   :: (Eq tv, Foldable t, Hashable tv, IsReft r, TyConable c, Binder b,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) c, SubsTy tv (RTypeBV b v c tv (NoReftB b)) r,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTypeBV b v c tv (NoReftB b)), FreeVar c tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTVar tv (RTypeBV b v c tv (NoReftB b))))
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
   => Bool
-  -> t (tv, RTypeBV b v c tv (NoReftB b), RTypeBV b v c tv r)
+  -> t (tv, RTypeBV b v c tv (NoReftBV b v), RTypeBV b v c tv r)
   -> RTypeBV b v c tv r
   -> RTypeBV b v c tv r
 subsTyVars meet' ats t = foldl' (flip (subsTyVar meet')) t ats
 
 subsTyVar
   :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) c, SubsTy tv (RTypeBV b v c tv (NoReftB b)) r,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTypeBV b v c tv (NoReftB b)), FreeVar c tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTVar tv (RTypeBV b v c tv (NoReftB b))))
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
   => Bool
-  -> (tv, RTypeBV b v c tv (NoReftB b), RTypeBV b v c tv r)
+  -> (tv, RTypeBV b v c tv (NoReftBV b v), RTypeBV b v c tv r)
   -> RTypeBV b v c tv r
   -> RTypeBV b v c tv r
 subsTyVar meet'        = subsFree meet' S.empty
 
 subsFree
   :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) c, SubsTy tv (RTypeBV b v c tv (NoReftB b)) r,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTypeBV b v c tv (NoReftB b)), FreeVar c tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTVar tv (RTypeBV b v c tv (NoReftB b)))
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v)))
      )
   => Bool
   -> S.HashSet tv
-  -> (tv, RTypeBV b v c tv (NoReftB b), RTypeBV b v c tv r)
+  -> (tv, RTypeBV b v c tv (NoReftBV b v), RTypeBV b v c tv r)
   -> RTypeBV b v c tv r
   -> RTypeBV b v c tv r
 subsFree m s z@(α, τ,_) (RAllP π t)
@@ -994,13 +994,13 @@ subsFree _ _ (α, τ, _) (RHole r)
 
 subsFrees
   :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) c, SubsTy tv (RTypeBV b v c tv (NoReftB b)) r,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTypeBV b v c tv (NoReftB b)), FreeVar c tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTVar tv (RTypeBV b v c tv (NoReftB b))))
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
   => Bool
   -> S.HashSet tv
-  -> [(tv, RTypeBV b v c tv (NoReftB b), RTypeBV b v c tv r)]
+  -> [(tv, RTypeBV b v c tv (NoReftBV b v), RTypeBV b v c tv r)]
   -> RTypeBV b v c tv r
   -> RTypeBV b v c tv r
 subsFrees m s zs t = foldl' (flip (subsFree m s)) t zs
@@ -1008,11 +1008,11 @@ subsFrees m s zs t = foldl' (flip (subsFree m s)) t zs
 -- GHC INVARIANT: RApp is Type Application to something other than TYCon
 subsFreeRAppTy
   :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) c, SubsTy tv (RTypeBV b v c tv (NoReftB b)) r,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTypeBV b v c tv (NoReftB b)),
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)),
       FreeVar c tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTVar tv (RTypeBV b v c tv (NoReftB b))))
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
   => Bool
   -> S.HashSet tv
   -> RTypeBV b v c tv r
@@ -1032,10 +1032,10 @@ subsFreeRAppTy _ _ t t' r'
 --    See [NOTE:Levity-Polymorphism]
 
 mkRApp :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) c, SubsTy tv (RTypeBV b v c tv (NoReftB b)) r,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTypeBV b v c tv (NoReftB b)), FreeVar c tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTVar tv (RTypeBV b v c tv (NoReftB b))))
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
   => Bool
   -> S.HashSet tv
   -> c
@@ -1094,20 +1094,20 @@ mkRApp m s c ts rs r r'
        • and other links from https://stackoverflow.com/a/35320729/946226 (edited)
  -}
 
-refAppTyToFun :: ToReft r => r -> r
+refAppTyToFun :: IsReft r => r -> r
 refAppTyToFun r
   | isTauto r = r
   | otherwise = panic Nothing "RefType.refAppTyToFun"
 
 subsFreeRef
   :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) c, SubsTy tv (RTypeBV b v c tv (NoReftB b)) r,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTypeBV b v c tv (NoReftB b)), FreeVar c tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftB b)) (RTVar tv (RTypeBV b v c tv (NoReftB b))))
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
   => Bool
   -> S.HashSet tv
-  -> (tv, RTypeBV b v c tv (NoReftB b), RTypeBV b v c tv r)
+  -> (tv, RTypeBV b v c tv (NoReftBV b v), RTypeBV b v c tv r)
   -> RTPropBV b v c tv r
   -> RTPropBV b v c tv r
 subsFreeRef _ _ (α', τ', _) (RProp ss (RHole r))

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -294,14 +294,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) c
   mempty  = panic Nothing "mempty: RTProp"
   mappend = (<>)
 
-instance Meet (RTProp RTyCon RTyVar UReft)
-instance Meet (RTProp RTyCon RTyVar NoReft)
-instance Meet (RTProp BTyCon BTyVar UReft)
-instance Meet (RTProp BTyCon BTyVar NoReft)
-instance Meet (RTProp RTyCon RTyVar Reft)
-
 instance Semigroup (RType RTyCon RTyVar r) => Meet (RType RTyCon RTyVar r) where
-instance Meet (RType BTyCon BTyVar UReft)
 
 -- MOVE TO TYPES
 instance Fixpoint String where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -176,10 +176,10 @@ findPVar ps upv = PV name ty v (zipWith (\(_, _, e) (t, s, _) -> (t, s, e)) (par
 
 -- | Various functions for converting vanilla `Reft` to `Spec`
 
-uRType          ::  RType c tv a -> RType c tv (UReft a)
+uRType          ::  RType c tv Reft -> RType c tv UReft
 uRType          = fmap uTop
 
-uRType'         ::  RType c tv (UReft a) -> RType c tv a
+uRType'         ::  RType c tv UReft -> RType c tv Reft
 uRType'         = fmap ur_reft
 
 uRTypeGen       :: IsReft b => RType c tv a -> RType c tv b
@@ -188,10 +188,10 @@ uRTypeGen       = fmap $ const trueReft
 uPVar           :: PVarV v t -> UsedPVarV v
 uPVar           = fmap (const NoReft)
 
-uReft           :: (Symbol, Expr) -> UReft Reft
+uReft           :: (Symbol, Expr) -> UReft
 uReft           = uTop . Reft
 
-uTop            ::  r -> UReftV v r
+uTop            :: ReftV v -> UReftV v
 uTop r          = MkUReft r (Pr [])
 
 --------------------------------------------------------------------
@@ -289,14 +289,14 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) c
   mempty  = panic Nothing "mempty: RTProp"
   mappend = (<>)
 
-instance Meet (RTProp RTyCon RTyVar (UReft Reft))
+instance Meet (RTProp RTyCon RTyVar UReft)
 instance Meet (RTProp RTyCon RTyVar NoReft)
-instance Meet (RTProp BTyCon BTyVar (UReft Reft))
+instance Meet (RTProp BTyCon BTyVar UReft)
 instance Meet (RTProp BTyCon BTyVar NoReft)
 instance Meet (RTProp RTyCon RTyVar Reft)
 
 instance Semigroup (RType RTyCon RTyVar r) => Meet (RType RTyCon RTyVar r) where
-instance Meet (RType BTyCon BTyVar (UReft Reft))
+instance Meet (RType BTyCon BTyVar UReft)
 
 -- MOVE TO TYPES
 instance Fixpoint String where
@@ -465,7 +465,7 @@ gApp tc αs πs = rApp tc
                   (rPropP [] . pdVarReft <$> πs)
                   mempty
 
-pdVarReft :: PVar t -> UReft Reft
+pdVarReft :: PVar t -> UReft
 pdVarReft = (\p -> MkUReft mempty p) . pdVar
 
 tyConRTyCon :: TyCon -> RTyCon
@@ -1240,7 +1240,7 @@ instance SubsTy RTyVar RSort RSort where
 instance SubsTy tv RSort Predicate where
   subt _ = id -- NV TODO
 
-instance (SubsTy tv ty r) => SubsTy tv ty (UReft r) where
+instance SubsTy tv ty Reft => SubsTy tv ty UReft where
   subt su r = r {ur_reft = subt su $ ur_reft r}
 
 -- Here the "String" is a Bare-TyCon. TODO: wrap in newtype
@@ -1250,11 +1250,11 @@ instance SubsTy BTyVar BSort BTyCon where
 instance SubsTy BTyVar BSort BSort where
   subt (α, τ) = subsTyVarMeet (α, τ, ofRSort τ)
 
-instance (SubsTy tv ty (UReft r), SubsTy tv ty (RType c tv NoReft)) => SubsTy tv ty (RTProp c tv (UReft r))  where
+instance (SubsTy tv ty UReft, SubsTy tv ty (RType c tv NoReft)) => SubsTy tv ty (RTProp c tv UReft)  where
   subt m (RProp ss (RHole p)) = RProp (fmap (subt m) <$> ss) $ RHole $ subt m p
   subt m (RProp ss t) = RProp (fmap (subt m) <$> ss) $ fmap (subt m) t
 
-subvUReft     :: (UsedPVar -> UsedPVar) -> UReft Reft -> UReft Reft
+subvUReft     :: (UsedPVar -> UsedPVar) -> UReft -> UReft
 subvUReft f (MkUReft r p) = MkUReft r (subvPredicate f p)
 
 subvPredicate :: (UsedPVar -> UsedPVar) -> Predicate -> Predicate
@@ -1491,23 +1491,23 @@ appSolRefa si s = mapKVars f0
 
 --------------------------------------------------------------------------------
 -- shiftVV :: Int -- SpecType -> Symbol -> SpecType
-shiftVV :: (TyConable c, IsReft (f Reft), Functor f, Subable (f Reft),
-            Variable (f Reft) ~ Variable Reft, ReftBind (f Reft) ~ ReftBind Reft)
-        => RType c tv (f Reft) -> Symbol -> RType c tv (f Reft)
+shiftVV :: (TyConable c, IsReft r, Subable r, Variable r ~ Symbol,
+            ReftBind r ~ Symbol, ReftVar r ~ Symbol)
+        => RType c tv r -> Symbol -> RType c tv r
 --------------------------------------------------------------------------------
 shiftVV t@(RApp _ ts rs r) vv'
   = t { rt_args  = subst1 ts (rTypeValueVar t, EVar vv') }
       { rt_pargs = subst1 rs (rTypeValueVar t, EVar vv') }
-      { rt_reft  = (`F.shiftVV` vv') <$> r }
+      { rt_reft  = mapReftField (`F.shiftVV` vv') r }
 
 shiftVV t@(RFun _ _ _ _ r) vv'
-  = t { rt_reft = (`F.shiftVV` vv') <$> r }
+  = t { rt_reft = mapReftField (`F.shiftVV` vv') r }
 
 shiftVV t@(RAppTy _ _ r) vv'
-  = t { rt_reft = (`F.shiftVV` vv') <$> r }
+  = t { rt_reft = mapReftField (`F.shiftVV` vv') r }
 
 shiftVV t@(RVar _ r) vv'
-  = t { rt_reft = (`F.shiftVV` vv') <$> r }
+  = t { rt_reft = mapReftField (`F.shiftVV` vv') r }
 
 shiftVV t _
   = t -- errorstar $ "shiftVV: cannot handle " ++ showpp t
@@ -1707,8 +1707,8 @@ isDecreasing _ _ _
 
 makeDecrType :: Symbolic a
              => S.HashSet TyCon
-             -> Maybe (a, (Symbol, RType RTyCon t (UReft Reft)))
-             -> Either (Symbol, RType RTyCon t (UReft Reft)) String
+             -> Maybe (a, (Symbol, RType RTyCon t UReft))
+             -> Either (Symbol, RType RTyCon t UReft) String
 makeDecrType autoenv (Just (v, (x, t)))
   = Left (x, t `strengthen` tr)
   where
@@ -1741,7 +1741,7 @@ cmpLexRef (v, x, g)
   = pAnd [PAtom Lt (g x) (g v), PAtom Ge (g x) zero]
   where zero = ECon $ I 0
 
-makeLexRefa :: [Located Expr] -> [Located Expr] -> UReft Reft
+makeLexRefa :: [Located Expr] -> [Located Expr] -> UReft
 makeLexRefa es' es = uTop $ Reft (vv', PIff (EVar vv') $ pOr rs)
   where
     rs  = makeLexReft [] [] (val <$> es) (val <$> es')

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -103,7 +103,6 @@ import           Data.Hashable
 import qualified Data.HashMap.Strict  as M
 import qualified Data.HashSet         as S
 import qualified Data.List as L
-import           Control.Monad  (void)
 import           Text.Printf
 import           Text.PrettyPrint.HughesPJ hiding ((<>), first)
 import           Language.Fixpoint.Misc
@@ -187,7 +186,7 @@ uRTypeGen       :: IsReft b => RType c tv a -> RType c tv b
 uRTypeGen       = fmap $ const trueReft
 
 uPVar           :: PVarV v t -> UsedPVarV v
-uPVar           = void
+uPVar           = fmap (const NoReft)
 
 uReft           :: (Symbol, Expr) -> UReft Reft
 uReft           = uTop . Reft

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -663,7 +663,7 @@ quantifyFreeRTy ty = quantifyRTy (freeTyVars ty) ty
 
 
 -------------------------------------------------------------------------
-addTyConInfo :: (PPrint r, ToReft r, SubsTy RTyVar RSort r, Variable r ~ Symbol, ReftBind r ~ Symbol, ReftVar r ~ Symbol, IsReft r, Meet r)
+addTyConInfo :: (PPrint r, IsReft r, SubsTy RTyVar RSort r, Variable r ~ Symbol, ReftBind r ~ Symbol, ReftVar r ~ Symbol, IsReft r, Meet r)
              => TCEmb TyCon
              -> TyConMap
              -> RRType r
@@ -672,7 +672,7 @@ addTyConInfo :: (PPrint r, ToReft r, SubsTy RTyVar RSort r, Variable r ~ Symbol,
 addTyConInfo tce tyi = mapBot (expandRApp tce tyi)
 
 -------------------------------------------------------------------------
-expandRApp :: (PPrint r, ToReft r, SubsTy RTyVar RSort r, Variable r ~ Symbol, ReftBind r ~ Symbol, ReftVar r ~ Symbol, IsReft r, Meet r)
+expandRApp :: (PPrint r, IsReft r, SubsTy RTyVar RSort r, Variable r ~ Symbol, ReftBind r ~ Symbol, ReftVar r ~ Symbol, IsReft r, Meet r)
            => TCEmb TyCon -> TyConMap -> RRType r -> RRType r
 -------------------------------------------------------------------------
 expandRApp tce tyi t@RApp{} = RApp rc' ts rs' r
@@ -892,7 +892,7 @@ tyClasses t               = panic Nothing ("RefType.tyClasses cannot handle" ++ 
 --------------------------------------------------------------------------------
 
 subsTyVarsMeet
-  :: (Eq tv, Foldable t, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
+  :: (Eq tv, Foldable t, Hashable tv, IsReft r, Eq (ReftVar r), TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -901,7 +901,7 @@ subsTyVarsMeet
 subsTyVarsMeet        = subsTyVars True
 
 subsTyVarsNoMeet
-  :: (Eq tv, Foldable t, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
+  :: (Eq tv, Foldable t, Hashable tv, IsReft r, Eq (ReftVar r), TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -910,7 +910,7 @@ subsTyVarsNoMeet
 subsTyVarsNoMeet      = subsTyVars False
 
 subsTyVarNoMeet
-  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
+  :: (Eq tv, Hashable tv, IsReft r, Eq (ReftVar r), TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -919,7 +919,7 @@ subsTyVarNoMeet
 subsTyVarNoMeet       = subsTyVar False
 
 subsTyVarMeet
-  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
+  :: (Eq tv, Hashable tv, IsReft r, Eq (ReftVar r), TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -928,7 +928,7 @@ subsTyVarMeet
 subsTyVarMeet         = subsTyVar True
 
 subsTyVarMeet'
-  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
+  :: (Eq tv, Hashable tv, IsReft r, Eq (ReftVar r), TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -937,7 +937,7 @@ subsTyVarMeet'
 subsTyVarMeet' (α, t) = subsTyVarMeet (α, toRSort t, t)
 
 subsTyVars
-  :: (Eq tv, Foldable t, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
+  :: (Eq tv, Foldable t, Hashable tv, IsReft r, Eq (ReftVar r), TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -949,7 +949,7 @@ subsTyVars
 subsTyVars meet' ats t = foldl' (flip (subsTyVar meet')) t ats
 
 subsTyVar
-  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
+  :: (Eq tv, Hashable tv, IsReft r, Eq (ReftVar r), TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -961,7 +961,7 @@ subsTyVar
 subsTyVar meet'        = subsFree meet' S.empty
 
 subsFree
-  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
+  :: (Eq tv, Hashable tv, IsReft r, Eq (ReftVar r), TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -1000,7 +1000,7 @@ subsFree _ _ (α, τ, _) (RHole r)
   = RHole (subt (α, τ) r)
 
 subsFrees
-  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
+  :: (Eq tv, Hashable tv, IsReft r, Eq (ReftVar r), TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -1014,7 +1014,7 @@ subsFrees m s zs t = foldl' (flip (subsFree m s)) t zs
 
 -- GHC INVARIANT: RApp is Type Application to something other than TYCon
 subsFreeRAppTy
-  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
+  :: (Eq tv, Hashable tv, IsReft r, Eq (ReftVar r), TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)),
       FreeVar c tv,
@@ -1038,7 +1038,7 @@ subsFreeRAppTy _ _ t t' r'
 --    parameters come from the "levity polymorphism" changes in GHC 8.6 (?)
 --    See [NOTE:Levity-Polymorphism]
 
-mkRApp :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
+mkRApp :: (Eq tv, Hashable tv, IsReft r, Eq (ReftVar r), TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -1101,13 +1101,13 @@ mkRApp m s c ts rs r r'
        • and other links from https://stackoverflow.com/a/35320729/946226 (edited)
  -}
 
-refAppTyToFun :: IsReft r => r -> r
+refAppTyToFun :: (IsReft r, Eq (ReftVar r)) => r -> r
 refAppTyToFun r
   | isTauto r = r
   | otherwise = panic Nothing "RefType.refAppTyToFun"
 
 subsFreeRef
-  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
+  :: (Eq tv, Hashable tv, IsReft r, Eq (ReftVar r), TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -1373,7 +1373,7 @@ isBaseTy (CastTy _ _)     = False
 isBaseTy (CoercionTy _)   = False
 
 
-dataConMsReft :: (ToReft r, ReftBind r ~ v, ReftVar r ~ v, F.Refreshable v) => RTypeBV v v c tv r -> [v] -> ReftBV v v
+dataConMsReft :: (IsReft r, ReftBind r ~ v, ReftVar r ~ v, F.Refreshable v) => RTypeBV v v c tv r -> [v] -> ReftBV v v
 dataConMsReft ty ys  = subst su (rTypeReft (ignoreOblig $ ty_res trep))
   where
     trep = toRTypeRep ty

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -169,9 +169,9 @@ pdVar :: PVarV v t -> PredicateV v
 pdVar v  = Pr [uPVar v]
 
 findPVar :: [PVar (RType c tv NoReft)] -> UsedPVar -> PVar (RType c tv NoReft)
-findPVar ps upv = PV name ty v (zipWith (\(_, _, e) (t, s, _) -> (t, s, e)) (pargs upv) args)
+findPVar ps upv = PV name ty (zipWith (\(_, _, e) (t, s, _) -> (t, s, e)) (pargs upv) args)
   where
-    PV name ty v args = fromMaybe (msg upv) $ L.find ((== pname upv) . pname) ps
+    PV name ty args = fromMaybe (msg upv) $ L.find ((== pname upv) . pname) ps
     msg p = panic Nothing $ "RefType.findPVar" ++ showpp p ++ "not found"
 
 -- | Various functions for converting vanilla `Reft` to `Spec`
@@ -1215,7 +1215,7 @@ instance SubsTy RTyVar RSort Sort where
   subt _ s          = s
 
 instance (SubsTy tv ty ty) => SubsTy tv ty (PVarBV b v ty) where
-  subt su (PV n pvk v xts) = PV n (subt su pvk) v [(subt su t, x, y) | (t,x,y) <- xts]
+  subt su (PV n pvk xts) = PV n (subt su pvk) [(subt su t, x, y) | (t,x,y) <- xts]
 
 instance SubsTy RTyVar RSort RTyCon where
    subt z c = RTyCon tc ps' i

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -209,6 +209,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTypeBV v v c tv (NoReftB v
          , F.Variable r ~ v
          , ReftBind r ~ v
          , IsReft r
+         , Meet r
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) r
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) tv
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTVar tv (RTypeBV v v c tv (NoReftB v)))
@@ -225,6 +226,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTypeBV v v c tv (NoReftB v
          , F.Variable r ~ v
          , ReftBind r ~ v
          , IsReft r
+         , Meet r
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) r
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) tv
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTVar tv (RTypeBV v v c tv (NoReftB v)))
@@ -238,6 +240,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) c
          , Variable r ~ v
          , ReftBind r ~ v
          , IsReft r
+         , Meet r
          , FreeVar c tv
          , Subable r
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) r
@@ -263,6 +266,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) c
          , Variable r ~ v
          , ReftBind r ~ v
          , IsReft r
+         , Meet r
          , FreeVar c tv
          , Subable r
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) r
@@ -278,6 +282,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) c
          , Variable r ~ v
          , ReftBind r ~ v
          , IsReft r
+         , Meet r
          , FreeVar c tv
          , Subable r
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) r
@@ -521,6 +526,7 @@ strengthenRefTypeGen, strengthenRefType ::
          , F.Variable r ~ v
          , ReftBind r ~ v
          , IsReft r
+         , Meet r
          , FreeVar c tv
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTypeBV v v c tv (NoReftB v))
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) c
@@ -535,6 +541,7 @@ strengthenRefType_ ::
          , F.Variable r ~ v
          , ReftBind r ~ v
          , IsReft r
+         , Meet r
          , FreeVar c tv
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTypeBV v v c tv (NoReftB v))
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) c
@@ -546,7 +553,7 @@ strengthenRefType_ ::
 
 strengthenRefTypeGen = strengthenRefType_ f
   where
-    f :: (OkRTBV v v c tv r, IsReft r) => RTypeBV v v c tv r -> RTypeBV v v c tv r -> RTypeBV v v c tv r
+    f :: (OkRTBV v v c tv r, IsReft r, Meet r) => RTypeBV v v c tv r -> RTypeBV v v c tv r -> RTypeBV v v c tv r
     f (RVar v1 r1) t  = RVar v1 (r1 `meet` fromMaybe trueReft (stripRTypeBase t))
     f t (RVar _ r1)  = t `strengthen` r1
     f t1 t2           = panic Nothing $ printf "strengthenRefTypeGen on differently shaped types \nt1 = %s [shape = %s]\nt2 = %s [shape = %s]"
@@ -656,7 +663,7 @@ quantifyFreeRTy ty = quantifyRTy (freeTyVars ty) ty
 
 
 -------------------------------------------------------------------------
-addTyConInfo :: (PPrint r, ToReft r, SubsTy RTyVar RSort r, Variable r ~ Symbol, ReftBind r ~ Symbol, ReftVar r ~ Symbol, IsReft r)
+addTyConInfo :: (PPrint r, ToReft r, SubsTy RTyVar RSort r, Variable r ~ Symbol, ReftBind r ~ Symbol, ReftVar r ~ Symbol, IsReft r, Meet r)
              => TCEmb TyCon
              -> TyConMap
              -> RRType r
@@ -665,7 +672,7 @@ addTyConInfo :: (PPrint r, ToReft r, SubsTy RTyVar RSort r, Variable r ~ Symbol,
 addTyConInfo tce tyi = mapBot (expandRApp tce tyi)
 
 -------------------------------------------------------------------------
-expandRApp :: (PPrint r, ToReft r, SubsTy RTyVar RSort r, Variable r ~ Symbol, ReftBind r ~ Symbol, ReftVar r ~ Symbol, IsReft r)
+expandRApp :: (PPrint r, ToReft r, SubsTy RTyVar RSort r, Variable r ~ Symbol, ReftBind r ~ Symbol, ReftVar r ~ Symbol, IsReft r, Meet r)
            => TCEmb TyCon -> TyConMap -> RRType r -> RRType r
 -------------------------------------------------------------------------
 expandRApp tce tyi t@RApp{} = RApp rc' ts rs' r
@@ -697,14 +704,14 @@ rtPropTop
    => PVar (RType c tv NoReft) -> Ref (RType c tv NoReft) (RType c tv r)
 rtPropTop pv = RProp (pvArgs pv) $ ofRSort $ ptype pv
 
-rtPropPV :: (Fixpoint a, IsReft r)
+rtPropPV :: (Fixpoint a, IsReft r, Meet r)
          => a
          -> [PVar (RType c tv NoReft)]
          -> [Ref (RType c tv NoReft) (RType c tv r)]
          -> [Ref (RType c tv NoReft) (RType c tv r)]
 rtPropPV _rc = zipWith mkRTProp
 
-mkRTProp :: IsReft r
+mkRTProp :: (IsReft r, Meet r)
          => PVar (RType c tv NoReft)
          -> Ref (RType c tv NoReft) (RType c tv r)
          -> Ref (RType c tv NoReft) (RType c tv r)
@@ -885,7 +892,7 @@ tyClasses t               = panic Nothing ("RefType.tyClasses cannot handle" ++ 
 --------------------------------------------------------------------------------
 
 subsTyVarsMeet
-  :: (Eq tv, Foldable t, Hashable tv, IsReft r, TyConable c, Binder b,
+  :: (Eq tv, Foldable t, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -894,7 +901,7 @@ subsTyVarsMeet
 subsTyVarsMeet        = subsTyVars True
 
 subsTyVarsNoMeet
-  :: (Eq tv, Foldable t, Hashable tv, IsReft r, TyConable c, Binder b,
+  :: (Eq tv, Foldable t, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -903,7 +910,7 @@ subsTyVarsNoMeet
 subsTyVarsNoMeet      = subsTyVars False
 
 subsTyVarNoMeet
-  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b,
+  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -912,7 +919,7 @@ subsTyVarNoMeet
 subsTyVarNoMeet       = subsTyVar False
 
 subsTyVarMeet
-  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b,
+  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -921,7 +928,7 @@ subsTyVarMeet
 subsTyVarMeet         = subsTyVar True
 
 subsTyVarMeet'
-  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b,
+  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -930,7 +937,7 @@ subsTyVarMeet'
 subsTyVarMeet' (α, t) = subsTyVarMeet (α, toRSort t, t)
 
 subsTyVars
-  :: (Eq tv, Foldable t, Hashable tv, IsReft r, TyConable c, Binder b,
+  :: (Eq tv, Foldable t, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -942,7 +949,7 @@ subsTyVars
 subsTyVars meet' ats t = foldl' (flip (subsTyVar meet')) t ats
 
 subsTyVar
-  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b,
+  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -954,7 +961,7 @@ subsTyVar
 subsTyVar meet'        = subsFree meet' S.empty
 
 subsFree
-  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b,
+  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -993,7 +1000,7 @@ subsFree _ _ (α, τ, _) (RHole r)
   = RHole (subt (α, τ) r)
 
 subsFrees
-  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b,
+  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -1007,7 +1014,7 @@ subsFrees m s zs t = foldl' (flip (subsFree m s)) t zs
 
 -- GHC INVARIANT: RApp is Type Application to something other than TYCon
 subsFreeRAppTy
-  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b,
+  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)),
       FreeVar c tv,
@@ -1031,7 +1038,7 @@ subsFreeRAppTy _ _ t t' r'
 --    parameters come from the "levity polymorphism" changes in GHC 8.6 (?)
 --    See [NOTE:Levity-Polymorphism]
 
-mkRApp :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b,
+mkRApp :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
@@ -1100,7 +1107,7 @@ refAppTyToFun r
   | otherwise = panic Nothing "RefType.refAppTyToFun"
 
 subsFreeRef
-  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b,
+  :: (Eq tv, Hashable tv, IsReft r, TyConable c, Binder b, Meet r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -427,7 +427,7 @@ data Spec lname ty = Spec
   , usedDataCons :: S.HashSet LHName                                  -- ^ Data constructors used in specs
   } deriving (Data, Generic)
 
-instance (F.PPrint lname, F.PPrint ty, F.Fixpoint lname, Ord lname) => F.PPrint (Spec lname ty) where
+instance (F.PPrint ty) => F.PPrint (Spec F.Symbol ty) where
     pprintTidy k sp = text "dataDecls = " <+> pprintTidy k  (dataDecls sp)
                          HughesPJ.$$
                       text "classes = " <+> pprintTidy k (classes sp)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -440,7 +440,7 @@ deriving instance Show BareSpec
 --
 --
 emapSpecM
-  :: (Monad m, Ord lname0)
+  :: (Monad m, F.Fixpoint lname0)
   =>
      -- | The bscope setting, which affects which names
      -- are considered to be in scope in refinement types.

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -440,7 +440,7 @@ deriving instance Show BareSpec
 --
 --
 emapSpecM
-  :: (Monad m, F.Fixpoint lname0)
+  :: Monad m
   =>
      -- | The bscope setting, which affects which names
      -- are considered to be in scope in refinement types.

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Specs.hs
@@ -427,7 +427,7 @@ data Spec lname ty = Spec
   , usedDataCons :: S.HashSet LHName                                  -- ^ Data constructors used in specs
   } deriving (Data, Generic)
 
-instance (F.PPrint lname, F.PPrint ty, PredicateCompat F.Symbol lname, F.Fixpoint lname, Ord lname) => F.PPrint (Spec lname ty) where
+instance (F.PPrint lname, F.PPrint ty, F.Fixpoint lname, Ord lname) => F.PPrint (Spec lname ty) where
     pprintTidy k sp = text "dataDecls = " <+> pprintTidy k  (dataDecls sp)
                          HughesPJ.$$
                       text "classes = " <+> pprintTidy k (classes sp)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -986,7 +986,7 @@ isHole :: Expr -> Bool
 isHole (F.PKVar "HOLE" _ _) = True
 isHole _                    = False
 
-hasHole :: (ToReft r, ReftBind r ~ Symbol, ReftVar r ~ Symbol) => r -> Bool
+hasHole :: (IsReft r, ReftBind r ~ Symbol, ReftVar r ~ Symbol) => r -> Bool
 hasHole = any isHole . F.conjuncts . F.reftPred . toReft
 
 instance F.Symbolic DataCon where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Annotate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Annotate.hs
@@ -126,7 +126,7 @@ doGenerate cfg tplAnnMap typAnnMap annTyp srcF
        jsonF      = extFileName Json  srcF
        vimF       = extFileName Vim   srcF
 
-mkBots :: ToReft r => AnnInfo (RType c tv r) -> [GHC.SrcSpan]
+mkBots :: IsReft r => AnnInfo (RType c tv r) -> [GHC.SrcSpan]
 mkBots (AI m) = [ src | (src, (Just _, t) : _) <- sortBy (ordSrcSpan `on` fst) $ M.toList m
                       , isFalse (rTypeReft t) ]
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Tidy.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Tidy.hs
@@ -179,7 +179,7 @@ tyVars (RHole _)         = []
 
 subsTyVarsAll
   :: (Eq k, Hashable k,
-      IsReft r, Meet r, TyConable c, SubsTy k (RType c k NoReft) c,
+      IsReft r, Meet r, Eq (ReftVar r), TyConable c, SubsTy k (RType c k NoReft) c,
       SubsTy k (RType c k NoReft) r,
       SubsTy k (RType c k NoReft) k,
       SubsTy k (RType c k NoReft) (RType c k NoReft),

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Tidy.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Tidy.hs
@@ -179,7 +179,7 @@ tyVars (RHole _)         = []
 
 subsTyVarsAll
   :: (Eq k, Hashable k,
-      IsReft r, TyConable c, SubsTy k (RType c k NoReft) c,
+      IsReft r, Meet r, TyConable c, SubsTy k (RType c k NoReft) c,
       SubsTy k (RType c k NoReft) r,
       SubsTy k (RType c k NoReft) k,
       SubsTy k (RType c k NoReft) (RType c k NoReft),

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/WiredIn.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/WiredIn.hs
@@ -194,8 +194,8 @@ listTyDataCons   = ( [TyConP l0 c [RTV tyv] [p] [Covariant] [Covariant] (Just fs
       fld        = "fldList"
       xHead      = "head"
       xTail      = "tail"
-      p          = PV "p" t (F.vv Nothing) [(t, fld, F.EVar fld)]
-      px         = pdVarReft $ PV "p" t (F.vv Nothing) [(t, fld, F.EVar xHead)]
+      p          = PV "p" t [(t, fld, F.EVar fld)]
+      px         = pdVarReft $ PV "p" t [(t, fld, F.EVar xHead)]
       lt         = rApp c [xt] [rPropP [] $ pdVarReft p] mempty
       xt         = rVar tyv
       xst        = rApp c [RVar (RTV tyv) px] [rPropP [] $ pdVarReft p] mempty
@@ -244,7 +244,7 @@ mkps_ :: [F.Symbol]
 mkps_ []     _       _          _    ps = ps
 mkps_ (n:ns) (t:ts) ((f, x):xs) args ps = mkps_ ns ts xs (a:args) (p:ps)
   where
-    p                                   = PV n t (F.vv Nothing) args
+    p                                   = PV n t args
     a                                   = (t, f, x)
 mkps_ _     _       _          _    _ = panic Nothing "Bare : mkps_"
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/WiredIn.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/WiredIn.hs
@@ -48,7 +48,6 @@ import qualified Language.Fixpoint.Types as F
 import           Data.Bifunctor (first)
 import qualified Data.HashSet as S
 import           Data.Maybe
-import           Data.Proxy
 
 import Language.Haskell.Liquid.GHC.TypeRep ()
 
@@ -85,7 +84,7 @@ dcPrefix = "lqdc"
 wiredSortedSyms :: [(F.Symbol, F.Sort)]
 wiredSortedSyms =
     (selfSymbol,selfSort) :
-    [(pappV (Proxy :: Proxy F.Symbol) n, pappSort n) | n <- [1..pappArity]] ++
+    [(pappV n, pappSort n) | n <- [1..pappArity]] ++
     wiredTheorySortedSyms
   where
     selfSort = F.FAbs 1 (F.FVar 0)


### PR DESCRIPTION
`r` parameter of RTypes is now constrained to be only one of three types.

It can be `NoReftBV b v`, or `ReftBV b v`, or `UReftBV b v`. This allows to do
case analysis on `r` values when they are polymorphic.

In order to make the instantiation assumption explicit, the `IsReft` type class
has earned methods that allow to cast between `r` and these types.

The PR does some clean up of type classes and fields to make the transition to
use the new methods.
* The `ToReft` class has been eliminated.
* `IsReft` is used instead of `ToReft`.
* Instances of `ToReft` and `IsReft` other than the identified three types have been removed.
* `UReftBV` does not have an `r` parameter anymore.
* `PVar` does not have the `parg` field anymore.
* The `PredicateCompat` class is gone.

Supports #2676