### PR TITLE
Fix crash with shorthand refinements in dependent pair components

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Plugged.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Plugged.hs
@@ -283,8 +283,26 @@ goPlug tce tyi err f = go
     go (RApp _ ts _ _)  (RApp c ts' p r)
     -- Removing length check because Haskell types can contain kinds which is safe based on the comment above
     --   | length ts == length ts'
-      = RApp c     (Misc.zipWithDef go ts $ Bare.matchKindArgs ts ts') p r
+      = RApp c     (Misc.zipWithDef go ts $ Bare.matchKindArgs ts ts') (goRProps c ts ts' p) r
+
     go hsT lqT                             = Ex.throw (err (F.pprint hsT) (F.pprint lqT))
+
+    -- For dependent tuples, RProp at index j corresponds to the
+    -- Haskell type arg at index j+1.  Plug RProp bodies so that any
+    -- RHole nodes inside them are elaborated against the GHC type
+    -- (fixes issue #2590 crash with shorthand refinements).
+    goRProps c hsTyArgs lqTyArgs ps
+      | isTuple c =
+          let hsTs = drop 1 hsTyArgs
+              lqTs = drop 1 lqTyArgs
+          in  zipWith3 goRProp hsTs lqTs ps ++ drop (length hsTs) ps
+        -- At the moment nested RHoles in RProp are only introduced by bTup (the
+        -- desugaring of dependent tuples). Top-level RHoles in RProp are
+        -- introduced by rPropP and eliminated by mkRTProp.
+      | otherwise = ps
+    goRProp hsT lqT (RProp ss body)
+      | RHole{} <- lqT = RProp ss (go hsT body)
+      | otherwise      = RProp ss body
 
     -- otherwise                          = Ex.throw err
     -- If we reach the default case, there's probably an error, but we defer

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Split.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Split.hs
@@ -5,9 +5,23 @@
 
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
---------------------------------------------------------------------------------
 -- | Constraint Splitting ------------------------------------------------------
---------------------------------------------------------------------------------
+--
+-- Constraint splitting is the process of decomposing high-level subtyping
+-- constraints between LiquidHaskell refinement types into low-level Horn
+-- clauses that the Liquid Fixpoint solver can check.
+--
+-- A subtyping constraint @t1 <: t2@ between two 'SpecType' values is created
+-- during constraint generation (Generate.hs) whenever LH needs to verify that
+-- one type is a subtype of another (e.g., function argument vs. parameter type,
+-- branch types, etc.). These constraints are represented as @SubC γ t1 t2@
+-- where @γ@ is the typing environment.
+--
+-- 'splitC' recursively walks the structure of @t1@ and @t2@ simultaneously,
+-- peeling off type constructors until it reaches base refinements, at which
+-- point it calls 'bsplitC' to emit a fixpoint `SubC`
+-- (a Horn clause of the form @∀ binds. lhs-reft ⟹ rhs-reft@).
+--
 
 module Language.Haskell.Liquid.Constraint.Split (
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -718,6 +718,8 @@ rtPropPV :: (Fixpoint a, IsReft r, Meet r)
          -> [Ref (RType c tv NoReft) (RType c tv r)]
 rtPropPV _rc = zipWith mkRTProp
 
+-- | Eliminates top-level RHoles. See @goRProps@ inside 'goPlugged' in
+-- Plugged.hs for the handling of nested RHoles.
 mkRTProp :: (IsReft r, Meet r)
          => PVar (RType c tv NoReft)
          -> Ref (RType c tv NoReft) (RType c tv r)

--- a/tests/names/pos/DependentPairShorthand.hs
+++ b/tests/names/pos/DependentPairShorthand.hs
@@ -1,0 +1,8 @@
+-- | Regression test for https://github.com/ucsd-progsys/liquidhaskell/issues/2590
+-- Shorthand refinement syntax in function types inside dependent pair
+-- components should not crash.
+module DependentPairShorthand where
+
+{-@ bar :: (n::Nat, Int -> { n >= 0 }) @-}
+bar :: (Int, Int -> ())
+bar = (0, \_ -> ())

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -752,6 +752,7 @@ executable names-pos
                     , DataFields
                     , DefineLenResolve
                     , DependentPairAlias
+                    , DependentPairShorthand
                     , ExpandsDependentPairs
                     , ExprAliases
                     , ExprAliasesCopycat


### PR DESCRIPTION
Fixes #2590

When a dependent pair component contains a function type with a shorthand refinement like { n >= 0 }, the RHole inside the RProp body was not being elaborated during goPlug, leading to:
  splitC unexpected: (RApp Unit) <: rHole

Fix: goPlug now processes RProp bodies for tuples only, plugging RHole nodes with the corresponding Haskell type (offset by 1 for the tuple encoding).