### PR TITLE
Fix error message dropping predicates with inlined functions

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Errors.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Errors.hs
@@ -122,11 +122,7 @@ expandVarDefs      = go mempty
 
 isInline :: (a, SpecType) -> Either (a, F.Expr) (a, SpecType)
 isInline (x, t) =
-    either (Left . (x,)) (Right . (x,)) (isInline' t')
-  where
-    -- tidyInternalRefas could drop some conjuncts which affects whether
-    -- bindings are eliminated in isInline'
-    t' = tidyInternalRefas t
+    either (Left . (x,)) (Right . (x,)) (isInline' t)
 
 isInline' :: SpecType -> Either F.Expr SpecType
 isInline' t = case ro of

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Tidy.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/Tidy.hs
@@ -14,7 +14,6 @@ module Language.Haskell.Liquid.UX.Tidy (
 
     -- * Tidying functions
     tidySpecType
-  , tidyInternalRefas
   , tidySymbol
 
     -- * Panic and Exit
@@ -85,7 +84,6 @@ tidySpecType k
   . tidyValueVars
   . tidyDSymbols
   . tidySymbols k
-  . tidyInternalRefas
   . tidyLocalRefas k
   . tidyFunBinds
   . tidyTyVars
@@ -127,16 +125,6 @@ tidyEqual = mapReft txReft
   where
     txReft u                      = u { ur_reft = mapPredReft dropInternals $ ur_reft u }
     dropInternals                 = pAnd . L.nub . conjuncts
-
--- | Drop conjuncts that contain data constructor testing or
--- selector functions.
-tidyInternalRefas   :: SpecType -> SpecType
-tidyInternalRefas = mapReft txReft
-  where
-    txReft u                      = u { ur_reft = mapPredReft dropInternals $ ur_reft u }
-    dropInternals                 = pAnd . filter (not . any isIntern . syms) . conjuncts
-    isIntern x                    = "is$" `isPrefixOfSym` x || "$select" `isSuffixOfSym` x
-
 
 tidyDSymbols :: SpecType -> SpecType
 tidyDSymbols t = mapBind tx $ substa tx t

--- a/tests/errors/T2650.hs
+++ b/tests/errors/T2650.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE LambdaCase #-}
+{-# OPTIONS_GHC -fplugin=LiquidHaskell #-}
+
+{-@ LIQUID "--reflection" @-}
+
+-- | Tests that error messages show predicates that mix user-defined functions
+-- with internal data constructor tests (is$) from inlined definitions.
+-- See https://github.com/ucsd-progsys/liquidhaskell/issues/2650
+--
+-- Before the fix, the error would show just:
+--   VV : T2650.State
+-- (dropping the predicate entirely because it contained is$T2650.Empty).
+--
+-- After the fix, the required type shows the full predicate:
+--   VV : {... | (if is$T2650.Empty VV then true else false) <=> T2650.isGood VV}
+
+{-@ LIQUID "--expect-error-containing=T2650.isGood" @-}
+
+module T2650 where
+
+import Prelude
+
+data State = Empty | NonEmpty
+
+{-@ inline isEmpty @-}
+isEmpty :: State -> Bool
+isEmpty = \case
+  Empty    -> True
+  NonEmpty -> False
+
+{-@ reflect isGood @-}
+isGood :: State -> Bool
+isGood Empty    = True
+isGood NonEmpty = False
+
+{-@
+test ::
+  s0 : State ->
+  { s1 : State | isEmpty s1 <=> isGood s1 }
+@-}
+test :: State -> State
+test x = x

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -668,6 +668,7 @@ executable errors
                     , T1498A
                     , T1498
                     , T2346
+                    , T2650
                     , T773
                     , T774
                     , TerminationExprNum


### PR DESCRIPTION
Fixes #2650

tidyInternalRefas was dropping any refinement conjunct containing is$ or $select symbols. When a user's specification uses an inlined function (which expands to is$Constructor), the entire predicate was lost from the error message, making it show just the base type with no refinement.

Removed the filter so no conjuncts are dropped.