### PR TITLE
Add `Diff` library static checks to test suite

### DIFF
--- a/tests/Diff/Diff.hs
+++ b/tests/Diff/Diff.hs
@@ -1,0 +1,507 @@
+{-@ LIQUID "--ple" @-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Algorithm.Diff
+-- Copyright   :  (c) Sterling Clover 2008-2011, Kevin Charter 2011
+-- License     :  BSD 3 Clause
+-- Maintainer  :  s.clover@gmail.com
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- This is an implementation of the diff algorithm as described in
+-- [/An \( O(ND) \) Difference Algorithm and Its Variations (1986)/
+-- by Eugene W. Myers](https://publications.mpi-cbg.de/Myers_1986_6330.pdf).
+-- For inputs of size \( O(N) \) with the number of differences \( D \)
+-- it has \( O(ND) \) time and \( O(D^2) \) space complexity.
+--
+-- == Algorithm overview
+--
+-- Finding the shortest edit script (SES) from a list \( as \) to a list \( bs \)
+-- is modelled as a shortest-path search on an /edit graph/: an
+-- \( (M+1) \times (N+1) \) grid of nodes \( (i, j) \),
+-- where \( M \) and \( N \) are the lengths of \( as \) and \( bs \) respectively,
+-- with \( i \) increasing rightward and \( j \) increasing downward.
+-- Each node represents the state of having consumed \( i \) elements of \( as \)
+-- and \( j \) elements of \( bs \). Three types of move are possible:
+--
+-- * A /rightward/ move \( (i,j) \to (i+1,j) \) represents
+--   /deleting/ \( as[i] \) and costs one edit.
+-- * A /downward/ move  \( (i,j) \to (i,j+1) \) represents
+--   /inserting/ \( bs[j] \) and costs one edit.
+-- * A /diagonal/ move  \( (i,j) \to (i+1,j+1) \) is free (zero edit cost)
+--   and is only available when \( as[i] = bs[j] \).
+--
+-- The SES corresponds to a path from \( (0,0) \) to \( (M,N) \) that minimises
+-- the number of non-diagonal moves.
+--
+-- Both input lists are 0-indexed, which leads to a slightly different
+-- interpretation of the edit graph than in the original paper. In the paper,
+-- each node represents the state of the traversal /after/ an edit, so a move
+-- is the edit that /produced/ that node. Here, each node represents the state
+-- /before/ an edit, so a move is the edit performed /on/ that node to yield its
+-- successor. This distinction is only relevant when reading the implementation
+-- alongside the paper.
+--
+-- === K-diagonals and the wave front
+--
+-- Every node \( (i,j) \) lies on the /k-diagonal/ \( k = i - j \).
+-- After exactly \( D \) non-diagonal moves, every reachable node lies on one of
+-- at most \( D+1 \) k-diagonals \( k \in \{-D,\,-D+2,\,\ldots,\,D-2,\,D\} \).
+-- On each diagonal it suffices to track only the /furthest-reaching/ node
+-- (the one with the largest \( i \)), collapsing the two-dimensional grid to a
+-- one-dimensional /wave front/ indexed by \( k \).
+--
+-- The algorithm performs a breadth-first search over \( D = 0, 1, 2, \ldots \),
+-- advancing the wave front by one edit at a time until a node reaches the goal
+-- \( (M, N) \). The edit trace stored in that node is the SES, which
+-- 'getDiffBy' reconstructs into a 'PolyDiff' list. The term /trace/ here
+-- differs from the paper, where it denotes the sequence of k-diagonals visited
+-- by the SES path; that structure is not materialised in this implementation.
+-----------------------------------------------------------------------------
+module Diff
+    ( Diff, PolyDiff(..)
+    -- * Comparing lists for differences
+    , getDiff
+    , getDiffBy
+
+    -- * Finding chunks of differences
+    , getGroupedDiff
+    , getGroupedDiffBy
+
+    -- * Predicates for LiquidHaskell specifications
+    , noStuttering
+    , noFFSS
+    , headIsFirst, headIsSecond, headIsBoth
+    ) where
+
+import Prelude hiding (pi)
+import Data.Array (listArray, (!))
+import Data.Bifunctor
+import LiftedFunctions
+
+-- | /Diff Instruction/ — an internal enum recording the direction of a single
+-- non-diagonal edge traversed in the Myers edit graph. Every non-diagonal
+-- move in the edit script is one of:
+--
+-- * 'F' — /First/ — a horizontal edge \( (i,j) \to (i+1,j) \), which
+--   corresponds to /deleting/ the element at position \( i \) of the first input
+--   sequence. The consumed element appears in the 'First' branch of the
+--   resulting 'PolyDiff'.
+--
+-- * 'S' — /Second/ — a vertical edge \( (i,j) \to (i,j+1) \), which
+--   corresponds to /inserting/ the element at position \( j \) of the second
+--   input sequence. The consumed element appears in the 'Second' branch of
+--   the resulting 'PolyDiff'.
+--
+-- Diagonal edges (free moves corresponding to equal elements) are /not/
+-- recorded as 'DI' steps; they are followed implicitly by 'addsnake' and
+-- produce 'Both' entries in the final output.
+data DI = F | S deriving (Show, Eq)
+
+-- | A value tagged with which of two input sequences it came from.
+-- The type parameters @a@ and @b@ may differ, which is useful when comparing
+-- sequences of different element types via a custom equality predicate.
+--
+-- Each constructor corresponds to one outcome for a position in the aligned
+-- sequences:
+--
+-- * 'First' — the element exists only in the /first/ input (a deletion).
+-- * 'Second' — the element exists only in the /second/ input (an insertion).
+-- * 'Both' — the element is common to both inputs.
+--   Both the left and right values are retained so that the original
+--   elements can be recovered even when equality ignores some fields.
+{-@ data PolyDiff a b = First a | Second b | Both a b @-}
+data PolyDiff a b = First a | Second b | Both a b
+    deriving (Show, Eq)
+
+instance Functor (PolyDiff a) where
+  fmap _ (First a) = First a
+  fmap g (Second b) = Second (g b)
+  fmap g (Both a b) = Both a (g b)
+
+instance Bifunctor PolyDiff where
+  bimap f _ (First a) = First (f a)
+  bimap _ g (Second b) = Second (g b)
+  bimap f g (Both a b) = Both (f a) (g b)
+
+-- | This is 'PolyDiff' specialized so both sides are the same type.
+type Diff a = PolyDiff a a
+
+-- A valid list diff is such that any `Both` value has arguments of equal length.
+{-@ type ValidListDiff a b = { d : PolyDiff [a] [b] | validListDiff d }@-}
+
+{-@ type GroupedDiff a b = { d : ValidListDiff a b | nonEmptyDiff d } @-}
+
+{-@
+inline validListDiff
+define length x = len x
+@-}
+-- | True when, for a 'Both' value, both sides have the same length.
+-- 'First' and 'Second' trivially satisfy this.
+validListDiff :: PolyDiff [a] [b] -> Bool
+validListDiff (Both xs ys) = length xs == length ys
+validListDiff (First _) = True
+validListDiff (Second _) = True
+
+{-@ inline nonEmptyDiff @-}
+nonEmptyDiff :: PolyDiff [a] [b] -> Bool
+nonEmptyDiff (First []) = False
+nonEmptyDiff (Second []) = False
+nonEmptyDiff (Both [] _) = False
+nonEmptyDiff (Both _ []) = False
+nonEmptyDiff _ = True
+
+{-@ reflect headIsFirst @-}
+{-@ reflect headIsSecond @-}
+{-@ reflect headIsBoth @-}
+-- | Head-constructor predicates for 'PolyDiff' lists.
+-- Reflected (not measures) to avoid sort errors: measures on @[PolyDiff a b]@
+-- would be attached to the polymorphic @[]@ constructor, clashing with
+-- lists of other element types.
+headIsFirst, headIsSecond, headIsBoth :: [PolyDiff a b] -> Bool
+headIsFirst (First _ : _) = True
+headIsFirst _ = False
+headIsSecond (Second _ : _) = True
+headIsSecond _ = False
+headIsBoth (Both _ _ : _) = True
+headIsBoth _ = False
+
+{-@ reflect noStuttering @-}
+-- | True if the list does not contain adjacent 'Diff's of the same type.
+-- Uses head-constructor measures so PLE can work with opaque tails.
+noStuttering :: [PolyDiff a b] -> Bool
+noStuttering [] = True
+noStuttering (First _ : xs) = not (headIsFirst xs) && noStuttering xs
+noStuttering (Second _ : xs) = not (headIsSecond xs) && noStuttering xs
+noStuttering (Both _ _ : xs) = not (headIsBoth xs) && noStuttering xs
+
+{-@ reflect noFFSS @-}
+-- | Like 'noStuttering' but allows Both-Both adjacencies.
+-- This is the invariant preserved by @doPrefix@\/@doSuffix@ which may split
+-- a single 'Both' into two consecutive 'Both' elements.
+noFFSS :: [PolyDiff a b] -> Bool
+noFFSS [] = True
+noFFSS (First _ : xs) = not (headIsFirst xs) && noFFSS xs
+noFFSS (Second _ : xs) = not (headIsSecond xs) && noFFSS xs
+noFFSS (Both _ _ : xs) = noFFSS xs
+
+-- | /D-path Location/ — a node on the wave front of the Myers O(ND) diff
+-- algorithm.
+--
+-- Each wave front consists of one 'DL' per /k-diagonal/.  A 'DL' stores the
+-- endpoint coordinates and the edit trace of a \( D \)-path, i.e. a path from the
+-- origin \( (0,0) \) that uses exactly \( D \) non-diagonal edges.
+{-@
+data DL = DL
+    { poi  :: Nat
+    , poj  :: Nat
+    , path :: { p : [DI] | len p <= poi + poj }
+    }
+@-}
+data DL = DL
+    { poi  :: !Int   -- ^ /Position On I/ — the @x@-coordinate of the endpoint
+                     --   in the edit graph, i.e. the number of elements
+                     --   consumed from the /first/ input sequence so far.
+    , poj  :: !Int   -- ^ /Position On J/ — the @y@-coordinate of the endpoint
+                     --   in the edit graph, i.e. the number of elements
+                     --   consumed from the /second/ input sequence so far.
+    , path :: [DI]   -- ^ The edit trace accumulated so far, stored in
+                     --   /reverse/ order (most recent step first).  Diagonal
+                     --   edges (matches) are not recorded here; only 'F' and
+                     --   'S' steps are stored.
+    } deriving (Show, Eq)
+
+-- | Select the furthest-reaching candidate of two 'DL' nodes competing for the
+-- same k-diagonal, as required by the Myers algorithm.
+{-@ dLength :: d : DL -> { n : Nat | n <= poi d + poj d }  @-}
+-- | A /D-path/'s edit trace length, or /D-length/.
+dLength :: DL -> Int
+dLength d = length $ path d
+
+-- This refinement type alias represents a 'DL' value with a fixed /D-length/,
+-- which we call a "D-path location node".
+{-@ type DLN D = { x : DL | len (path x) = D } @-}
+
+{-@ reflect boundedNodes @-}
+-- | Checks if the coordinates of all nodes within a list are bounded
+-- by the given number.
+{-@ boundedNodes :: Nat -> [DL] -> Bool @-}
+boundedNodes :: Int -> [DL] -> Bool
+boundedNodes n [] = True
+boundedNodes n (dl : dls) = (poi dl <= n && poj dl <= n) && boundedNodes n dls
+
+{-@ inline kdiag @-}
+-- | Computes the k-diagonal of a node.
+-- Used in LiquidHaskell logic as a predicate.
+kdiag :: DL -> Int
+kdiag dl = poi dl - poj dl
+
+{-@ reflect wfDiags @-}
+{-@ wfDiags :: Int -> xs : [DL] -> Bool / [len xs] @-}
+-- | Checks if succesive nodes of a wave front lie within k-diagonals
+-- differing by 2 as described in the Myers algorithm.
+wfDiags :: Int -> [DL] -> Bool
+wfDiags _ [] = True
+wfDiags k (dl:dls) = poi dl - poj dl == k && wfDiags (k - 2) dls
+
+-- A wave front is a list of 'DL' nodes, all at the same edit distance @D@,
+-- with k-diagonals @K@, @K−2@, @K−4@, …
+{-@ type WaveFront D K = {xs : [DLN D] | wfDiags K xs} @-}
+
+-- | Select the furthest-reaching candidate of two 'DL' nodes competing for the
+-- same k-diagonal, as required by the Myers algorithm.
+--
+-- The candidate that has advanced further along the \( x \)-axis (larger 'poi')
+-- is the furthest-reaching endpoint on that diagonal.
+--
+-- Precondition: arguments @x@ and @y@ in @furthestReaching x y@ are in the
+-- same /k-diagonal/, meaning that
+--
+-- > poi x - poj x == poi y - poj y`
+--
+-- and both argument nodes are within the same wave front,
+--
+-- > length (path x) == length (path y)
+{-@ furthestReaching ::  x : DL
+                     -> {y : DL | kdiag x = kdiag y}
+                     -> {v : DL | v = x || v = y} @-}
+furthestReaching :: DL -> DL -> DL
+furthestReaching x y
+  | poi x >= poi y = x
+  | otherwise      = y
+
+-- | Build a /diagonal predicate/ — a closure that tests whether position
+-- @(i, j)@ in the edit graph has a diagonal edge (a /match point/ in Myers'
+-- terminology).
+--
+-- Indices are 0-based (\( i \in [0, lena) \), \( j \in [0, lenb) \) ),
+-- unlike the 1-based convention of the original paper.
+--
+-- The first two 'Int' parameters stand for the lengths of the input lists,
+-- which are captured from the outer scope to compute them only once.
+canDiag :: (a -> b -> Bool) -> [a] -> [b] -> Int -> Int -> Int -> Int -> Bool
+canDiag eq as bs lena lenb = \ i j ->
+   if i < lena && j < lenb then (arAs ! i) `eq` (arBs ! j) else False
+   where
+     -- Lists are converted into arrays to have O(1) lookups.
+     arAs = listArray (0,lena - 1) as
+     arBs = listArray (0,lenb - 1) bs
+
+-- This refinement type alias encodes the exit condition of 'canDiag' within
+-- the recursive definition of 'addsnake' necessary to prove the latter
+-- terminates without merging both functions.
+{-@ type BoundedPred B = (i : Nat -> j : Nat -> {b : Bool | (i >= B || j >= B) => b == False}) @-}
+
+-- | Perform one breadth-first search expansion step, advancing every wave front
+-- 'DL' node by one 'DI' edit (one non-diagonal edge) and then following
+-- any available snake.
+--
+-- For each node the 'dstep' produces two candidate successors by adding:
+--
+-- * An 'F' (delete) move: 'poi' incremented by 1.
+-- * An 'S' (insert) move: 'poj' incremented by 1.
+--
+-- 'addsnake' is applied to each candidate immediately to extend it along any
+-- available sequence of matching elements.
+--
+-- The resulting candidates are merged pairwise: the vertical successor of each
+-- node is paired with the horizontal successor of the next node in the wave
+-- front. When this function is iterated from a single-node seed (as in 'ses'),
+-- each such pair always lies on the same diagonal: an 'F' edge advances to the
+-- next higher diagonal while an 'S' edge retreats to the next lower one, so the
+-- two members of each pair straddle the same diagonal from opposite sides.
+--
+-- Precondition: The node list must be non-empty.
+{-@
+dstep
+  :: boundary : Nat
+  -> BoundedPred boundary
+  -> d : Nat
+  -> {nodes : WaveFront d (kdiag (head nodes)) | len nodes > 0 && boundedNodes boundary nodes}
+  -> {v : WaveFront (d + 1) (kdiag (head nodes) + 1) | len v = len nodes + 1}
+@-}
+dstep
+  :: Int                  -- ^ Boundary value for 'addsnake' termination check
+  -> (Int -> Int -> Bool) -- ^ Diagonal predicate
+  -> Int                  -- ^ The current D-length; used for the static check of wave front invariant.
+  -> [DL]                 -- ^ A non-empty wave front of nodes at edit distance D
+  -> [DL]                 -- ^ A non-empty wave front of nodes at edit distance D+1
+dstep b _ d [] = error "dstep: Cannot perform expansion on an empty list of nodes"
+dstep b cd d (dl:dls) = hStep dl : stepAndMerge dl dls
+  where
+    {-@ hStep
+          :: {x : DLN d | poi x <= b && poj x <= b}
+          -> {v : DLN (d + 1) | kdiag v = kdiag x + 1} @-}
+    hStep node = addsnake b cd $ node {poi = poi node + 1, path = F : path node}
+    {-@ vStep
+          :: {x : DLN d | poi x <= b && poj x <= b}
+          -> {v : DLN (d + 1) | kdiag v = kdiag x - 1} @-}
+    vStep node = addsnake b cd $ node {poj = poj node + 1, path = S : path node}
+    -- Merge vertical step of previous node with horizontal step of next node,
+    -- selecting the furthest-reaching candidate for each shared k-diagonal.
+    {-@ stepAndMerge
+          :: {prev : DLN d | poi prev <= b && poj prev <= b}
+          -> {rest : WaveFront d (kdiag prev - 2) | boundedNodes b rest}
+          -> {v : WaveFront (d + 1) (kdiag prev - 1) | len v = len rest + 1}
+          / [len rest] @-}
+    stepAndMerge :: DL -> [DL] -> [DL]
+    stepAndMerge prev [] = [vStep prev]
+    stepAndMerge prev (next:rest) =
+      furthestReaching (vStep prev) (hStep next) : stepAndMerge next rest
+
+-- | Follow a /snake/ from the current position of a 'DL' node.
+--
+-- A snake is a sequence of diagonal (cost-free) edges in the edit graph,
+-- i.e. a run of equal elements that can be consumed simultaneously
+-- from both input sequences without counting as an edit.  Starting from
+-- @(poi dl, poj dl)@, this function advances both 'poi' and 'poj' as long
+-- as consecutive elements match, leaving 'path' unchanged (diagonal moves
+-- are not recorded as edit steps).
+{-@
+addsnake :: boundary : Nat
+         -> BoundedPred boundary
+         -> {dl : DL | poi dl <= boundary + 1 && poj dl <= boundary + 1}
+         -> {v : DL | path v == path dl && kdiag v = kdiag dl}
+         / [(boundary + 1 - poi dl) + (boundary + 1 - poj dl)]
+@-}
+addsnake :: Int                  -- ^ Boundary value for termination check
+         -> (Int -> Int -> Bool) -- ^ Equality predicate, a.k.a. 'canDiag'
+         -> DL
+         -> DL
+addsnake boundary cd dl
+    | cd pi pj = addsnake boundary cd $
+                 dl {poi = pi + 1, poj = pj + 1, path = path dl}
+    | otherwise   = dl
+    where pi = poi dl; pj = poj dl
+
+{-@ ignore ses @-}
+-- | Compute shortest edit script (SES), as the minimum sequence of 'DI' edit
+-- steps that transforms @as@ into @bs@, returned in reverse order.
+--
+-- @ses eq as bs@ runs the Myers O(ND) diff algorithm following
+-- a five-step pipeline:
+--
+-- 1. __Seed__: create an initial 0-path wave front @[addsnake boundary cd (DL 0 0 [])]@
+--    having a single node on the tip of the longest origin-sourced snake.
+-- 2. __Iterate__: apply 'dstep' repeatedly via 'iterate', producing an
+--    infinite list of wave fronts (one per edit distance D = 0, 1, 2, …).
+-- 3. __Flatten__: 'concat' all wave fronts into a single stream of 'DL' nodes.
+-- 4. __Find__: 'dropWhile' skips nodes until one reaches @(lena, lenb)@ — the
+--    bottom-right corner of the edit graph — which is the terminal node of a
+--    shortest edit script.
+-- 5. __Extract__: 'head' returns that node; its 'path' field carries the edit
+--    trace in reverse order.
+--
+-- This implementation is purely functional: rather than updating a shared
+-- diagonal frontier array in place, as in the original paper, it builds a new
+-- list of 'DL' nodes for each value of \( D \) and concatenates them into
+-- a single lazy stream. This is simpler but carries a larger per-node overhead:
+-- each 'DL' holds its own edit trace as a @['DI']@ list that structurally
+-- shares its tail with the parent node's trace (consing one step reuses the
+-- existing spine), rather than the paper's single-integer-per-diagonal
+-- representation. The asymptotic time
+-- and space complexity — \( O(ND) \) and \( O(D^2) \) respectively — is
+-- unchanged. Unlike the paper, which selects the better candidate per
+-- diagonal before extending its snake, 'dstep' extends snakes on /both/
+-- candidates before 'selectBestDLFromPairs' selects the winner, discarding the other
+-- extension. This does not affect the time bound: on any given diagonal,
+-- all snake intervals — retained and discarded — are non-overlapping across
+-- successive values of \( D \), because each new candidate starts at or
+-- beyond the previous winner's endpoint. The total number of element
+-- comparisons across all snake extensions is therefore \( O(ND) \).
+ses :: (a -> b -> Bool) -> [a] -> [b] -> [DI]
+ses eq as bs = path . head . dropWhile (\dl -> poi dl /= lena || poj dl /= lenb) .
+            concat . iterate (uncurry (dstep boundary cd) . withD) . (:[]) . addsnake boundary cd $
+            DL {poi=0,poj=0,path=[]}
+            where cd = canDiag eq as bs lena lenb
+                  lena = length as; lenb = length bs
+                  withD xs = (dLength (head xs), xs)
+                  boundary = max lena lenb
+
+-- | Takes two lists and returns a list of differences between them. This is
+-- 'getDiffBy' with '==' used as predicate.
+--
+-- > > getDiff ["a","b","c","d","e"] ["a","c","d","f"]
+-- > [Both "a" "a",First "b",Both "c" "c",Both "d" "d",First "e",Second "f"]
+-- > > getDiff "abcde" "acdf"
+-- > [Both 'a' 'a',First 'b',Both 'c' 'c',Both 'd' 'd',First 'e',Second 'f']
+getDiff :: (Eq a) => [a] -> [a] -> [Diff a]
+getDiff = getDiffBy (==)
+
+-- | Takes two lists and returns a list of differences between them, grouped
+-- into chunks. This is 'getGroupedDiffBy' with '==' used as predicate.
+--
+-- > > getGroupedDiff "abcde" "acdf"
+-- > [Both "a" "a",First "b",Both "cd" "cd",First "e",Second "f"]
+{-@ getGroupedDiff :: Eq a => [a] -> [a]
+                           -> {v:[GroupedDiff a a] | noStuttering v} @-}
+getGroupedDiff :: (Eq a) => [a] -> [a] -> [Diff [a]]
+getGroupedDiff = getGroupedDiffBy (==)
+
+-- | A form of 'getDiff' with no 'Eq' constraint. Instead, an equality predicate
+-- is taken as the first argument.
+getDiffBy :: (a -> b -> Bool) -> [a] -> [b] -> [PolyDiff a b]
+getDiffBy eq a b = markup a b . reverse $ ses eq a b
+    where markup (x:xs) (y:ys) ds
+            | eq x y = Both x y : markup xs ys ds
+          markup (x:xs)   ys   (F:ds) = First x  : markup xs ys ds
+          markup   xs   (y:ys) (S:ds) = Second y : markup xs ys ds
+          markup _ _ _ = []
+
+-- | Like 'getGroupedDiff' but accepts a custom equality predicate.
+--
+-- Postcondition: the output list is guaranteed to be /chunked/. i.e. no two adjacent
+-- elements share the same constructor.
+{-@ getGroupedDiffBy :: (a -> b -> Bool) -> [a] -> [b]
+                     -> {vs : [GroupedDiff a b] | noStuttering vs} @-}
+getGroupedDiffBy :: (a -> b -> Bool) -> [a] -> [b] -> [PolyDiff [a] [b]]
+getGroupedDiffBy eq a b = groupDiff $ getDiffBy eq a b
+
+{-@ groupDiff :: xs : [PolyDiff a b]
+              -> {vs : [GroupedDiff a b] | noStuttering vs
+                  // The following predicates allow LiquidHaskell keep track
+                  // of the head constructor in each recursive call.
+                  && (headIsFirst xs  <=> headIsFirst vs)
+                  && (headIsSecond xs <=> headIsSecond vs)
+                  && (headIsBoth xs   <=> headIsBoth vs)} @-}
+groupDiff :: [PolyDiff a b] -> [PolyDiff [a] [b]]
+groupDiff (First x  : xs) = let (fs, rest) = leadingFirsts  xs
+                             in First (x:fs) : groupDiff rest
+groupDiff (Second x : xs) = let (sc, rest) = leadingSeconds xs
+                             in Second (x:sc) : groupDiff rest
+groupDiff (Both x y : xs) = let (bxs, bys, rest) = leadingBoths xs
+                             in Both (x:bxs) (y:bys) : groupDiff rest
+groupDiff [] = []
+
+{-@ leadingFirsts :: xs : [PolyDiff a b]
+                   -> {v : ([a], [PolyDiff a b]) | not (headIsFirst (snd v))
+                       // Here and in the analogous helpers,
+                       // the length comparison is needed for termination check.
+                       && len (snd v) <= len xs
+                       && (headIsSecond xs => headIsSecond (snd v))
+                       && (headIsBoth xs   => headIsBoth (snd v))} @-}
+leadingFirsts :: [PolyDiff a b] -> ([a], [PolyDiff a b])
+leadingFirsts (First y : diffs) = let (firsts, rest) = leadingFirsts diffs
+                                   in (y:firsts, rest)
+leadingFirsts diffs = ([],diffs)
+
+{-@ leadingSeconds :: xs : [PolyDiff a b]
+                    -> {v : ([b], [PolyDiff a b]) | not (headIsSecond (snd v))
+                        && len (snd v) <= len xs
+                        && (headIsFirst xs => headIsFirst (snd v))
+                        && (headIsBoth xs  => headIsBoth (snd v))} @-}
+leadingSeconds :: [PolyDiff a b] -> ([b], [PolyDiff a b])
+leadingSeconds (Second y : diffs) = let (seconds, rest) = leadingSeconds diffs
+                                     in (y:seconds, rest)
+leadingSeconds diffs = ([],diffs)
+
+{-@ leadingBoths :: xs : [PolyDiff a b]
+                  -> {v : ([a], [b], [PolyDiff a b]) | not (headIsBoth (thd3 v))
+                      && len (thd3 v) <= len xs
+                      && (headIsFirst xs  => headIsFirst (thd3 v))
+                      && (headIsSecond xs => headIsSecond (thd3 v))
+                      && len (fst3 v) == len (snd3 v)} @-}
+leadingBoths :: [PolyDiff a b] -> ([a], [b], [PolyDiff a b])
+leadingBoths (Both w z : diffs) = let (as, bs, rest) = leadingBoths diffs
+                                   in (w:as, z:bs, rest)
+leadingBoths diffs = ([], [], diffs)

--- a/tests/Diff/DiffContext.hs
+++ b/tests/Diff/DiffContext.hs
@@ -1,0 +1,273 @@
+{-@ LIQUID "--ple" @-}
+{-@ LIQUID "--ple-with-undecided-guards" @-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Algorithm.DiffContext
+-- Copyright   :  (c) David Fox (2015)
+-- License     :  BSD 3 Clause
+-- Maintainer  :  s.clover@gmail.com
+-- Stability   :  experimental
+-- Portability :  portable
+-- Author      :  David Fox (ddssff at the email service from google)
+--
+-- Generates a grouped diff with merged runs, and outputs them in the manner of @diff -u@.
+-----------------------------------------------------------------------------
+module DiffContext
+    ( ContextDiff, Hunk
+    , getContextDiff
+    , prettyContextDiff
+    , prettyContextDiffOld
+    , getContextDiffNumbered
+    , Numbered(Numbered), numbered, unnumber
+    , unNumberContextDiff
+    ) where
+
+import Diff (PolyDiff(..), Diff, getGroupedDiff,
+                            noStuttering, noFFSS,
+                            headIsFirst, headIsSecond)
+import Data.Bifunctor
+import Text.PrettyPrint (Doc, text, empty, hcat)
+
+{-@ type ContextDiff c = [Hunk c] @-}
+-- | A diff consisting of disjoint 'Hunk's.
+type ContextDiff c = [Hunk c]
+
+{-@ type Hunk c = { h : [ValidListDiff c c] | noStuttering h} @-}
+-- | A 'Hunk' is a list of adjacent 'Diff's.
+--
+-- No two consecutive elements in a 'Hunk' are both applications
+-- of 'First', 'Second', or 'Both', i.e. the list does not stutter
+-- on 'Diff' constructors.
+type Hunk c = [Diff [c]]
+
+-- | Split a 'Diff' list at consecutive 'Both'-'Both' boundaries.
+{-@ splitBothBoth :: {ds:[ValidListDiff c c] | noFFSS ds} -> [Hunk c] @-}
+splitBothBoth :: [Diff [c]] -> [Hunk c]
+splitBothBoth = go []
+  where
+    {-@ go
+          :: g:Hunk c
+          -> {xs : [ValidListDiff c c] | noFFSS xs && not (headAlike g xs) }
+          -> [Hunk c] / [len xs]
+      @-}
+    go :: Hunk c -> [Diff [c]] -> [Hunk c]
+    go g (x@Both{} : y@Both{} : xs) = reverse (x:g) : go [] (y:xs)
+      where
+        lemma = lemmaReverseStuttering (x:g)
+    go g (x : xs) = go (x:g) xs
+    go g [] = [reverse g]
+      where
+        lemma = lemmaReverseStuttering g
+
+{-@ type ContextSize = Nat @-}
+type ContextSize = Int
+
+{-@ opaque-reflect reverse @-}
+
+{-@ assume lemmaReverseStuttering
+      :: xs:_ -> { noStuttering (reverse xs) = noStuttering xs } @-}
+lemmaReverseStuttering :: Hunk c -> ()
+lemmaReverseStuttering _ = ()
+
+{-@ reflect headAlike  @-}
+headAlike :: Hunk c -> Hunk c -> Bool
+headAlike (Both{} : _) (Both{} : _) = True
+headAlike (First{} : _) (First{} : _) = True
+headAlike (Second{} : _) (Second{} : _) = True
+headAlike _ _ = False
+
+data Numbered a = Numbered Int a deriving Show
+instance Eq a => Eq (Numbered a) where
+  Numbered _ a == Numbered _ b = a == b
+instance Ord a => Ord (Numbered a) where
+  compare (Numbered _ a) (Numbered _ b) = compare a b
+
+numbered :: [a] -> [Numbered a]
+numbered xs = fmap (uncurry Numbered) (zip [1..] xs)
+
+unnumber :: Numbered a -> a
+unnumber (Numbered _ a) = a
+
+-- |
+-- > > let textA = ["a","b","c","d","e","f","g","h","i","j","k"]
+-- > > let textB = ["a","b","d","e","f","g","h","i","j"]
+-- > > let diff = getContextDiff (Just 2) textA textB
+-- > > prettyContextDiff (text "file1") (text "file2") (text . unnumber) diff
+-- > --- file1
+-- > +++ file2
+-- > @@ -1,5 +1,4 @@
+-- >  a
+-- >  b
+-- > -c
+-- >  d
+-- >  e
+-- > @@ -9,3 +8,2 @@
+-- >  i
+-- >  j
+-- > -k
+{-@
+getContextDiff ::
+  Eq a
+  => Maybe ContextSize
+  -> [a]
+  -> [a]
+  -> ContextDiff (Numbered a)
+@-}
+getContextDiff ::
+  Eq a
+  => Maybe ContextSize -- ^ Context size. 'Nothing' means returning a whole-diff 'Hunk'.
+  -> [a]
+  -> [a]
+  -> ContextDiff (Numbered a)
+getContextDiff contextSize a b =
+  getContextDiffNumbered contextSize (numbered a) (numbered b)
+
+-- | If for some reason you need the line numbers stripped from the
+-- result of 'getContextDiff' for backwards compatibility.
+{-@ unNumberContextDiff :: ContextDiff (Numbered a) -> [[Diff [a]]] @-}
+unNumberContextDiff :: ContextDiff (Numbered a) -> ContextDiff a
+unNumberContextDiff = fmap (fmap (bimap (fmap unnumber) (fmap unnumber)))
+
+-- | Create a diff of separate 'Hunk's, each containing a sequence
+-- of differing elements surrounded by common elements for context.
+--
+-- The context size determines when to merge adjacent hunks:
+-- two hunks are merged when the number of common elements between them does not
+-- exceed twice the context size. Furthermore, if @contextSize@ is 'Nothing'
+-- a single hunk with the whole diff is produced.
+{-@
+getContextDiffNumbered ::
+  Eq a
+  => Maybe ContextSize
+  -> [Numbered a]
+  -> [Numbered a]
+  -> ContextDiff (Numbered a)
+@-}
+getContextDiffNumbered ::
+  Eq a
+  => Maybe ContextSize -- ^ Context size. 'Nothing' means returning a whole-diff 'Hunk'.
+  -> [Numbered a]
+  -> [Numbered a]
+  -> ContextDiff (Numbered a)
+getContextDiffNumbered Nothing a0 b0 = [getGroupedDiff a0 b0]
+getContextDiffNumbered (Just contextSize) a0 b0 =
+    -- The 'Diff' list is grouped into 'Hunks' that begin and end
+    -- with matching ('Both') text, having non-matching ('First' and 'Second')
+    -- text in the middle. Note that a non-trivial partition can only happen after
+    -- the matching text has been reduced to become consecutive 'Both' values
+    -- corresponding to a hunk's suffix and the following hunk prefix.
+    splitBothBoth $ doPrefix $ getGroupedDiff a0 b0
+    where
+      -- | Handle the common text leading up to a diff.
+      --
+      -- Postcondition: The @a@ elements in @doPrefix h@ are a subset of those in @h@,
+      -- in the same order. Additionaly, 'First' and 'Second' diffs
+      -- are identical in both lists.
+      --
+      -- The difference between input and output is that some 'Both' diffs might
+      -- be split into two other 'Both' diffs. This happens when their contents
+      -- are too large compared with the contex size, resulting in some @a@
+      -- elements being dropped.
+      {-@ doPrefix ::  h : Hunk c
+                   -> {v : [ValidListDiff c c] | noFFSS v
+                       && (headIsFirst h <=> headIsFirst v)
+                       && (headIsSecond h <=> headIsSecond v)} / [len h, 0] @-}
+      doPrefix :: [Diff [c]] -> [Diff [c]]
+      doPrefix [] = []
+      -- Trailing common elements are no prefix.
+      -- This case corresponds to when both input lists are identical, so the
+      -- resulting 'ContextDiff' is empty.
+      doPrefix [Both _ _] = []
+      -- Do the prefix and then make the suffix.
+      doPrefix (Both xs ys : more) =
+        Both (drop (length xs - contextSize) xs)
+             (drop (length ys - contextSize) ys) : doSuffix more
+      -- Prefix finished, do the diff then the following suffix.
+      doPrefix (d : ds) = d : doSuffix ds
+
+      -- | Handle the common text following a diff.
+      --
+      -- Precondition: The input does not start with a 'Both' diff. Otherwise,
+      -- it behaves like @doPrefix@.
+      {-@ doSuffix ::  h : Hunk c
+                   -> {v : [ValidListDiff c c] | noFFSS v
+                       && (headIsFirst h <=> headIsFirst v)
+                       && (headIsSecond h <=> headIsSecond v)} / [len h, 1] @-}
+      doSuffix :: [Diff [c]] -> [Diff [c]]
+      doSuffix [] = []
+      -- A trailing suffix.
+      doSuffix [Both xs ys] = [Both (take contextSize xs) (take contextSize ys)]
+      -- If the common text is too short compared with the context,
+      -- we preserve it and continue. As the following element cannot be a 'Both'
+      -- as well, this effectively places the common text in the inner part of the diff.
+      -- Otherwise, we split it into a suffix and prefix
+      -- (resulting in some elements excluded from the diff in the middle).
+      doSuffix (Both xs ys : more)
+        | length xs <= contextSize * 2 =
+            Both xs ys : doPrefix more
+        | otherwise =
+            Both (take contextSize xs) (take contextSize ys) :
+            doPrefix (Both (drop contextSize xs) (drop contextSize ys) : more)
+      -- 'First' and 'Second' elements are no suffix, preserve them and continue looking.
+      doSuffix (d : ds) = d : doSuffix ds
+
+-- | Pretty print a ContextDiff in the manner of diff -u.
+prettyContextDiff ::
+       Doc            -- ^ Document 1 name
+    -> Doc            -- ^ Document 2 name
+    -> (Numbered c -> Doc)     -- ^ Element pretty printer
+    -> ContextDiff (Numbered c)
+    -> Doc
+prettyContextDiff _ _ _ [] = empty
+prettyContextDiff old new prettyElem hunks =
+    hcat . map (<> text "\n") $ (text "--- " <> old :
+                                 text "+++ " <> new :
+                                 concatMap prettyRun hunks)
+    where
+      -- Pretty print a run of adjacent changes
+      prettyRun hunk =
+        text ("@@ " <> formatHunk hunk <> " @@") : concatMap prettyChange hunk
+
+      -- Pretty print a single change (e.g. one line of a text file)
+      prettyChange (Both ts _) = map (\ l -> text " " <> prettyElem l) ts
+      prettyChange (First ts)  = map (\ l -> text "-" <> prettyElem l) ts
+      prettyChange (Second ts) = map (\ l -> text "+" <> prettyElem l) ts
+
+      formatHunk hunk = "-" <> formatRun (firsts hunk) <> " +" <> formatRun (seconds hunk)
+
+      formatRun :: [Int] -> String
+      formatRun [] = "-0,0"
+      formatRun [n] = show n
+      formatRun ns@(n : _) = show n <> "," <> show (length ns)
+
+      firsts (Both ns _ : more) = fmap (\(Numbered n _) -> n) ns <> firsts more
+      firsts (First ns : more) = fmap (\(Numbered n _) -> n) ns <> firsts more
+      firsts (Second _ : more) = firsts more
+      firsts [] = []
+
+      seconds (Both _ ns : more) = fmap (\(Numbered n _) -> n) ns <> seconds more
+      seconds (First _ : more) = seconds more
+      seconds (Second ns : more) = fmap (\(Numbered n _) -> n) ns <> seconds more
+      seconds [] = []
+
+-- | Pretty print without line numbers.
+prettyContextDiffOld ::
+       Doc            -- ^ Document 1 name
+    -> Doc            -- ^ Document 2 name
+    -> (c -> Doc)     -- ^ Element pretty printer
+    -> ContextDiff c
+    -> Doc
+prettyContextDiffOld _ _ _ [] = empty
+prettyContextDiffOld old new prettyElem hunks =
+    hcat . map (<> text "\n") $ (text "--- " <> old :
+                                 text "+++ " <> new :
+                                 concatMap prettyRun hunks)
+    where
+      -- Pretty print a run of adjacent changes
+      prettyRun hunk =
+          text "@@" : concatMap prettyChange hunk
+
+      -- Pretty print a single change (e.g. one line of a text file)
+      prettyChange (Both ts _) = map (\ l -> text " " <> prettyElem l) ts
+      prettyChange (First ts)  = map (\ l -> text "-" <> prettyElem l) ts
+      prettyChange (Second ts) = map (\ l -> text "+" <> prettyElem l) ts

--- a/tests/Diff/DiffOutput.hs
+++ b/tests/Diff/DiffOutput.hs
@@ -1,0 +1,249 @@
+{-@ LIQUID "--ple" @-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Algorithm.DiffOutput
+-- Copyright   :  (c) Sterling Clover 2008-2011, Kevin Charter 2011
+-- License     :  BSD 3 Clause
+-- Maintainer  :  s.clover@gmail.com
+-- Stability   :  experimental
+-- Portability :  portable
+-- Author      :  Stephan Wehr (wehr@factisresearch.com) and JP Moresmau (jp@moresmau.fr)
+--
+-- Generates a string output that is similar to diff normal mode.
+-----------------------------------------------------------------------------
+module DiffOutput where
+import Diff
+import Text.PrettyPrint hiding ((<>))
+import Data.Char
+import Data.List
+
+-- Non-empty lists as refinements of regular lists.
+{-@ type NonEmpty a = {xs : [a] | len xs >0}@-}
+
+{-@ reflect coherentDiff @-}
+-- | This functions checks that both contents match whenever we have a 'Both'
+-- value.
+coherentDiff :: Eq c => Diff c -> Bool
+coherentDiff (Both x y) = x == y
+coherentDiff (First _) = True
+coherentDiff (Second _) = True
+
+-- This refinement type synonym encodes the invariants on the 'Diff' type
+-- that we expect throughout this module. Namely:
+--
+-- * They have non-empty contents
+-- * 'Both' values have equal arguments
+{-@ type StringDiff = {d : Diff (NonEmpty String) | coherentDiff d } @-}
+
+-- | Converts 'Diff's to 'DiffOperation's. 'First' and 'Second'
+-- ocurrances are converted to 'Addition' and 'Deletion', respectively, while
+-- consecutive ocurrances of them are replaced by a 'Change'.
+{-@ diffToLineRanges :: [StringDiff] -> [DiffOperation LineRange]@-}
+diffToLineRanges :: [Diff [String]] -> [DiffOperation LineRange]
+diffToLineRanges = toLineRange 1 1
+   where
+          -- | In @toLineRange x y ds@, @x@ is the index of the current string in the
+          -- left input of the diff @ds@, and @y@ is the index of the corresponding
+          -- string in the right input of the diff @ds@.
+          {-@ toLineRange :: {l:Int | l >= 1}
+                          -> {r:Int | r >= 1}
+                          -> diffs : [StringDiff]
+                          -> [DiffOperation LineRange] / [len diffs, 0] @-}
+          toLineRange :: Int -> Int -> [Diff [String]] -> [DiffOperation LineRange]
+          toLineRange _ _ [] = []
+          -- If the lines are the same, we just move forward.
+          toLineRange leftLine rightLine (Both ls _ : rs) =
+                let lins=length ls
+                in  toLineRange (leftLine+lins) (rightLine+lins) rs
+          -- A 'Change' is introduced when an addition is followed by a deletion, or vice versa.
+          toLineRange leftLine rightLine (Second lsS@(_:_) : First lsF@(_:_) : rs) =
+                toChange leftLine rightLine lsF lsS rs
+          toLineRange leftLine rightLine (First lsF@(_:_) : Second lsS@(_:_) : rs) =
+                toChange leftLine rightLine lsF lsS rs
+          -- Introduce 'Addition's.
+          toLineRange leftLine rightLine (Second lsS@(_:_) : rs) =
+                let diff = Addition (mkLineRange rightLine lsS) (leftLine-1)
+                in  diff : toLineRange leftLine (rightLine + length lsS) rs
+          -- Introduce 'Deletion's.
+          toLineRange leftLine rightLine (First lsF@(_:_):rs)=
+                let diff = Deletion (mkLineRange leftLine lsF) (rightLine-1)
+                in  diff : toLineRange (leftLine + length lsF) rightLine rs
+          -- Skip empty 'Second' and 'First' entries.
+          -- NOTE: Both these cases are unreachable.
+          toLineRange leftLine rightLine (Second [] : rs) =
+                toLineRange leftLine rightLine rs
+          toLineRange leftLine rightLine (First [] : rs) =
+                toLineRange leftLine rightLine rs
+          -- | Build 'Change's from adjacent additions and deletions.
+          {-@ toChange :: {l:Int | l >= 1}
+                       -> {r:Int | r >= 1}
+                       -> {lf:[String] | len lf > 0}
+                       -> {ls:[String] | len ls > 0}
+                       -> diffs : [StringDiff]
+                       -> [DiffOperation LineRange] / [len diffs, 1] @-}
+          toChange :: Int -- ^ Current left line number.
+                   -> Int -- ^ Current right line number.
+                   -> [String] -- ^ Lines from the 'First' list (corresponding to deletions).
+                   -> [String] -- ^ Lines from the 'Second' list (corresponding to additions).
+                   -> [Diff [String]] -- ^ Remaining 'Diff's.
+                   -> [DiffOperation LineRange]
+          toChange leftLine rightLine lsF lsS rs=
+                Change (mkLineRange leftLine lsF) (mkLineRange rightLine lsS)
+                    : toLineRange (leftLine + length lsF) (rightLine + length lsS) rs
+
+{-@ ppDiff :: [StringDiff] -> String @-}
+-- | Pretty print the differences. The output is similar to the output of the @diff@ utility.
+--
+-- > > putStr (ppDiff (getGroupedDiff ["a","b","c","d","e"] ["a","c","d","f"]))
+-- > 2d1
+-- > < b
+-- > 5c4
+-- > < e
+-- > ---
+-- > > f
+ppDiff :: [Diff [String]] -> String
+ppDiff gdiff =
+   let  diffLineRanges = diffToLineRanges gdiff
+   in
+        render (prettyDiffs diffLineRanges) ++ "\n"
+
+
+-- | Pretty print of diff operations.
+prettyDiffs :: [DiffOperation LineRange] -> Doc
+prettyDiffs [] = empty
+prettyDiffs (d : rest) = prettyDiff d $$ prettyDiffs rest
+    where
+      prettyDiff (Deletion inLeft lineNoRight) =
+          prettyRange (lrNumbers inLeft) <> char 'd' <> int lineNoRight $$
+          prettyLines '<' (lrContents inLeft)
+      prettyDiff (Addition inRight lineNoLeft) =
+          int lineNoLeft <> char 'a' <> prettyRange (lrNumbers inRight) $$
+          prettyLines '>' (lrContents inRight)
+      prettyDiff (Change inLeft inRight) =
+          prettyRange (lrNumbers inLeft) <> char 'c' <> prettyRange (lrNumbers inRight) $$
+          prettyLines '<' (lrContents inLeft) $$
+          text "---" $$
+          prettyLines '>' (lrContents inRight)
+      prettyRange (start, end) =
+          if start == end then int start else int start <> comma <> int end
+      prettyLines start lins =
+          vcat (map (\l -> char start <+> text l) lins)
+
+-- | Parse pretty printed 'Diff's as 'DiffOperation's.
+parsePrettyDiffs :: String -> [DiffOperation LineRange]
+parsePrettyDiffs = reverse . doParse [] . lines
+  where
+    -- | Parsing entry point that iteratively accumulates 'DiffOperation's
+    -- until the input is exhausted.
+    {-@ doParse :: [DiffOperation LineRange] -> diffs : [String] -> [DiffOperation LineRange] / [len diffs] @-}
+    doParse :: [DiffOperation LineRange] -> [String] -> [DiffOperation LineRange]
+    -- NOTE: Incorrectly formatted lines are ignored.
+    doParse acc [] = acc
+    doParse acc s =
+        let (mnd,r) = parseDiff s
+        in case mnd of
+            Just nd -> doParse (nd:acc) r
+            _          -> doParse acc r
+
+    {-@ parseDiff :: s:{[String] | len s > 0} -> {v:(Maybe (DiffOperation LineRange), [String]) | len (snd v) < len s} @-}
+    parseDiff :: [String] -> (Maybe (DiffOperation LineRange), [String])
+    parseDiff [] = (Nothing,[])
+    parseDiff (h:rs) = let
+        (r1,hrs1) = parseRange h
+        in case hrs1 of
+                -- In each case, we pass the left line range,
+                -- the remaining string after the type character,
+                -- which must contain the right line range,
+                -- and the remaining lines to parse.
+                ('d':hrs2) -> parseDel r1 hrs2 rs
+                ('a':hrs2) -> parseAdd r1 hrs2 rs
+                ('c':hrs2) -> parseChange r1 hrs2 rs
+                _ -> (Nothing,rs)
+
+    {-@ parseDel :: (Nat, Nat) -> String -> rs:[String] -> {v:(Maybe (DiffOperation LineRange), [String]) | len (snd v) <= len rs} @-}
+    parseDel :: (LineNo, LineNo) -> String -> [String] -> (Maybe (DiffOperation LineRange), [String])
+    parseDel r1 hrs2 rs = let
+        (r2,_) = parseRange hrs2
+        (ls,rs2) = span (isPrefixOf "<") rs
+        contents = map (drop 2) ls
+        in case contents of
+            (_:_) -> (Just $ Deletion (mkLineRange (fst r1) contents) (fst r2), rs2)
+            _ -> (Nothing, rs2)
+
+    {-@ parseAdd :: (Nat, Nat) -> String -> rs:[String] -> {v:(Maybe (DiffOperation LineRange), [String]) | len (snd v) <= len rs} @-}
+    parseAdd :: (LineNo, LineNo) -> String -> [String] -> (Maybe (DiffOperation LineRange), [String])
+    parseAdd r1 hrs2 rs = let
+        (r2,_) = parseRange hrs2
+        (ls,rs2) = span (isPrefixOf ">") rs
+        contents = map (drop 2) ls
+        in case contents of
+            (_:_) -> (Just $ Addition (mkLineRange (fst r2) contents) (fst r1), rs2)
+            _ -> (Nothing, rs2)
+
+    {-@ parseChange :: (Nat, Nat) -> String -> rs:[String] -> {v:(Maybe (DiffOperation LineRange), [String]) | len (snd v) <= len rs} @-}
+    parseChange :: (LineNo, LineNo) -> String -> [String] -> (Maybe (DiffOperation LineRange), [String])
+    parseChange r1 hrs2 rs = let
+        (r2,_) = parseRange hrs2
+        (ls1,rs2) = span (isPrefixOf "<") rs
+        in case rs2 of
+            -- The left and right diff of a 'Change' are separated by a "---" line.
+            ("---":rs3) -> let
+                (ls2,rs4) = span (isPrefixOf ">") rs3
+                contents1 = map (drop 2) ls1
+                contents2 = map (drop 2) ls2
+                in case (contents1, contents2) of
+                    (_:_, _:_) -> (Just $ Change (mkLineRange (fst r1) contents1) (mkLineRange (fst r2) contents2), rs4)
+                    _ -> (Nothing, rs4)
+            _ -> (Nothing,rs2)
+
+    {-@ parseRange :: String -> {v : ((Nat, Nat), String) | fst (fst v) <= snd (fst v)} @-}
+    parseRange :: String -> ((LineNo, LineNo), String)
+    parseRange l = let
+        (fstLine,rs) = span isDigit l
+        a = max 0 (read fstLine)
+        (sndLine,rs3) = case rs of
+                                    -- The comma is used to separate
+                                    -- the start and end line numbers in a range,
+                                    -- but is omitted if they are the same.
+                                    -- i.e. the range is a single line.
+                                    (',':rs2) -> span isDigit rs2
+                                    _ -> (fstLine,rs)
+        b = max a (read sndLine)
+        in ((a, b), rs3)
+
+-- | Line number alias. Always non-negative.
+type LineNo = Int
+
+-- | Line Range: start, end and contents.
+--
+-- The following invariants hold:
+--
+-- > snd lrNumbers >= fst lrNumbers
+-- > snd lrNumbers - fst lrNumbers + 1 == length lrContents
+--
+-- which imply @lrContents@ cannot be empty.
+{-@
+data LineRange = LineRange { lrNumbers :: {range : (Nat, Nat) | fst range <= snd range}
+                           , lrContents :: {contents : [String] | snd lrNumbers - fst lrNumbers = len contents - 1}
+                           }
+@-}
+data LineRange = LineRange { lrNumbers :: (LineNo, LineNo)
+                           , lrContents :: [String]
+                           }
+            deriving (Show, Read, Eq, Ord)
+
+-- | Smart constructor for 'LineRange' that computes the end line from the
+-- start line and the content length, guaranteeing that its content length and
+-- range match.
+{-@ mkLineRange :: start:Nat -> contents:{[String] | len contents > 0} -> LineRange @-}
+mkLineRange :: Int -> [String] -> LineRange
+mkLineRange start contents = LineRange (start, start + length contents - 1) contents
+
+-- | Diff operation representing changes to apply.
+data DiffOperation a
+  = Deletion a LineNo  -- ^ Element deleted on the left input, line number
+                       -- preceding the deleted lines in the right input.
+  | Addition a LineNo  -- ^ Element added from the right input, line number
+                       -- preceding the added lines in the left input.
+  | Change a a         -- ^ Element changed from the left input to the right input.
+  deriving (Show,Read,Eq,Ord)

--- a/tests/Diff/LiftedFunctions.hs
+++ b/tests/Diff/LiftedFunctions.hs
@@ -1,0 +1,15 @@
+-- | Utilify functions for Diff static checks.
+module LiftedFunctions where
+ 
+-- | Measures for triplet projections.
+{-@
+measure fst3
+measure snd3
+measure thd3
+@-}
+fst3 :: (a, b, c) -> a
+fst3 (x, _, _) = x
+snd3 :: (a, b, c) -> b
+snd3 (_, y, _) = y
+thd3 :: (a, b, c) -> c
+thd3 (_, _, z) = z

--- a/tests/harness/Test/Groups.hs
+++ b/tests/harness/Test/Groups.hs
@@ -22,6 +22,7 @@ microTestGroups =
   , "measure-neg"
   , "datacon-pos"
   , "datacon-neg"
+  , "Diff"
   , "names-pos"
   , "names-neg"
   , "name-resolution-pos"

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -1093,6 +1093,7 @@ executable datacon-neg
 flag Diff
      default: False
 
+-- Test annotations for the Diff package
 executable Diff
     import:           common-ghc-options
     main-is:          Main.hs

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -1090,6 +1090,28 @@ executable datacon-neg
     hs-source-dirs:   app
                     , datacon/neg
 
+flag Diff
+     default: False
+
+executable Diff
+    import:           common-ghc-options
+    main-is:          Main.hs
+    if !flag(Diff) && flag(stack)
+      buildable:      False
+
+    other-modules:    Diff
+                    , DiffContext
+                    , DiffOutput
+                    , LiftedFunctions
+
+    build-depends:    array
+                    , base
+                    , liquidhaskell
+                    , pretty
+
+    hs-source-dirs:   app
+                    , Diff
+
 flag unit-neg
      default: False
 


### PR DESCRIPTION
I've been working on writing LH static checks for several invariants in the [`Diff` package](https://hackage.haskell.org/package/Diff) as part of a project at Tweag. It is still unknown if they would be merged upstream; nevertheless, they leverage recent fixes and exercise much functionality, so they might be a good fit for the test-suite.