### PR TITLE
Avoid generating opaque definitions for internal names

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs
@@ -436,7 +436,9 @@ makeOpaqueReflMeasures env measEnv specs eqs =
     getVar sym = case Bare.lookupGhcIdLHName env sym of
       Right x -> x
       Left _ -> panic (Just $ GM.fSrcSpan sym) "function to reflect not in scope"
-    definedSymbols = getDefinedSymbolsInLogic env measEnv specs
+    definedSymbols =
+      getDefinedSymbolsInLogic env measEnv specs
+        `S.union` S.fromList [F.eqName eq | (_, _, eq) <- eqs]
     undefinedInLogic v = not (S.member (F.symbol v) definedSymbols)
     -- Variables to consider
     varsUndefinedInLogic = S.unions $

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2697,6 +2697,7 @@ executable typeclass-pos
                     , PNat
                     , SemigroupLib
                     , ConstrainedGADT
+                    , SingleMethod
 
     build-depends:    base
                     , liquid-prelude

--- a/tests/typeclasses/pos/SingleMethod.hs
+++ b/tests/typeclasses/pos/SingleMethod.hs
@@ -1,0 +1,12 @@
+{-@ LIQUID "--typeclass" @-}
+module SingleMethod where
+
+class HasNat a where
+  {-@ nat :: a -> Nat @-}
+  nat :: a -> Int
+
+instance HasNat Bool where
+  nat False = 0
+  nat True  = 1
+
+


### PR DESCRIPTION
This PR is an attempt for a solution to issue https://github.com/ucsd-progsys/liquidhaskell/issues/2728. This is a secondary issue found after merging PR https://github.com/ucsd-progsys/liquidhaskell/pull/2716, and is relevant to issue https://github.com/ucsd-progsys/liquidhaskell/issues/2450.

I also added a test that served as a minimal failing example, now passing correctly (no warnings, no panic). Next, I explain the reasoning behind this fix, I suggest reading the linked issue before reading the explanation.

## Why only single-method instances?

In GHC 9.14, a new way to encode single-method instances [was introduced](https://github.com/ghc/ghc/blob/eb0dfb011b43451e88181fb6b9807104f883812a/compiler/GHC/Core/TyCon.hs#L1458). This new representation [gives single-method instances](https://github.com/ghc/ghc/blob/eb0dfb011b43451e88181fb6b9807104f883812a/compiler/GHC/Core/TyCon.hs#L1534) a [CoreUnfolding](https://hackage-content.haskell.org/package/ghc-9.14.1/docs/GHC-Core.html#v:CoreUnfolding). Multi-method classes use a different unfolding.

In `Language.Haskell.Liquid.Bare.Measure`, the definition and use of [`getUnfoldingOfVar`](https://github.com/ucsd-progsys/liquidhaskell/blob/7daadcce984453c236720d0ce442cc531e774dd9/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Measure.hs#L456) shows that symbols inside `CoreUnfolding`s eventually end up being reflected as opaque unless marked as defined.

In particular, method names (such as `$cnat_...`, mentioned in the issue) will be visible after the unfolding.

Unfortunately, typeclass restoration happened in GHC 9.14, so we don't really have a way to check against other 9.xx versions. But this can be safely concluded after reading the [Unary class magic](https://github.com/ghc/ghc/blob/eb0dfb011b43451e88181fb6b9807104f883812a/compiler/GHC/Core/TyCon.hs#L1458) note in GHC.

## Why is being opaque a problem?

For method names, we don't want them to be reflected with opaque definitions because they have actual definitions. The problem is that they were being added to that category ahead of time.

This wasn't a problem before because previous versions of GHC weren't able to look inside class definitions (they didn't have a `CoreUnfolding`). But now, names such as `$cnat_...` would be added to `gsTySigs` as well. That in turn would cause the warning `Assume Overwrites Specifications for $cnat`.

This implies that, in general, the way in which opaque reflections were generated was faulty, but the erroneous path hadn't manifested because LH wasn't unfolding classes.

## How the fix avoids the warning

The check that decides whether a referenced symbol needs an opaque reflection was consulting only previously processed specs, so it didn't know that method names (such as `$cnat_...`) were defined, even though they were part of the input.

The fix adds the current input's equation names to the defined set, so the reference is correctly recognized as already defined and no opaque reflection is created.

This is the natural thing to do, and I claim that this is not a workaround, but how things should have been done from the beginning. This was an actual gap in the code that wasn't noticed before because the representation of classes was conveniently hiding it.

## How this fixes the panic

Names in GHC are either external (when they are part of a module) or internal. The panic is caused by calling `nameModule` on an internal name: `$cnat_...` in our example. In particular, method names are internal.

I tried tracking down the `nameModule` call that was throwing the panic within the LH codebase. Noticing that LH is able to output the `SAFE` message before panicing was evidence that the call had to happen after LH's checks, narrowed the search area. But that was still an unsuccessful attempt, because even after adding logs around all calls to `nameModule`, I couldn't find the faulty one.

A more fruitful approach was tracing what takes place once the checks are complete and the `SAFE` message is shown. That led to the `encodeLiquidLib` function, which fails when there are internal names in the logic.

This function deals with the serialization of the LH specs. In particular, it requires names to be serializable via the `Binary` typeclass. The instantiation of that class will call `GHC.put_`. This suggests that the call to `nameModule` is actually taking place on the GHC side.

Inspecting the module [`GHC.Iface.Binary`](https://github.com/ghc/ghc/blob/6f9d7c71a762d3cc7e942cddb34680cd4ee4bb7e/compiler/GHC/Iface/Binary.hs), [`serialiseName`](https://github.com/ghc/ghc/blob/6f9d7c71a762d3cc7e942cddb34680cd4ee4bb7e/compiler/GHC/Iface/Binary.hs#L680) looks like a viable candidate for the caller to `nameModule`, causing the panic.[^1]

The panic is solved the same way as the warning. By avoiding the opaque reflection of the method, no internal names will be serialized, hence preventing the panic.

[^1]: It's worth mentioning that this module was recently refactored, and the `serialiseName` function was removed. The latest version of the code at the time still has a few calls to `nameModule` though.