### PR TITLE
Eliminate uses of const when eliminating (?) as well

### DIFF
--- a/liquid-prelude/src/Language/Haskell/Liquid/ProofCombinators.hs
+++ b/liquid-prelude/src/Language/Haskell/Liquid/ProofCombinators.hs
@@ -115,7 +115,7 @@ infixl 3 =>=
 _ =>= y  = y
 
 -------------------------------------------------------------------------------
--- | @e ? lemma@ lets you use the type of @lemma@ when checking that @e@ haskell
+-- | @e ? lemma@ lets you use the type of @lemma@ when checking that @e@
 -- has some expected refinement type.
 --
 -- Schematically, @?@ allows to use @q x@ to check that @e@ satisfies @p x e@
@@ -127,14 +127,14 @@ _ =>= y  = y
 -- >     lemma :: y:t0 -> { q y }
 -- >     lemma = ...
 --
--- While @?@ is defined as Haskell's 'const', @?@ is optimized by Liquid
--- Haskell. The 'const' function, on the other hand, would incur some extra
--- verification overhead because Liquid Haskell needs to go through the trouble
--- of checking that @const e lemma@ is actually @e@.
+-- @?@ is defined as Haskell's 'const' and both are interchangeable. @?@ is
+-- a bit more convenient to use in infix form. Liquid Haskell optimizes both
+-- forms to avoid extra verification overhead that would otherwise require
+-- of checking that @const e lemma@ or @e ? lemma@ is actually @e@.
 --
 -- === At a lower level
 --
--- Liquid Haskell treats @e ? lemma@ as
+-- Liquid Haskell treats @e ? lemma@ and @const e lemma@ as
 --
 -- > let fresh0 = e
 -- >  in let fresh1 = lemma

--- a/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
+++ b/liquidhaskell-boot/src-ghc/Liquid/GHC/API.hs
@@ -722,7 +722,7 @@ import GHC.Types.Name.Reader          as Ghc
     , GlobalRdrEnv
     , GREInfo (..)
     , ImpItemSpec(ImpAll)
-    , LookupGRE(LookupRdrName)
+    , LookupGRE(LookupOccName, LookupRdrName)
     , WhichGREs
         ( SameNameSpace
         , RelevantGREs

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/QuestionMark.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/QuestionMark.hs
@@ -25,15 +25,14 @@ module Language.Haskell.Liquid.Transforms.QuestionMark (eliminateQuestionMark) w
 import qualified Language.Haskell.TH.Syntax as TH (nameModule)
 import Liquid.GHC.API as Ghc
 
--- | Look up the '?' operator in the 'GlobalRdrEnv'. If found, eliminate all
--- its applications from the Core program. If not found (module doesn't import
--- ProofCombinators), return the bindings unchanged.
+-- | Look up the 'FunctionNames' in the 'GlobalRdrEnv'. If found, eliminate all
+-- their applications from the Core program. If not found, return the bindings unchanged.
 eliminateQuestionMark :: GlobalRdrEnv -> [CoreBind] -> [CoreBind]
 eliminateQuestionMark rdrEnv cbs =
   case lookupFunctionNames rdrEnv of
     Nothing    -> cbs
     Just names -> map (goBind names) cbs
-
+-- | A record of function names whose applications are to be removed form the core program.
 data FunctionNames = FunctionNames
   { questionMarkName :: Maybe Name
   , constName        :: Maybe Name

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/QuestionMark.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/QuestionMark.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE PatternGuards #-}
--- | Eliminate applications of the '?' operator from Core after ANF.
+{-# LANGUAGE TemplateHaskellQuotes #-}
+-- | Eliminate applications of the '?' operator and 'const' from Core after ANF.
 --
 -- After ANF, @e ? s@ becomes:
 --
@@ -13,9 +14,15 @@
 -- are introduced in the signature of @?@. The binding @a2 = s@ remains in
 -- scope, so the lemma's postcondition still enters the environment during
 -- constraint generation.
+--
+-- This pass fixes #2544.
+--
+-- Eliminating applications of 'const' is convenient when importing modules from
+-- liquid-prelude is unwanted and therefore `?` is unavailable.
 
 module Language.Haskell.Liquid.Transforms.QuestionMark (eliminateQuestionMark) where
 
+import qualified Language.Haskell.TH.Syntax as TH (nameModule)
 import Liquid.GHC.API as Ghc
 
 -- | Look up the '?' operator in the 'GlobalRdrEnv'. If found, eliminate all
@@ -23,28 +30,58 @@ import Liquid.GHC.API as Ghc
 -- ProofCombinators), return the bindings unchanged.
 eliminateQuestionMark :: GlobalRdrEnv -> [CoreBind] -> [CoreBind]
 eliminateQuestionMark rdrEnv cbs =
-  case lookupQuestionMark rdrEnv of
-    Nothing   -> cbs
-    Just name -> map (goBind name) cbs
+  case lookupFunctionNames rdrEnv of
+    Nothing    -> cbs
+    Just names -> map (goBind names) cbs
+
+data FunctionNames = FunctionNames
+  { questionMarkName :: Maybe Name
+  , constName        :: Maybe Name
+  }
+
+lookupFunctionNames :: GlobalRdrEnv -> Maybe FunctionNames
+lookupFunctionNames rdrEnv =
+  case (lookupQuestionMark rdrEnv, lookupConst rdrEnv) of
+    (Nothing, Nothing) -> Nothing
+    (n0, n1) -> Just (FunctionNames n0 n1)
 
 -- | Find the 'Name' of '?' from @Language.Haskell.Liquid.ProofCombinators@
 -- in the renamer environment.
 lookupQuestionMark :: GlobalRdrEnv -> Maybe Name
 lookupQuestionMark rdrEnv =
-  case lookupGRE rdrEnv (LookupRdrName rdrName SameNameSpace) of
-    [gre] -> Just (greName gre)
-    _     -> Nothing
-  where
-    rdrName = mkRdrQual (mkModuleName "Language.Haskell.Liquid.ProofCombinators")
-                        (mkVarOcc "?")
+  let m = "Language.Haskell.Liquid.ProofCombinators"
+   in case filter (nameModuleIs m . greName) $
+             lookupGRE rdrEnv (LookupOccName (mkVarOcc "?") SameNameSpace) of
+        [gre] -> Just (greName gre)
+        _     -> Nothing
 
-goBind :: Name -> CoreBind -> CoreBind
+-- | Find the 'Name' of 'const' from @base@ in the renamer environment.
+lookupConst :: GlobalRdrEnv -> Maybe Name
+lookupConst rdrEnv = do
+  m <- TH.nameModule 'const
+  case filter (nameModuleIs m . greName) $
+         lookupGRE rdrEnv (LookupOccName (mkVarOcc "const") SameNameSpace) of
+    [gre] -> do
+      Just (greName gre)
+    _     -> Nothing
+
+nameModuleIs :: String -> Name -> Bool
+nameModuleIs m n = case nameModule_maybe n of
+  Just m' -> moduleNameString (moduleName m') == m
+  Nothing -> False
+
+goBind :: FunctionNames -> CoreBind -> CoreBind
 goBind n (NonRec x e) = NonRec x (goExpr n e)
 goBind n (Rec xes)    = Rec [(x, goExpr n e) | (x, e) <- xes]
 
-goExpr :: Name -> CoreExpr -> CoreExpr
+goExpr :: FunctionNames -> CoreExpr -> CoreExpr
 goExpr n e
-  | Just firstArg <- isQuestionMarkApp n e = goExpr n firstArg
+  | Just qmName <- questionMarkName n
+  , Just firstArg <- isQuestionMarkApp qmName e =
+      goExpr n firstArg
+  | Just cName <- constName n
+  , Just firstArg <- isQuestionMarkApp cName e =
+      goExpr n firstArg
 goExpr n (Lam x e)         = Lam x (goExpr n e)
 goExpr n (Let b e)          = Let (goBind n b) (goExpr n e)
 goExpr n (Case s x t alts) = Case (goExpr n s) x t [goAlt n a | a <- alts]
@@ -53,10 +90,10 @@ goExpr n (Tick t e)         = Tick t (goExpr n e)
 goExpr n (App f a)          = App (goExpr n f) (goExpr n a)
 goExpr _ e                  = e -- Var, Lit, Type, Coercion
 
-goAlt :: Name -> CoreAlt -> CoreAlt
+goAlt :: FunctionNames -> CoreAlt -> CoreAlt
 goAlt n (Alt con bs e) = Alt con bs (goExpr n e)
 
--- | Detect a fully-saturated application of '?': four arguments total
+-- | Detect a fully-saturated application of '?' or `const`: four arguments total
 -- (two types + two values), possibly wrapped in ticks.
 -- Returns @Just arg1@ (the first value argument).
 isQuestionMarkApp :: Name -> CoreExpr -> Maybe CoreExpr


### PR DESCRIPTION
When working on the Diff package it was convenient to use the `?` operator to introduce lemmas. However, this would mean that Diff modules had to import `Language.Haskell.Liquid.ProofCombinators` which would make Diff depend on `liquid-prelude`.

While this could be handled with conditional compilation, I thought it would be simpler to just optimize `const` in the same way that LH optimizes `?` to solve #2544. This is what this PR does.

In addition, the PR fixes the name lookup of `const` and `?` in the GlobalRdrEnv, which could fail sometimes depending on how the identifiers were brought in scope.

Benchmarks show only positive changes, and this happens only on two files which unsurprisingly use `const` instead of `?` in proofs. These are `tests/typeclasses/pos/Lemma.hs` and `tests/typeclasses/pos/All.hs`.