### PR TITLE
Implement capture avoiding substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The `-f` and `-s` options can be used/omitted independently. If both are omitted
 will be produced covering the full input test set. Additionally, their effects can be combined by providing a third `-c`
 option (this  will produce 2 files `filtered-top.svg` and `filtered-bot.svg` instead of 3). An optional key `-o` can be
 supplied to specify an output directory for the generated files.
+The `--allocs` flag produces charts for the memory allocations instead of time.
 
 There is also a legacy script `scripts/plot-performance/chart_perf.sh` that can be used to generate comparison charts
 in both `svg` and `png` formats. It requires [gnuplot](http://www.gnuplot.info/) to run and assumes both files contain

--- a/benchmark-timings/app/Main.hs
+++ b/benchmark-timings/app/Main.hs
@@ -32,6 +32,7 @@ instance FromJSON Phase
 data PhasesSummary = PhasesSummary
   { test :: String
   , time :: Double
+  , allocs :: Double
   , result :: Bool
   } deriving stock (Eq, Ord, Show, Generic)
 
@@ -89,8 +90,10 @@ program Options {..} = do
       (originalFilename, _):_ -> do
         Just (phases :: [Phase]) <- decodeFileStrict' fp
         let time = foldl' (+) 0 [ phaseTime p | p <- phases, elem (init (phaseName p)) optsPhasesToCount ]
+            allocs = foldl' (+) 0 [ phaseAlloc p | p <- phases, elem (init (phaseName p)) optsPhasesToCount ]
         -- convert milliseconds -> seconds
-        pure . Just $ PhasesSummary originalFilename (time / 1000) True
+        -- convert bytes -> megabytes
+        pure . Just $ PhasesSummary originalFilename (time / 1000) (fromIntegral allocs / 1000000) True
       _ ->
         error $ "can't parse: " ++ show fp
   let csvData = encodeDefaultOrderedByNameWith (defaultEncodeOptions { encUseCrLf = False }) $ catMaybes csvFields

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Check.hs
@@ -581,7 +581,7 @@ checkRType bsc emb senv lt =
     insertPEnv p γ     = insertsSEnv γ (fmap (rTypeSortedReft emb) <$> pbinds p)
     pbinds p           = (pname p, pvarRType p :: RSort) : [(x, tx) | (tx, x, _) <- pargs p]
 
-tyToBind :: F.TCEmb TyCon -> RTVar RTyVar RSort  -> [(F.Symbol, F.SortedReft)]
+tyToBind :: F.TCEmb TyCon -> SpecRTVar -> [(F.Symbol, F.SortedReft)]
 tyToBind emb = go . ty_var_info
   where
     go RTVInfo{..} = [(rtv_name, rTypeSortedReft emb rtv_kind)]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -296,8 +296,8 @@ dataConSel permitTC dc n (Proj i) = mkArrow (map (, mempty) as) [] [xt] (mempty 
     (as, ts, xt)         = {- F.tracepp ("bkDatacon dc = " ++ F.showpp (dc, n)) $ -} bkDataCon permitTC dc n
     err                  = panic Nothing $ "DataCon " ++ show dc ++ "does not have " ++ show i ++ " fields"
 
--- bkDataCon :: DataCon -> Int -> ([RTVar RTyVar RSort], [SpecType], (Symbol, SpecType, RReft))
-bkDataCon :: (PPrint r, IsReft r) => Bool -> Ghc.DataCon -> Int -> ([RTVar RTyVar RSort], [RRType r], (F.Symbol, RFInfo, RRType r, r))
+-- bkDataCon :: DataCon -> Int -> ([SpecRTVar], [SpecType], (Symbol, SpecType, RReft))
+bkDataCon :: (PPrint r, IsReft r) => Bool -> Ghc.DataCon -> Int -> ([SpecRTVar], [RRType r], (F.Symbol, RFInfo, RRType r, r))
 bkDataCon permitTC dcn nFlds  = (as, ts, (F.dummySymbol, classRFInfo permitTC, t, trueReft))
   where
     ts                = RT.ofType <$> Misc.takeLast nFlds (map Ghc.irrelevantMult _ts)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -309,7 +309,15 @@ ofBareType env l ps t = either fail' id (ofBareTypeE env l ps t)
     -- fail                   = Misc.errorP "error-ofBareType" . F.showpp
 
 ofBareTypeE :: HasCallStack => Env -> F.SourcePos -> Maybe [PVar BSort] -> BareType -> Lookup SpecType
-ofBareTypeE env l ps t = ofBRType env (const (resolveReft l ps t)) l t
+ofBareTypeE env l ps t =
+    ofBRType env rebindUReftBV (const (resolveReft l ps t)) l t
+  where
+    rebindUReftBV (x, y) (MkUReft (F.Reft (v, e)) p) =
+      let su = (x, F.EVar y)
+          e' = F.subst1 e su
+          p' = F.subst1 p su
+       in
+          MkUReft (F.Reft (v, e')) p'
 
 resolveReft :: F.SourcePos -> Maybe [PVar BSort] -> BareType -> RReft -> RReft
 resolveReft l ps t
@@ -337,7 +345,7 @@ ofBSort :: HasCallStack => Env -> F.SourcePos -> BSort -> RSort
 ofBSort env l t = either (Misc.errorP "error-ofBSort" . F.showpp) id (ofBSortE env l t)
 
 ofBSortE :: HasCallStack => Env -> F.SourcePos -> BSort -> Lookup RSort
-ofBSortE env l t = ofBRType env (const id) l t
+ofBSortE env l t = ofBRType env (const id) (const id) l t
 
 ofBPVar :: Env -> F.SourcePos -> BPVar -> RPVar
 ofBPVar env l = fmap (ofBSort env l)
@@ -374,14 +382,26 @@ type Expandable r = ( PPrint r
                     , SubsTy RTyVar (RType RTyCon RTyVar NoReft) r
                     , HasCallStack)
 
-ofBRType :: (Expandable r) => Env -> ([F.Symbol] -> r -> r) -> F.SourcePos -> BRType r
-         -> Lookup (RRType r)
-ofBRType env f l = go []
+ofBRType
+  :: (Expandable r)
+  => Env
+  -> ((F.Symbol, F.Symbol) -> r -> r)
+  -> ([F.Symbol] -> r -> r)
+  -> F.SourcePos
+  -> BRType r
+  -> Lookup (RRType r)
+ofBRType env rebindR f l = go []
   where
     goReft bs r             = return (f bs r)
-    goRFun bs x i t1 t2 r  = RFun x i{permitTC = Just (typeclass (getConfig env))} <$> (rebind x <$> go bs t1) <*> go (x:bs) t2 <*> goReft bs r
+    goRFun bs x i t1 t2 r  =
+      RFun x i{permitTC = Just (typeclass (getConfig env))}
+        <$> (rebind x <$> go bs t1)
+        <*> go (x:bs) t2
+        <*> goReft bs r
     -- See the documentation of 'RFun' for what rebind accomplishes.
-    rebind x t              = F.subst1 t (x, F.EVar $ rTypeValueVar t)
+    rebind x t =
+      let su = (x, rTypeValueVar t)
+       in mapReftRecs (`F.subst1` (F.EVar <$> su)) (`F.subst1` (F.EVar <$> su)) (mapRBase (rebindR su) t)
     go bs (RAppTy t1 t2 r)  = RAppTy <$> go bs t1 <*> go bs t2 <*> goReft bs r
     go bs (RApp tc ts rs r) = goRApp bs tc ts rs r
     go bs (RFun x i t1 t2 r) = goRFun bs x i t1 t2 r
@@ -403,6 +423,21 @@ ofBRType env f l = go []
       where
         lc'                    = F.atLoc lc <$> lookupGhcTyConLHName (reTyLookupEnv env) lc
         lc                     = btc_tc tc
+
+    -- | Applies the given functions to the recursive occurrences of the RTypeV,
+    -- but only where rTypeReft retrieves a value.
+    --
+    -- This is needed when rebinding to ensure that name changes are applied
+    -- over the scope of the names.
+    mapReftRecs
+      :: (RTypeBV b v c tv r -> RTypeBV b v c tv r)
+      -> (RTPropBV b v c tv r -> RTPropBV b v c tv r)
+      -> RTypeBV b v c tv r -> RTypeBV b v c tv r
+    mapReftRecs f g (RApp c ts rs r)  = RApp  c (f <$> ts) (g <$> rs) r
+    mapReftRecs f _ (RFun x i t t' r) = RFun  x i (f t) (f t') r
+    mapReftRecs f _ (RAppTy t t' r)   = RAppTy (f t) (f t') r
+    mapReftRecs f _ (RAllT α t r)     = RAllT α (f t) r
+    mapReftRecs _ _ t                 = t
 
 lookupGhcTyConLHName :: HasCallStack => GHCTyLookupEnv -> Located LHName -> Lookup Ghc.TyCon
 lookupGhcTyConLHName env lc = do

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -433,11 +433,11 @@ ofBRType env rebindR f l = go []
       :: (RTypeBV b v c tv r -> RTypeBV b v c tv r)
       -> (RTPropBV b v c tv r -> RTPropBV b v c tv r)
       -> RTypeBV b v c tv r -> RTypeBV b v c tv r
-    mapReftRecs f g (RApp c ts rs r)  = RApp  c (f <$> ts) (g <$> rs) r
-    mapReftRecs f _ (RFun x i t t' r) = RFun  x i (f t) (f t') r
-    mapReftRecs f _ (RAppTy t t' r)   = RAppTy (f t) (f t') r
-    mapReftRecs f _ (RAllT α t r)     = RAllT α (f t) r
-    mapReftRecs _ _ t                 = t
+    mapReftRecs ft gt (RApp c ts rs r)  = RApp  c (ft <$> ts) (gt <$> rs) r
+    mapReftRecs ft _  (RFun x i t t' r) = RFun  x i (ft t) (ft t') r
+    mapReftRecs ft _  (RAppTy t t' r)   = RAppTy (ft t) (ft t') r
+    mapReftRecs ft _  (RAllT α t r)     = RAllT α (ft t) r
+    mapReftRecs _  _  t                 = t
 
 lookupGhcTyConLHName :: HasCallStack => GHCTyLookupEnv -> Located LHName -> Lookup Ghc.TyCon
 lookupGhcTyConLHName env lc = do

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -387,7 +387,8 @@ ofBRType env f l = go []
     go bs (RFun x i t1 t2 r) = goRFun bs x i t1 t2 r
     go bs (RVar a r)        = RVar (RT.bareRTyVar a) <$> goReft bs r
     go bs (RAllT a t r)     = RAllT a' <$> go bs t <*> goReft bs r
-      where a'              = dropTyVarInfo (mapTyVarValue RT.bareRTyVar a)
+      where a' = let RTVar v _s = a
+                  in RTVar (RT.bareRTyVar v) (RTVNoInfo True)
     go bs (RAllP a t)       = RAllP a' <$> go bs t
       where a'              = ofBPVar env l a
     go bs (REx x t1 t2)     = REx   x  <$> go bs t1    <*> go (x:bs) t2

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/ToBare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/ToBare.hs
@@ -74,7 +74,8 @@ txRType cF vF = go
     goPV = txPV cF vF
 
 txRTV :: (c1 -> c2) -> (tv1 -> tv2) -> RTVU c1 tv1 -> RTVU c2 tv2
-txRTV cF vF (RTVar α z) = RTVar (vF α) (txRType cF vF <$> z)
+txRTV _cF vF (RTVar α (RTVNoInfo p))          = RTVar (vF α) (RTVNoInfo p)
+txRTV cF vF (RTVar α ri@RTVInfo{rtv_kind=k}) = RTVar (vF α) ri{rtv_kind = txRType cF vF k}
 
 txPV :: (c1 -> c2) -> (tv1 -> tv2) -> PVU c1 tv1 -> PVU c2 tv2
 txPV cF vF (PV sym k txes) = PV sym k' txes'

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Split.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Split.hs
@@ -140,7 +140,7 @@ splitfWithVariance f t1 t2 Bivariant     = (++) <$> f t1 t2 <*> f t2 t1
 splitfWithVariance f t1 t2 Covariant     = f t1 t2
 splitfWithVariance f t1 t2 Contravariant = f t2 t1
 
-updateEnv :: CGEnv -> RTVar RTyVar (RType RTyCon RTyVar b0) -> CG CGEnv
+updateEnv :: CGEnv -> RTVar F.Symbol F.Symbol RTyCon RTyVar -> CG CGEnv
 updateEnv γ a
   | Just (x, s) <- rTVarToBind a
   = γ += ("splitS RAllT", x, fmap (const mempty) s)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -41,6 +41,7 @@ import           Language.Haskell.Liquid.Transforms.Rewrite (rewriteBinds)
 
 import           Control.Monad
 import qualified Control.Monad.Catch as Ex
+import           Control.Exception (SomeException, displayException)
 import           Control.Monad.IO.Class (MonadIO)
 
 import           Data.Coerce
@@ -405,6 +406,9 @@ liquidHaskellCheckWithConfig cfg pipelineData modSummary = do
     `Ex.catch` (\(e :: UserError) -> reportErrs [e])
     `Ex.catch` (\(e :: Error) -> reportErrs [e])
     `Ex.catch` (\(es :: [Error]) -> reportErrs es)
+    `Ex.catch` (\(e :: SomeException) -> do
+                   liftIO $ putStrLn $ displayException e
+                   Ex.throwM e)
 
   where
     thisFile = LH.modSummaryHsFile modSummary
@@ -587,6 +591,9 @@ processModule LiquidHaskellContext{..} = do
       `Ex.catch` (\(e :: UserError) -> reportErrs [e])
       `Ex.catch` (\(e :: Error) -> reportErrs [e])
       `Ex.catch` (\(es :: [Error]) -> reportErrs es)
+      `Ex.catch` (\(e :: SomeException) -> do
+                     liftIO $ putStrLn $ displayException e
+                     Ex.throwM e)
 
 makeTargetSrc :: Config
               -> FilePath

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Measure.hs
@@ -155,7 +155,9 @@ strengthenResult t r = fromRTypeRep $ rep {ty_res = ty_res rep `strengthen` r}
     rep              = toRTypeRep t
 
 
-noDummySyms :: (OkRT c tv r, Subable r, Variable r ~ Symbol, IsReft r) => RType c tv r -> RType c tv r
+noDummySyms
+  :: (OkRT c tv r, Subable r, Variable r ~ Symbol, IsReft r, ReftVar r ~ Symbol)
+  => RType c tv r -> RType c tv r
 noDummySyms t
   | any isDummy (ty_binds rep)
   = subst su $ fromRTypeRep $ rep{ty_binds = xs'}

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Measure.hs
@@ -154,19 +154,24 @@ strengthenResult t r = fromRTypeRep $ rep {ty_res = ty_res rep `strengthen` r}
   where
     rep              = toRTypeRep t
 
-
+-- | If there are any dummy symbols in the type, replace them with fresh
+-- variables.
+--
+-- WARNING: the current implementation might rename variables named as
+-- dummySymbols event if they are not in the scope of the binder of a
+-- dummy symbol. Might not be a problem at the places where noDummySyms is used,
+-- but be careful if you want to use it in other places.
 noDummySyms
   :: (OkRT c tv r, Subable r, Variable r ~ Symbol, IsReft r, ReftVar r ~ Symbol)
   => RType c tv r -> RType c tv r
 noDummySyms t
   | any isDummy (ty_binds rep)
-  = subst su $ fromRTypeRep $ rep{ty_binds = xs'}
+  = F.subst su t -- substitution forces renaming of ty_binds to fresh variables
   | otherwise
   = t
   where
     rep = toRTypeRep t
-    xs' = zipWith (\_ i -> symbol ("x" ++ show i)) (ty_binds rep) [(1::Int)..]
-    su  = mkSubst $ zip (ty_binds rep) (EVar <$> xs')
+    su  = mkSubst [ (v, EVar v) | v <- ty_binds rep ]
 
 combineDCTypes :: String -> Type -> [RRType Reft] -> RRType Reft
 combineDCTypes _msg t ts = L.foldl' strengthenRefTypeGen (ofType t) ts

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PredType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PredType.hs
@@ -455,12 +455,21 @@ meetListWithPSubs :: (Foldable t, PPrint t1, F.Subable b, F.Variable b ~ F.Symbo
                   => t (PVar t1) -> [(F.Symbol, RSort)] -> b -> b -> b
 meetListWithPSubs πs ss r1 r2    = L.foldl' (meetListWithPSub ss r1) r2 πs
 
-meetListWithPSubsRef :: (Foldable t, Meet (RType c tv r), TyConable c, IsReft r, F.Subable r, F.Variable r ~ F.Symbol, ReftBind r ~ F.Symbol)
-                     => t (PVar t4)
-                     -> [(F.Symbol, b)]
-                     -> Ref τ (RType c tv r)
-                     -> Ref τ (RType c tv r)
-                     -> Ref τ (RType c tv r)
+meetListWithPSubsRef
+  :: ( Foldable t
+     , Meet (RType c tv r)
+     , TyConable c
+     , IsReft r
+     , F.Subable r
+     , F.Variable r ~ F.Symbol
+     , ReftBind r ~ F.Symbol
+     , ReftVar r ~ F.Symbol
+     )
+  => t (PVar t4)
+  -> [(F.Symbol, b)]
+  -> Ref τ (RType c tv r)
+  -> Ref τ (RType c tv r)
+  -> Ref τ (RType c tv r)
 meetListWithPSubsRef πs ss r1 r2 = L.foldl' (meetListWithPSubRef ss r1) r2 πs
 
 meetListWithPSub ::  (PPrint t, F.Subable r, F.Variable r ~ F.Symbol, Meet r) => [(F.Symbol, RSort)]-> r -> r -> PVar t -> r
@@ -474,12 +483,20 @@ meetListWithPSub ss r1 r2 π
   where
     su  = F.mkSubst [(x, y) | (x, (_, _, y)) <- zip (fst <$> ss) (pargs π)]
 
-meetListWithPSubRef :: (Meet (RType c tv r), TyConable c, IsReft r, F.Subable r, F.Variable r ~ F.Symbol, ReftBind r ~ F.Symbol)
-                    => [(F.Symbol, b)]
-                    -> Ref τ (RType c tv r)
-                    -> Ref τ (RType c tv r)
-                    -> PVar t3
-                    -> Ref τ (RType c tv r)
+meetListWithPSubRef
+  :: ( Meet (RType c tv r)
+     , TyConable c
+     , IsReft r
+     , F.Subable r
+     , F.Variable r ~ F.Symbol
+     , ReftBind r ~ F.Symbol
+     , ReftVar r ~ F.Symbol
+     )
+ => [(F.Symbol, b)]
+ -> Ref τ (RType c tv r)
+ -> Ref τ (RType c tv r)
+ -> PVar t3
+ -> Ref τ (RType c tv r)
 meetListWithPSubRef _ (RProp _ (RHole _)) _ _ -- TODO: Is this correct?
   = panic Nothing "PredType.meetListWithPSubRef called with invalid input"
 meetListWithPSubRef _ _ (RProp _ (RHole _)) _

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PredType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PredType.hs
@@ -198,7 +198,7 @@ dcWrapSpecType allowTC dc (DataConP _ _ vs ps cs yts rt _ _ _)
     ts'      = map ("" , classRFInfo allowTC , , mempty) cs ++ yts'
     subst    = F.mkSubst [(x, F.EVar y) | (x, y) <- zip as1 bs]
     rt'      = F.subst subst rt
-    makeVars = filter (`elem` fvs) $ zipWith (\v a -> RTVar v (rTVarInfo a :: RTVInfo RSort)) vs (fst $ splitForAllTyCoVars $ dataConRepType dc)
+    makeVars = filter (`elem` fvs) $ zipWith (\v a -> RTVar v (rTVarInfo a)) vs (fst $ splitForAllTyCoVars $ dataConRepType dc)
     makeVars' = map (, mempty) makeVars
     fvs = freeTyVars $ mkArrow [] ps ts' rt'
 
@@ -366,7 +366,7 @@ substRCon
       SubsTy tv (RType RTyCon tv NoReft) (RType RTyCon tv NoReft),
       SubsTy tv (RType RTyCon tv NoReft) RTyCon,
       SubsTy tv (RType RTyCon tv NoReft) tv,
-      SubsTy tv (RType RTyCon tv NoReft) (RTVar tv (RType RTyCon tv NoReft)),
+      SubsTy tv (RType RTyCon tv NoReft) (RTVar F.Symbol F.Symbol RTyCon tv),
       FreeVar RTyCon tv,
       Meet r,
       Meet (RType RTyCon tv r))

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
@@ -374,7 +374,7 @@ pprForall bb p t = maybeParen p funPrec $ sep [
     dπs False _               = empty
     dπs True πs               = angleBrackets $ intersperse comma $ pprPvarDef bb p <$> πs
 
-pprRtvarDef :: (PPrint tv) => [RTVar tv (RTypeBV b v c tv (NoReftB b))] -> Doc
+pprRtvarDef :: (PPrint tv) => [RTVar b v c tv] -> Doc
 pprRtvarDef = sep . map (pprint . ty_var_value)
 
 pprCls

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -1103,7 +1103,7 @@ data RTVar b v c tv = RTVar
 data RTVInfo b v c tv
   = RTVNoInfo { rtv_is_pol :: Bool }
   | RTVInfo { rtv_name   :: b
-            , rtv_kind   :: (RTypeBV b v c tv (NoReftBV b v))
+            , rtv_kind   :: RTypeBV b v c tv (NoReftBV b v)
             , rtv_is_val :: Bool
             , rtv_is_pol :: Bool -- true iff the type variable gets instantiated with
                                  -- any refinement (ie is polymorphic on refinements),

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -50,8 +50,8 @@ module Language.Haskell.Liquid.Types.RType (
 
   -- * Type Variables
   , RTVar (..), RTVInfo (..)
-  , makeRTVar, mapTyVarValue
-  , dropTyVarInfo, rTVarToBind
+  , makeRTVar
+  , rTVarToBind
   , setRtvPol
 
   -- * Predicate Variables
@@ -705,7 +705,7 @@ instance F.PPrint BTyCon where
       LHRIndex i -> text $ "(Unknown LHRIndex " ++ show i ++ ")"
       LHRLogic _ -> text $ F.symbolString $ lhNameToResolvedSymbol $ F.val $ btc_tc b
 
-instance F.PPrint v => F.PPrint (RTVar v s) where
+instance F.PPrint v => F.PPrint (RTVar b v c v) where
   pprintTidy k (RTVar x _) = F.pprintTidy k x
 
 instance F.Loc BTyCon where
@@ -745,7 +745,7 @@ instance NFData TyConInfo
 
 type RTVU c tv = RTVUV Symbol c tv
 type RTVUV v c tv = RTVUBV Symbol v c tv
-type RTVUBV b v c tv = RTVar tv (RTypeBV b v c tv (NoReftBV b v))
+type RTVUBV b v c tv = RTVar b v c tv
 type PVU c tv = PVUV Symbol c tv
 type PVUV v c tv = PVarV v (RTypeV v c tv NoReft)
 type PVUBV b v c tv = PVarBV b v (RTypeBV b v c tv (NoReftBV b v))
@@ -1083,56 +1083,50 @@ data RTypeBV b v c tv r
   deriving (Eq, Generic, Data, Functor, Foldable, Show, Traversable)
   deriving (B.Binary, Hashable) via Generically (RTypeBV b v c tv r)
 
-instance (NFData c, NFData tv, NFData r)       => NFData (RType c tv r)
+instance (NFData b, NFData v, NFData c, NFData tv, NFData r) => NFData (RTypeBV b v c tv r)
 
-makeRTVar :: tv -> RTVar tv s
+makeRTVar :: tv -> RTVar b v c tv
 makeRTVar a = RTVar a (RTVNoInfo True)
 
 notExprArg :: RTypeV v c tv r -> Bool
 notExprArg (RExprArg _) = False
 notExprArg _            = True
 
-instance (Eq tv) => Eq (RTVar tv s) where
+instance (Eq tv) => Eq (RTVar b v c tv) where
   t1 == t2 = ty_var_value t1 == ty_var_value t2
 
 -- | @RTVar@ is the type of type variables in the refinement type system. It
 -- contains a type variable, optionally a kind, and information about how to
 -- instantiate it (polymorphic vs. monomorphic refinements).
-data RTVar tv s = RTVar
+data RTVar b v c tv = RTVar
   { ty_var_value :: tv
-  , ty_var_info  :: RTVInfo s
-  } deriving (Generic, Data, Functor, Foldable, Show, Traversable)
-    deriving (B.Binary, Hashable) via Generically (RTVar tv s)
+  , ty_var_info  :: RTVInfo b v c tv
+  } deriving (Generic, Data, Show)
+    deriving (B.Binary, Hashable) via Generically (RTVar b v c tv)
 
-mapTyVarValue :: (tv1 -> tv2) -> RTVar tv1 s -> RTVar tv2 s
-mapTyVarValue f v = v {ty_var_value = f $ ty_var_value v}
-
-dropTyVarInfo :: RTVar tv s1 -> RTVar tv s2
-dropTyVarInfo v = v{ty_var_info = RTVNoInfo True }
-
-data RTVInfo s
+data RTVInfo b v c tv
   = RTVNoInfo { rtv_is_pol :: Bool }
-  | RTVInfo { rtv_name   :: Symbol
-            , rtv_kind   :: s
+  | RTVInfo { rtv_name   :: b
+            , rtv_kind   :: (RTypeBV b v c tv (NoReftBV b v))
             , rtv_is_val :: Bool
             , rtv_is_pol :: Bool -- true iff the type variable gets instantiated with
                                  -- any refinement (ie is polymorphic on refinements),
                                  -- false iff instantiation is with true refinement
-            } deriving (Generic, Data, Functor, Eq, Foldable, Show, Traversable)
-              deriving (B.Binary, Hashable) via Generically (RTVInfo s)
+            } deriving (Generic, Data, Eq, Show)
+              deriving (B.Binary, Hashable) via Generically (RTVInfo b v c tv)
 
 
-setRtvPol :: RTVar tv a -> Bool -> RTVar tv a
+setRtvPol :: RTVar b v c tv -> Bool -> RTVar b v c tv
 setRtvPol (RTVar a i) b = RTVar a (i{rtv_is_pol = b})
 
-rTVarToBind :: RTVar RTyVar s  -> Maybe (Symbol, s)
+rTVarToBind :: RTVar b v c tv -> Maybe (b, RTypeBV b v c tv (NoReftBV b v))
 rTVarToBind = go . ty_var_info
   where
     go RTVInfo{..} | rtv_is_val = Just (rtv_name, rtv_kind)
     go _                        = Nothing
 
-instance (NFData tv, NFData s)     => NFData   (RTVar tv s)
-instance (NFData s)                => NFData   (RTVInfo s)
+instance (NFData b, NFData v, NFData c, NFData tv) => NFData   (RTVar b v c tv)
+instance (NFData b, NFData v, NFData c, NFData tv) => NFData   (RTVInfo b v c tv)
 
 type Ref τ t = RefB Symbol τ t
 
@@ -1151,7 +1145,7 @@ data RefB b τ t = RProp
   } deriving (Eq, Generic, Data, Functor, Foldable, Show, Traversable)
     deriving (B.Binary, Hashable) via Generically (RefB b τ t)
 
-instance (NFData τ,   NFData t)   => NFData   (Ref τ t)
+instance (NFData b, NFData τ, NFData t) => NFData (RefB b τ t)
 
 rPropP :: [(b, τ)] -> r -> RefB b τ (RTypeV v c tv r)
 rPropP τ r = RProp τ (RHole r)
@@ -1269,7 +1263,7 @@ type SpecProp    = RRProp    RReft
 type RRProp r    = Ref       RSort (RRType r)
 type BRProp r    = BRPropV Symbol r
 type BRPropV v r = Ref       (BSortV v) (BRTypeV v r)
-type SpecRTVar   = RTVar     RTyVar RSort
+type SpecRTVar   = RTVar Symbol Symbol RTyCon RTyVar
 
 
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -453,17 +453,19 @@ pdAnd ps       = Pr (nub $ concatMap pvars ps)
 pvars :: PredicateBV b v -> [UsedPVarBV b v]
 pvars (Pr pvs) = pvs
 
-instance Hashable v => F.Subable (UsedPVarBV v v) where
+instance (Hashable v, F.Refreshable v) => F.Subable (UsedPVarBV v v) where
   type Variable (UsedPVarBV v v) = v
   syms pv = F.syms [ e | (_, _x, e) <- pargs pv ]
+  substr ns s pv = pv { pargs = mapThd3 (F.substr ns s) <$> pargs pv }
   subst s pv      = pv { pargs = mapThd3 (F.subst s)  <$> pargs pv }
   substf f pv     = pv { pargs = mapThd3 (F.substf f) <$> pargs pv }
   substa f pv     = pv { pargs = mapThd3 (F.substa f) <$> pargs pv }
 
 
-instance Hashable v => F.Subable (PredicateBV v v) where
+instance (Hashable v, F.Refreshable v) => F.Subable (PredicateBV v v) where
   type Variable (PredicateBV v v) = v
   syms (Pr pvs) = F.syms pvs
+  substr ns s (Pr pvs) = Pr (F.substr ns s <$> pvs)
   subst  s (Pr pvs) = Pr (F.subst s  <$> pvs)
   substf f (Pr pvs) = Pr (F.substf f <$> pvs)
   substa f (Pr pvs) = Pr (F.substa f <$> pvs)
@@ -1232,6 +1234,7 @@ instance F.PPrint (NoReftBV b v) where
 instance Hashable b => F.Subable (NoReftBV b v) where
   type Variable (NoReftBV b v) = b
   syms _   = S.empty
+  substr _ _  = id
   substa _ = id
   substf _ = id
   subst _  = id
@@ -1409,7 +1412,7 @@ instance F.Binder b => IsReft (UReftBV b v) where
   ofConcreteReft (ConcreteUReft r) = r
   toConcreteReft = ConcreteUReft
 
-instance (F.Binder v, F.Fixpoint v) => Meet (F.ReftBV v v) where
+instance (F.Binder v, F.Fixpoint v, F.Refreshable v) => Meet (F.ReftBV v v) where
 
 instance F.Binder b => IsReft (F.ReftBV b v) where
   type ReftVar (F.ReftBV b v) = v
@@ -1429,7 +1432,7 @@ instance Top t => Top (RefB b τ t) where
 instance Top (PredicateBV b v) where
   top _ = pdTrue
 
-instance (F.Binder v, F.Fixpoint v) => Semigroup (F.ReftBV v v) where
+instance (F.Binder v, F.Fixpoint v, F.Refreshable v) => Semigroup (F.ReftBV v v) where
   (<>) = F.meetReft
 
 instance Monoid F.Reft where
@@ -1443,6 +1446,7 @@ instance (Semigroup (F.ReftBV b v), Eq b, Eq v) => Meet (UReftBV b v)
 instance (F.Refreshable v, Hashable v) => F.Subable (UReftBV v v) where
   type Variable (UReftBV v v) = v
   syms (MkUReft r p)     = F.syms r `S.union` F.syms p
+  substr ns s (MkUReft r z) = MkUReft (F.substr ns s r) (F.substr ns s z)
   subst s (MkUReft r z)  = MkUReft (F.subst s r)  (F.subst s z)
   substf f (MkUReft r z) = MkUReft (F.substf f r) (F.substf f z)
   substa f (MkUReft r z) = MkUReft (F.substa f r) (F.substa f z)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -459,7 +459,6 @@ instance (Hashable v, F.Refreshable v) => F.Subable (UsedPVarBV v v) where
   substr ns s pv = pv { pargs = mapThd3 (F.substr ns s) <$> pargs pv }
   subst s pv      = pv { pargs = mapThd3 (F.subst s)  <$> pargs pv }
   substf f pv     = pv { pargs = mapThd3 (F.substf f) <$> pargs pv }
-  substa f pv     = pv { pargs = mapThd3 (F.substa f) <$> pargs pv }
 
 
 instance (Hashable v, F.Refreshable v) => F.Subable (PredicateBV v v) where
@@ -468,7 +467,6 @@ instance (Hashable v, F.Refreshable v) => F.Subable (PredicateBV v v) where
   substr ns s (Pr pvs) = Pr (F.substr ns s <$> pvs)
   subst  s (Pr pvs) = Pr (F.subst s  <$> pvs)
   substf f (Pr pvs) = Pr (F.substf f <$> pvs)
-  substa f (Pr pvs) = Pr (F.substa f <$> pvs)
 
 instance NFData UReft
 
@@ -1235,7 +1233,6 @@ instance Hashable b => F.Subable (NoReftBV b v) where
   type Variable (NoReftBV b v) = b
   syms _   = S.empty
   substr _ _  = id
-  substa _ = id
   substf _ = id
   subst _  = id
 
@@ -1448,7 +1445,6 @@ instance (F.Refreshable v, Hashable v) => F.Subable (UReftBV v v) where
   substr ns s (MkUReft r z) = MkUReft (F.substr ns s r) (F.substr ns s z)
   subst s (MkUReft r z)  = MkUReft (F.subst s r)  (F.subst s z)
   substf f (MkUReft r z) = MkUReft (F.substf f r) (F.substf f z)
-  substa f (MkUReft r z) = MkUReft (F.substa f r) (F.substa f z)
 
 instance Meet Predicate
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -458,7 +458,6 @@ instance (Hashable v, F.Refreshable v) => F.Subable (UsedPVarBV v v) where
   syms pv = F.syms [ e | (_, _x, e) <- pargs pv ]
   substr ns s pv = pv { pargs = mapThd3 (F.substr ns s) <$> pargs pv }
   subst s pv      = pv { pargs = mapThd3 (F.subst s)  <$> pargs pv }
-  substf f pv     = pv { pargs = mapThd3 (F.substf f) <$> pargs pv }
 
 
 instance (Hashable v, F.Refreshable v) => F.Subable (PredicateBV v v) where
@@ -466,7 +465,6 @@ instance (Hashable v, F.Refreshable v) => F.Subable (PredicateBV v v) where
   syms (Pr pvs) = F.syms pvs
   substr ns s (Pr pvs) = Pr (F.substr ns s <$> pvs)
   subst  s (Pr pvs) = Pr (F.subst s  <$> pvs)
-  substf f (Pr pvs) = Pr (F.substf f <$> pvs)
 
 instance NFData UReft
 
@@ -1233,7 +1231,6 @@ instance Hashable b => F.Subable (NoReftBV b v) where
   type Variable (NoReftBV b v) = b
   syms _   = S.empty
   substr _ _  = id
-  substf _ = id
   subst _  = id
 
 instance Semigroup (NoReftBV b v) where
@@ -1444,7 +1441,6 @@ instance (F.Refreshable v, Hashable v) => F.Subable (UReftBV v v) where
   syms (MkUReft r p)     = F.syms r `S.union` F.syms p
   substr ns s (MkUReft r z) = MkUReft (F.substr ns s r) (F.substr ns s z)
   subst s (MkUReft r z)  = MkUReft (F.subst s r)  (F.subst s z)
-  substf f (MkUReft r z) = MkUReft (F.substf f r) (F.substf f z)
 
 instance Meet Predicate
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -457,14 +457,12 @@ instance (Hashable v, F.Refreshable v) => F.Subable (UsedPVarBV v v) where
   type Variable (UsedPVarBV v v) = v
   syms pv = F.syms [ e | (_, _x, e) <- pargs pv ]
   substr ns s pv = pv { pargs = mapThd3 (F.substr ns s) <$> pargs pv }
-  subst s pv      = pv { pargs = mapThd3 (F.subst s)  <$> pargs pv }
 
 
 instance (Hashable v, F.Refreshable v) => F.Subable (PredicateBV v v) where
   type Variable (PredicateBV v v) = v
   syms (Pr pvs) = F.syms pvs
   substr ns s (Pr pvs) = Pr (F.substr ns s <$> pvs)
-  subst  s (Pr pvs) = Pr (F.subst s  <$> pvs)
 
 instance NFData UReft
 
@@ -1231,7 +1229,6 @@ instance Hashable b => F.Subable (NoReftBV b v) where
   type Variable (NoReftBV b v) = b
   syms _   = S.empty
   substr _ _  = id
-  subst _  = id
 
 instance Semigroup (NoReftBV b v) where
   _ <> _ = NoReft
@@ -1440,7 +1437,6 @@ instance (F.Refreshable v, Hashable v) => F.Subable (UReftBV v v) where
   type Variable (UReftBV v v) = v
   syms (MkUReft r p)     = F.syms r `S.union` F.syms p
   substr ns s (MkUReft r z) = MkUReft (F.substr ns s r) (F.substr ns s z)
-  subst s (MkUReft r z)  = MkUReft (F.subst s r)  (F.subst s z)
 
 instance Meet Predicate
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -455,7 +455,7 @@ pvars (Pr pvs) = pvs
 
 instance Hashable v => F.Subable (UsedPVarBV v v) where
   type Variable (UsedPVarBV v v) = v
-  syms pv         = S.fromList [ y | (_, x, F.EVar y) <- pargs pv, x /= y ]
+  syms pv = F.syms [ e | (_, _x, e) <- pargs pv ]
   subst s pv      = pv { pargs = mapThd3 (F.subst s)  <$> pargs pv }
   substf f pv     = pv { pargs = mapThd3 (F.substf f) <$> pargs pv }
   substa f pv     = pv { pargs = mapThd3 (F.substa f) <$> pargs pv }

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -1238,7 +1238,6 @@ instance Hashable b => F.Subable (NoReftBV b v) where
   substa _ = id
   substf _ = id
   subst _  = id
-  subst1 r = const r
 
 instance Semigroup (NoReftBV b v) where
   _ <> _ = NoReft

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
@@ -74,6 +74,7 @@ import           Data.Bifunctor (bimap)
 import           Data.Coerce (coerce)
 import           Data.Hashable (Hashable)
 import qualified Data.HashSet as S
+import qualified Data.List as List
 
 import qualified Language.Fixpoint.Types as F
 import           Language.Fixpoint.Types (ExprBV, Symbol)
@@ -258,7 +259,14 @@ instance ( IsReft r
          ) =>
          F.Subable (RefB v (RTypeBV v v c tv r) t) where
   type Variable (RefB v (RTypeBV v v c tv r) t) = v
-  syms (RProp  ss r)     = S.fromList (fst <$> ss) `S.union` F.syms r
+  syms (RProp ss r) =
+    let (bs, tss) =
+          List.mapAccumL
+            (\bs0 (b, tb) -> (S.insert b bs0, F.syms tb `S.difference` bs0))
+            S.empty
+            ss
+     in
+        S.unions $ (F.syms r `S.difference` bs) : tss
 
   subst su (RProp  ss t) = RProp ss (F.subst su t)
 
@@ -269,7 +277,61 @@ instance ( IsReft r
 
 instance (F.Subable r, IsReft r, TyConable c, F.Binder v, F.Variable r ~ v, ReftBind r ~ v) => F.Subable (RTypeBV v v c tv r) where
   type Variable (RTypeBV v v c tv r) = v
-  syms        = foldReft False (\_ r acc -> F.syms r `S.union` acc) S.empty
+  syms = go
+    where
+      deletev r0 = case toConcreteReft r0 of
+        ConcreteNoReft -> id
+        ConcreteReft r -> S.delete (F.reftBind r)
+        ConcreteUReft (MkUReft r _) -> S.delete (F.reftBind r)
+
+      go :: RTypeBV v v c tv r -> S.HashSet v
+      go (RVar _ r) = F.syms r
+      go (RFun x _ t1 t2 r)  =
+        -- x scopes over t1, t2, and r
+        deletev r (S.delete x $ F.syms t1 `S.union` F.syms t2)
+        `S.union` F.syms r
+      go (RAllT α t r)       =
+        let kindSyms = maybe S.empty (F.syms . snd) (rTVarToBind α)
+            deleteα = maybe id (S.delete . fst) (rTVarToBind α)
+         in
+            deletev r (kindSyms `S.union` deleteα (F.syms t))
+            `S.union` F.syms r
+      go (RAllP pb t) =
+        let (bs, tss) =
+              List.mapAccumL
+                (\bs0 (tb, b, _) -> (S.insert b bs0, F.syms tb `S.difference` bs0))
+                S.empty
+                (pargs pb)
+         in S.unions $
+              S.delete (pname pb) (F.syms t)
+              : F.syms (ptype pb) `S.difference` bs
+              : tss
+      go (RApp _ ts ps r) =
+        deletev r (F.syms ts `S.union` F.syms ps)
+        `S.union` F.syms r
+      go (REx x t1 t2) =
+        -- x scopes over t2 only
+        F.syms t1 `S.union` S.delete x (F.syms t2)
+      go (RExprArg e) = F.syms e
+      go (RAppTy t1 t2 r) =
+        deletev r (F.syms t1 `S.union` F.syms t2)
+        `S.union` F.syms r
+      go (RRTy env r _ t) =
+          -- env scopes over the refinement type
+          let (bs, envSyms) = symsEnv env
+              rsyms = F.syms r `S.difference` bs
+           in
+              envSyms `S.union` rsyms `S.union` F.syms t
+        where
+          symsEnv = foldl'
+              (\(s, env') (x, xt) ->
+                let s' = S.insert x s
+                 in (s', (F.syms xt `S.difference` s) `S.union` env')
+              )
+              (S.empty, S.empty)
+
+      go (RHole r) = F.syms r
+
   -- 'substa' will substitute bound vars
   substa f    = emapExprArg (\_ -> F.substa f) []      . mapReft  (F.substa f)
   -- 'substf' will NOT substitute bound vars

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
@@ -289,7 +289,6 @@ instance ( IsReft r
           ([], ns1, su1)
           ss1
 
-  subst su (RProp  ss t) = RProp ss (F.subst su t)
 
 
 instance (F.Subable r, IsReft r, TyConable c, F.Binder v, F.Refreshable v, F.Variable r ~ v, ReftBind r ~ v, ReftVar r ~ v) => F.Subable (RTypeBV v v c tv r) where
@@ -449,8 +448,6 @@ instance (F.Subable r, IsReft r, TyConable c, F.Binder v, F.Refreshable v, F.Var
               env0
 
       go s su (RHole r)        = RHole (F.substr s su r)
-
-  subst su    = emapExprArg (\_ -> F.subst su) []      . emapReft (F.subst  . F.substExcept su) []
 
 mapExprReft :: (b -> ExprBV b v -> ExprBV b v) -> RTypeBV b v c tv (RReftBV b v) -> RTypeBV b v c tv (RReftBV b v)
 mapExprReft f = mapReft g
@@ -620,23 +617,6 @@ emapDataCtorTyM f d = do
     dcResult <- traverse (f (map (lhNameToUnqualifiedSymbol . fst) (dcFields d))) $ dcResult d
     dcFields <- snd <$> mapAccumM (\γ  (s, t) -> (lhNameToUnqualifiedSymbol s:γ,) . (s,) <$> f γ t) [] (dcFields d)
     return d{dcTheta, dcFields, dcResult}
-
-emapExprArg :: ([b] -> ExprBV b v -> ExprBV b v) -> [b] -> RTypeBV b v c tv r -> RTypeBV b v c tv r
-emapExprArg f = go
-  where
-    go _ t@RVar{}          = t
-    go _ t@RHole{}         = t
-    go γ (RAllT α t r)     = RAllT α (go γ t) r
-    go γ (RAllP π t)       = RAllP π (go γ t)
-    go γ (RFun x i t t' r) = RFun  x i (go γ t) (go (x:γ) t') r
-    go γ (RApp c ts rs r)  = RApp  c (go γ <$> ts) (mo γ <$> rs) r
-    go γ (REx z t t')      = REx   z (go γ t) (go γ t')
-    go γ (RExprArg e)      = RExprArg (f γ <$> e) -- <---- actual substitution
-    go γ (RAppTy t t' r)   = RAppTy (go γ t) (go γ t') r
-    go γ (RRTy e r o t)    = RRTy  (fmap (go γ) <$> e) r o (go γ t)
-
-    mo _ t@(RProp _ RHole{}) = t
-    mo γ (RProp s t)         = RProp s (go γ t)
 
 parsedToBareType :: BareTypeParsed -> BareType
 parsedToBareType = mapRTypeV F.val . mapReft (mapUReftV F.val (fmap F.val))

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
@@ -258,6 +258,7 @@ instance ( IsReft r
          , F.Variable r ~ v
          , F.Variable t ~ v
          , ReftBind r ~ v
+         , ReftVar r ~ v
          ) =>
          F.Subable (RefB v (RTypeBV v v c tv r) t) where
   type Variable (RefB v (RTypeBV v v c tv r) t) = v
@@ -270,7 +271,23 @@ instance ( IsReft r
      in
         S.unions $ (F.syms r `S.difference` bs) : tss
 
-  substr ns su (RProp  ss t) = RProp ss (F.substr ns su t)
+  substr ns0 su0 (RProp ss0 t0) =
+      let ((bs', ns', su'), ts) = substInArgs ss0 ns0 su0
+          ss' = zip bs' ts
+      in RProp ss' (F.substr ns' su' t0)
+    where
+      substInArgs ss1 ns1 su1 =
+        List.mapAccumR
+          (\(bs, ns, su) (x, t) ->
+             let (ns', x') = F.freshInNS x ns
+                 su' = F.extendSubst su x (F.EVar x')
+              in
+                 ( (x' : bs, ns', su')
+                 , F.substr ns su t
+                 )
+          )
+          ([], ns1, su1)
+          ss1
 
   subst su (RProp  ss t) = RProp ss (F.subst su t)
 
@@ -279,7 +296,7 @@ instance ( IsReft r
   substa f (RProp  ss t) = RProp ss (F.substa f t)
 
 
-instance (F.Subable r, IsReft r, TyConable c, F.Binder v, F.Refreshable v, F.Variable r ~ v, ReftBind r ~ v) => F.Subable (RTypeBV v v c tv r) where
+instance (F.Subable r, IsReft r, TyConable c, F.Binder v, F.Refreshable v, F.Variable r ~ v, ReftBind r ~ v, ReftVar r ~ v) => F.Subable (RTypeBV v v c tv r) where
   type Variable (RTypeBV v v c tv r) = v
   syms = go
     where
@@ -301,15 +318,17 @@ instance (F.Subable r, IsReft r, TyConable c, F.Binder v, F.Refreshable v, F.Var
             deletev r (kindSyms `S.union` deleteα (F.syms t))
             `S.union` F.syms r
       go (RAllP pb t) =
-        let (bs, tss) =
-              List.mapAccumL
-                (\bs0 (tb, b, _) -> (S.insert b bs0, F.syms tb `S.difference` bs0))
-                S.empty
-                (pargs pb)
-         in S.unions $
-              S.delete (pname pb) (F.syms t)
-              : F.syms (ptype pb) `S.difference` bs
-              : tss
+          S.delete (pname pb) (F.syms t) `S.union` symsPVar pb
+        where
+          symsPVar p =
+            let (bs, tss) =
+                  List.mapAccumL
+                    (\bs0 (tb, b, _) -> (S.insert b bs0, F.syms tb `S.difference` bs0))
+                    S.empty
+                    (pargs p)
+             in
+                S.unions $ (F.syms (ptype p) `S.difference` bs) : tss
+
       go (RApp _ ts ps r) =
         deletev r (F.syms ts `S.union` F.syms ps)
         `S.union` F.syms r
@@ -340,14 +359,108 @@ instance (F.Subable r, IsReft r, TyConable c, F.Binder v, F.Refreshable v, F.Var
   substa f    = emapExprArg (\_ -> F.substa f) []      . mapReft  (F.substa f)
   -- 'substf' will NOT substitute bound vars
   substf f    = emapExprArg (\_ -> F.substf f) []      . emapReft (F.substf . F.substfExcept f) []
-  substr ns su = emapExprArg (\_ -> F.substr ns su) [] . emapReft (\xs -> F.substr ns (F.substExcept su xs)) []
+  substr = go
+    where
+      -- Given a reft 'r' and the nameset 's' that will be passed to
+      -- 'F.substr' for 'r', compute the fresh reft-binder 'v0'' and return
+      -- the updated nameset and substitution for sub-fields that have 'v0'
+      -- in scope (i.e. all fields of the same constructor other than 'r').
+      substReft :: r -> S.HashSet v -> F.SubstV v -> (S.HashSet v, F.SubstV v, r)
+      substReft r s su =
+        case toConcreteReft r of
+          ConcreteNoReft -> (s, su, r)
+          ConcreteReft (F.Reft (v0, e)) ->
+            let (s', v0') = F.freshInNS v0 s
+                su' = F.extendSubst su v0 (F.EVar v0')
+             in (s', su', F.Reft (v0', F.substr s' su' e))
+          ConcreteUReft (MkUReft (F.Reft (v0, e)) ps) ->
+            let (s', v0') = F.freshInNS v0 s
+                su' = F.extendSubst su v0 (F.EVar v0')
+                e' = F.substr s' su' e
+                ps' = F.substr s su ps
+                ur' = MkUReft (F.Reft (v0', e')) ps'
+             in (s', su', ur')
+
+      go :: S.HashSet v -> F.SubstV v -> RTypeBV v v c tv r -> RTypeBV v v c tv r
+      go s su (RFun x i t1 t2 r) =
+        -- x scopes over t1 and t2; v0 (reft binder of r) scopes over t1 and t2.
+        let (s_x, x')     = F.freshInNS x s
+            su_x          = F.extendSubst su x (F.EVar x')
+            (s_xv, su_xv, r') = substReft r s_x su_x    -- nameset/subst for t1, t2
+         in RFun x' i (go s_xv su_xv t1) (go s_xv su_xv t2) r'
+      go s su (REx x t1 t2) =
+        -- x scopes over t2 only; no reft field.
+        let (s', x') = F.freshInNS x s
+            su' = F.extendSubst su x (F.EVar x')
+         in REx x' (go s su t1) (go s' su' t2)
+      go s su (RAllT α t r) =
+        -- v0 (reft binder of r) scopes over the kind inside α and over t.
+        let (s', su', r') = substReft r s su
+            (s'', su'', α') = αScope s' su' α
+         in RAllT α' (go s'' su'' t) r'
+        where
+          αScope s0 su0 rtv@(RTVar _tv (RTVNoInfo _)) = (s0, su0, rtv)
+          αScope s0 su0 (RTVar tv (RTVInfo b k v pol)) =
+            let (s1, b') = F.freshInNS b s0
+                su1 = F.extendSubst su0 b (F.EVar b')
+                k' = F.substr s0 su0 k
+             in (s1, su1, RTVar tv (RTVInfo b' k' v pol))
+
+      go s su (RAllP π t) =
+        let (ns_p, pname') = F.freshInNS (pname π) s
+            su_p = F.extendSubst su (pname π) (F.EVar pname')
+            π' = (substPVar s su π) { pname = pname' }
+         in
+            RAllP π' (go ns_p su_p t)
+        where
+          substPVar s0 su0 π0 =
+            let ((ns_pargs, su_pargs), pargs') =
+                  List.mapAccumR
+                    (\(ns', su') (tb, b, e) ->
+                      let (ns'', b') = F.freshInNS b ns'
+                          su'' = F.extendSubst su' b (F.EVar b')
+                          e' = F.substr ns' su' e
+                       in ((ns'', su''), (F.substr ns' su' tb, b', e'))
+                    )
+                    (s0, su0)
+                    (pargs π)
+             in
+                PV { pname = pname π0
+                   , ptype = F.substr ns_pargs su_pargs (ptype π0)
+                   , pargs = pargs'
+                   }
+
+      go s su (RVar α r)       = RVar α (F.substr s su r)
+      go s su (RApp c ts ps r) =
+        -- v0 (reft binder of r) scopes over ts and ps.
+        let (s', su', r') = substReft r s su
+         in RApp c (go s' su' <$> ts) (F.substr s' su' ps) r'
+      go s su (RAppTy t1 t2 r) =
+        -- v0 (reft binder of r) scopes over t1 and t2.
+        let (s', su', r') = substReft r s su
+        in RAppTy (go s' su' t1) (go s' su' t2) r'
+      go s su (RExprArg e) = RExprArg (F.substr s su <$> e)
+      go s su (RRTy env r o t) =
+          let ((s', su'), env') = substEnv s su env
+           in
+              RRTy env' (F.substr s' su' r) o (go s su t)
+        where
+          substEnv s0 su0 env0 =
+            List.mapAccumL
+              (\(s', su') (x, xt) ->
+                 let (s'', x') = F.freshInNS x s'
+                     su'' = F.extendSubst su' x (F.EVar x')
+                     xt' = F.substr s' su' xt
+                  in ((s'', su''), (x', xt'))
+              )
+              (s0, su0)
+              env0
+
+      go s su (RHole r)        = RHole (F.substr s su r)
+
   subst su    = emapExprArg (\_ -> F.subst su) []      . emapReft (F.subst  . F.substExcept su) []
   subst1 t su = emapExprArg (\_ e -> F.subst1 e su) [] $ emapReft (\xs r -> F.subst1Except xs r su) [] t
 
-
---------------------------------------------------------------------------------
--- | Visitors ------------------------------------------------------------------
---------------------------------------------------------------------------------
 mapExprReft :: (b -> ExprBV b v -> ExprBV b v) -> RTypeBV b v c tv (RReftBV b v) -> RTypeBV b v c tv (RReftBV b v)
 mapExprReft f = mapReft g
   where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
@@ -291,8 +291,6 @@ instance ( IsReft r
 
   subst su (RProp  ss t) = RProp ss (F.subst su t)
 
-  substf f (RProp  ss t) = RProp ss (F.substf f t)
-
 
 instance (F.Subable r, IsReft r, TyConable c, F.Binder v, F.Refreshable v, F.Variable r ~ v, ReftBind r ~ v, ReftVar r ~ v) => F.Subable (RTypeBV v v c tv r) where
   type Variable (RTypeBV v v c tv r) = v
@@ -353,8 +351,6 @@ instance (F.Subable r, IsReft r, TyConable c, F.Binder v, F.Refreshable v, F.Var
 
       go (RHole r) = F.syms r
 
-  -- 'substf' will NOT substitute bound vars
-  substf f    = emapExprArg (\_ -> F.substf f) []      . emapReft (F.substf . F.substfExcept f) []
   substr = go
     where
       -- Given a reft 'r' and the nameset 's' that will be passed to

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
@@ -417,7 +417,9 @@ instance ( F.Subable r
                     (\(ns', su') (tb, b, e) ->
                       let (ns'', b') = F.freshInNS b ns'
                           su'' = F.extendSubstWithVar su' b b'
-                          e' = F.substr ns' su' e
+                          -- b must be in scope for substituting into e (which is typically EVar b)
+                          nsE = S.insert b ns'
+                          e' = F.substr nsE su' e
                        in ((ns'', su''), (F.substr ns' su' tb, b', e'))
                     )
                     (s0, su0)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
@@ -254,6 +254,7 @@ instance ( IsReft r
          , F.Subable t
          , TyConable c
          , F.Binder v
+         , F.Refreshable v
          , F.Variable r ~ v
          , F.Variable t ~ v
          , ReftBind r ~ v
@@ -269,6 +270,8 @@ instance ( IsReft r
      in
         S.unions $ (F.syms r `S.difference` bs) : tss
 
+  substr ns su (RProp  ss t) = RProp ss (F.substr ns su t)
+
   subst su (RProp  ss t) = RProp ss (F.subst su t)
 
   substf f (RProp  ss t) = RProp ss (F.substf f t)
@@ -276,7 +279,7 @@ instance ( IsReft r
   substa f (RProp  ss t) = RProp ss (F.substa f t)
 
 
-instance (F.Subable r, IsReft r, TyConable c, F.Binder v, F.Variable r ~ v, ReftBind r ~ v) => F.Subable (RTypeBV v v c tv r) where
+instance (F.Subable r, IsReft r, TyConable c, F.Binder v, F.Refreshable v, F.Variable r ~ v, ReftBind r ~ v) => F.Subable (RTypeBV v v c tv r) where
   type Variable (RTypeBV v v c tv r) = v
   syms = go
     where
@@ -337,6 +340,7 @@ instance (F.Subable r, IsReft r, TyConable c, F.Binder v, F.Variable r ~ v, Reft
   substa f    = emapExprArg (\_ -> F.substa f) []      . mapReft  (F.substa f)
   -- 'substf' will NOT substitute bound vars
   substf f    = emapExprArg (\_ -> F.substf f) []      . emapReft (F.substf . F.substfExcept f) []
+  substr ns su = emapExprArg (\_ -> F.substr ns su) [] . emapReft (\xs -> F.substr ns (F.substExcept su xs)) []
   subst su    = emapExprArg (\_ -> F.subst su) []      . emapReft (F.subst  . F.substExcept su) []
   subst1 t su = emapExprArg (\_ e -> F.subst1 e su) [] $ emapReft (\xs r -> F.subst1Except xs r su) [] t
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
@@ -280,7 +280,7 @@ instance ( IsReft r
         List.mapAccumR
           (\(bs, ns, su) (x, t) ->
              let (ns', x') = F.freshInNS x ns
-                 su' = F.extendSubst su x (F.EVar x')
+                 su' = F.extendSubstWithVar su x x'
               in
                  ( (x' : bs, ns', su')
                  , F.substr ns su t
@@ -369,11 +369,11 @@ instance ( F.Subable r
           ConcreteNoReft -> (s, su, r)
           ConcreteReft (F.Reft (v0, e)) ->
             let (s', v0') = F.freshInNS v0 s
-                su' = F.extendSubst su v0 (F.EVar v0')
+                su' = F.extendSubstWithVar su v0 v0'
              in (s', su', F.Reft (v0', F.substr s' su' e))
           ConcreteUReft (MkUReft (F.Reft (v0, e)) ps) ->
             let (s', v0') = F.freshInNS v0 s
-                su' = F.extendSubst su v0 (F.EVar v0')
+                su' = F.extendSubstWithVar su v0 v0'
                 e' = F.substr s' su' e
                 ps' = F.substr s su ps
                 ur' = MkUReft (F.Reft (v0', e')) ps'
@@ -383,13 +383,13 @@ instance ( F.Subable r
       go s su (RFun x i t1 t2 r) =
         -- x scopes over t1 and t2; v0 (reft binder of r) scopes over t1 and t2.
         let (s_x, x')     = F.freshInNS x s
-            su_x          = F.extendSubst su x (F.EVar x')
+            su_x          = F.extendSubstWithVar su x x'
             (s_xv, su_xv, r') = substReft r s_x su_x    -- nameset/subst for t1, t2
          in RFun x' i (go s_xv su_xv t1) (go s_xv su_xv t2) r'
       go s su (REx x t1 t2) =
         -- x scopes over t2 only; no reft field.
         let (s', x') = F.freshInNS x s
-            su' = F.extendSubst su x (F.EVar x')
+            su' = F.extendSubstWithVar su x x'
          in REx x' (go s su t1) (go s' su' t2)
       go s su (RAllT α t r) =
         -- v0 (reft binder of r) scopes over the kind inside α and over t.
@@ -400,13 +400,13 @@ instance ( F.Subable r
           αScope s0 su0 rtv@(RTVar _tv (RTVNoInfo _)) = (s0, su0, rtv)
           αScope s0 su0 (RTVar tv (RTVInfo b k v pol)) =
             let (s1, b') = F.freshInNS b s0
-                su1 = F.extendSubst su0 b (F.EVar b')
+                su1 = F.extendSubstWithVar su0 b b'
                 k' = F.substr s0 su0 k
              in (s1, su1, RTVar tv (RTVInfo b' k' v pol))
 
       go s su (RAllP π t) =
         let (ns_p, pname') = F.freshInNS (pname π) s
-            su_p = F.extendSubst su (pname π) (F.EVar pname')
+            su_p = F.extendSubstWithVar su (pname π) pname'
             π' = (substPVar s su π) { pname = pname' }
          in
             RAllP π' (go ns_p su_p t)
@@ -416,7 +416,7 @@ instance ( F.Subable r
                   List.mapAccumR
                     (\(ns', su') (tb, b, e) ->
                       let (ns'', b') = F.freshInNS b ns'
-                          su'' = F.extendSubst su' b (F.EVar b')
+                          su'' = F.extendSubstWithVar su' b b'
                           e' = F.substr ns' su' e
                        in ((ns'', su''), (F.substr ns' su' tb, b', e'))
                     )
@@ -447,7 +447,7 @@ instance ( F.Subable r
             List.mapAccumL
               (\(s', su') (x, xt) ->
                  let (s'', x') = F.freshInNS x s'
-                     su'' = F.extendSubst su' x (F.EVar x')
+                     su'' = F.extendSubstWithVar su' x x'
                      xt' = F.substr s' su' xt
                   in ((s'', su''), (x', xt'))
               )

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
@@ -104,7 +104,7 @@ type SpecRep     = RRep      RReft
 type RTypeRep = RTypeRepV Symbol
 type RTypeRepV = RTypeRepBV Symbol
 data RTypeRepBV b v c tv r = RTypeRep
-  { ty_vars   :: [(RTVar tv (RTypeBV b v c tv (NoReftBV b v)), r)]
+  { ty_vars   :: [(RTVar b v c tv, r)]
   , ty_preds  :: [PVarBV b v (RTypeBV b v c tv (NoReftBV b v))]
   , ty_binds  :: [b]
   , ty_info   :: [RFInfo]
@@ -132,7 +132,7 @@ toRTypeRep t         = RTypeRep αs πs xs is rs ts t''
     (αs, πs, t') = bkUniv t
     ((xs, is, ts, rs), t'') = bkArrow t'
 
-mkArrow :: [(RTVar tv (RTypeBV b v c tv (NoReftBV b v)), r)]
+mkArrow :: [(RTVar b v c tv, r)]
         -> [PVarBV b v (RTypeBV b v c tv (NoReftBV b v))]
         -> [(b, RFInfo, RTypeBV b v c tv r, r)]
         -> RTypeBV b v c tv r
@@ -168,7 +168,7 @@ safeBkArrow (RAllP _ _)     = Prelude.error {- panic Nothing -} "safeBkArrow on 
 safeBkArrow t               = bkArrow t
 
 mkUnivs :: (Foldable t, Foldable t1)
-        => t  (RTVar tv (RTypeBV b v c tv (NoReftBV b v)), r)
+        => t  (RTVar b v c tv, r)
         -> t1 (PVarBV b v (RTypeBV b v c tv (NoReftBV b v)))
         -> RTypeBV b v c tv r
         -> RTypeBV b v c tv r
@@ -181,7 +181,7 @@ bkUnivClass t        = (as, ps, cs, t2)
     (cs, t2)     = bkClass t1
 
 
-bkUniv :: RTypeBV b v tv c r -> ([(RTVar c (RTypeBV b v tv c (NoReftBV b v)), r)], [PVarBV b v (RTypeBV b v tv c (NoReftBV b v))], RTypeBV b v tv c r)
+bkUniv :: RTypeBV b v c tv r -> ([(RTVar b v c tv, r)], [PVarBV b v (RTypeBV b v c tv (NoReftBV b v))], RTypeBV b v c tv r)
 bkUniv (RAllT α t r) = let (αs, πs, t') = bkUniv t in ((α, r):αs, πs, t')
 bkUniv (RAllP π t)   = let (αs, πs, t') = bkUniv t in (αs, π:πs, t')
 bkUniv t             = ([], [], t)
@@ -312,9 +312,13 @@ emapRef :: ([b] -> t -> s) ->  [b] -> RTPropBV b v c tv t -> RTPropBV b v c tv s
 emapRef  f γ (RProp s (RHole r))  = RProp s $ RHole (f γ r)
 emapRef  f γ (RProp s t)         = RProp s $ emapReft f γ t
 
+mapRTVarV :: (v -> v') -> RTVar b v c tv -> RTVar b v' c tv
+mapRTVarV _ (RTVar tv (RTVNoInfo p))         = RTVar tv (RTVNoInfo p)
+mapRTVarV f (RTVar tv ri@RTVInfo{rtv_kind=k}) = RTVar tv ri{rtv_kind = coerce (mapRTypeV f k)}
+
 mapRTypeV ::  (v -> v') -> RTypeBV b v c tv r -> RTypeBV b v' c tv r
 mapRTypeV _ (RVar α r)        = RVar α r
-mapRTypeV f (RAllT α t r)     = RAllT (mapRTypeV f <$> coerce α) (mapRTypeV f t) r
+mapRTypeV f (RAllT α t r)     = RAllT (mapRTVarV f (coerce α)) (mapRTypeV f t) r
 mapRTypeV f (RAllP π t)       = RAllP (mapPVarV f (mapRTypeV f) $ coerce π) (mapRTypeV f t)
 mapRTypeV f (RFun x i t t' r) = RFun x i (mapRTypeV f t) (mapRTypeV f t') r
 mapRTypeV f (RApp c ts rs r)  = RApp c (mapRTypeV f <$> ts) (mapRefV <$> coerce rs) r
@@ -326,9 +330,15 @@ mapRTypeV f (RAppTy t t' r)   = RAppTy (mapRTypeV f t) (mapRTypeV f t') r
 mapRTypeV f (RRTy e r o t)    = RRTy (fmap (mapRTypeV f) <$> e) r o (mapRTypeV f t)
 mapRTypeV _ (RHole r)         = RHole r
 
+mapRTVarVM :: (Hashable b, Monad m) => (v -> m v') -> RTVar b v c tv -> m (RTVar b v' c tv)
+mapRTVarVM _ (RTVar tv (RTVNoInfo p))         = pure $ RTVar tv (RTVNoInfo p)
+mapRTVarVM f (RTVar tv ri@RTVInfo{rtv_kind=k}) = do
+  k' <- mapRTypeVM f k
+  pure $ RTVar tv ri{rtv_kind = coerce k'}
+
 mapRTypeVM :: (Hashable b, Monad m) => (v -> m v') -> RTypeBV b v c tv r -> m (RTypeBV b v' c tv r)
 mapRTypeVM _ (RVar α r)        = return $ RVar α r
-mapRTypeVM f (RAllT α t r)     = RAllT <$> traverse (mapRTypeVM f) (coerce α) <*> mapRTypeVM f t <*> pure r
+mapRTypeVM f (RAllT α t r)     = RAllT <$> mapRTVarVM f (coerce α) <*> mapRTypeVM f t <*> pure r
 mapRTypeVM f (RAllP π t)       = RAllP <$> emapPVarVM (const f) (const (mapRTypeVM f)) (coerce π) <*> mapRTypeVM f t
 mapRTypeVM f (RFun x i t t' r) = RFun x i <$> mapRTypeVM f t <*> mapRTypeVM f t' <*> pure r
 mapRTypeVM f (RApp c ts rs r)  = RApp c <$> mapM (mapRTypeVM f) ts <*> mapM mapRefVM (coerce rs) <*> pure r
@@ -345,7 +355,7 @@ emapFReftM f (F.Reft (v, e)) = F.reft v <$> emapExprVM (f . (v:)) e
 
 -- The first parameter corresponds to the bscope config setting
 emapReftM
-  :: (Monad m, IsReft r1, F.Binder b, CompatibleBinder b tv, ReftBind r1 ~ b)
+  :: forall m b v1 v2 c tv r1 r2. (Monad m, IsReft r1, F.Binder b, CompatibleBinder b tv, ReftBind r1 ~ b)
   => Bool
   -> ([b] -> v1 -> m v2)
   -> ([b] -> r1 -> m r2)
@@ -354,8 +364,15 @@ emapReftM
   -> m (RTypeBV b v2 c tv r2)
 emapReftM bscp vf f = go
   where
+    emapRTVarM :: (RTypeBV b v1 c tv (NoReftBV b v1) -> m (RTypeBV b v2 c tv (NoReftBV b v1))) -> RTVar b v1 c tv -> m (RTVar b v2 c tv)
+    emapRTVarM _ (RTVar tv (RTVNoInfo p))          = pure $ RTVar tv (RTVNoInfo p)
+    emapRTVarM rf (RTVar tv ri@RTVInfo{rtv_kind=k}) = do
+      t' <- rf k
+      pure $ RTVar tv ri{rtv_kind = coerce t'}
+
+    go :: [b] -> RTypeBV b v1 c tv r1 -> m (RTypeBV b v2 c tv r2)
     go γ (RVar α r)        = RVar  α <$> f γ r
-    go γ (RAllT α t r)     = RAllT <$> traverse (emapReftM bscp vf (const pure) γ) (coerce α) <*> go (coerceBinder (ty_var_value α) : γ) t <*> f γ r
+    go γ (RAllT α t r)     = RAllT <$> emapRTVarM (emapReftM bscp vf (const pure) γ) (coerce α) <*> go (coerceBinder (ty_var_value α) : γ) t <*> f γ r
     go γ (RAllP π t)       = RAllP <$> emapPVarVM vf (emapReftM bscp vf (const pure)) (coerce π) <*> go γ t
     go γ (RFun x i t t' r) = RFun  x i <$> go (x:γ) t <*> go (x:γ) t' <*> f (x:γ) r
     go γ (RApp c ts rs r)  =
@@ -557,17 +574,17 @@ foldReft' bsc g f
               (\_ γ -> γ)
               F.emptySEnv
 
-tyVarIsVal :: RTVar tv s -> Bool
+tyVarIsVal :: RTVar b v c tv -> Bool
 tyVarIsVal = rtvinfoIsVal . ty_var_info
 
-rtvinfoIsVal :: RTVInfo s -> Bool
+rtvinfoIsVal :: RTVInfo b v c tv -> Bool
 rtvinfoIsVal RTVNoInfo{} = False
 rtvinfoIsVal RTVInfo{..} = rtv_is_val
 
 efoldReft :: (IsReft r, TyConable c, F.Binder b, ReftBind r ~ b)
           => BScope
           -> (c  -> [RTypeBV b v c tv r] -> [(b, a)])
-          -> (RTVar tv (RTypeBV b v c tv (NoReftBV b v)) -> [(b, a)])
+          -> (RTVar b v c tv -> [(b, a)])
           -> (RTypeBV b v c tv r -> a)
           -> (F.SEnvB b a -> Maybe (RTypeBV b v c tv r) -> r -> z -> z)
           -> (PVarBV b v (RTypeBV b v c tv (NoReftBV b v)) -> F.SEnvB b a -> F.SEnvB b a)
@@ -657,7 +674,7 @@ mapBind f = go
     mapT (RTVar tv i)     = RTVar tv (mapI i)
     mapS                  = mapReft (\NoReft -> NoReft) . mapBind f
     mapI RTVNoInfo{..}    = RTVNoInfo{..}
-    mapI RTVInfo{..}      = RTVInfo { rtv_kind = mapS rtv_kind, .. }
+    mapI RTVInfo{..}      = RTVInfo {rtv_name = f rtv_name, rtv_kind = mapS rtv_kind, .. }
     mapP (PV n τ as)    = PV (f n) (mapS τ) (mapA <$> as)
     mapA (τ, b, e)        = (mapS τ, f b, F.mapBindExpr f e)
     mapR (RProp as t)     = RProp (bimap f mapS <$> as) (go t)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
@@ -293,8 +293,6 @@ instance ( IsReft r
 
   substf f (RProp  ss t) = RProp ss (F.substf f t)
 
-  substa f (RProp  ss t) = RProp ss (F.substa f t)
-
 
 instance (F.Subable r, IsReft r, TyConable c, F.Binder v, F.Refreshable v, F.Variable r ~ v, ReftBind r ~ v, ReftVar r ~ v) => F.Subable (RTypeBV v v c tv r) where
   type Variable (RTypeBV v v c tv r) = v
@@ -355,8 +353,6 @@ instance (F.Subable r, IsReft r, TyConable c, F.Binder v, F.Refreshable v, F.Var
 
       go (RHole r) = F.syms r
 
-  -- 'substa' will substitute bound vars
-  substa f    = emapExprArg (\_ -> F.substa f) []      . mapReft  (F.substa f)
   -- 'substf' will NOT substitute bound vars
   substf f    = emapExprArg (\_ -> F.substf f) []      . emapReft (F.substf . F.substfExcept f) []
   substr = go

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
@@ -290,8 +290,15 @@ instance ( IsReft r
           ss1
 
 
-
-instance (F.Subable r, IsReft r, TyConable c, F.Binder v, F.Refreshable v, F.Variable r ~ v, ReftBind r ~ v, ReftVar r ~ v) => F.Subable (RTypeBV v v c tv r) where
+instance ( F.Subable r
+         , IsReft r
+         , TyConable c
+         , F.Binder v
+         , F.Refreshable v
+         , F.Variable r ~ v
+         , ReftBind r ~ v
+         , ReftVar r ~ v
+         ) => F.Subable (RTypeBV v v c tv r) where
   type Variable (RTypeBV v v c tv r) = v
   syms = go
     where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
@@ -459,7 +459,6 @@ instance (F.Subable r, IsReft r, TyConable c, F.Binder v, F.Refreshable v, F.Var
       go s su (RHole r)        = RHole (F.substr s su r)
 
   subst su    = emapExprArg (\_ -> F.subst su) []      . emapReft (F.subst  . F.substExcept su) []
-  subst1 t su = emapExprArg (\_ e -> F.subst1 e su) [] $ emapReft (\xs r -> F.subst1Except xs r su) [] t
 
 mapExprReft :: (b -> ExprBV b v -> ExprBV b v) -> RTypeBV b v c tv (RReftBV b v) -> RTypeBV b v c tv (RReftBV b v)
 mapExprReft f = mapReft g

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RTypeOp.hs
@@ -38,6 +38,7 @@ module Language.Haskell.Liquid.Types.RTypeOp (
   , mapRTypeVM
   , mapDataDeclV
   , mapDataDeclVM
+  , mapRBase
   , emapDataDeclM
   , emapDataCtorTyM
   , emapBareTypeVM
@@ -791,4 +792,5 @@ mapRBase f (RApp c ts rs r)   = RApp c ts rs $ f r
 mapRBase f (RVar a r)         = RVar a $ f r
 mapRBase f (RFun x i t1 t2 r) = RFun x i t1 t2 $ f r
 mapRBase f (RAppTy t1 t2 r)   = RAppTy t1 t2 $ f r
+mapRBase f (RAllT b t r)      = RAllT b t (f r)
 mapRBase _ t                  = t

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -1491,7 +1491,8 @@ appSolRefa si s = mapKVars f0
       where
         txK (PKVar k _tsu su)
           | Just p' <- f k =
-              rapierSubstExpr (substSymbolsSet $ substFromKSubst su) (renameDomain k su) p'
+              let su' = renameDomain k su
+               in rapierSubstExpr (substSymbolsSet su' `S.union` syms p') su' p'
         txK p = p
 
         -- The parameters of kvars all seem to have prefix $ and suffix ##k_

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -210,6 +210,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTypeBV v v c tv (NoReftB v
          , ReftBind r ~ v
          , IsReft r
          , Meet r
+         , F.Refreshable v
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) r
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) tv
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTVar v v c tv)
@@ -227,6 +228,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTypeBV v v c tv (NoReftB v
          , ReftBind r ~ v
          , IsReft r
          , Meet r
+         , F.Refreshable v
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) r
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) tv
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTVar v v c tv)
@@ -243,6 +245,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) c
          , Meet r
          , FreeVar c tv
          , Subable r
+         , F.Refreshable v
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) r
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTypeBV v v c tv (NoReftB v))
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) tv
@@ -269,6 +272,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) c
          , Meet r
          , FreeVar c tv
          , Subable r
+         , F.Refreshable v
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) r
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTypeBV v v c tv (NoReftB v))
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) tv
@@ -285,6 +289,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) c
          , Meet r
          , FreeVar c tv
          , Subable r
+         , F.Refreshable v
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) r
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTypeBV v v c tv (NoReftB v))
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) tv
@@ -520,6 +525,7 @@ strengthenRefTypeGen, strengthenRefType ::
          , ReftBind r ~ v
          , IsReft r
          , Meet r
+         , F.Refreshable v
          , FreeVar c tv
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTypeBV v v c tv (NoReftB v))
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) c
@@ -535,6 +541,7 @@ strengthenRefType_ ::
          , ReftBind r ~ v
          , IsReft r
          , Meet r
+         , F.Refreshable v
          , FreeVar c tv
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTypeBV v v c tv (NoReftB v))
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) c

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -212,7 +212,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTypeBV v v c tv (NoReftB v
          , Meet r
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) r
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) tv
-         , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTVar tv (RTypeBV v v c tv (NoReftB v)))
+         , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTVar v v c tv)
          )
         => Semigroup (RTypeBV v v c tv r)  where
   (<>) = strengthenRefType
@@ -229,7 +229,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTypeBV v v c tv (NoReftB v
          , Meet r
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) r
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) tv
-         , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTVar tv (RTypeBV v v c tv (NoReftB v)))
+         , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTVar v v c tv)
          )
         => Monoid (RTypeBV v v c tv r)  where
   mempty  = panic Nothing "mempty: RType"
@@ -246,7 +246,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) c
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) r
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTypeBV v v c tv (NoReftB v))
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) tv
-         , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTVar tv (RTypeBV v v c tv (NoReftB v)))
+         , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTVar v v c tv)
          )
          => Semigroup (RTPropBV v v c tv r) where
   (<>) (RProp s1 (RHole r1)) (RProp s2 (RHole r2))
@@ -272,7 +272,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) c
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) r
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTypeBV v v c tv (NoReftB v))
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) tv
-         , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTVar tv (RTypeBV v v c tv (NoReftB v)))
+         , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTVar v v c tv)
          )
          => Meet (RTPropBV v v c tv r) where
 
@@ -288,7 +288,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) c
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) r
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTypeBV v v c tv (NoReftB v))
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) tv
-         , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTVar tv (RTypeBV v v c tv (NoReftB v)))
+         , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTVar v v c tv)
          )
          => Monoid (RTPropBV v v c tv r) where
   mempty  = panic Nothing "mempty: RTProp"
@@ -387,22 +387,22 @@ rVar   = (`RVar` trueReft) . RTV
 rTyVar :: TyVar -> RTyVar
 rTyVar = RTV
 
-updateRTVar :: IsReft r => RTVar RTyVar i -> RTVar RTyVar (RType RTyCon RTyVar r)
+updateRTVar :: RTVar b v c RTyVar -> RTVar Symbol Symbol RTyCon RTyVar
 updateRTVar (RTVar (RTV a) _) = RTVar (RTV a) (rTVarInfo a)
 
-rTVar :: IsReft r => TyVar -> RTVar RTyVar (RRType r)
+rTVar :: TyVar -> RTVar Symbol Symbol RTyCon RTyVar
 rTVar a = RTVar (RTV a) (rTVarInfo a)
 
-bTVar :: IsReft r => TyVar -> RTVar BTyVar (BRType r)
+bTVar :: TyVar -> RTVar Symbol Symbol BTyCon BTyVar
 bTVar a = RTVar (BTV (symbol <$> GM.locNamedThing a)) (bTVarInfo a)
 
-bTVarInfo :: IsReft r => TyVar -> RTVInfo (BRType r)
+bTVarInfo :: TyVar -> RTVInfo Symbol Symbol BTyCon BTyVar
 bTVarInfo = mkTVarInfo kindToBRType
 
-rTVarInfo :: IsReft r => TyVar -> RTVInfo (RRType r)
+rTVarInfo :: TyVar -> RTVInfo Symbol Symbol RTyCon RTyVar
 rTVarInfo = mkTVarInfo kindToRType
 
-mkTVarInfo :: (Kind -> s) -> TyVar -> RTVInfo s
+mkTVarInfo :: (Kind -> RTypeBV Symbol v c tv (NoReftBV Symbol v)) -> TyVar -> RTVInfo Symbol v c tv
 mkTVarInfo k2t a = RTVInfo
   { rtv_name   = symbol    $ varName a
   , rtv_kind   = k2t       $ tyVarKind a
@@ -525,7 +525,7 @@ strengthenRefTypeGen, strengthenRefType ::
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) c
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) r
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) tv
-         , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTVar tv (RTypeBV v v c tv (NoReftB v)))
+         , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTVar v v c tv)
          ) => RTypeBV v v c tv r -> RTypeBV v v c tv r -> RTypeBV v v c tv r
 
 strengthenRefType_ ::
@@ -539,7 +539,7 @@ strengthenRefType_ ::
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTypeBV v v c tv (NoReftB v))
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) c
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) r
-         , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTVar tv (RTypeBV v v c tv (NoReftB v)))
+         , SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTVar v v c tv)
          , SubsTy tv (RTypeBV v v c tv (NoReftB v)) tv
          ) => (RTypeBV v v c tv r -> RTypeBV v v c tv r -> RTypeBV v v c tv r)
            ->  RTypeBV v v c tv r -> RTypeBV v v c tv r -> RTypeBV v v c tv r
@@ -647,7 +647,7 @@ strengthenWith mt = go
     go t                  _  = t
 
 
-quantifyRTy :: (Monoid r, Eq tv) => [RTVar tv (RTypeV v c tv (NoReftBV Symbol v))] -> RTypeV v c tv r -> RTypeV v c tv r
+quantifyRTy :: (Monoid r, Eq tv) => [RTVar Symbol v c tv] -> RTypeV v c tv r -> RTypeV v c tv r
 quantifyRTy tvs ty = foldr rAllT ty tvs
   where rAllT a t = RAllT a t mempty
 
@@ -693,7 +693,7 @@ rtPropTop
       SubsTy tv (RType c tv NoReft) c, SubsTy tv (RType c tv NoReft) r,
       SubsTy tv (RType c tv NoReft) (RType c tv NoReft), FreeVar c tv,
       SubsTy tv (RType c tv NoReft) tv,
-      SubsTy tv (RType c tv NoReft) (RTVar tv (RType c tv NoReft)))
+      SubsTy tv (RType c tv NoReft) (RTVar Symbol Symbol c tv))
    => PVar (RType c tv NoReft) -> Ref (RType c tv NoReft) (RType c tv r)
 rtPropTop pv = RProp (pvArgs pv) $ ofRSort $ ptype pv
 
@@ -850,7 +850,7 @@ allTyVars' t = fmap ty_var_value $ vs ++ vs'
     vs'     = freeTyVars t
 
 
-freeTyVars :: Eq tv => RTypeV v c tv r -> [RTVar tv (RTypeV v c tv (NoReftBV Symbol v))]
+freeTyVars :: Eq tv => RTypeV v c tv r -> [RTVar Symbol v c tv]
 freeTyVars (RAllP _ t)       = freeTyVars t
 freeTyVars (RAllT α t _)     = freeTyVars t L.\\ [α]
 freeTyVars (RFun _ _ t t' _) = freeTyVars t `L.union` freeTyVars t'
@@ -889,7 +889,7 @@ subsTyVarsMeet
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar b v c tv))
   => t (tv, RTypeBV b v c tv (NoReftBV b v), RTypeBV b v c tv r) -> RTypeBV b v c tv r -> RTypeBV b v c tv r
 subsTyVarsMeet        = subsTyVars True
 
@@ -898,7 +898,7 @@ subsTyVarsNoMeet
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar b v c tv))
   => t (tv, RTypeBV b v c tv (NoReftBV b v), RTypeBV b v c tv r) -> RTypeBV b v c tv r -> RTypeBV b v c tv r
 subsTyVarsNoMeet      = subsTyVars False
 
@@ -907,7 +907,7 @@ subsTyVarNoMeet
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar b v c tv))
   => (tv, RTypeBV b v c tv (NoReftBV b v), RTypeBV b v c tv r) -> RTypeBV b v c tv r -> RTypeBV b v c tv r
 subsTyVarNoMeet       = subsTyVar False
 
@@ -916,7 +916,7 @@ subsTyVarMeet
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar b v c tv))
   => (tv, RTypeBV b v c tv (NoReftBV b v), RTypeBV b v c tv r) -> RTypeBV b v c tv r -> RTypeBV b v c tv r
 subsTyVarMeet         = subsTyVar True
 
@@ -925,7 +925,7 @@ subsTyVarMeet'
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar b v c tv))
   => (tv, RTypeBV b v c tv r) -> RTypeBV b v c tv r -> RTypeBV b v c tv r
 subsTyVarMeet' (α, t) = subsTyVarMeet (α, toRSort t, t)
 
@@ -934,7 +934,7 @@ subsTyVars
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar b v c tv))
   => Bool
   -> t (tv, RTypeBV b v c tv (NoReftBV b v), RTypeBV b v c tv r)
   -> RTypeBV b v c tv r
@@ -946,7 +946,7 @@ subsTyVar
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar b v c tv))
   => Bool
   -> (tv, RTypeBV b v c tv (NoReftBV b v), RTypeBV b v c tv r)
   -> RTypeBV b v c tv r
@@ -958,7 +958,7 @@ subsFree
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v)))
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar b v c tv)
      )
   => Bool
   -> S.HashSet tv
@@ -997,7 +997,7 @@ subsFrees
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar b v c tv))
   => Bool
   -> S.HashSet tv
   -> [(tv, RTypeBV b v c tv (NoReftBV b v), RTypeBV b v c tv r)]
@@ -1012,7 +1012,7 @@ subsFreeRAppTy
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)),
       FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar b v c tv))
   => Bool
   -> S.HashSet tv
   -> RTypeBV b v c tv r
@@ -1035,7 +1035,7 @@ mkRApp :: (Eq tv, Hashable tv, IsReft r, Eq (ReftVar r), TyConable c, Binder b, 
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar b v c tv))
   => Bool
   -> S.HashSet tv
   -> c
@@ -1104,7 +1104,7 @@ subsFreeRef
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) c, SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) r,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTypeBV b v c tv (NoReftBV b v)), FreeVar c tv,
       SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) tv,
-      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar tv (RTypeBV b v c tv (NoReftBV b v))))
+      SubsTy tv (RTypeBV b v c tv (NoReftBV b v)) (RTVar b v c tv))
   => Bool
   -> S.HashSet tv
   -> (tv, RTypeBV b v c tv (NoReftBV b v), RTypeBV b v c tv r)
@@ -1129,7 +1129,7 @@ instance SubsTy RTyVar (RType RTyCon RTyVar NoReft) RTyVar where
   subt _ v
     = v
 
-instance SubsTy RTyVar (RType RTyCon RTyVar NoReft) (RTVar RTyVar (RType RTyCon RTyVar NoReft)) where
+instance SubsTy RTyVar (RType RTyCon RTyVar NoReft) (RTVar Symbol Symbol RTyCon RTyVar) where
   -- NV TODO: update kind
   subt su rty = rty { ty_var_value = subt su $ ty_var_value rty }
 
@@ -1137,7 +1137,7 @@ instance SubsTy RTyVar (RType RTyCon RTyVar NoReft) (RTVar RTyVar (RType RTyCon 
 instance SubsTy BTyVar (RType c BTyVar NoReft) BTyVar where
   subt _ = id
 
-instance SubsTy BTyVar (RType c BTyVar NoReft) (RTVar BTyVar (RType c BTyVar NoReft)) where
+instance SubsTy BTyVar (RType c BTyVar NoReft) (RTVar Symbol Symbol c BTyVar) where
   subt _ = id
 
 instance SubsTy tv ty NoReft   where
@@ -1316,7 +1316,7 @@ holeLit = StrTyLit "$LH_RHOLE"
 
 data TyConv c tv r = TyConv
   { tcFVar  :: TyVar -> RType c tv r
-  , tcFTVar :: TyVar -> RTVar tv (RType c tv NoReft)
+  , tcFTVar :: TyVar -> RTVar Symbol Symbol c tv
   , tcFApp  :: TyCon -> [RType c tv r] -> RType c tv r
   , tcFLit  :: TyLit -> RType c tv r
   }

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -208,6 +208,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTypeBV v v c tv (NoReftB v
          , Subable r
          , F.Variable r ~ v
          , ReftBind r ~ v
+         , ReftVar r ~ v
          , IsReft r
          , Meet r
          , F.Refreshable v
@@ -226,6 +227,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) (RTypeBV v v c tv (NoReftB v
          , Subable r
          , F.Variable r ~ v
          , ReftBind r ~ v
+         , ReftVar r ~ v
          , IsReft r
          , Meet r
          , F.Refreshable v
@@ -241,6 +243,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) c
          , OkRTBV v v c tv r
          , Variable r ~ v
          , ReftBind r ~ v
+         , ReftVar r ~ v
          , IsReft r
          , Meet r
          , FreeVar c tv
@@ -268,6 +271,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) c
          , OkRTBV v v c tv r
          , Variable r ~ v
          , ReftBind r ~ v
+         , ReftVar r ~ v
          , IsReft r
          , Meet r
          , FreeVar c tv
@@ -285,6 +289,7 @@ instance ( SubsTy tv (RTypeBV v v c tv (NoReftB v)) c
          , OkRTBV v v c tv r
          , Variable r ~ v
          , ReftBind r ~ v
+         , ReftVar r ~ v
          , IsReft r
          , Meet r
          , FreeVar c tv
@@ -523,6 +528,7 @@ strengthenRefTypeGen, strengthenRefType ::
          , Subable r
          , F.Variable r ~ v
          , ReftBind r ~ v
+         , ReftVar r ~ v
          , IsReft r
          , Meet r
          , F.Refreshable v
@@ -539,6 +545,7 @@ strengthenRefType_ ::
          , Subable r
          , F.Variable r ~ v
          , ReftBind r ~ v
+         , ReftVar r ~ v
          , IsReft r
          , Meet r
          , F.Refreshable v

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -792,17 +792,12 @@ instance F.PPrint (CMeasure t) => Show (CMeasure t) where
 
 instance F.Subable (Measure ty ctor) where
   syms m = F.syms (msEqns m)
-  substa f m  = m { msEqns = F.substa f  <$> msEqns m }
   substf f m  = m { msEqns = F.substf f  <$> msEqns m }
   substr ns su m = m { msEqns = F.substr ns su <$> msEqns m }
   subst  su m = m { msEqns = F.subst  su <$> msEqns m }
-  -- substa f  (M n s es _) = M n s (F.substa f  <$> es) k
-  -- substf f  (M n s es _) = M n s $ F.substf f  <$> es
-  -- subst  su (M n s es _) = M n s $ F.subst  su <$> es
 
 instance F.Subable (Def ty ctor) where
   syms (Def _ _ _ sb bd)  = S.fromList (fst <$> sb) `S.union` F.syms bd
-  substa f  (Def m c t b bd) = Def m c t b $ F.substa f  bd
   substf f  (Def m c t b bd) = Def m c t b $ F.substf f  bd
   substr ns su (Def m c t b bd) = Def m c t b $ F.substr ns su bd
   subst  su (Def m c t b bd) = Def m c t b $ F.subst  su bd
@@ -811,10 +806,6 @@ instance F.Subable Body where
   syms (E e)       = F.syms e
   syms (P e)       = F.syms e
   syms (R s e)     = S.delete s (F.syms e)
-
-  substa f (E e)   = E   (F.substa f e)
-  substa f (P e)   = P   (F.substa f e)
-  substa f (R s e) = R s (F.substa f e)
 
   substf f (E e)   = E   (F.substf f e)
   substf f (P e)   = P   (F.substf f e)
@@ -835,7 +826,6 @@ instance F.Subable t => F.Subable (WithModel t) where
   type Variable (WithModel t) = F.Variable t
   syms (NoModel t)     = F.syms t
   syms (WithModel _ t) = F.syms t
-  substa f             = fmap (F.substa f)
   substf f             = fmap (F.substf f)
   substr ns su         = fmap (F.substr ns su)
   subst su             = fmap (F.subst su)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -807,7 +807,7 @@ instance F.Subable Body where
   substr ns su (P e)   = P   (F.substr ns su e)
   substr ns su (R s e) =
     let (ns', s') = F.freshInNS s ns
-        su' = F.extendSubst su s (F.EVar s')
+        su' = F.extendSubstWithVar su s s'
     in R s' (F.substr ns' su' e)
 
 instance F.Subable t => F.Subable (WithModel t) where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -794,6 +794,7 @@ instance F.Subable (Measure ty ctor) where
   syms m = F.syms (msEqns m)
   substa f m  = m { msEqns = F.substa f  <$> msEqns m }
   substf f m  = m { msEqns = F.substf f  <$> msEqns m }
+  substr ns su m = m { msEqns = F.substr ns su <$> msEqns m }
   subst  su m = m { msEqns = F.subst  su <$> msEqns m }
   -- substa f  (M n s es _) = M n s (F.substa f  <$> es) k
   -- substf f  (M n s es _) = M n s $ F.substf f  <$> es
@@ -803,6 +804,7 @@ instance F.Subable (Def ty ctor) where
   syms (Def _ _ _ sb bd)  = S.fromList (fst <$> sb) `S.union` F.syms bd
   substa f  (Def m c t b bd) = Def m c t b $ F.substa f  bd
   substf f  (Def m c t b bd) = Def m c t b $ F.substf f  bd
+  substr ns su (Def m c t b bd) = Def m c t b $ F.substr ns su bd
   subst  su (Def m c t b bd) = Def m c t b $ F.subst  su bd
 
 instance F.Subable Body where
@@ -818,6 +820,10 @@ instance F.Subable Body where
   substf f (P e)   = P   (F.substf f e)
   substf f (R s e) = R s (F.substf f e)
 
+  substr ns su (E e)   = E   (F.substr ns su e)
+  substr ns su (P e)   = P   (F.substr ns su e)
+  substr ns su (R s e) = R s (F.substr ns su e)
+
   subst su (E e)   = E   (F.subst su e)
   subst su (P e)   = P   (F.subst su e)
   subst su (R s e) = R s (F.subst su e)
@@ -828,6 +834,7 @@ instance F.Subable t => F.Subable (WithModel t) where
   syms (WithModel _ t) = F.syms t
   substa f             = fmap (F.substa f)
   substf f             = fmap (F.substf f)
+  substr ns su         = fmap (F.substr ns su)
   subst su             = fmap (F.subst su)
 
 data RClass ty = RClass

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -808,7 +808,7 @@ instance F.Subable (Def ty ctor) where
 instance F.Subable Body where
   syms (E e)       = F.syms e
   syms (P e)       = F.syms e
-  syms (R s e)     = S.insert s (F.syms e)
+  syms (R s e)     = S.delete s (F.syms e)
 
   substa f (E e)   = E   (F.substa f e)
   substa f (P e)   = P   (F.substa f e)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -822,7 +822,10 @@ instance F.Subable Body where
 
   substr ns su (E e)   = E   (F.substr ns su e)
   substr ns su (P e)   = P   (F.substr ns su e)
-  substr ns su (R s e) = R s (F.substr ns su e)
+  substr ns su (R s e) =
+    let (ns', s') = F.freshInNS s ns
+        su' = F.extendSubst su s (F.EVar s')
+    in R s' (F.substr ns' su' e)
 
   subst su (E e)   = E   (F.subst su e)
   subst su (P e)   = P   (F.subst su e)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -793,12 +793,10 @@ instance F.PPrint (CMeasure t) => Show (CMeasure t) where
 instance F.Subable (Measure ty ctor) where
   syms m = F.syms (msEqns m)
   substr ns su m = m { msEqns = F.substr ns su <$> msEqns m }
-  subst  su m = m { msEqns = F.subst  su <$> msEqns m }
 
 instance F.Subable (Def ty ctor) where
   syms (Def _ _ _ sb bd)  = S.fromList (fst <$> sb) `S.union` F.syms bd
   substr ns su (Def m c t b bd) = Def m c t b $ F.substr ns su bd
-  subst  su (Def m c t b bd) = Def m c t b $ F.subst  su bd
 
 instance F.Subable Body where
   syms (E e)       = F.syms e
@@ -812,16 +810,11 @@ instance F.Subable Body where
         su' = F.extendSubst su s (F.EVar s')
     in R s' (F.substr ns' su' e)
 
-  subst su (E e)   = E   (F.subst su e)
-  subst su (P e)   = P   (F.subst su e)
-  subst su (R s e) = R s (F.subst su e)
-
 instance F.Subable t => F.Subable (WithModel t) where
   type Variable (WithModel t) = F.Variable t
   syms (NoModel t)     = F.syms t
   syms (WithModel _ t) = F.syms t
   substr ns su         = fmap (F.substr ns su)
-  subst su             = fmap (F.subst su)
 
 data RClass ty = RClass
   { rcName    :: BTyCon

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Types.hs
@@ -792,13 +792,11 @@ instance F.PPrint (CMeasure t) => Show (CMeasure t) where
 
 instance F.Subable (Measure ty ctor) where
   syms m = F.syms (msEqns m)
-  substf f m  = m { msEqns = F.substf f  <$> msEqns m }
   substr ns su m = m { msEqns = F.substr ns su <$> msEqns m }
   subst  su m = m { msEqns = F.subst  su <$> msEqns m }
 
 instance F.Subable (Def ty ctor) where
   syms (Def _ _ _ sb bd)  = S.fromList (fst <$> sb) `S.union` F.syms bd
-  substf f  (Def m c t b bd) = Def m c t b $ F.substf f  bd
   substr ns su (Def m c t b bd) = Def m c t b $ F.substr ns su bd
   subst  su (Def m c t b bd) = Def m c t b $ F.subst  su bd
 
@@ -806,10 +804,6 @@ instance F.Subable Body where
   syms (E e)       = F.syms e
   syms (P e)       = F.syms e
   syms (R s e)     = S.delete s (F.syms e)
-
-  substf f (E e)   = E   (F.substf f e)
-  substf f (P e)   = P   (F.substf f e)
-  substf f (R s e) = R s (F.substf f e)
 
   substr ns su (E e)   = E   (F.substr ns su e)
   substr ns su (P e)   = P   (F.substr ns su e)
@@ -826,7 +820,6 @@ instance F.Subable t => F.Subable (WithModel t) where
   type Variable (WithModel t) = F.Variable t
   syms (NoModel t)     = F.syms t
   syms (WithModel _ t) = F.syms t
-  substf f             = fmap (F.substf f)
   substr ns su         = fmap (F.substr ns su)
   subst su             = fmap (F.subst su)
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Tidy.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Tidy.hs
@@ -183,7 +183,7 @@ subsTyVarsAll
       SubsTy k (RType c k NoReft) r,
       SubsTy k (RType c k NoReft) k,
       SubsTy k (RType c k NoReft) (RType c k NoReft),
-      SubsTy k (RType c k NoReft) (RTVar k (RType c k NoReft)),
+      SubsTy k (RType c k NoReft) (RTVar Symbol Symbol c k),
       FreeVar c k)
    => [(k, RType c k NoReft, RType c k r)] -> RType c k r -> RType c k r
 subsTyVarsAll ats = go

--- a/scripts/benchmark-comparison.sh
+++ b/scripts/benchmark-comparison.sh
@@ -13,7 +13,7 @@ clean_run_collect() {
     local run_label="$1"  # "before" or "after"
     echo "Running benchmarks for $run_label branch..."
     find dist-newstyle -name "tests-*" -o -name "prover-ple-lib-*" | xargs rm -rf
-    ./scripts/test/test_plugin.sh --measure-timings-j1
+    ./scripts/test/test_plugin.sh --measure-timings
     rm -rf tmp tmp-${run_label}
     cabal build ghc-timings
     cabal exec ghc-timings dist-newstyle
@@ -31,4 +31,4 @@ echo "Checking out AFTER branch: $AFTER_BRANCH"
 git checkout "$AFTER_BRANCH"
 git submodule update --init --recursive
 
-cabal run plot-performance -- -b summary-before.csv -a summary-after.csv -s 50
+cabal run plot-performance -- --allocs -b summary-before.csv -a summary-after.csv -s 50

--- a/scripts/plot-performance/app/Benchmark.hs
+++ b/scripts/plot-performance/app/Benchmark.hs
@@ -100,8 +100,10 @@ hiBenchmarks :: (Benchmark -> Double) -> Int -> BenchmarkComparison -> Benchmark
 hiBenchmarks f n bc =
     bc { bcCombined =
            L.take n
-           $ filter (\(bt, _) -> test bt `notElem` (map fst $ bcWarnings bc))
-           $ sortOn (\(bt, at) -> f at - f bt) (bcCombined bc)
+           $ sortOn (\(bt, at) -> (f at - f bt) / f bt)
+           $ filter
+               (\(bt, _) -> test bt `notElem` map fst (bcWarnings bc))
+               (bcCombined bc)
        }
 
 -- | Sort the benchmarks by the difference in the given field, and take the bottom
@@ -110,6 +112,8 @@ loBenchmarks :: (Benchmark -> Double) -> Int -> BenchmarkComparison -> Benchmark
 loBenchmarks f n bc =
     bc { bcCombined =
            L.take n
-           $ filter (\(bt, _) -> test bt `notElem` (map fst $ bcWarnings bc))
-           $ sortOn (\(bt, at) -> f bt - f at) (bcCombined bc)
+           $ sortOn (\(bt, at) -> (f bt - f at) / f bt)
+           $ filter
+               (\(bt, _) -> test bt `notElem` map fst (bcWarnings bc))
+               (bcCombined bc)
        }

--- a/scripts/plot-performance/app/Benchmark.hs
+++ b/scripts/plot-performance/app/Benchmark.hs
@@ -9,7 +9,8 @@ module Benchmark where
 import Prelude hiding (readFile, writeFile, filter, zip, lookup)
 import Data.String (fromString)
 import Data.List as L
-import Data.Vector as V hiding (length, concat, null, (++), last, find)
+import Data.Vector (Vector)
+import qualified Data.Vector as V
 import qualified Data.Map.Strict as Map
 import Data.ByteString.Char8 (unpack)
 import Data.ByteString.Lazy.Char8 (readFile, writeFile)
@@ -18,11 +19,16 @@ import Data.Csv hiding (Options, Parser, lookup)
 
 -- Individual entries
 
+-- | A single benchmark entry
 data Benchmark = Benchmark
-  { test :: String
-  , time :: Double
-  , result :: Bool
+  { test :: String   -- ^ test name
+  , time :: Double   -- ^ time in seconds
+  , allocs :: Double -- ^ allocations in MBs
+  , result :: Bool   -- ^ whether the test passed or failed
   } deriving stock (Eq, Ord, Show, Generic)
+
+zeroBenchmark :: Benchmark -> Benchmark
+zeroBenchmark b = b { time = 0, allocs = 0 }
 
 instance FromField Bool where
   parseField = pure . read . unpack
@@ -34,6 +40,7 @@ instance FromNamedRecord Benchmark where
     parseNamedRecord m = Benchmark
                          <$> m .: "test"
                          <*> m .: "time"
+                         <*> m .: "allocs"
                          <*> m .: "result"
 
 instance ToNamedRecord Benchmark
@@ -52,8 +59,6 @@ writeCSV f dat = do
 
 -- Data sets
 
-type BData = Double
-
 data BenchmarkWarning
     = MissingMeasureAfter
     | MissingMeasureBefore
@@ -64,14 +69,14 @@ data BenchmarkComparison = BenchmarkComparison
     { -- | Warnings for tests with the given labels
       bcWarnings :: [(String, BenchmarkWarning)]
       -- | Data of benchmars present in both sets
-    , bcCombined :: [(String, (BData, BData))]
+    , bcCombined :: [(Benchmark, Benchmark)]
     }
 
 bcLen :: BenchmarkComparison -> Int
 bcLen bc = length (bcCombined bc) + warningsLength bc
-
-warningsLength :: BenchmarkComparison -> Int
-warningsLength bc = length (bcWarnings bc)
+  where
+    warningsLength :: BenchmarkComparison -> Int
+    warningsLength = length . bcWarnings
 
 compareBenchmarks :: Vector Benchmark -> Vector Benchmark -> BenchmarkComparison
 compareBenchmarks v1 v2 = BenchmarkComparison
@@ -81,23 +86,30 @@ compareBenchmarks v1 v2 = BenchmarkComparison
         , Map.map (const MissingMeasureBefore) (Map.difference after before)
         , Map.map (const MissingMeasureAfter) (Map.difference before after)
         ]
-    , bcCombined = Map.toList $
-        Map.unionWith (\(t0, _) (_, t1) -> (t0, t1)) before after
+    , bcCombined = Map.elems $ Map.unionWith (\(a, _) (_, b) -> (a, b)) before after
     }
   where
     (vBefore, failedBefore) = V.partition result v1
     (vAfter, failedAfter) = V.partition result v2
-    before = Map.fromList [ (test b, (time b, 0)) | b <- V.toList vBefore]
-    after = Map.fromList [ (test b, (0, time b)) | b <- V.toList vAfter]
+    before = Map.fromList [ (test b, (b, zeroBenchmark b)) | b <- V.toList vBefore]
+    after = Map.fromList [ (test b, (zeroBenchmark b, b)) | b <- V.toList vAfter]
 
-hiBenchmarks :: Int -> BenchmarkComparison -> BenchmarkComparison
-hiBenchmarks n bc =
+-- | Sort the benchmarks by the difference in the given field, and take the top
+-- N (after removing warnings)
+hiBenchmarks :: (Benchmark -> Double) -> Int -> BenchmarkComparison -> BenchmarkComparison
+hiBenchmarks f n bc =
     bc { bcCombined =
-           L.take (n - warningsLength bc) $ sortOn (\(_, (bt, at)) -> at - bt) (bcCombined bc)
+           L.take n
+           $ filter (\(bt, _) -> test bt `notElem` (map fst $ bcWarnings bc))
+           $ sortOn (\(bt, at) -> f at - f bt) (bcCombined bc)
        }
 
-loBenchmarks :: Int -> BenchmarkComparison -> BenchmarkComparison
-loBenchmarks n bc =
+-- | Sort the benchmarks by the difference in the given field, and take the bottom
+-- N (after removing warnings)
+loBenchmarks :: (Benchmark -> Double) -> Int -> BenchmarkComparison -> BenchmarkComparison
+loBenchmarks f n bc =
     bc { bcCombined =
-           L.take (n - warningsLength bc) $ sortOn (\(_, (bt, at)) -> bt - at) (bcCombined bc)
+           L.take n
+           $ filter (\(bt, _) -> test bt `notElem` (map fst $ bcWarnings bc))
+           $ sortOn (\(bt, at) -> f bt - f at) (bcCombined bc)
        }

--- a/scripts/plot-performance/app/Main.hs
+++ b/scripts/plot-performance/app/Main.hs
@@ -19,6 +19,7 @@ data Options = Options
   , optsAfterFile :: FilePath
   , optsCombine :: Bool
   , optsSort :: Maybe Int
+  , optsAllocs :: Bool
   , optsFilter :: [String]
   , optsOutputDir :: Maybe FilePath
   } deriving stock (Eq, Ord, Show)
@@ -40,6 +41,8 @@ options = Options <$>
                 <> short 's'
                 <> metavar "N"
                 <> help "Generate two graphs for top and bottom N differences."))
+  <*> switch (long "allocs"
+              <> help "Compare allocations instead of time." )
   <*> (concat <$> many (option (words <$> str) (long "filter"
                                                  <> short 'f'
                                                  <> metavar "FILTER"
@@ -67,6 +70,8 @@ main = do op <- execParser opts
           let isSelectedTest b = Prelude.any (`isPrefixOf` test b) (optsFilter op)
               selectTests = V.filter isSelectedTest
               dropAppMain = V.filter (\b -> test b /= "app/Main")
+              dataSelector = if optsAllocs op then allocs else time
+              mkTitle s = if optsAllocs op then s ++ " (MBs)" else s ++ " (seconds)"
 
           vb <- dropAppMain <$> readCSV (optsBeforeFile op)
           va <- dropAppMain <$> readCSV (optsAfterFile op)
@@ -74,27 +79,27 @@ main = do op <- execParser opts
           case (optsSort op, null $ optsFilter op, optsCombine op) of
             (Just n , False, True ) ->
               let bdsf = compareBenchmarks (selectTests vb) (selectTests va)
-                  hif = hiBenchmarks n bdsf
-                  lof = loBenchmarks n bdsf
-              in do chartToFile "Top filtered speedups (seconds)" hif (outdir ++ "filtered-top.svg")
-                    chartToFile "Top filtered slowdowns (seconds)" lof (outdir ++ "filtered-bot.svg")
+                  hif = hiBenchmarks dataSelector n bdsf
+                  lof = loBenchmarks dataSelector n bdsf
+              in do chartToFile (mkTitle "Top filtered speedups") dataSelector hif (outdir ++ "filtered-top.svg")
+                    chartToFile (mkTitle "Top filtered slowdowns") dataSelector lof (outdir ++ "filtered-bot.svg")
             (Just n , False, False) ->
               let bds = compareBenchmarks vb va
                   bdsf = compareBenchmarks (selectTests vb) (selectTests va)
-                  hi = hiBenchmarks n bds
-                  lo = loBenchmarks n bds
-              in do chartToFile ("Perf diff: " ++ show (optsFilter op) ++ " (seconds)") bdsf (outdir ++ "filtered.svg")
-                    chartToFile "Top speedups (seconds)" hi (outdir ++ "top.svg")
-                    chartToFile "Top slowdowns (seconds)" lo (outdir ++ "bot.svg")
+                  hi = hiBenchmarks dataSelector n bds
+                  lo = loBenchmarks dataSelector n bds
+              in do chartToFile (mkTitle $ "Perf diff: " ++ show (optsFilter op)) dataSelector bdsf (outdir ++ "filtered.svg")
+                    chartToFile (mkTitle "Top speedups") dataSelector hi (outdir ++ "top.svg")
+                    chartToFile (mkTitle "Top slowdowns") dataSelector lo (outdir ++ "bot.svg")
             (Just n , True , _    ) ->
               let bds = compareBenchmarks vb va
-                  hi = hiBenchmarks n bds
-                  lo = loBenchmarks n bds
-              in do chartToFile "Top speedups (seconds)" hi (outdir ++ "top.svg")
-                    chartToFile "Top slowdowns (seconds)" lo (outdir ++ "bot.svg")
+                  hi = hiBenchmarks dataSelector n bds
+                  lo = loBenchmarks dataSelector n bds
+              in do chartToFile (mkTitle "Top speedups") dataSelector hi (outdir ++ "top.svg")
+                    chartToFile (mkTitle "Top slowdowns") dataSelector lo (outdir ++ "bot.svg")
             (Nothing, False, _    ) ->
               let bdsf = compareBenchmarks (selectTests vb) (selectTests va)
-              in chartToFile "Perf diff (seconds)" bdsf (outdir ++ "filtered.svg")
+              in chartToFile (mkTitle "Perf diff") dataSelector bdsf (outdir ++ "filtered.svg")
             (Nothing, True , _    ) ->
               let bds = compareBenchmarks vb va
-              in do chartToFile "Perf" bds (outdir ++ "perf.svg")
+              in do chartToFile "Perf" dataSelector bds (outdir ++ "perf.svg")

--- a/scripts/plot-performance/app/Plot.hs
+++ b/scripts/plot-performance/app/Plot.hs
@@ -10,8 +10,13 @@ import Data.Colour.Names ( green, grey, red )
 
 import Benchmark
 
-chart :: String -> BenchmarkComparison -> Renderable (LayoutPick LogValue PlotIndex PlotIndex)
-chart title bds = layoutToRenderable layout
+-- | Generate a bar chart comparing two sets of benchmarks, with warnings.
+chart
+  :: String  -- ^ Title of the chart
+  -> (Benchmark -> Double) -- ^ Function to extract the value to compare (e.g. time or allocations)
+  -> BenchmarkComparison    -- ^ The benchmark comparison data
+  -> Renderable (LayoutPick LogValue PlotIndex PlotIndex)
+chart title f bds = layoutToRenderable layout
  where
   layout =
       -- title + legend
@@ -58,14 +63,14 @@ chart title bds = layoutToRenderable layout
       $ plot_bars_label_style . font_size .~ 15
       $ def
 
-  (lab, dat) = diffData bds
+  (lab, dat) = diffData f bds
 
   colors = map (\c -> (solidFillStyle $ withOpacity c 0.7, Nothing)) [grey, red, green]
 
-diffData :: BenchmarkComparison -> ([String], [[(LogValue, String)]])
-diffData bc = unzip $ concat
+diffData :: (Benchmark -> Double) -> BenchmarkComparison -> ([String], [[(LogValue, String)]])
+diffData f bc = unzip $ concat
     [ [ (l, warningData w) | (l, w) <- bcWarnings bc ]
-    , [ (l, mkPlotData a b) | (l, (a, b)) <- bcCombined bc ]
+    , [ (test a, mkPlotData (f a) (f b)) | (a, b) <- bcCombined bc ]
     ]
   where
   mkPlotData a b
@@ -104,12 +109,12 @@ heightHeuristic n | n < 10    = 8.0
                   | n < 577   = 13.0
                   | otherwise = 14.0
 
-chartToFile :: String -> BenchmarkComparison -> FilePath -> IO ()
-chartToFile title bds path =
+chartToFile :: String -> (Benchmark -> Double) -> BenchmarkComparison -> FilePath -> IO ()
+chartToFile title f bds path =
   do let len = bcLen bds
      let wh = (2048.0, 2.0 ** heightHeuristic len)
      let fo = FileOptions wh SVG loadSansSerifFonts
-     let plot = chart title bds
+     let plot = chart title f bds
      let cb = render plot wh
      putStrLn $ printf "Writing %s (%d entries, %.0fx%.0f)" path len (fst wh) (snd wh)
      _ <- cBackendToFile fo cb path


### PR DESCRIPTION
This adapts to corresponding changes in liquid-fixpoint. https://github.com/ucsd-progsys/liquid-fixpoint/pull/847

The commit history is roughly as follows:
* First make syms methods more precise. They were returning sometimes more variables than the strictly free
* Fix rebinding of variables in Resolve.hs. A point in the code where substitutions were expected to capture variables.
* Add an implementation of capture avoiding substitution to the Subable class.
* Remove the other methods of the Subable class, one at a time.
* Fix uses of substitutions that produce assertion errors.

 
Fixes #2676 