### PR TITLE
preserve signatures of data constructors over modules

### DIFF
--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -645,6 +645,7 @@ import GHC.Types.Id                   as Ghc
     , idInfo
     , idOccInfo
     , isConLikeId
+    , isDataConId_maybe
     , idInlinePragma
     , modifyIdInfo
     , mkExportedLocalId

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -135,7 +135,7 @@ makeTargetSpec cfg localVars lnameEnv lmap targetSrc bareSpec dependencies = do
           exportedAssumption (LHNResolved (LHRGHC n) _) =
             case Ghc.lookupTypeEnv (Ghc.tcg_type_env tcg) n of
               Just (Ghc.AnId v)
-                | Just dc <- dataConId_maybe v ->
+                | Just dc <- dataConIdMaybe v ->
                     constructorIsExported exportedStableNames dc
               _ -> case Ghc.nameModule_maybe n of
                 Nothing -> Ghc.elemNameSet n exportedNames
@@ -149,8 +149,8 @@ makeTargetSpec cfg localVars lnameEnv lmap targetSrc bareSpec dependencies = do
 
     ghcSpecToLiftedSpec = toLiftedSpec . toBareSpecLHName cfg lnameEnv . _gsLSpec
 
-dataConId_maybe :: Ghc.Var -> Maybe Ghc.DataCon
-dataConId_maybe = Ghc.isDataConId_maybe
+dataConIdMaybe :: Ghc.Var -> Maybe Ghc.DataCon
+dataConIdMaybe = Ghc.isDataConId_maybe
 
 
 -------------------------------------------------------------------------------------
@@ -1560,12 +1560,12 @@ makeLiftedSpec name src env refl sData sig qual myRTE lSpec0 = lSpec0
         False
 
     isExportedDataConVar src' x =
-      case dataConId_maybe x of
+      case dataConIdMaybe x of
         Just dc -> mkStableName (Ghc.getName dc) `S.member` gsExports src'
         Nothing -> isExportedVar src' x
 
     isLocalDataConVar x =
-      case dataConId_maybe x of
+      case dataConIdMaybe x of
         Just dc -> Just (Ghc.tcg_mod (Bare.reTcGblEnv env)) == Ghc.nameModule_maybe (Ghc.getName dc)
         Nothing -> isLocalName (val (makeGHCLHNameLocatedFromId x))
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -33,7 +33,7 @@ import qualified Language.Fixpoint.Types                    as F
 import qualified Language.Haskell.Liquid.Misc               as Misc -- (nubHashOn)
 import qualified Language.Haskell.Liquid.GHC.Misc           as GM
 import qualified Liquid.GHC.API            as Ghc
-import           Language.Haskell.Liquid.GHC.Types          (StableName)
+import           Language.Haskell.Liquid.GHC.Types          (StableName, availsToStableNameSet, mkStableName)
 import           Language.Haskell.Liquid.LHNameResolution
 import           Language.Haskell.Liquid.Types.Errors
 import           Language.Haskell.Liquid.Types.DataDecl
@@ -131,14 +131,26 @@ makeTargetSpec cfg localVars lnameEnv lmap targetSrc bareSpec dependencies = do
     removeUnexportedLocalAssumptions lspec = do
       tcg <- Ghc.getGblEnv
       let exportedNames = Ghc.availsToNameSet (Ghc.tcg_exports tcg)
+          exportedStableNames = availsToStableNameSet (Ghc.tcg_exports tcg)
           exportedAssumption (LHNResolved (LHRGHC n) _) =
-            case Ghc.nameModule_maybe n of
-              Nothing -> Ghc.elemNameSet n exportedNames
-              Just m -> m /= Ghc.tcg_mod tcg || Ghc.elemNameSet n exportedNames
+            case Ghc.lookupTypeEnv (Ghc.tcg_type_env tcg) n of
+              Just (Ghc.AnId v)
+                | Just dc <- dataConId_maybe v ->
+                    constructorIsExported exportedStableNames dc
+              _ -> case Ghc.nameModule_maybe n of
+                Nothing -> Ghc.elemNameSet n exportedNames
+                Just m -> m /= Ghc.tcg_mod tcg || Ghc.elemNameSet n exportedNames
           exportedAssumption _ = True
       return lspec { liftedAsmSigs = S.filter (exportedAssumption . val . fst) (liftedAsmSigs lspec) }
 
+    constructorIsExported :: S.HashSet StableName -> Ghc.DataCon -> Bool
+    constructorIsExported exportedNames dc =
+      mkStableName (Ghc.getName dc) `S.member` exportedNames
+
     ghcSpecToLiftedSpec = toLiftedSpec . toBareSpecLHName cfg lnameEnv . _gsLSpec
+
+dataConId_maybe :: Ghc.Var -> Maybe Ghc.DataCon
+dataConId_maybe = Ghc.isDataConId_maybe
 
 
 -------------------------------------------------------------------------------------
@@ -1525,11 +1537,17 @@ makeLiftedSpec name src env refl sData sig qual myRTE lSpec0 = lSpec0
   , Ms.qualifiers = filter (isLocInFile srcF) (gsQualifiers qual)
   }
   where
-    myDCs         = filter (isLocalName . val . fst) $ mkSigs (gsCtors sData)
+    myDCs         = mkConSigs (gsCtors sData)
     mkSigs xts    = [ toBare (x, t) | (x, t) <- xts
                     , not (S.member x reflVars) && isExportedVar (toTargetSrc src) x
                     ]
+    mkConSigs xts = [ toBareCon (x, t) | (x, t) <- xts
+                    , not (S.member x reflVars)
+                    , isLocalDataConVar x
+                    , isExportedDataConVar (toTargetSrc src) x
+                    ]
     toBare (x, t) = (makeGHCLHNameLocatedFromId x, Bare.specToBare <$> t)
+    toBareCon (x, t) = (makeGHCLHNameLocated x, Bare.specToBare <$> t)
     xbs           = toBare <$> reflTySigs
     reflTySigs    = [(x, t) | (x,t,_) <- gsHAxioms refl]
     reflVars      = S.fromList (fst <$> reflTySigs)
@@ -1540,6 +1558,16 @@ makeLiftedSpec name src env refl sData sig qual myRTE lSpec0 = lSpec0
         Just (Ghc.tcg_mod (Bare.reTcGblEnv env)) == Ghc.nameModule_maybe n
       _ ->
         False
+
+    isExportedDataConVar src' x =
+      case dataConId_maybe x of
+        Just dc -> mkStableName (Ghc.getName dc) `S.member` gsExports src'
+        Nothing -> isExportedVar src' x
+
+    isLocalDataConVar x =
+      case dataConId_maybe x of
+        Just dc -> Just (Ghc.tcg_mod (Bare.reTcGblEnv env)) == Ghc.nameModule_maybe (Ghc.getName dc)
+        Nothing -> isLocalName (val (makeGHCLHNameLocatedFromId x))
 
 -- | Returns 'True' if the input determines a location within the input file. Due to the fact we might have
 -- Haskell sources which have \"companion\" specs defined alongside them, we also need to account for this

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Init.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Init.hs
@@ -72,7 +72,7 @@ initEnv info
        fi       <- refreshArgs' $ catMaybes $ [(x,) . val <$> getMethodType mt | (x, mt) <- gsMethods $ gsSig $ giSpec info ]
        (invs1, f41) <- traverse refreshArgs' $ makeAutoDecrDataCons dcsty  (gsAutosize (gsTerm sp)) dcs
        (invs2, f42) <- traverse refreshArgs' $ makeAutoDecrDataCons dcsty' (gsAutosize (gsTerm sp)) dcs'
-       let f4    = mergeDataConTypes tce (mergeDataConTypes tce f40 (f41 ++ f42)) (filter (isDataConId . fst) f2)
+       let f4    = mergeDataConTypes tce (mergeDataConTypes tce f40 (f41 ++ f42)) (filter (isDataConId . fst) (f2 ++ f3))
        let tx    = first F.symbol . addRInv ialias . predsUnify sp
        f6       <- map tx . addPolyInfo' <$> refreshArgs' (vals gsRefSigs (gsSig sp))
        let bs    = (tx <$> ) <$> [f0 ++ f0' ++ fi, f1 ++ f1', f2, f3 ++ f3', f4, f5]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -337,10 +337,7 @@ isTupleId :: Id -> Bool
 isTupleId = maybe False Ghc.isTupleDataCon . idDataConM
 
 idDataConM :: Id -> Maybe DataCon
-idDataConM x = case idDetails x of
-  DataConWorkId d -> Just d
-  DataConWrapId d -> Just d
-  _               -> Nothing
+idDataConM = Ghc.isDataConId_maybe
 
 isDataConId :: Id -> Bool
 isDataConId = isJust . idDataConM

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -375,6 +375,7 @@ serialiseSpec tcGblEnv liquidLib = do
   -- ---
 
   serialisedSpec <- liftIO $ Serialisation.serialiseLiquidLib liquidLib thisModule
+  liftIO $ recordLiquidLib thisModule liquidLib
   debugLog $ "Serialised annotation ==> " ++ (O.showSDocUnsafe . O.ppr $ serialisedSpec)
 
   -- liftIO $ putStrLn "liquidHaskellCheck 10"

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/SpecFinder.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/SpecFinder.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE RankNTypes   #-}
 
@@ -67,14 +68,18 @@ findRelevantSpecs lhAssmPkgExcludes hscEnv mods = do
 
     loadRelevantSpec :: ExternalPackageState -> Module -> TcM SpecFinderResult
     loadRelevantSpec eps currentModule = do
-      res <- liftIO $ runMaybeT $
-        lookupInterfaceAnnotations eps (ue_hpt $ hsc_unit_env hscEnv) (hsc_NC hscEnv) currentModule
-      case res of
-        Nothing         -> do
-          mAssm <- loadModuleLHAssumptionsIfAny currentModule
-          return $ fromMaybe (SpecNotFound currentModule) mAssm
-        Just specResult ->
-          return specResult
+      liftIO (lookupLiquidLib currentModule) >>= \case
+        Just lib ->
+          return (LibFound currentModule lib)
+        Nothing -> do
+          res <- liftIO $ runMaybeT $
+            lookupInterfaceAnnotations eps (ue_hpt $ hsc_unit_env hscEnv) (hsc_NC hscEnv) currentModule
+          case res of
+            Nothing         -> do
+              mAssm <- loadModuleLHAssumptionsIfAny currentModule
+              return $ fromMaybe (SpecNotFound currentModule) mAssm
+            Just specResult ->
+              return specResult
 
     loadModuleLHAssumptionsIfAny m | isImportExcluded m = return Nothing
                                    | otherwise = do

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/Types.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/Types.hs
@@ -14,6 +14,8 @@ module Language.Haskell.Liquid.GHC.Plugin.Types
     , libDeps
     , allDeps
     , addLibDependencies
+    , lookupLiquidLib
+    , recordLiquidLib
 
     -- * Carrying data across stages of the compilation pipeline
     , PipelineData(..)
@@ -23,7 +25,10 @@ module Language.Haskell.Liquid.GHC.Plugin.Types
 
 import           Data.Binary                             as B
 import           Data.Data                               ( Data )
+import qualified Data.HashMap.Strict                     as M
+import           Data.IORef
 import           GHC.Generics                      hiding ( moduleName )
+import           System.IO.Unsafe                        ( unsafePerformIO )
 
 import           Language.Haskell.Liquid.Parse (BPspec)
 import           Language.Haskell.Liquid.Types.Specs
@@ -40,6 +45,22 @@ data LiquidLib = LiquidLib
   } deriving (Show, Data, Generic)
 
 instance B.Binary LiquidLib
+
+-- Interface annotations are only available after GHC has written and reloaded
+-- an interface. Keep freshly serialised specs visible to later modules in the
+-- same compiler invocation (for example, `ghc A.hs B.hs -fno-code`).
+liquidLibsRef :: IORef (M.HashMap StableModule LiquidLib)
+liquidLibsRef = unsafePerformIO $ newIORef mempty
+{-# NOINLINE liquidLibsRef #-}
+
+lookupLiquidLib :: Module -> IO (Maybe LiquidLib)
+lookupLiquidLib thisModule =
+  M.lookup (toStableModule thisModule) <$> readIORef liquidLibsRef
+
+recordLiquidLib :: Module -> LiquidLib -> IO ()
+recordLiquidLib thisModule liquidLib =
+  atomicModifyIORef' liquidLibsRef $ \libs ->
+    (M.insert (toStableModule thisModule) liquidLib libs, ())
 
 -- | Creates a new 'LiquidLib' with no dependencies.
 mkLiquidLib :: LiftedSpec -> LiquidLib

--- a/tests/import/client/ReproUse.hs
+++ b/tests/import/client/ReproUse.hs
@@ -1,0 +1,14 @@
+{-@ LIQUID "--reflection" @-}
+
+{-# LANGUAGE GADTs #-}
+
+module ReproUse where
+
+import ReproDef
+
+main :: IO ()
+main = pure ()
+
+{-@ contradictionThere :: Evidence -> {v:() | 0 /= 0} @-}
+contradictionThere :: Evidence -> ()
+contradictionThere (Refuter p contra) = contra p

--- a/tests/import/lib/ReproDef.hs
+++ b/tests/import/lib/ReproDef.hs
@@ -1,0 +1,15 @@
+{-@ LIQUID "--reflection" @-}
+
+{-# LANGUAGE GADTs #-}
+
+module ReproDef where
+
+data Evidence where
+  {-@ Refuter :: p:Int
+              -> (x:{Int | x == p} -> {v:() | 0 /= 0})
+              -> Evidence @-}
+  Refuter :: Int -> (Int -> ()) -> Evidence
+
+{-@ contradictionHere :: Evidence -> {v:() | 0 /= 0} @-}
+contradictionHere :: Evidence -> ()
+contradictionHere (Refuter p contra) = contra p

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2348,6 +2348,7 @@ executable import-cli
                     , ListClient
                     , NameClashClient
                     , RC1015
+                    , ReproUse
                     , ReExportClient
                     , ReflectClient0
                     , ReflectClient1
@@ -2380,6 +2381,7 @@ executable import-cli
                     , NameClashLib
                     , PeanoLib
                     , RL1015Lib
+                    , ReproDef
                     , ReExportLib
                     , ReflectLib0
                     , ReflectLib1


### PR DESCRIPTION
Before, in `tests/import/lib/ReproDef.hs`, the refinements of the signature of `Refuter` were not imported, and verification of `contradictionThere` was failing. 