### PR TITLE
Reject ple annotations when PLE is disabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Reject `ple` and `automatic-instances` annotations in modules that enable
   neither `--ple-local` nor `--ple`
   [#2737](https://github.com/ucsd-progsys/liquidhaskell/issues/2737)
+  [#2739](https://github.com/ucsd-progsys/liquidhaskell/pull/2739)
 
 ## 0.9.14.1.1 (2026-06-04)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+- Reject `ple` and `automatic-instances` annotations in modules that enable
+  neither `--ple-local` nor `--ple`
+  [#2737](https://github.com/ucsd-progsys/liquidhaskell/issues/2737)
+
 ## 0.9.14.1.1 (2026-06-04)
 
 - Stop shadowing reflected signatures with assumed signatures

--- a/docs/mkDocs/docs/options.md
+++ b/docs/mkDocs/docs/options.md
@@ -60,6 +60,9 @@ liquid annotation
 {-@ automatic-instances theorem @-}
 ```
 
+The directive is read only under `--ple-local`. A module that sets neither
+`--ple-local` nor `--ple` and still carries the directive is rejected.
+
 Normally, PLE will only unfold invocations only if the arguments are known
 with enough precision to enter some of the equations of the function. For
 instance, in

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare.hs
@@ -959,11 +959,20 @@ addReflSigs env name rtEnv measEnv refl sig =
     reflected               = S.fromList $ fst <$> notReflActualTySigs
     notReflected xt         = fst xt `notElem` reflected
 
+-- | Resolves the binders of the @ple@ and @automatic-instances@ annotations.
+--
+-- They are read only under @--ple-local@, and @--ple@ already covers the whole
+-- module, so with neither flag set the annotation would be dropped without a
+-- word. Report it. See #2737.
 makeAutoInst :: Bare.Env -> Ms.BareSpec ->
                 Bare.Lookup (S.HashSet Ghc.Var)
-makeAutoInst env spec = S.fromList <$> kvs
+makeAutoInst env spec
+  | not (S.null autois), not (allowPLE (getConfig env)) =
+      Left [ ErrPleDisabled (GM.fSrcSpan lx) (pprint (val lx)) | lx <- S.toList autois ]
+  | otherwise = S.fromList <$> kvs
   where
-    kvs = forM (S.toList (Ms.autois spec)) $
+    autois = Ms.autois spec
+    kvs = forM (S.toList autois) $
             Bare.lookupGhcIdLHName env
 
 

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Errors.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Errors.hs
@@ -479,6 +479,11 @@ data TError t =
                 , msg :: !Doc
                 }
 
+  | ErrPleDisabled { pos :: !SrcSpan
+                   , var :: !Doc
+                   } -- ^ 'ple' or 'automatic-instances' annotation in a module
+                     --   that enables neither --ple-local nor --ple
+
   | ErrPosTyCon { pos  :: SrcSpan
                 , tc   :: !Doc
                 , dc   :: !Doc
@@ -1116,6 +1121,14 @@ ppError' _ dCtx (ErrRewrite _ msg )
   = text "Rewrite error"
         $+$ dCtx
         $+$ nest 4 msg
+
+ppError' _ dCtx (ErrPleDisabled _ v)
+  = text "PLE is not enabled for" <+> ppTicks v
+        $+$ dCtx
+        $+$ nest 4 (vcat
+              [ text "Add {-@ LIQUID \"--ple-local\" @-} to run PLE on the annotated binders,"
+              , text "or {-@ LIQUID \"--ple\" @-} to run it on the whole module."
+              ])
 
 ppError' _ dCtx (ErrPosTyCon _ tc dc)
   = text "Negative occurence of" <+> tc <+> "in" <+> dc

--- a/tests/errors/T2737.hs
+++ b/tests/errors/T2737.hs
@@ -1,0 +1,15 @@
+{-@ LIQUID "--expect-error-containing=PLE is not enabled for `prop`" @-}
+{-@ LIQUID "--reflection" @-}
+
+-- Neither --ple-local nor --ple is set, so the annotation below has nothing to
+-- act on.
+module T2737 where
+
+{-@ reflect double @-}
+double :: Int -> Int
+double x = x + x
+
+{-@ automatic-instances prop @-}
+{-@ prop :: {v:() | double 2 == 4} @-}
+prop :: ()
+prop = ()

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -668,6 +668,7 @@ executable errors
                     , T1498
                     , T2346
                     , T2650
+                    , T2737
                     , T773
                     , T774
                     , TerminationExprNum


### PR DESCRIPTION
Fixes #2737. Discussion in https://github.com/ucsd-progsys/liquidhaskell/issues/2737#issuecomment-5309137273.

`{-@ ple f @-}` and `{-@ automatic-instances f @-}` fill `gsAutoInst`, but `doExpand` reads it only under `--ple-local`, so a module that sets neither `--ple-local` nor `--ple` drops the annotation and the proof fails exactly as if PLE were off. `makeAutoInst` now rejects the annotation in that case, located at the binder:

```
tests/errors/T2737.hs:12:25: error:
    PLE is not enabled for `prop`
    Add {-@ LIQUID "--ple-local" @-} to run PLE on the annotated binders,
    or {-@ LIQUID "--ple" @-} to run it on the whole module.
   |
12 | {-@ automatic-instances prop @-}
   |                         ^^^^^
```

`--ple` on its own is still accepted. PLE runs for the whole module there, so the annotation is redundant rather than dead, and six tests pair the two: `tests/ple/pos/IndPal0.hs`, `IndPal00.hs`, `IndPalindrome.hs` and `tests/benchmarks/popl18/ple/pos/{Lists,Overview,ApplicativeList}.hs`. Say so if you would rather reject the redundant case as well, and I will drop the annotations from those tests.

Test: `tests/errors/T2737.hs`. Docs: `options.md`.
