### PR TITLE
Restore typeclass support

### DIFF
--- a/docs/mkDocs/docs/options.md
+++ b/docs/mkDocs/docs/options.md
@@ -690,10 +690,14 @@ instantiate type variables with `Int` (as seen in the example above).
 
 **Status:** `experimental`
 
-The `--typeclass` flag enables LiquidHaskell's support of
-typeclasses. One limitation is that proofs cannot be written directly
-within the instance definition unless the `--aux-inline` flag is
-turned on as well.
+The `--typeclass` flag enables experimental support for typeclass
+declarations and instances. Class methods can be used in refinements, and
+LiquidHaskell derives their default types from their Haskell signatures; an
+explicit LiquidHaskell signature is needed only to state a stronger refinement
+or a law.
+
+When proof or law methods are implemented directly in an instance and their
+auxiliary implementations must be unfolded, also enable `--aux-inline`.
 
 ## Refcore Calculus Extraction
 

--- a/docs/mkDocs/docs/specifications.md
+++ b/docs/mkDocs/docs/specifications.md
@@ -130,21 +130,53 @@ incr x = x + 1
 
 ## Modules WITH code: Type Classes
 
-Write the specification directly into the .hs or .lhs file. The constrained variable must match the one from the class definition. A class must have at least one refinement signature (even if it's a trivial one) to be lifted to the refinement logic. [For example](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/pos/Class.hs):
+LiquidHaskell's typeclass support can be enabled in modules that use class methods in specifications with:
+
 ```haskell
-class Semigroup a where
-    {-@ mappend :: a -> a -> a @-}
-    mappend :: a -> a -> a
-    sconcat :: NonEmpty a -> a
-
-class Semigroup a => VSemigroup a where
-    {-@ lawAssociative :: v:a -> v':a -> v'':a ->
-          {mappend (mappend v v') v'' == mappend v (mappend v' v'')} @-}
-    lawAssociative :: a -> a -> a -> ()
+{-@ LIQUID "--typeclass" @-}
 ```
-Without the extra signature for `mappend`, the above example would not work.
 
-Instances can be defined without any special annotations:
+Write class and instance declarations in the Haskell source file as usual.
+LiquidHaskell derives the default type of every class method from its Haskell
+signature, so a LiquidHaskell signature for a method is optional. You can add a
+LiquidHaskell signature as usual when the method needs a stronger refinement or
+states a law.
+
+For example, `eq` has no LiquidHaskell signature, but it can still be used in the
+refinement for `lawRefl'`:
+
+```haskell
+-- Basic.hs
+{-@ LIQUID "--typeclass" @-}
+module Basic where
+
+import Prelude (Bool (True), (==))
+
+class MyEq a where
+  eq :: a -> a -> Bool
+```
+
+It can nevertheless be used in a refinement in `BasicImport.hs`:
+
+```haskell
+-- BasicImport.hs
+{-@ LIQUID "--typeclass" @-}
+module BasicImport where
+
+import Basic
+
+class MyEq a => MyVEq a where
+  {-@ lawRefl :: v:a -> {eq v v == True} @-}
+  lawRefl :: a -> ()
+```
+
+The annotation on `lawRefl` states a refinement law about `eq`; it is not needed
+merely to make `eq` available to the refinement logic. See [`Basic.hs`](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/typeclasses/pos/Basic.hs)
+and [`BasicImport.hs`](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/typeclasses/pos/BasicImport.hs)
+for the complete examples.
+
+Ordinary instances need no additional LiquidHaskell annotations:
+
 ```haskell
 data PNat = Z | S PNat
 
@@ -157,7 +189,10 @@ instance VSemigroup PNat where
   lawAssociative Z     _ _ = ()
   lawAssociative (S p) m n = lawAssociative p m n
 ```
-The example above inlines the proofs directly into the instance definition. This requires the `--aux-inline` flag.
+
+The example above inlines the proofs directly into the instance definition.
+This requires the `--aux-inline` flag. See [`PNat.hs`](https://github.com/ucsd-progsys/liquidhaskell/blob/develop/tests/typeclasses/pos/PNat.hs)
+for a complete example.
 
 ## Modules WITH code: Type Classes (Legacy)
 

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -622,6 +622,7 @@ import GHC.Types.Basic                as Ghc
     , isStrongLoopBreaker
     , noOccInfo
     , topPrec
+    , TyConFlavour (..)
     )
 import GHC.Types.CostCentre           as Ghc
     ( CostCentre(cc_loc)
@@ -716,7 +717,7 @@ import GHC.Types.Name.Occurrence      as Ghc
 import GHC.Types.Name.Reader          as Ghc
     ( FieldsOrSelectors(WantNormal)
     , GlobalRdrEnv
-    , GREInfo
+    , GREInfo (..)
     , ImpItemSpec(ImpAll)
     , LookupGRE(LookupRdrName)
     , WhichGREs
@@ -729,6 +730,8 @@ import GHC.Types.Name.Reader          as Ghc
     , getRdrName
     , globalRdrEnvElts
     , greName
+    , greInfo
+    , greParent_maybe
     , isLocalGRE
     , lookupGRE
     , lookupGRE_Name

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -166,6 +166,7 @@ import GHC.Builtin.Names              as Ghc
     , Unique
     , and_RDR
     , bindMName
+    , eq_RDR
     , eqClassKey
     , eqClassName
     , ge_RDR
@@ -594,6 +595,8 @@ import GHC.Tc.Utils.Monad             as Ghc
 import GHC.Tc.Utils.TcType            as Ghc (tcSplitDFunTy, tcSplitMethodTy)
 import GHC.Tc.Zonk.Type               as Ghc
     ( zonkTopLExpr )
+import GHC.ThToHs as Ghc
+    ( thRdrNameGuesses )
 import GHC.Types.PkgQual              as Ghc
     ( PkgQual(NoPkgQual) )
 import GHC.Types.Annotations          as Ghc

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -181,6 +181,8 @@ ghcSpecEnv sp = F.notracepp "RENV" $ fromListSEnv binds
                  [ [(x,        rSort t) | (x, Loc _ _ t)  <- gsMeas     (_gsData sp)]
                  , [(symbol v, rSort t) | (v, Loc _ _ t)  <- gsCtors    (_gsData sp)]
                  , [(symbol v, vSort v) | v               <- gsReflects (_gsRefl sp)]
+                 , [(symbol v, vSort v) | (v, _)          <- gsTySigs   (_gsSig  sp), Mb.isJust (Ghc.isClassOpId_maybe v)]
+                 , [(symbol v, vSort v) | (v, _)          <- gsAsmSigs  (_gsSig  sp), Mb.isJust (Ghc.isClassOpId_maybe v)]
                  , [(x, RR s mempty)    | (x, s)          <- wiredSortedSyms       ]
                  , [(x, RR s mempty)    | (x, s)          <- _gsImps sp       ]
                  ]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Elaborate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Elaborate.hs
@@ -629,12 +629,15 @@ bopToHsExpr bop = noLocA (HsVar Ghc.noExtField (noLocA (f bop)))
 brelToHsExpr :: F.Brel -> LHsExpr GhcPs
 brelToHsExpr brel = noLocA (HsVar Ghc.noExtField (noLocA (f brel)))
  where
-  f F.Eq = mkVarUnqual (mkFastString "==")
+  f F.Eq = eq_RDR
   f F.Gt = gt_RDR
   f F.Lt = lt_RDR
   f F.Ge = ge_RDR
   f F.Le = le_RDR
-  f F.Ne = mkVarUnqual (mkFastString "/=")
+  f F.Ne = case Ghc.thRdrNameGuesses False '(/=) of
+    [] -> impossible Nothing "brelToExpr: Could not find (/=) in GHC"
+    [x] -> x
+    _ -> impossible Nothing "brelToExpr: Found multiple (/=) in GHC"
   f _    = impossible Nothing "brelToExpr: Unsupported operation"
 
 symbolToRdrNameNs :: NameSpace -> F.Symbol -> RdrName

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -300,11 +300,13 @@ dataConSel permitTC dc n (Proj i) = mkArrow (map (, mempty) as) [] [xt] (mempty 
 bkDataCon :: (PPrint r, IsReft r) => Bool -> Ghc.DataCon -> Int -> ([SpecRTVar], [RRType r], (F.Symbol, RFInfo, RRType r, r))
 bkDataCon permitTC dcn nFlds  = (as, ts, (F.dummySymbol, classRFInfo permitTC, t, trueReft))
   where
-    ts                = RT.ofType <$> Misc.takeLast nFlds (map Ghc.irrelevantMult _ts)
+    ts                = RT.ofType <$> Misc.takeLast nFlds _ts
+    _ts = if permitTC && Ghc.isClassTyCon (Ghc.dataConTyCon dcn) then dicts ++ ts1 else ts1
+    ts1 = map Ghc.irrelevantMult ts0
     t                 = -- Misc.traceShow ("bkDataConResult" ++ GM.showPpr (dc, _t, _t0)) $
                           RT.ofType  $ Ghc.mkTyConApp tc tArgs'
     as                = makeRTVar . RT.rTyVar <$> (αs ++ αs')
-    ((αs,αs',_,_,_ts,_t), _t0) = hammer dcn
+    ((αs,αs',_,dicts,ts0,_t), _t0) = hammer dcn
     tArgs'            = take (nArgs - nVars) tArgs ++ (Ghc.mkTyVarTy <$> αs)
     nVars             = length αs
     nArgs             = length tArgs

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Plugged.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Plugged.hs
@@ -103,7 +103,10 @@ makePluggedDataCon allowTC embs tyi ldcp
                           }
   where
     (tArgs, tRes)     = plugMany allowTC  embs tyi ldcp (das, dts, dt) (dcVars, dcArgs, dcpTyRes dcp)
-    (das, _, dts, dt) = {- F.notracepp ("makePluggedDC: " ++ F.showpp dc) $ -} Ghc.dataConSig dc
+    (das, theta, originDts, dt) = {- F.notracepp ("makePluggedDC: " ++ F.showpp dc) $ -} Ghc.dataConSig dc
+    consClassArgs     = if allowTC then filter (not . GM.isEmbeddedDictType) theta else []
+    dts               = consClassArgs ++ originDts
+
     dcArgs            = reverse $ filter (not . (if allowTC then isEmbeddedClass else isClassType) . snd) (dcpTyArgs dcp)
     dcVars            = if isGADT
                           then padGADVars $ L.nub (dcpFreeTyVars dcp ++ concatMap (map ty_var_value . freeTyVars) (dcpTyRes dcp:(snd <$> dcArgs)))

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Plugged.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Plugged.hs
@@ -149,7 +149,15 @@ plugMany allowTC embs tyi ldcp (hsAs, hsArgs, hsRes) (lqAs, lqArgs, lqRes)
     ((xs,_,ts,_), t) = bkArrow (val pT)
     pT               = plugHoles allowTC (Bare.LqTV dcName) embs tyi (const killHoles) hsT (F.atLoc ldcp lqT)
     hsT              = foldr (Ghc.mkFunTy Ghc.FTF_T_T Ghc.ManyTy) hsRes hsArgs'
-    lqT              = foldr (uncurry (rFun' (classRFInfo allowTC))) lqRes lqArgs'
+    lqT              = foldr (uncurry (rFun' (classRFInfo allowTC))) lqRes' lqArgs'
+    -- Substitute the GHC type variables (hsAs) in lqRes with the corresponding
+    -- LQ type variables (lqAs). This is needed because lqRes (= dcpTyRes) may
+    -- have been derived from ofType/dataConOrigResTy and therefore carries the
+    -- actual GHC TyVar objects, while lqAs (= dcpFreeTyVars) was built from
+    -- symbolRTyVar and therefore carries distinct synthetic RTyVars.
+    -- Without this substitution, runMapTyVars sees the same GHC type variable
+    -- mapped to two different Liquid RTyVars and throws an ErrMismatch.
+    lqRes'           = subts (zip (rTyVar <$> hsAs) lqAs) lqRes
     hsArgs'          = [ Ghc.mkTyVarTy a               | a <- hsAs] ++ hsArgs
     lqArgs'          = [(F.dummySymbol, RVar a mempty) | a <- lqAs] ++ map (Bifunctor.first lhNameToUnqualifiedSymbol) lqArgs
     nTyVars          = length hsAs -- == length lqAs

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Plugged.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Plugged.hs
@@ -98,14 +98,19 @@ makePluggedDataCon allowTC embs tyi ldcp
   | mismatchTyVars    = Ex.throw (err "type variables")
   | otherwise         = F.atLoc ldcp $ F.notracepp "makePluggedDataCon" $ dcp
                           { dcpFreeTyVars = dcVars
+                          , dcpTyConstrs  = constrs
                           , dcpTyArgs     = reverse tArgs
                           , dcpTyRes      = tRes
                           }
   where
     (tArgs, tRes)     = plugMany allowTC  embs tyi ldcp (das, dts, dt) (dcVars, dcArgs, dcpTyRes dcp)
     (das, theta, originDts, dt) = {- F.notracepp ("makePluggedDC: " ++ F.showpp dc) $ -} Ghc.dataConSig dc
-    consClassArgs     = if allowTC then filter (not . GM.isEmbeddedDictType) theta else []
+    consClassArgs     = if allowTC && isClassDc then filter (not . GM.isEmbeddedDictType) theta else []
     dts               = consClassArgs ++ originDts
+    isClassDc         = Ghc.isClassTyCon (Ghc.dataConTyCon dc)
+    -- For class dictionary constructors, the dictionary arguments correspond to
+    -- constructor fields and are included in `dts`, and not in `constrs`.
+    constrs           = if allowTC && isClassDc then [] else dcpTyConstrs dcp
 
     dcArgs            = reverse $ filter (not . (if allowTC then isEmbeddedClass else isClassType) . snd) (dcpTyArgs dcp)
     dcVars            = if isGADT

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
@@ -111,7 +111,7 @@ compileClasses src env (name, spec) rest =
   instClss =
     [ (inst, cls)
     | inst <- mconcat . Mb.maybeToList . _gsCls $ src
-    , Ghc.moduleName (Ghc.nameModule (Ghc.getName inst)) == getModName name
+    , (Ghc.moduleName <$> Ghc.nameModule_maybe (Ghc.getName inst)) == Just (getModName name)
     , let cls = Ghc.is_cls inst
     , cls `elem` refinedClasses
     ]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
@@ -391,7 +391,7 @@ makeClassAuxTypesOne elab (ldcp, inst, methods) =
     -- Monoid.mappend, ...
     clsMethods = filter (\x -> GM.dropModuleNames (F.symbol x) `elem` fmap mkSymbol methods) $
       Ghc.classAllSelIds (Ghc.is_cls inst)
-    yts = [(lhNameToResolvedSymbol y, t) | (y, t) <- dcpTyArgs dcp]
+    yts = [(lhNameToUnqualifiedSymbol y, t) | (y, t) <- dcpTyArgs dcp]
     mkSymbol x
       | -- F.notracepp ("isDictonaryId:" ++ GM.showPpr x) $
         Ghc.isDictonaryId x = F.mappendSym "$" (F.dropSym 2 $ GM.simplesymbol x)

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
@@ -90,10 +90,6 @@ compileClasses src env (name, spec) rest =
   methods = [ makeGHCLHNameLocatedFromId x | (_, xs) <- instmethods, x <- xs ]
       -- instance methods
 
-  mkSymbol x
-    | Ghc.isDictonaryId x = F.mappendSym "$" (F.dropSym 2 $ GM.simplesymbol x)
-    | otherwise           = F.dropSym 2 $ GM.simplesymbol x
-
   instmethods :: [(Ghc.ClsInst, [Ghc.Var])]
   instmethods =
     [ (inst, ms)
@@ -123,7 +119,6 @@ compileClasses src env (name, spec) rest =
   resolveClassMaybe d =
     either (const Nothing) Just (Bare.lookupGhcTyConLHName (Bare.reTyLookupEnv env) $ dataNameSymbol $ tycName d)
       >>= Ghc.tyConClass_maybe
-
 
 -- a list of class with user defined refinements
 makeClassDataDecl :: [(Ghc.Class, [(Ghc.Id, LocBareType)])] -> [DataDecl]
@@ -392,11 +387,6 @@ makeClassAuxTypesOne elab (ldcp, inst, methods) =
     clsMethods = filter (\x -> GM.dropModuleNames (F.symbol x) `elem` fmap mkSymbol methods) $
       Ghc.classAllSelIds (Ghc.is_cls inst)
     yts = [(lhNameToUnqualifiedSymbol y, t) | (y, t) <- dcpTyArgs dcp]
-    mkSymbol x
-      | -- F.notracepp ("isDictonaryId:" ++ GM.showPpr x) $
-        Ghc.isDictonaryId x = F.mappendSym "$" (F.dropSym 2 $ GM.simplesymbol x)
-      | otherwise = F.dropSym 2 $ GM.simplesymbol x
-        -- res = dcpTyRes dcp
     clsTvs = dcpFreeTyVars dcp
         -- copy/pasted from Bare/Class.hs
     subst [] t = t
@@ -427,3 +417,16 @@ substAuxMethod dfun methods = F.notracepp "substAuxMethod" . go
         go (F.PIff e0 e1) = F.PIff (go e0) (go e1)
         go (F.PAtom brel e0 e1) = F.PAtom brel (go e0) (go e1)
         go e = F.notracepp "LEAF" e
+
+-- Normalise typeclass names for looking up class selector symbols.
+-- Instance methods are named `$c(method)`. GHC 9 can also expose superclass
+-- dictionary bindings named `$cp(n)(Class)`. These correspond to
+-- `$p(n)(Class)` selector symbols.
+-- Since class methods are always identified by variables with the `$c`
+-- prefix, we can ignore other cases.
+mkSymbol :: Ghc.Var -> F.Symbol
+mkSymbol x =
+  case Ghc.getOccString x of
+    '$' : 'c' : 'p' : rest -> F.symbol ('$' : 'p' : rest)
+    '$' : 'c' : rest       -> F.symbol rest
+    occ                    -> impossible Nothing $ "mkSymbol : should only be called with class methods, received " ++ F.showpp occ

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/ToFixpoint.hs
@@ -272,7 +272,11 @@ makeSimplify (var, t)
       Ghc.DataConWorkId dc ->
         let nCoerce = length $ filter (Ghc.isSimplePredTy . Ghc.irrelevantMult)
                               $ Ghc.dataConRepArgTys dc
-        in  drop nCoerce (ty_binds trep)
+        -- Class dictionary constructors can take superclass dictionaries as
+        -- arguments. Keep their binders so the dictionary arguments are retained.
+        in if Ghc.isClassTyCon (Ghc.dataConTyCon dc)
+            then ty_binds trep
+            else drop nCoerce (ty_binds trep)
       _                    -> ty_binds trep
     eVal  = F.eApps (F.EVar dcSym) (F.EVar <$> valBs)
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -947,4 +947,4 @@ prependGHCRealQual :: FastString -> RdrName
 prependGHCRealQual = varQual_RDR realModule
 
 isFromGHCReal :: NamedThing a => a -> Bool
-isFromGHCReal x = Ghc.nameModule (Ghc.getName x) == realModule
+isFromGHCReal x = Ghc.nameModule_maybe (Ghc.getName x) == Just realModule

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Misc.hs
@@ -769,18 +769,18 @@ elabRnExpr rdr_expr = do
              tcInferRho rn_expr
 
     -- Generalise
+    -- Simplify the constraints and keep the resulting evidence bindings.
     uniq <- newUnique
     let { fresh_it = itName uniq (getLocA rdr_expr) }
-    ((_qtvs, _dicts, evbs, _), residual)
-         <- captureConstraints $
-            simplifyInfer NotTopLevel tclvl NoRestrictions
+    (_qtvs, _dicts, evbs, _)
+         <- simplifyInfer NotTopLevel tclvl NoRestrictions
                           []    {- No sig vars -}
                           [(fresh_it, res_ty)]
                           lie
 
-    -- Ignore the dictionary bindings
-    evbs' <- simplifyInteractive residual
-    full_expr <- zonkTopLExpr (mkHsDictLet (EvBinds evbs') (mkHsDictLet evbs tc_expr))
+    -- Reintroduce the solved evidence before desugaring. In particular, this
+    -- makes dictionary and superclass-selector bindings available.
+    full_expr <- zonkTopLExpr (mkHsDictLet evbs tc_expr)
     (ds_msgs, me) <- initDsTc $ dsLExpr full_expr
 
     logger <- getLogger
@@ -793,7 +793,45 @@ elabRnExpr rdr_expr = do
       Just e -> do
         when (errorsOrFatalWarningsFound ds_msgs)
           failM
-        return e
+        -- `collectArgs` only takes direct applications. Another option would
+        -- be using `collectFunSimple` here, which also looks through casts and
+        -- ticks. We use the more conservative `collectArgs` for now.
+        return $ fst $ Ghc.collectArgs $ inlineEvidenceLets e
+
+-- | inlineEvidenceLets will check traverse a Core expression and inline
+--   the definition of let bindings which serve as evidence variables.
+--
+--   GHC introduces typeclass dictionaries, superclass selectors, and related
+--   proof evidence as local Core bindings. LiquidHaskell needs that evidence to
+--   occur directly in the elaborated expression, so that subsequent
+--   translation can see the dictionary applications and their binders.
+--
+--   Ordinary program bindings are preserved, only dictionary and evidence
+--   variables are substituted.
+inlineEvidenceLets :: CoreExpr -> CoreExpr
+inlineEvidenceLets = go
+  where
+    go (Let (NonRec x rhs) body)
+      -- Keep ordinary bindings, but inline typeclass and evidence bindings.
+      | isEvidenceVar x = substCoreVar x (go rhs) (go body)
+      | otherwise = Let (NonRec x (go rhs)) (go body)
+    go (Let (Rec xes) body) = Let (Rec [(x, go rhs) | (x, rhs) <- xes]) (go body)
+    go (Lam x e) = Lam x (go e)
+    go (App e1 e2) = App (go e1) (go e2)
+    go (Case e x t alts) = Case (go e) x t [Alt c xs (go rhs) | Alt c xs rhs <- alts]
+    go (Cast e co) = Cast (go e) co
+    go (Tick tick e) = Tick tick (go e)
+    go e = e
+
+isEvidenceVar :: Var -> Bool
+isEvidenceVar x = isDictonaryId x || isEvVar x
+
+substCoreVar :: Id -> CoreExpr -> CoreExpr -> CoreExpr
+substCoreVar x rhs body =
+  substExpr subs body
+  where
+    fvs = exprFreeVars rhs `unionVarSet` exprFreeVars body
+    subs = extendIdSubst (mkEmptySubst (mkInScopeSet fvs)) x rhs
 
 newtype HashableType = HashableType {getHType :: Type}
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/LHNameResolution.hs
@@ -388,6 +388,16 @@ errResolve alts k msg ls =
         PJ.sep (PJ.text "Maybe you meant one of:" : map pprint alts)
     )
 
+errTypeclassDisabled :: PPrint a => Located a -> TError t
+errTypeclassDisabled locSym =
+  ErrResolve
+    (LH.fSrcSpan locSym)
+    "logic name"
+    (pprint $ val locSym)
+    (PJ.vcat
+      [ PJ.text "This is a class method, but typeclass support is disabled."
+      , PJ.text "Enable it with {-@ LIQUID \"--typeclass\" @-}."
+      ])
 
 -- | Produces an LHName from a symbol by looking it in the rdr environment.
 resolveSymbolToTcName :: GHC.GlobalRdrEnv -> LocSymbol -> Either Error (Located LHName)
@@ -854,16 +864,25 @@ resolveLogicNames cfg thisModule env globalRdrEnv lmap0 localVars lnameEnv priva
       | otherwise =
         case lookupInScopeEnv env s of
           Left alts ->
-            -- If names are not in the environment, they must be data constructors,
-            -- or they must be reflected functions, or they must be in the logicmap.
+            -- If names are not in the environment, they must be one of the
+            -- following: class methods, data constructors, reflected functions,
+            -- or they must be in the logicmap.
             case resolveDataConName ls `mplus` resolveVarName lmap0 ls of
               Just m -> m
-              Nothing
-                | elem s wiredInNames ->
-                  return $ makeLocalLHName s
-                | otherwise -> do
-                    addError $ errResolve alts "logic name" "Cannot resolve name" ls
-                    return $ makeLocalLHName s
+              Nothing ->
+                case resolveClassMethodName ls of
+                  Just m
+                    | typeclass cfg -> m
+                    | otherwise -> do
+                        addError $ errTypeclassDisabled ls
+                        return $ makeLocalLHName s
+
+                  Nothing
+                    | elem s wiredInNames ->
+                      return $ makeLocalLHName s
+                    | otherwise -> do
+                        addError $ errResolve alts "logic name" "Cannot resolve name" ls
+                        return $ makeLocalLHName s
           Right [(_, lhname, _)] -> pure lhname
           -- In case of multiple matches, we give precedence to locally defined
           -- logic entities for the user to be able to overwrite them.
@@ -931,6 +950,34 @@ resolveLogicNames cfg thisModule env globalRdrEnv lmap0 localVars lnameEnv priva
                  (map (PJ.text . GHC.showPprUnsafe) es)
               )
             return $ makeLocalLHName $ val s
+    resolveClassMethodName s =
+      case GHC.lookupGRE globalRdrEnv (mkLookupGRE (LHVarName LHAnyModuleNameF) $ val s) of
+        [e]
+          | GHC.Vanilla <- GHC.greInfo e
+          , Just pName <- GHC.greParent_maybe e
+          , isClassTyCon pName ->
+            Just $ do
+              let n = GHC.greName e
+              -- Do not register the class selector as reflected: typeclass
+              -- compilation reflects generated `$c...` implementation methods,
+              -- not selector IDs. Don't add the selector to `lneReflected`,
+              -- i.e. don't use `Just n` instead of `Nothing` in the argument of
+              -- type `Maybe Name` in `makeLogicLHName`.
+              let lhName = makeLogicLHName
+                            (symbol $ GHC.getOccString n)
+                            (GHC.nameModule n)
+                            Nothing
+              addName lhName
+              return lhName
+        _ -> Nothing
+
+    isClassTyCon parentName =
+      case GHC.lookupGRE globalRdrEnv (mkLookupGRE (LHTcName LHAnyModuleNameF) (symbol $ GHC.occNameString $ GHC.nameOccName parentName)) of
+        [parentGre] ->
+          case GHC.greInfo parentGre of
+            GHC.IAmTyCon GHC.ClassFlavour -> True
+            _ -> False
+        _ -> False
 
     -- Resolves names of reflected functions or names in the logic map
     --

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Measure.hs
@@ -170,10 +170,10 @@ splitType t  = (αs, map irrelevantMult ts, tr)
     (αs, tb) = splitForAllTyCoVars t
     (ts, tr) = splitFunTys tb
 
-stitchArgs :: (Monoid t1, PPrint a)
+stitchArgs :: Monoid t1
            => Bool
            -> SrcSpan
-           -> a
+           -> DataCon
            -> [(Symbol, Maybe (RRType Reft))]
            -> [Type]
            -> [(Symbol, RFInfo, RRType Reft, t1)]
@@ -182,14 +182,21 @@ stitchArgs allowTC sp dc allXs allTs
                       ++ zipWith g xs (ofType <$> ts)
   | otherwise          = panicFieldNumMismatch sp dc nXs nTs
     where
-      (pts, ts)        = L.partition (\t -> notracepp ("isPredTy: " ++ showpp t) $ (if allowTC then isEmbeddedDictType else Ghc.isSimplePredTy ) t) allTs
+      (pts, ts)        = L.partition (\t -> notracepp ("isPredTy: " ++ showpp t) $ isErasable t) allTs
       (_  , xs)        = L.partition (coArg . snd) allXs
       nXs              = length xs
       nTs              = length ts
       g (x, Just t) _  = (x, classRFInfo allowTC, t, mempty)
       g (x, _)      t  = (x, classRFInfo allowTC, t, mempty)
       coArg Nothing    = False
-      coArg (Just t)   = (if allowTC then isEmbeddedDictType else Ghc.isSimplePredTy ). toType False $ t
+      coArg (Just t)   = isErasable (toType False t)
+      isClassDc = Ghc.isClassTyCon (Ghc.dataConTyCon dc)
+      -- For ordinary constructors, class dictionaries are constraint evidence,
+      -- not fields. For class dictionary constructors, superclass dictionaries
+      -- are fields and must be retained
+      isErasable t
+        | allowTC = isEmbeddedDictType t || (not isClassDc && Ghc.isClassPred t)
+        | otherwise = Ghc.isSimplePredTy t
 
 panicFieldNumMismatch :: (PPrint a, PPrint a1, PPrint a3)
                       => SrcSpan -> a3 -> a1 -> a -> a2

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
@@ -53,7 +53,7 @@ import qualified Data.Binary as B
 import Data.Data (Data, gmapM, gmapT)
 import Data.Generics (extM, extT)
 import Data.Hashable
-import Data.Maybe (isNothing)
+import Data.Maybe (fromMaybe, isNothing)
 import Data.String (fromString)
 import qualified Data.Text                               as Text
 import GHC.Generics
@@ -377,7 +377,7 @@ updateLHNameSymbol f (LHNUnresolved n s) = LHNUnresolved n (f s)
 -- Otherwise, LH would fail to link the two at various places where it is needed.
 lhNameToResolvedSymbol :: LHName -> Symbol
 lhNameToResolvedSymbol (LHNResolved (LHRLogic (LogicName s om mReflectionOf)) _) =
-    let m = maybe om GHC.nameModule mReflectionOf
+    let m = maybe om (\n -> fromMaybe om (GHC.nameModule_maybe n)) mReflectionOf
         msymbol = Text.pack $ GHC.moduleNameString $ GHC.moduleName m
      in symbol $ mconcat [msymbol, ".", symbolText s]
         {-

--- a/src/GHC/Num_LHAssumptions.hs
+++ b/src/GHC/Num_LHAssumptions.hs
@@ -6,7 +6,7 @@ import GHC.Num
 import GHC.Num.Integer_LHAssumptions()
 
 {-@
-assume fromInteger :: x:Integer -> {v:a | v = x }
+assume fromInteger :: (Num a) => x:Integer -> {v:a | v = x }
 
 assume negate :: (Num a)
                => x:a
@@ -16,6 +16,6 @@ assume abs :: (Num a) => x:a -> {y:a | (x >= 0 ==> y = x) && (x < 0 ==> y = -x) 
 
 define abs x = if x >=0 then x else -x
 
-assume + :: x:a -> y:a -> {v:a | v = x + y }
+assume + :: (Num a) => x:a -> y:a -> {v:a | v = x + y }
 assume - :: (Num a) => x:a -> y:a -> {v:a | v = x - y }
 @-}

--- a/src/GHC/Real_LHAssumptions.hs
+++ b/src/GHC/Real_LHAssumptions.hs
@@ -8,9 +8,9 @@ import GHC.Types_LHAssumptions()
 import GHC.Num_LHAssumptions()
 
 {-@
-assume (^) :: x:a -> y:{n:b | n >= 0} -> {z:a | (y == 0 => z == 1) && ((x == 0 && y /= 0) <=> z == 0)}
+assume (^) :: (Num a, Integral b) => x:a -> y:{n:b | n >= 0} -> {z:a | (y == 0 => z == 1) && ((x == 0 && y /= 0) <=> z == 0)}
 
-assume fromIntegral    :: x:a -> {v:b|v=x}
+assume fromIntegral    :: (Integral a, Num b) => x:a -> {v:b|v=x}
 
 class Num a => Fractional a where
   (/)   :: x:a -> y:{v:a | v /= 0} -> {v:a | v == x / y}

--- a/tests/harness/Test/Groups.hs
+++ b/tests/harness/Test/Groups.hs
@@ -38,6 +38,7 @@ microTestGroups =
   , "terminate-neg"
   , "pattern-pos"
   , "typeclass-pos"
+  , "typeclass-neg"
   , "typed-holes"
   , "plugin-package-pos"
   ]

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2687,14 +2687,15 @@ executable typeclass-pos
     if !flag(typeclass-pos) && flag(stack)
       buildable:      False
 
-    -- Fails on GHC 9.0.1
-    if impl(ghc < 9)
-      other-modules:
+    other-modules:
                       All
+                    , Basic
+                    , BasicImport
                     , Lib
                     , Lemma
                     , PNat
                     , SemigroupLib
+                    , ConstrainedGADT
 
     build-depends:    base
                     , liquid-prelude
@@ -2702,6 +2703,24 @@ executable typeclass-pos
 
     hs-source-dirs:   app
                     , typeclasses/pos
+
+flag typeclass-neg
+     default: False
+
+executable typeclass-neg
+    import:           common-ghc-options, ghc-options-for-negated-tests
+    main-is:          Main.hs
+    if !flag(typeclass-neg) && flag(stack)
+      buildable:      False
+
+    other-modules:    ClassMethodWithoutTypeclass
+
+    build-depends:    base
+                    , liquid-prelude
+                    , liquidhaskell
+
+    hs-source-dirs:   app
+                    , typeclasses/neg
 
 flag refcore
      default: False

--- a/tests/typeclasses/neg/ClassMethodWithoutTypeclass.hs
+++ b/tests/typeclasses/neg/ClassMethodWithoutTypeclass.hs
@@ -1,0 +1,8 @@
+{-@ LIQUID "--expect-error-containing=This is a class method, but typeclass support is disabled." @-}
+module ClassMethodWithoutTypeclass where
+
+import Prelude (Int, Enum(succ))
+
+{-@ succId :: x:Int -> {v:Int | succ x == succ x} @-}
+succId :: Int -> Int
+succId x = x

--- a/tests/typeclasses/pos/Basic.hs
+++ b/tests/typeclasses/pos/Basic.hs
@@ -1,0 +1,8 @@
+{-@ LIQUID "--typeclass" @-}
+module Basic where
+
+import Prelude (Bool (True), (==))
+
+class MyEq a where
+    {-@ eq :: a -> a -> Bool @-}
+    eq :: a -> a -> Bool

--- a/tests/typeclasses/pos/BasicImport.hs
+++ b/tests/typeclasses/pos/BasicImport.hs
@@ -1,0 +1,9 @@
+{-@ LIQUID "--typeclass" @-}
+module BasicImport where
+
+import Prelude (Bool (True), (==))
+import Basic
+
+class MyEq a => MyVEq a where
+    {-@ lawRefl :: v:a -> {eq v v == True} @-}
+    lawRefl :: a -> ()

--- a/tests/typeclasses/pos/ConstrainedGADT.hs
+++ b/tests/typeclasses/pos/ConstrainedGADT.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE GADTs #-}
+
+{-@ LIQUID "--typeclass" @-}
+module ConstrainedGADT where
+
+class C a where
+  c :: a -> a
+
+-- `Box` is an ordinary GADT constructor, not a class dictionary constructor.
+-- Its GHC constructor signature nevertheless has a `C a` dictionary constraint.
+data Box a where
+  Box :: C a => a -> Box a
+
+{-@ data Box a where
+      Box :: a -> Box a
+  @-}
+
+box :: C a => a -> Box a
+box = Box
+
+unbox :: Box a -> a
+unbox (Box x) = x


### PR DESCRIPTION
This PR re-enables the type class infrastructure for GHC 9, fixing several errors that prevented the `--typeclass` tests from passing. The changes include name resolution, measure generation, and expression elaboration.

This solves the issue https://github.com/ucsd-progsys/liquidhaskell/issues/2450 which is one of the main goals for my [GSoC 2026 project](https://summerofcode.withgoogle.com/myprojects/details/lnBMUfdU), but there's still room for improvement in the test suite and the documentation. I expect to work on that too during the coming weeks.

**What changed:**

Changes stream from the addition of the new name resolution mechanism in LH, how the GHC API retrieves dictionary arguments of dictionary data constructors, and minor variation in the result of desugaring during the elaboration pass that produces dictionaries from type information.

- GHC 9 API migration: Updated calls to functions that changed or were removed in GHC 9, e.g. `dataConSig`, `GREInfo`, etc.

- Measure generation for class dictionary constructors: `bkDataCon` and `makeSimplify` in `ToFixpoint.hs` were double-counting or dropping the superclass dictionary fields that class dict constructors carry. The fixes ensure the correct arities.

- Data constructor plugging: `makePluggedDataCon` now includes class constraints from `dataConSig`'s `theta` in the constructor's argument list.

- Evidence bindings are inlined: Evidence bindings (dictionaries, superclass selectors) are now inlined into the elaborated core expression, this is to align with the way this used to work in GHC 8, and make the "wrong number of binders" errors.

- **Tests**: Re-enable `typeclasses/pos` tests. These tests used to work correctly in GHC 8, but were disabled in GHC 9 due to the many errors that were present.