### PR TITLE
cmdline: export shellWords and add regression tests for LIQUIDHASKELL_OPTS parsing (#1990)

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/UX/CmdLine.hs
@@ -35,6 +35,9 @@ module Language.Haskell.Liquid.UX.CmdLine (
    -- * Diff check mode
    , diffcheck
 
+   -- * Shell-word splitting (used by LIQUIDHASKELL_OPTS parsing)
+   , shellWords
+
 ) where
 
 import Prelude hiding (error)

--- a/liquidhaskell-boot/tests/Parser.hs
+++ b/liquidhaskell-boot/tests/Parser.hs
@@ -20,8 +20,9 @@ import           Data.Generics.Aliases
 import           Data.Generics.Schemes
 
 import           Language.Fixpoint.Types.Spans
-import qualified Language.Haskell.Liquid.Parse as LH
-import qualified Language.Fixpoint.Types       as F
+import qualified Language.Haskell.Liquid.Parse           as LH
+import qualified Language.Fixpoint.Types                 as F
+import           Language.Haskell.Liquid.UX.CmdLine      (shellWords)
 
 import           Text.Megaparsec.Error
 import           Text.Megaparsec.Pos
@@ -45,7 +46,28 @@ tests =
     , testReservedAliases
     , testFails
     , testErrorReporting
+    , testShellWords
     ]
+
+-- | Tests for 'shellWords', which is used to parse LIQUIDHASKELL_OPTS.
+-- Regression test for https://github.com/ucsd-progsys/liquidhaskell/issues/1990
+testShellWords :: TestTree
+testShellWords = testGroup "shellWords"
+  [ testCase "empty string yields no tokens" $
+      shellWords "" @?= []
+  , testCase "single flag" $
+      shellWords "--ple" @?= ["--ple"]
+  , testCase "multiple space-separated flags" $
+      shellWords "--ple --reflection" @?= ["--ple", "--reflection"]
+  , testCase "flag with value" $
+      shellWords "--smtsolver z3" @?= ["--smtsolver", "z3"]
+  , testCase "multiple flags with leading/trailing spaces" $
+      shellWords "  --ple  --reflection  " @?= ["--ple", "--reflection"]
+  , testCase "double-quoted value preserves spaces" $
+      shellWords "--smtsolver \"my z3\"" @?= ["--smtsolver", "my z3"]
+  , testCase "single-quoted value preserves spaces" $
+      shellWords "--smtsolver 'my z3'" @?= ["--smtsolver", "my z3"]
+  ]
 
 -- Test that the top level production works, each of the sub-elements will be tested separately
 testSpecP :: TestTree


### PR DESCRIPTION
## Summary

Closes #1990.

The multi-argument fix for `LIQUIDHASKELL_OPTS` was already applied as part of the GetOpt migration (the env var is now parsed with `shellWords` which correctly splits on whitespace). However, issue #1990 remained open because:

1. `shellWords` was not exported, making it impossible to unit-test independently
2. No regression tests existed to prevent future breakage

This PR:
- Exports `shellWords` from `Language.Haskell.Liquid.UX.CmdLine`
- Adds a `testShellWords` group to the existing `liquidhaskell-parser` test suite covering: empty input, single flag, multiple flags, flag-with-value, leading/trailing spaces, and quoted values

## Test plan

```
cabal test liquidhaskell-parser
```

All new `shellWords` cases should pass, confirming that `LIQUIDHASKELL_OPTS="--ple --reflection"` correctly produces two separate flags rather than one.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)