### PR TITLE
Qualify the autosize measure name and report mixed-type recursive groups

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,9 +9,11 @@
 - Emit the `autosize` measure under its resolved name, so constraints that
   mention it are no longer rejected as having a free variable
   [#2736](https://github.com/ucsd-progsys/liquidhaskell/issues/2736)
+  [#2738](https://github.com/ucsd-progsys/liquidhaskell/pull/2738)
 - Skip the termination metric of a recursive group whose decreasing parameters
   have different types, instead of building one the solver cannot sort check
   [#2736](https://github.com/ucsd-progsys/liquidhaskell/issues/2736)
+  [#2738](https://github.com/ucsd-progsys/liquidhaskell/pull/2738)
 
 ## 0.9.14.1.1 (2026-06-04)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@
   neither `--ple-local` nor `--ple`
   [#2737](https://github.com/ucsd-progsys/liquidhaskell/issues/2737)
   [#2739](https://github.com/ucsd-progsys/liquidhaskell/pull/2739)
+- Emit the `autosize` measure under its resolved name, so constraints that
+  mention it are no longer rejected as having a free variable
+  [#2736](https://github.com/ucsd-progsys/liquidhaskell/issues/2736)
 
 ## 0.9.14.1.1 (2026-06-04)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@
 - Emit the `autosize` measure under its resolved name, so constraints that
   mention it are no longer rejected as having a free variable
   [#2736](https://github.com/ucsd-progsys/liquidhaskell/issues/2736)
+- Skip the termination metric of a recursive group whose decreasing parameters
+  have different types, instead of building one the solver cannot sort check
+  [#2736](https://github.com/ucsd-progsys/liquidhaskell/issues/2736)
 
 ## 0.9.14.1.1 (2026-06-04)
 

--- a/docs/mkDocs/docs/specifications.md
+++ b/docs/mkDocs/docs/specifications.md
@@ -961,6 +961,17 @@ invariant  {v:L a| autosize v >= 0 }
 This information is all LiquidHaskell needs to prove termination
 on functions that recurse on `L a` (on ADTs in general.)
 
+A group of mutually recursive functions gets one size function for the whole
+group, so the parameter it decreases on must have the same type in every
+function of the group. A group that recurses on, say, both an `L a` and a
+`[a]` is rejected with
+
+```
+The decreasing parameters should be of same type
+```
+
+and needs an explicit termination expression instead.
+
 ### Disabling Termination Checking
 
 To *disable* termination checking for `foo` that is,

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Termination.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Termination.hs
@@ -184,9 +184,15 @@ consCBSizedTys consBind γ xes
        autoenv  <- gets autoSize
        ts       <- forM ts' $ T.mapM refreshArgs
        let vs    = zipWith collectArgs' ts es
-       is       <- mapM makeDecrIndex (zip vars ts) >>= checkSameLens
+       is0      <- mapM makeDecrIndex (zip vars ts) >>= checkSameLens
+       sameTys  <- checkEqTypes =<< mapM checkIndex (zip4 vars vs ts is0)
+       -- The size function of a group is taken from the type of one decreasing
+       -- parameter and applied to all of them, so a group whose parameters have
+       -- different types has no metric to build. Drop it: building one anyway
+       -- produces a refinement the solver cannot sort check, and the error from
+       -- checkEqTypes never gets seen.
+       let is    = if sameTys then is0 else Nothing <$ is0
        let xeets = zipWith (\v i -> [((v,i), x) | x <- zip3 vars is $ map unTemplate ts]) vs is
-       _        <- mapM checkIndex (zip4 vars vs ts is) >>= checkEqTypes
        let rts   = (recType autoenv <$>) <$> xeets
        γ'       <- foldM extender γ (zip vars ts)
        let γs    = zipWith makeRecInvariants [γ' `setTRec` zip vars rts' | rts' <- rts] (filter (not . noMakeRec) <$> vs)
@@ -198,19 +204,26 @@ consCBSizedTys consBind γ xes
        (vars, es)     = unzip xes
        dxs            = F.pprint <$> vars
        collectArgs'   = collectArguments . length . ty_binds . toRTypeRep . unOCons . unTemplate
-       checkEqTypes :: [Maybe SpecType] -> CG [SpecType]
-       checkEqTypes x = checkAllVsHead err1 toRSort (catMaybes x)
+       checkEqTypes :: [Maybe SpecType] -> CG Bool
+       checkEqTypes x =
+         if allEqual (map toRSort $ catMaybes x) then
+           return True
+         else
+           addWarning err1 >> return False
        err1           = ErrTermin loc dxs $ text "The decreasing parameters should be of same type"
        checkSameLens :: [Maybe Int] -> CG [Maybe Int]
-       checkSameLens  = checkAllVsHead err2 length
+       checkSameLens xs =
+         if allEqual (map length xs) then
+           return xs
+         else
+           addWarning err2 >> return []
        err2           = ErrTermin loc dxs $ text "All Recursive functions should have the same number of decreasing parameters"
        loc            = GHC.getSrcSpan (head vars)
 
-       checkAllVsHead :: Eq b => Error -> (a -> b) -> [a] -> CG [a]
-       checkAllVsHead _   _ []          = return []
-       checkAllVsHead err f (x:xs)
-         | all (== f x) (f <$> xs) = return (x:xs)
-         | otherwise               = addWarning err >> return []
+-- All elements of the input are equal to each other
+allEqual :: Eq a => [a] -> Bool
+allEqual []     = True
+allEqual (x:xs) = all (== x) xs
 
 -- See Note [Shape of normalized terms] in
 -- Language.Haskell.Liquid.Transforms.ANF

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
@@ -88,9 +88,13 @@ instance CompatibleBinder (Located Symbol) (Located Symbol)
 instance CompatibleBinder Symbol (Located Symbol) where
   coerceBinder (Loc _ _ s) = s
 
--- RJ: Please add docs
+-- | The size measure applied to values of a type marked @{-@ autosize T @-}@.
+--
+-- It is declared in @GHC.Base_LHAssumptions@, so it must be spelled with that
+-- qualification here: the solver only knows the resolved name, and an
+-- unqualified occurrence is rejected as a free variable.
 lenLocSymbol :: Located Symbol
-lenLocSymbol = dummyLoc $ symbol ("autolen" :: String)
+lenLocSymbol = dummyLoc $ symbol ("GHC.Base_LHAssumptions.autolen" :: String)
 
 anyTypeSymbol :: Symbol
 anyTypeSymbol = symbol (show ''Any)

--- a/tests/errors/T2736.hs
+++ b/tests/errors/T2736.hs
@@ -1,0 +1,25 @@
+{-@ LIQUID "--expect-error-containing=The decreasing parameters should be of same type" @-}
+
+-- sizeTree, sizeForest and sizeTrees recurse on a Tree, a Forest and a list, so
+-- no single size function covers the group.
+module T2736 where
+
+data Tree = Leaf Int | Node Forest
+
+data Forest = Forest
+  { label :: Int
+  , trees :: [Tree] }
+
+{-@ autosize Tree @-}
+{-@ autosize Forest @-}
+
+sizeTree :: Tree -> Int
+sizeTree (Leaf _)   = 1
+sizeTree (Node frs) = 1 + sizeForest frs
+
+sizeForest :: Forest -> Int
+sizeForest (Forest _ ts) = 1 + sizeTrees ts
+
+sizeTrees :: [Tree] -> Int
+sizeTrees []       = 0
+sizeTrees (t : ts) = sizeTree t + sizeTrees ts

--- a/tests/pos/T2736.hs
+++ b/tests/pos/T2736.hs
@@ -1,0 +1,14 @@
+-- The autosize measure reaches the solver under the name it is declared with in
+-- GHC.Base_LHAssumptions. The signature below keeps a constraint that mentions
+-- it; with an unqualified name that constraint is rejected as having a free
+-- variable.
+module T2736 where
+
+data List a = N | Cons a (List a)
+
+{-@ autosize List @-}
+
+{-@ sizeList :: List a -> Nat @-}
+sizeList :: List a -> Int
+sizeList N           = 0
+sizeList (Cons _ xs) = 1 + sizeList xs

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -668,6 +668,7 @@ executable errors
                     , T1498
                     , T2346
                     , T2650
+                    , T2736
                     , T2737
                     , T773
                     , T774

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -1736,6 +1736,7 @@ executable unit-pos-3
                     , T2535
                     , T2579
                     , T2619
+                    , T2736
                     , T385
                     , T531
                     , T595a


### PR DESCRIPTION
Fixes #2736. Longer diagnosis in https://github.com/ucsd-progsys/liquidhaskell/issues/2736#issuecomment-5309137197.

Two independent bugs, the second only reachable once the first is out of the way.

`lenLocSymbol` emitted the bare symbol `autolen`, while the measure is declared in `GHC.Base_LHAssumptions` and resolves to `GHC.Base_LHAssumptions.autolen`, so any constraint that reached the solver with an `autolen` term was rejected with `Constraint with free vars [autolen]`. The existing `autosize` tests pass only because their constraints are sliced away before that check runs, so this was never about mutual recursion: `tests/pos/T2736.hs` is a self-recursive list with one signature that keeps a constraint alive, and it crashes on `develop`. `WiredIn.hs` has spelled the list size function `GHC.Types_LHAssumptions.len` since 5991f007d.

`consCBSizedTys` takes the size function from the type of one decreasing parameter and applies it to the decreasing parameter of every binder in the group, so a group whose parameters have different types produced a term the solver cannot sort check, and elaboration panicked with `Uh oh. elaborate solver failed on ...`. `checkEqTypes` already detected the condition and reported `The decreasing parameters should be of same type`, but its result was discarded and the metric was built regardless. It now suppresses the metric, so the error is what the user sees. This half has nothing to do with `autosize`: a hand-written size measure on the same shape panicked identically.

Tests: `tests/pos/T2736.hs` for the first, `tests/errors/T2736.hs` (the module from the issue) for the second. Docs: the restriction on decreasing-parameter types is reachable from user code now that it is an error rather than a panic, so `specifications.md` states it.

Left out on purpose: `makeSizedDataCons` counts only constructor arguments whose sort equals the result sort, so for mutually recursive types the size is constant (`autolen (Node f) = 1` for `Node :: Forest -> Tree`). Counting arguments of the other autosized types would make it grow across the mutual edge, but it changes `autolen` for existing code and does not change the outcome for the module in the issue, where the `[Tree]` hop is the blocker. Happy to do it in a separate PR if you want it.
