### PR TITLE
Fix splitC panic with higher-kinded types

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Split.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Split.hs
@@ -277,8 +277,8 @@ splitC _ (SubR γ o r)
     g   = reLocal $ renv γ
 
 traceTy :: SpecType -> String
-traceTy (RVar v _)      = parens ("RVar " ++ showpp v)
-traceTy (RApp c ts _ _) = parens ("RApp " ++ showpp c ++ unwords (traceTy <$> ts))
+traceTy (RVar v _)      = parens ("RVar " ++ show (F.symbol v))
+traceTy (RApp c ts rs _) = parens ("RApp " ++ showpp c ++ unwords (traceTy <$> ts) ++ if null rs then "" else " {rprops=" ++ show (map traceRProp rs) ++ "}")
 traceTy (RAllP _ t)     = parens ("RAllP " ++ traceTy t)
 traceTy (RAllT _ t _)   = parens ("RAllT " ++ traceTy t)
 traceTy (RFun _ _ t t' _) = parens ("RFun " ++ parens (traceTy t) ++ parens (traceTy t'))
@@ -287,6 +287,9 @@ traceTy (RExprArg _)    = "RExprArg"
 traceTy (RAppTy t t' _) = parens ("RAppTy " ++ parens (traceTy t) ++ parens (traceTy t'))
 traceTy (RHole _)       = "rHole"
 traceTy (RRTy _ _ _ t)  = parens ("RRTy " ++ traceTy t)
+
+traceRProp :: SpecProp -> String
+traceRProp (RProp ss body) = "RProp[" ++ show (map fst ss) ++ "](" ++ traceTy body ++ ")"
 
 parens :: String -> String
 parens s = "(" ++ s ++ ")"

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RType.hs
@@ -866,6 +866,12 @@ data RTypeBV b v c tv r
     --
     --   The scope of @v@ is the entire type application and @e@.
     --
+    -- Invariant: the types in the predicates of @rt_pargs@ must match the types
+    -- of the predicates that @rt_tycon@ expects when applied to @rt_args@.
+    -- This invariant is loosely maintained when processing @RApp@. It is not
+    -- trivial to enforce at construction time (e.g. with a smart constructor)
+    -- becase the expected types are not available in the arguments of @RApp@.
+    --
   | RApp  {
       rt_tycon  :: !c
     , rt_args   :: ![RTypeBV b v c tv r]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -669,16 +669,30 @@ quantifyFreeRTy :: (Monoid r, Eq tv) => RTypeV v c tv r -> RTypeV v c tv r
 quantifyFreeRTy ty = quantifyRTy (freeTyVars ty) ty
 
 
--------------------------------------------------------------------------
+-- | Populates the PVar/RProp slots of all 'RApp' nodes in the given type.
+--
+-- A refinement type application @RApp rc ts rs r@ has three parts beyond the
+-- type constructor:
+--
+-- * @ts@ – type arguments
+-- * @rs@ – abstract-refinement arguments (the `RProp` slots, one per PVar
+--   declared for the type constructor)
+-- * @r@ – the base refinement
+--
+-- When a type first enters LiquidHaskell from source or from GHC's
+-- representation, the @rs@ list is usually empty or carries 'RHole's as
+-- placeholders. This function fills in the @rs@ list with the appropriate
+-- 'RProp's, using the 'TCEmb TyCon' to determine which PVars are declared for
+-- the type constructor.
+--
 addTyConInfo :: (PPrint r, IsReft r, SubsTy RTyVar RSort r, Variable r ~ Symbol, ReftBind r ~ Symbol, ReftVar r ~ Symbol, IsReft r, Meet r)
              => TCEmb TyCon
              -> TyConMap
              -> RRType r
              -> RRType r
--------------------------------------------------------------------------
 addTyConInfo tce tyi = mapBot (expandRApp tce tyi)
 
--------------------------------------------------------------------------
+-- | Populates the PVar/RProp slots of an 'RApp' node.
 expandRApp :: (PPrint r, IsReft r, SubsTy RTyVar RSort r, Variable r ~ Symbol, ReftBind r ~ Symbol, ReftVar r ~ Symbol, IsReft r, Meet r)
            => TCEmb TyCon -> TyConMap -> RRType r -> RRType r
 -------------------------------------------------------------------------
@@ -764,6 +778,9 @@ pvArgs pv = [(s, t) | (t, s, _) <- pargs pv]
 
  -}
 
+-- | Retrieves the 'RTyCon' from the 'TyConMap' (which was built from
+-- @{-@@ data … @@-}@ or wired-in annotations) and substitutes the actual type
+-- arguments into the PVar types, yielding specialised pvars.
 appRTyCon :: (ToTypeable r) => TCEmb TyCon -> TyConMap -> RTyCon -> [RRType r] -> (RTyCon, [RPVar])
 appRTyCon tce tyi rc ts = F.notracepp _msg (resTc, ps'')
   where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -725,16 +725,19 @@ rtPropTop
    => PVar (RType c tv NoReft) -> Ref (RType c tv NoReft) (RType c tv r)
 rtPropTop pv = RProp (pvArgs pv) $ ofRSort $ ptype pv
 
-rtPropPV :: (Fixpoint a, IsReft r, Meet r)
+rtPropPV :: (Fixpoint a, IsReft r, Meet r
+           , Eq c, Eq tv, Hashable tv, F.PPrint tv, TyConable c, F.PPrint c)
          => a
          -> [PVar (RType c tv NoReft)]
          -> [Ref (RType c tv NoReft) (RType c tv r)]
          -> [Ref (RType c tv NoReft) (RType c tv r)]
 rtPropPV _rc = zipWith mkRTProp
 
--- | Eliminates top-level RHoles. See @goRProps@ inside 'goPlugged' in
--- Plugged.hs for the handling of nested RHoles.
-mkRTProp :: (IsReft r, Meet r)
+-- | Eliminates top-level RHoles, and normalizes stale RProp bodies whose
+-- sort no longer matches the PVar's expected type (can happen when types
+-- are copied via toRSort/ofRSort during type-argument substitution).
+mkRTProp :: (IsReft r, Meet r
+           , Eq c, Eq tv, Hashable tv, F.PPrint tv, TyConable c, F.PPrint c)
          => PVar (RType c tv NoReft)
          -> Ref (RType c tv NoReft) (RType c tv r)
          -> Ref (RType c tv NoReft) (RType c tv r)
@@ -743,7 +746,10 @@ mkRTProp pv (RProp ss (RHole r))
 
 mkRTProp pv (RProp ss t)
   | length (pargs pv) == length ss
-  = RProp ss t
+  = if toRSort t == pvType pv then
+      RProp ss t
+    else
+      RProp ss $ ofRSort (pvType pv) `strengthen` fromMaybe trueReft (stripRTypeBase t)
   | otherwise
   = RProp (pvArgs pv) t
 

--- a/tests/basic/pos/T2692.hs
+++ b/tests/basic/pos/T2692.hs
@@ -1,0 +1,12 @@
+-- | Test that higher-kinded type parameters with self-nesting
+-- do not cause a splitC panic due to RProp body depth asymmetry.
+-- See GitHub issue #2692.
+module T2692 where
+
+data T f a = Cons a (f a)
+
+removeEach :: T [] a -> T [] (a, [a])
+removeEach = undefined
+
+test :: T [] (T [] Int) -> T [] (T [] Int, [T [] Int])
+test = removeEach

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2285,6 +2285,7 @@ executable basic-pos
                     , SkipDerived00
                     , T2349
                     , T2369
+                    , T2692
                     , TestAdmit
 
     build-depends:    base


### PR DESCRIPTION
There is an invariant of the RApp that is not always maintained:

The types of the RTProp predicates need to match the types of the predicates that the type constructor expects.

This patch reestablishes the invariant at a point that prevents the failure of #2692.

Fixes #2692