### PR TITLE
Attach measures to the worker data constructors of GADTs

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Measure.hs
@@ -88,6 +88,9 @@ checkDuplicateMeasure measures
       mkError m ms = ErrDupMeas (fSrcSpan m) (pprint (val m)) (fSrcSpan <$> ms)
 
 
+-- | Returns the specification types of all data constructors augmented with
+-- the refinements from the measures. Also returns the specification types of
+-- the measures in the second component of the result.
 dataConTypes :: Bool -> MSpec (RRType Reft) DataCon -> ([(Var, RRType Reft)], [(F.Located LHName, RRType Reft)])
 dataConTypes allowTC  s = (ctorTys, measTys)
   where

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Measure.hs
@@ -109,7 +109,13 @@ makeDataConType allowTC ds | Mb.isNothing (dataConWrapId_maybe dc)
 makeDataConType allowTC ds
   = [(woId, noDummySyms woRType), (wrId, noDummySyms wrRType)]
   where
-    (wo, wr) = L.partition isWorkerDef ds
+    -- A measure with missing argument types comes from a selector or checker
+    -- measure that describes the worker data constructor. A measure
+    -- with all the argument types available comes from a user definition
+    -- and describes both the worker and the wrapper.
+    (workerOnlyDs, bothDs) = L.partition hasMissingFieldTypes ds
+    wo       = workerOnlyDs ++ bothDs
+    wr       = bothDs
     dc       = ctor $ head ds
     woId     = dataConWorkId dc
     wot      = varType woId
@@ -121,14 +127,9 @@ makeDataConType allowTC ds
     wrRType  = combineDCTypes "cdc1" wrt wrts
     woRType  = combineDCTypes "cdc2" wot wots
 
-
-    isWorkerDef def
-      -- types are missing for arguments, so definition came from a logical measure
-      -- and it is for the worker datacon
-      | any (Mb.isNothing . snd) (binds def)
-      = True
-      | otherwise
-      = length (binds def) == length (fst $ splitFunTys $ snd $ splitForAllTyCoVars wot)
+    -- types are missing for arguments, so the definition came from a logical
+    -- measure and it is for the worker datacon only
+    hasMissingFieldTypes def = any (Mb.isNothing . snd) (binds def)
 
 -- | If there are any dummy symbols in the type, replace them with fresh
 -- variables.

--- a/tests/measure/pos/MeasureGadt.hs
+++ b/tests/measure/pos/MeasureGadt.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MonoLocalBinds #-}
+module MeasureGadt where
+
+-- | A measure over a GADT whose constructor has a concrete (non-vanilla)
+-- result type. The constructor @C :: T ()@ has a worker type of the form
+-- @forall a. (a ~ ()) => T a@, i.e. it carries an equality coercion argument.
+-- LiquidHaskell must still attach the measure equation to the worker data
+-- constructor so that pattern matching on @C@ learns @m v = 0@.
+data T a where
+  C :: T ()
+
+{-@ measure m @-}
+{-@ m :: T a -> Int @-}
+m :: T a -> Int
+m C = 0
+
+{-@ go :: v : T a -> { n : Int | n = m v } @-}
+go :: T a -> Int
+go C = 0

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -981,6 +981,7 @@ executable measure-pos
                     , List01
                     , List02
                     , List02Lib
+                    , MeasureGadt
                     , Ple00
                     , Ple01
                     , Ple1


### PR DESCRIPTION
The previous implementation was not attaching measures to worker data constructors for GADTs.
It was deciding that given that the measure had less arguments than the worker, it should only apply to the wrapper data constructor.

The implementation allows now to apply measures to worker data cons. Despite the arity mismatch, the type manipulations can conciliate the differences. That is, a data constructor like `C :: T ()` having a worker like `$WC :: (a ~ ()) => T a`. 

Fixes #2702