### PR TITLE
Change div/mod definition to match Haskell rounding semantics

### DIFF
--- a/src/GHC/Real_LHAssumptions.hs
+++ b/src/GHC/Real_LHAssumptions.hs
@@ -18,11 +18,11 @@ class Num a => Fractional a where
   fromRational :: Ratio Integer -> a
 
 class (Real a, Enum a) => Integral a where
-  quot :: x:a -> y:{v:a | v /= 0} -> {v:a | (v = (x / y)) &&
+  quot :: x:a -> y:{v:a | v /= 0} -> {v:a | (v = quot x y) &&
                                                      ((x >= 0 && y >= 0) => v >= 0) &&
                                                      ((x >= 0 && y >= 1) => v <= x) }
-  rem :: x:a -> y:{v:a | v /= 0} -> {v:a | ((v >= 0) && (v < y))}
-  mod :: x:a -> y:{v:a | v /= 0} -> {v:a | v = x mod y && ((0 <= x && 0 < y) => (0 <= v && v < y))}
+  rem :: x:a -> y:{v:a | v /= 0} -> {v:a | (v = rem x y) && ((v >= 0) && (v < y))}
+  mod :: x:a -> y:{v:a | v /= 0} -> {v:a | (v = GHC.Real.mod x y) && ((0 <= x && 0 < y) => (0 <= v && v < y))}
 
   div :: x:a -> y:{v:a | v /= 0} -> {v:a | (v = div x y) &&
                                                     ((x >= 0 && y >= 0) => v >= 0) &&
@@ -34,28 +34,24 @@ class (Real a, Enum a) => Integral a where
                                                     ((x > 0 && y < 0)   => v <= 0) &&
                                                     ((x < 0 && y < 0)   => v >= 0)
                                                     }
-  quotRem :: x:a -> y:{v:a | v /= 0} -> ( {v:a | (v = (x / y)) &&
+  quotRem :: x:a -> y:{v:a | v /= 0} -> ( {v:a | (v = quot x y) &&
                                                           ((x >= 0 && y >= 0) => v >= 0) &&
                                                           ((x >= 0 && y >= 1) => v <= x)}
-                                                 , {v:a | ((v >= 0) && (v < y))})
-  divMod :: x:a -> y:{v:a | v /= 0} -> ( {v:a | (v = (x / y)) &&
+                                                 , {v:a | (v = rem x y) && ((v >= 0) && (v < y))})
+  divMod :: x:a -> y:{v:a | v /= 0} -> ( {v:a | (v = div x y) &&
                                                          ((x >= 0 && y >= 0) => v >= 0) &&
                                                          ((x >= 0 && y >= 1) => v <= x) }
-                                                , {v:a | v = x mod y && ((0 <= x && 0 < y) => (0 <= v && v < y))}
+                                                , {v:a | (v = GHC.Real.mod x y) && ((0 <= x && 0 < y) => (0 <= v && v < y))}
                                                 )
   toInteger :: x:a -> {v:Integer | v = x}
 
 //  fixpoint can't handle (x mod y), only (x mod c) so we need to be more clever here
 //  mod :: x:a -> y:a -> {v:a | v = (x mod y) }
 
-define div x y        = (x / y)
-define mod x y        = (x mod y)
-define quot x y =  if x >= 0
-                   then (if y >= 0 then x / y else -(x / abs y))
-                   else -(abs x / y)
-define rem x y = if x >= 0
-                 then (if y >= 0 then x mod y else x mod (abs y))
-                 else - ((abs x) mod y)
+define div x y        = if y > 0 then x / y else -((- x) / y)
+define mod x y        = if y > 0 then x mod y else -((- x) mod y)
+define quot x y       = if x >= 0 then x / y else -((- x) / y)
+define rem x y        = if x >= 0 then x mod y else -((- x) mod y)
 define fromIntegral x = (x)
 
 @-}

--- a/tests/pos/SimplerNotation.hs
+++ b/tests/pos/SimplerNotation.hs
@@ -1,5 +1,5 @@
 module SimplerNotation () where
 
-{-@ myDiv :: x:Int -> y:{Int | y != 0} -> {v:Int | v = x / y} @-}
+{-@ myDiv :: x:Int -> y:{Int | y != 0} -> {v:Int | v = div x y} @-}
 myDiv :: Int -> Int -> Int
 myDiv = div

--- a/tests/reflect/pos/QuotRemInt.hs
+++ b/tests/reflect/pos/QuotRemInt.hs
@@ -55,3 +55,33 @@ examplesRem
 @-}
 examplesRem :: ()
 examplesRem = ()
+
+{-@
+examplesDiv
+   :: { 2 = div (-5) (-2) &&
+        -3 = div 5 (-2) &&
+        2 = div 5 2 &&
+        0 = div 0 2 &&
+        0 = div 1 2 &&
+        -1 = div (-1) 2 &&
+        2 = div (-5) (-2) &&
+        0 = div (-1) (-2) &&
+        -1 = div 1 (-1)
+      }
+@-}
+examplesDiv = ()
+
+{-@
+examplesMod
+   :: { -1 = Prelude.mod (-5) (-2) &&
+        -1 = Prelude.mod 5 (-2) &&
+        1 = Prelude.mod 5 2 &&
+        0 = Prelude.mod 0 2 &&
+        1 = Prelude.mod 1 2 &&
+        1 = Prelude.mod (-1) 2 &&
+        -1 = Prelude.mod (-5) (-2) &&
+        -1 = Prelude.mod (-1) (-2) &&
+        0 = Prelude.mod 1 (-1)
+      }
+@-}
+examplesMod = ()


### PR DESCRIPTION
A continuation of #2733.

Now LiquidHaskell has operations `div` and prefix `mod` in the logic. We should consider renaming `/` for integer division and infix `mod` in a separate issue (#2735).