### PR TITLE
Implement flag --allocs to plot allocations in benchmark comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The `-f` and `-s` options can be used/omitted independently. If both are omitted
 will be produced covering the full input test set. Additionally, their effects can be combined by providing a third `-c`
 option (this  will produce 2 files `filtered-top.svg` and `filtered-bot.svg` instead of 3). An optional key `-o` can be
 supplied to specify an output directory for the generated files.
+The `--allocs` flag produces charts for the memory allocations instead of time.
 
 There is also a legacy script `scripts/plot-performance/chart_perf.sh` that can be used to generate comparison charts
 in both `svg` and `png` formats. It requires [gnuplot](http://www.gnuplot.info/) to run and assumes both files contain

--- a/benchmark-timings/app/Main.hs
+++ b/benchmark-timings/app/Main.hs
@@ -32,6 +32,7 @@ instance FromJSON Phase
 data PhasesSummary = PhasesSummary
   { test :: String
   , time :: Double
+  , allocs :: Double
   , result :: Bool
   } deriving stock (Eq, Ord, Show, Generic)
 
@@ -89,8 +90,10 @@ program Options {..} = do
       (originalFilename, _):_ -> do
         Just (phases :: [Phase]) <- decodeFileStrict' fp
         let time = foldl' (+) 0 [ phaseTime p | p <- phases, elem (init (phaseName p)) optsPhasesToCount ]
+            allocs = foldl' (+) 0 [ phaseAlloc p | p <- phases, elem (init (phaseName p)) optsPhasesToCount ]
         -- convert milliseconds -> seconds
-        pure . Just $ PhasesSummary originalFilename (time / 1000) True
+        -- convert bytes -> megabytes
+        pure . Just $ PhasesSummary originalFilename (time / 1000) (fromIntegral allocs / 1000000) True
       _ ->
         error $ "can't parse: " ++ show fp
   let csvData = encodeDefaultOrderedByNameWith (defaultEncodeOptions { encUseCrLf = False }) $ catMaybes csvFields

--- a/scripts/benchmark-comparison.sh
+++ b/scripts/benchmark-comparison.sh
@@ -13,7 +13,7 @@ clean_run_collect() {
     local run_label="$1"  # "before" or "after"
     echo "Running benchmarks for $run_label branch..."
     find dist-newstyle -name "tests-*" -o -name "prover-ple-lib-*" | xargs rm -rf
-    ./scripts/test/test_plugin.sh --measure-timings-j1
+    ./scripts/test/test_plugin.sh --measure-timings
     rm -rf tmp tmp-${run_label}
     cabal build ghc-timings
     cabal exec ghc-timings dist-newstyle
@@ -31,4 +31,4 @@ echo "Checking out AFTER branch: $AFTER_BRANCH"
 git checkout "$AFTER_BRANCH"
 git submodule update --init --recursive
 
-cabal run plot-performance -- -b summary-before.csv -a summary-after.csv -s 50
+cabal run plot-performance -- --allocs -b summary-before.csv -a summary-after.csv -s 50

--- a/scripts/plot-performance/app/Benchmark.hs
+++ b/scripts/plot-performance/app/Benchmark.hs
@@ -100,8 +100,10 @@ hiBenchmarks :: (Benchmark -> Double) -> Int -> BenchmarkComparison -> Benchmark
 hiBenchmarks f n bc =
     bc { bcCombined =
            L.take n
-           $ filter (\(bt, _) -> test bt `notElem` (map fst $ bcWarnings bc))
-           $ sortOn (\(bt, at) -> f at - f bt) (bcCombined bc)
+           $ sortOn (\(bt, at) -> (f at - f bt) / f bt)
+           $ filter
+               (\(bt, _) -> test bt `notElem` map fst (bcWarnings bc))
+               (bcCombined bc)
        }
 
 -- | Sort the benchmarks by the difference in the given field, and take the bottom
@@ -110,6 +112,8 @@ loBenchmarks :: (Benchmark -> Double) -> Int -> BenchmarkComparison -> Benchmark
 loBenchmarks f n bc =
     bc { bcCombined =
            L.take n
-           $ filter (\(bt, _) -> test bt `notElem` (map fst $ bcWarnings bc))
-           $ sortOn (\(bt, at) -> f bt - f at) (bcCombined bc)
+           $ sortOn (\(bt, at) -> (f bt - f at) / f bt)
+           $ filter
+               (\(bt, _) -> test bt `notElem` map fst (bcWarnings bc))
+               (bcCombined bc)
        }

--- a/scripts/plot-performance/app/Benchmark.hs
+++ b/scripts/plot-performance/app/Benchmark.hs
@@ -9,7 +9,8 @@ module Benchmark where
 import Prelude hiding (readFile, writeFile, filter, zip, lookup)
 import Data.String (fromString)
 import Data.List as L
-import Data.Vector as V hiding (length, concat, null, (++), last, find)
+import Data.Vector (Vector)
+import qualified Data.Vector as V
 import qualified Data.Map.Strict as Map
 import Data.ByteString.Char8 (unpack)
 import Data.ByteString.Lazy.Char8 (readFile, writeFile)
@@ -18,11 +19,16 @@ import Data.Csv hiding (Options, Parser, lookup)
 
 -- Individual entries
 
+-- | A single benchmark entry
 data Benchmark = Benchmark
-  { test :: String
-  , time :: Double
-  , result :: Bool
+  { test :: String   -- ^ test name
+  , time :: Double   -- ^ time in seconds
+  , allocs :: Double -- ^ allocations in MBs
+  , result :: Bool   -- ^ whether the test passed or failed
   } deriving stock (Eq, Ord, Show, Generic)
+
+zeroBenchmark :: Benchmark -> Benchmark
+zeroBenchmark b = b { time = 0, allocs = 0 }
 
 instance FromField Bool where
   parseField = pure . read . unpack
@@ -34,6 +40,7 @@ instance FromNamedRecord Benchmark where
     parseNamedRecord m = Benchmark
                          <$> m .: "test"
                          <*> m .: "time"
+                         <*> m .: "allocs"
                          <*> m .: "result"
 
 instance ToNamedRecord Benchmark
@@ -52,8 +59,6 @@ writeCSV f dat = do
 
 -- Data sets
 
-type BData = Double
-
 data BenchmarkWarning
     = MissingMeasureAfter
     | MissingMeasureBefore
@@ -64,14 +69,14 @@ data BenchmarkComparison = BenchmarkComparison
     { -- | Warnings for tests with the given labels
       bcWarnings :: [(String, BenchmarkWarning)]
       -- | Data of benchmars present in both sets
-    , bcCombined :: [(String, (BData, BData))]
+    , bcCombined :: [(Benchmark, Benchmark)]
     }
 
 bcLen :: BenchmarkComparison -> Int
 bcLen bc = length (bcCombined bc) + warningsLength bc
-
-warningsLength :: BenchmarkComparison -> Int
-warningsLength bc = length (bcWarnings bc)
+  where
+    warningsLength :: BenchmarkComparison -> Int
+    warningsLength = length . bcWarnings
 
 compareBenchmarks :: Vector Benchmark -> Vector Benchmark -> BenchmarkComparison
 compareBenchmarks v1 v2 = BenchmarkComparison
@@ -81,23 +86,30 @@ compareBenchmarks v1 v2 = BenchmarkComparison
         , Map.map (const MissingMeasureBefore) (Map.difference after before)
         , Map.map (const MissingMeasureAfter) (Map.difference before after)
         ]
-    , bcCombined = Map.toList $
-        Map.unionWith (\(t0, _) (_, t1) -> (t0, t1)) before after
+    , bcCombined = Map.elems $ Map.unionWith (\(a, _) (_, b) -> (a, b)) before after
     }
   where
     (vBefore, failedBefore) = V.partition result v1
     (vAfter, failedAfter) = V.partition result v2
-    before = Map.fromList [ (test b, (time b, 0)) | b <- V.toList vBefore]
-    after = Map.fromList [ (test b, (0, time b)) | b <- V.toList vAfter]
+    before = Map.fromList [ (test b, (b, zeroBenchmark b)) | b <- V.toList vBefore]
+    after = Map.fromList [ (test b, (zeroBenchmark b, b)) | b <- V.toList vAfter]
 
-hiBenchmarks :: Int -> BenchmarkComparison -> BenchmarkComparison
-hiBenchmarks n bc =
+-- | Sort the benchmarks by the difference in the given field, and take the top
+-- N (after removing warnings)
+hiBenchmarks :: (Benchmark -> Double) -> Int -> BenchmarkComparison -> BenchmarkComparison
+hiBenchmarks f n bc =
     bc { bcCombined =
-           L.take (n - warningsLength bc) $ sortOn (\(_, (bt, at)) -> at - bt) (bcCombined bc)
+           L.take n
+           $ filter (\(bt, _) -> test bt `notElem` (map fst $ bcWarnings bc))
+           $ sortOn (\(bt, at) -> f at - f bt) (bcCombined bc)
        }
 
-loBenchmarks :: Int -> BenchmarkComparison -> BenchmarkComparison
-loBenchmarks n bc =
+-- | Sort the benchmarks by the difference in the given field, and take the bottom
+-- N (after removing warnings)
+loBenchmarks :: (Benchmark -> Double) -> Int -> BenchmarkComparison -> BenchmarkComparison
+loBenchmarks f n bc =
     bc { bcCombined =
-           L.take (n - warningsLength bc) $ sortOn (\(_, (bt, at)) -> bt - at) (bcCombined bc)
+           L.take n
+           $ filter (\(bt, _) -> test bt `notElem` (map fst $ bcWarnings bc))
+           $ sortOn (\(bt, at) -> f bt - f at) (bcCombined bc)
        }

--- a/scripts/plot-performance/app/Main.hs
+++ b/scripts/plot-performance/app/Main.hs
@@ -19,6 +19,7 @@ data Options = Options
   , optsAfterFile :: FilePath
   , optsCombine :: Bool
   , optsSort :: Maybe Int
+  , optsAllocs :: Bool
   , optsFilter :: [String]
   , optsOutputDir :: Maybe FilePath
   } deriving stock (Eq, Ord, Show)
@@ -40,6 +41,8 @@ options = Options <$>
                 <> short 's'
                 <> metavar "N"
                 <> help "Generate two graphs for top and bottom N differences."))
+  <*> switch (long "allocs"
+              <> help "Compare allocations instead of time." )
   <*> (concat <$> many (option (words <$> str) (long "filter"
                                                  <> short 'f'
                                                  <> metavar "FILTER"
@@ -67,6 +70,8 @@ main = do op <- execParser opts
           let isSelectedTest b = Prelude.any (`isPrefixOf` test b) (optsFilter op)
               selectTests = V.filter isSelectedTest
               dropAppMain = V.filter (\b -> test b /= "app/Main")
+              dataSelector = if optsAllocs op then allocs else time
+              mkTitle s = if optsAllocs op then s ++ " (MBs)" else s ++ " (seconds)"
 
           vb <- dropAppMain <$> readCSV (optsBeforeFile op)
           va <- dropAppMain <$> readCSV (optsAfterFile op)
@@ -74,27 +79,27 @@ main = do op <- execParser opts
           case (optsSort op, null $ optsFilter op, optsCombine op) of
             (Just n , False, True ) ->
               let bdsf = compareBenchmarks (selectTests vb) (selectTests va)
-                  hif = hiBenchmarks n bdsf
-                  lof = loBenchmarks n bdsf
-              in do chartToFile "Top filtered speedups (seconds)" hif (outdir ++ "filtered-top.svg")
-                    chartToFile "Top filtered slowdowns (seconds)" lof (outdir ++ "filtered-bot.svg")
+                  hif = hiBenchmarks dataSelector n bdsf
+                  lof = loBenchmarks dataSelector n bdsf
+              in do chartToFile (mkTitle "Top filtered speedups") dataSelector hif (outdir ++ "filtered-top.svg")
+                    chartToFile (mkTitle "Top filtered slowdowns") dataSelector lof (outdir ++ "filtered-bot.svg")
             (Just n , False, False) ->
               let bds = compareBenchmarks vb va
                   bdsf = compareBenchmarks (selectTests vb) (selectTests va)
-                  hi = hiBenchmarks n bds
-                  lo = loBenchmarks n bds
-              in do chartToFile ("Perf diff: " ++ show (optsFilter op) ++ " (seconds)") bdsf (outdir ++ "filtered.svg")
-                    chartToFile "Top speedups (seconds)" hi (outdir ++ "top.svg")
-                    chartToFile "Top slowdowns (seconds)" lo (outdir ++ "bot.svg")
+                  hi = hiBenchmarks dataSelector n bds
+                  lo = loBenchmarks dataSelector n bds
+              in do chartToFile (mkTitle $ "Perf diff: " ++ show (optsFilter op)) dataSelector bdsf (outdir ++ "filtered.svg")
+                    chartToFile (mkTitle "Top speedups") dataSelector hi (outdir ++ "top.svg")
+                    chartToFile (mkTitle "Top slowdowns") dataSelector lo (outdir ++ "bot.svg")
             (Just n , True , _    ) ->
               let bds = compareBenchmarks vb va
-                  hi = hiBenchmarks n bds
-                  lo = loBenchmarks n bds
-              in do chartToFile "Top speedups (seconds)" hi (outdir ++ "top.svg")
-                    chartToFile "Top slowdowns (seconds)" lo (outdir ++ "bot.svg")
+                  hi = hiBenchmarks dataSelector n bds
+                  lo = loBenchmarks dataSelector n bds
+              in do chartToFile (mkTitle "Top speedups") dataSelector hi (outdir ++ "top.svg")
+                    chartToFile (mkTitle "Top slowdowns") dataSelector lo (outdir ++ "bot.svg")
             (Nothing, False, _    ) ->
               let bdsf = compareBenchmarks (selectTests vb) (selectTests va)
-              in chartToFile "Perf diff (seconds)" bdsf (outdir ++ "filtered.svg")
+              in chartToFile (mkTitle "Perf diff") dataSelector bdsf (outdir ++ "filtered.svg")
             (Nothing, True , _    ) ->
               let bds = compareBenchmarks vb va
-              in do chartToFile "Perf" bds (outdir ++ "perf.svg")
+              in do chartToFile "Perf" dataSelector bds (outdir ++ "perf.svg")

--- a/scripts/plot-performance/app/Plot.hs
+++ b/scripts/plot-performance/app/Plot.hs
@@ -10,8 +10,13 @@ import Data.Colour.Names ( green, grey, red )
 
 import Benchmark
 
-chart :: String -> BenchmarkComparison -> Renderable (LayoutPick LogValue PlotIndex PlotIndex)
-chart title bds = layoutToRenderable layout
+-- | Generate a bar chart comparing two sets of benchmarks, with warnings.
+chart
+  :: String  -- ^ Title of the chart
+  -> (Benchmark -> Double) -- ^ Function to extract the value to compare (e.g. time or allocations)
+  -> BenchmarkComparison    -- ^ The benchmark comparison data
+  -> Renderable (LayoutPick LogValue PlotIndex PlotIndex)
+chart title f bds = layoutToRenderable layout
  where
   layout =
       -- title + legend
@@ -58,14 +63,14 @@ chart title bds = layoutToRenderable layout
       $ plot_bars_label_style . font_size .~ 15
       $ def
 
-  (lab, dat) = diffData bds
+  (lab, dat) = diffData f bds
 
   colors = map (\c -> (solidFillStyle $ withOpacity c 0.7, Nothing)) [grey, red, green]
 
-diffData :: BenchmarkComparison -> ([String], [[(LogValue, String)]])
-diffData bc = unzip $ concat
+diffData :: (Benchmark -> Double) -> BenchmarkComparison -> ([String], [[(LogValue, String)]])
+diffData f bc = unzip $ concat
     [ [ (l, warningData w) | (l, w) <- bcWarnings bc ]
-    , [ (l, mkPlotData a b) | (l, (a, b)) <- bcCombined bc ]
+    , [ (test a, mkPlotData (f a) (f b)) | (a, b) <- bcCombined bc ]
     ]
   where
   mkPlotData a b
@@ -104,12 +109,12 @@ heightHeuristic n | n < 10    = 8.0
                   | n < 577   = 13.0
                   | otherwise = 14.0
 
-chartToFile :: String -> BenchmarkComparison -> FilePath -> IO ()
-chartToFile title bds path =
+chartToFile :: String -> (Benchmark -> Double) -> BenchmarkComparison -> FilePath -> IO ()
+chartToFile title f bds path =
   do let len = bcLen bds
      let wh = (2048.0, 2.0 ** heightHeuristic len)
      let fo = FileOptions wh SVG loadSansSerifFonts
-     let plot = chart title bds
+     let plot = chart title f bds
      let cb = render plot wh
      putStrLn $ printf "Writing %s (%d entries, %.0fx%.0f)" path len (fst wh) (snd wh)
      _ <- cBackendToFile fo cb path


### PR DESCRIPTION
Allocations are more convenient to measure since they depend less on the load of the machine running benchmarks.

One of the nice things about it is that the benchmarks can then run in parallel, taking only a few minutes to measure the whole testsuite.

This PR implements an `--allocs` flag in `plot-performance` which switches all the charts to show allocations instead of time.