### PR TITLE
Enable deactivated POPL18 benchmarks (Ackermann, OverviewListInfix)

### DIFF
--- a/tests/benchmarks/popl18/nople/neg/Ackermann.hs
+++ b/tests/benchmarks/popl18/nople/neg/Ackermann.hs
@@ -4,7 +4,7 @@
 -- | http://www.cs.yorku.ca/~gt/papers/Ackermann-function.pdf
 
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--autoproofs"      @-}
+{- @ LIQUID "--autoproofs"      @-}
 
 module Ackermann where
 
@@ -316,7 +316,7 @@ ladder_prop1 n l x
 
 
 {-@ ladder_prop2 :: x:Nat -> y:Nat -> n:{Int | 0 < n} -> z:Nat
-   -> {v:Proof | ladder (x + y) n z == ladder x n (ladder y n z)} / [x] @-}
+      -> {v:Proof | ladder (x + y) n z == ladder x n (ladder y n z)} / [x] @-}
 ladder_prop2 :: Int -> Int -> Int -> Int -> Proof
 ladder_prop2 x y n z
   | x == 0
@@ -329,7 +329,7 @@ ladder_prop2 x y n z
                        ==. ladder x n (ladder y n z)
 
 {-@ ladder_prop3 :: x:Nat -> y:{Nat | x < y} -> n:{Int | 0 < n} -> l:Nat
-   -> {v:Proof | ladder l n x < ladder l n y }  @-}
+      -> {v:Proof | ladder l n x < ladder l n y }  @-}
 ladder_prop3 :: Int -> Int -> Int -> Int -> Proof
 ladder_prop3 x y n l
   = proof $

--- a/tests/benchmarks/popl18/nople/pos/Ackermann.hs
+++ b/tests/benchmarks/popl18/nople/pos/Ackermann.hs
@@ -3,7 +3,7 @@
 -- | http://www.cs.yorku.ca/~gt/papers/Ackermann-function.pdf
 
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--autoproofs"      @-}
+{- @ LIQUID "--autoproofs"      @-}
 
 
 module Ackermann where
@@ -314,7 +314,7 @@ ladder_prop1 n l x
 
 
 {-@ ladder_prop2 :: x:Nat -> y:Nat -> n:{Int | 0 < n} -> z:Nat
-   -> { ladder (x + y) n z == ladder x n (ladder y n z)} / [x] @-}
+                          -> { ladder (x + y) n z == ladder x n (ladder y n z)} / [x] @-}
 ladder_prop2 :: Int -> Int -> Int -> Int -> Proof
 ladder_prop2 x y n z
   | x == 0
@@ -326,7 +326,7 @@ ladder_prop2 x y n z
                        *** QED
 
 {-@ ladder_prop3 :: x:Nat -> y:{Nat | x < y} -> n:{Int | 0 < n} -> l:Nat
-   -> {ladder l n x < ladder l n y }  @-}
+                          -> {ladder l n x < ladder l n y }  @-}
 ladder_prop3 :: Int -> Int -> Int -> Int -> Proof
 ladder_prop3 x y n l
   =  iack l n x <. iack l n y ? (  ladder_prop1 n l x

--- a/tests/benchmarks/popl18/nople/pos/OverviewListInfix.hs
+++ b/tests/benchmarks/popl18/nople/pos/OverviewListInfix.hs
@@ -1,5 +1,5 @@
 {-@ LIQUID "--higherorder"     @-}
-{-@ LIQUID "--eliminate" @-}
+{- @ LIQUID "--eliminate" @-}
 {-@ LIQUID "--maxparams=10"  @-}
 {-@ LIQUID "--higherorderqs" @-}
 

--- a/tests/benchmarks/popl18/ple/pos/Ackermann.hs
+++ b/tests/benchmarks/popl18/ple/pos/Ackermann.hs
@@ -10,6 +10,7 @@ module Ackermann where
 
 import Language.Haskell.Liquid.ProofCombinators
 import Helper
+import Proves ((<.))
 
 -- | First ackermann definition
 
@@ -39,7 +40,7 @@ iack h n x
 def_eq :: Int -> Int -> Proof
 def_eq n x
   | x == 0
-  = trivial 
+  = trivial
   | otherwise
   = def_eq n (x-1)
 
@@ -49,10 +50,10 @@ def_eq n x
 lemma2 :: Int -> Int -> Proof
 {-@ lemma2 :: n:Nat -> x:Nat -> { x + 1 < ack n x } / [n, x] @-}
 lemma2 n x
-  | x == 0
-  = trivial 
   | n == 0
-  = trivial 
+  = trivial
+  | x == 0
+  = trivial
   | otherwise
   =   lemma2 (n-1) (ack n (x-1))
   &&& lemma2 n (x-1)
@@ -105,6 +106,8 @@ lemma4_gen n m x
 lemma4_eq     :: Int -> Int -> Proof
 {-@ lemma4_eq :: n:Nat -> x:Nat -> { ack n x <= ack (n+1) x } @-}
 lemma4_eq n x
+  | n == 0, x == 0
+  = trivial 
   | x == 0
   = trivial 
   | otherwise
@@ -249,7 +252,7 @@ ladder_prop1 n l x
 
 
 {-@ ladder_prop2 :: x:Nat -> y:Nat -> n:{Int | 0 < n} -> z:Nat
-   -> { ladder (x + y) n z == ladder x n (ladder y n z)} / [x] @-}
+                 -> { ladder (x + y) n z == ladder x n (ladder y n z)} / [x] @-}
 ladder_prop2 :: Int -> Int -> Int -> Int -> Proof
 ladder_prop2 x y n z
   | x == 0
@@ -258,7 +261,7 @@ ladder_prop2 x y n z
   = ladder_prop2 (x-1) y n z
 
 {-@ ladder_prop3 :: x:Nat -> y:{Nat | x < y} -> n:{Int | 0 < n} -> l:Nat
-   -> {ladder l n x < ladder l n y }  @-}
+                 -> {ladder l n x < ladder l n y }  @-}
 ladder_prop3 :: Int -> Int -> Int -> Int -> Proof
 ladder_prop3 x y n l
   =   ladder_prop1 n l x

--- a/tests/benchmarks/popl18/ple/pos/OverviewListInfix.hs
+++ b/tests/benchmarks/popl18/ple/pos/OverviewListInfix.hs
@@ -7,7 +7,7 @@
 
 module OverviewListInfix where
 
-import Prelude hiding (map, (++), (.))
+import Prelude hiding (map, (++))
 
 import Language.Haskell.Liquid.ProofCombinators
 

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -372,14 +372,14 @@ executable prover-nople-pos
                     , Peano
                     , Solver
                     , Unification
+                    , Ackermann
+                    , OverviewListInfix
                     -- IGNORED:
                     -- , MonadReader
                     -- , FunctorReader_NoExtensionality
                     -- , FunctorReader
-                    -- , Ackermann
                     -- , ApplicativeList
                     -- , ApplicativeReader
-                    -- , OverviewListInfix
 
   build-depends:      base
                     , liquid-prelude
@@ -409,9 +409,9 @@ executable prover-nople-neg
                     , MapFusion
                     , MonadList
                     , MonadMaybe
+                    , Ackermann
                     -- IGNORED:
                     -- , MonadReader
-                    -- , Ackermann
                     -- , ApplicativeList
                     -- , ApplicativeReader
 
@@ -459,9 +459,8 @@ executable prover-ple-pos
                     , Peano
                     , Solver
                     , Unification
-                    -- IGNORED:
-                    -- , Ackermann
-                    -- , OverviewListInfix
+                    , Ackermann
+                    , OverviewListInfix
 
   build-depends:      base
                     , liquid-prelude


### PR DESCRIPTION
Update of #1843.

Restore Ackermann.hs and OverviewListInfix.hs to the test suite across all three benchmark executables (prover-nople-pos, prover-nople-neg, prover-ple-pos).

Fixes applied:
- Disable removed --autoproofs flag in nople Ackermann files
- Disable --eliminate flag in nople OverviewListInfix
- Fix LH annotation indentation (multi-line -> continuations)
- Add missing import Proves ((<.)) in ple Ackermann
- Remove unnecessary (.) from Prelude hiding in ple OverviewListInfix
- Reorder guards in lemma2 and add case split in lemma4_eq to help PLE unfold ack for symbolic arguments