### PR TITLE
Count the fields of every autosized type in the size measure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@
   have different types, instead of building one the solver cannot sort check
   [#2736](https://github.com/ucsd-progsys/liquidhaskell/issues/2736)
   [#2738](https://github.com/ucsd-progsys/liquidhaskell/pull/2738)
+- Count the fields of every autosized type in the `autosize` measure, so the
+  size grows along the edges between mutually recursive types
+  [#2736](https://github.com/ucsd-progsys/liquidhaskell/issues/2736)
 
 ## 0.9.14.1.1 (2026-06-04)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - Count the fields of every autosized type in the `autosize` measure, so the
   size grows along the edges between mutually recursive types
   [#2736](https://github.com/ucsd-progsys/liquidhaskell/issues/2736)
+  [#2742](https://github.com/ucsd-progsys/liquidhaskell/pull/2742)
 
 ## 0.9.14.1.1 (2026-06-04)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,9 +9,11 @@
 - Emit the `autosize` measure under its resolved name, so constraints that
   mention it are no longer rejected as having a free variable
   [#2736](https://github.com/ucsd-progsys/liquidhaskell/issues/2736)
+  [#2738](https://github.com/ucsd-progsys/liquidhaskell/pull/2738)
 - Skip the termination metric of a recursive group whose decreasing parameters
   have different types, instead of building one the solver cannot sort check
   [#2736](https://github.com/ucsd-progsys/liquidhaskell/issues/2736)
+  [#2738](https://github.com/ucsd-progsys/liquidhaskell/pull/2738)
 
 ## 0.9.14.1.1 (2026-06-04)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@
   neither `--ple-local` nor `--ple`
   [#2737](https://github.com/ucsd-progsys/liquidhaskell/issues/2737)
   [#2739](https://github.com/ucsd-progsys/liquidhaskell/pull/2739)
+- Emit the `autosize` measure under its resolved name, so constraints that
+  mention it are no longer rejected as having a free variable
+  [#2736](https://github.com/ucsd-progsys/liquidhaskell/issues/2736)
 
 ## 0.9.14.1.1 (2026-06-04)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@
 - Emit the `autosize` measure under its resolved name, so constraints that
   mention it are no longer rejected as having a free variable
   [#2736](https://github.com/ucsd-progsys/liquidhaskell/issues/2736)
+- Skip the termination metric of a recursive group whose decreasing parameters
+  have different types, instead of building one the solver cannot sort check
+  [#2736](https://github.com/ucsd-progsys/liquidhaskell/issues/2736)
 
 ## 0.9.14.1.1 (2026-06-04)
 

--- a/docs/mkDocs/docs/specifications.md
+++ b/docs/mkDocs/docs/specifications.md
@@ -961,6 +961,26 @@ invariant  {v:L a| autosize v >= 0 }
 This information is all LiquidHaskell needs to prove termination
 on functions that recurse on `L a` (on ADTs in general.)
 
+A field whose own type is autosized counts towards the size, so the size grows
+along the edges between mutually recursive types
+
+```haskell
+{-@ autosize Tree @-}
+{-@ autosize Forest @-}
+data Tree   = Leaf Int | Node Forest
+data Forest = Nil | Cons Tree Forest
+```
+
+refines the constructors of both types with
+
+```haskell
+Node :: f:Forest -> {v:Tree | autosize v = 1 + autosize f}
+Cons :: t:Tree -> f:Forest -> {v:Forest | autosize v = 1 + autosize t + autosize f}
+```
+
+A field of a type that is not autosized itself, `[Tree]` for instance,
+contributes nothing.
+
 A group of mutually recursive functions gets one size function for the whole
 group, so the parameter it decreases on must have the same type in every
 function of the group. A group that recurses on, say, both an `L a` and a

--- a/docs/mkDocs/docs/specifications.md
+++ b/docs/mkDocs/docs/specifications.md
@@ -961,6 +961,17 @@ invariant  {v:L a| autosize v >= 0 }
 This information is all LiquidHaskell needs to prove termination
 on functions that recurse on `L a` (on ADTs in general.)
 
+A group of mutually recursive functions gets one size function for the whole
+group, so the parameter it decreases on must have the same type in every
+function of the group. A group that recurses on, say, both an `L a` and a
+`[a]` is rejected with
+
+```
+The decreasing parameters should be of same type
+```
+
+and needs an explicit termination expression instead.
+
 ### Disabling Termination Checking
 
 To *disable* termination checking for `foo` that is,

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Init.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Init.hs
@@ -110,6 +110,13 @@ addPolyInfo t = mkUnivs (go <$> as) ps t'
 makeDataConTypes :: Bool -> Var -> CG (Var, SpecType)
 makeDataConTypes allowTC x = (x,) <$> trueTy allowTC (varType x)
 
+-- | Refines the data constructors of every autosized type with an equation for
+--   the @autolen@ measure, and returns one invariant per refined type stating
+--   that the size is non-negative.
+--
+--   @dcts@ gives the unrefined type of every constructor, @specenv@ the types
+--   declared @autosize@ and @dcs@ the constructors in scope. Constructors of a
+--   type that was not declared @autosize@ are left alone.
 makeAutoDecrDataCons :: [(Id, SpecType)] -> S.HashSet TyCon -> [Id] -> ([LocSpecType], [(Id, SpecType)])
 makeAutoDecrDataCons dcts specenv dcs
   = (simplify rsorts, tys)
@@ -131,6 +138,14 @@ idTyCon = fmap dataConTyCon . Ghc.isDataConId_maybe
 lenOf :: F.Symbol -> F.Expr
 lenOf x = F.mkEApp lenLocSymbol [F.EVar x]
 
+-- | Refines the result type of @x'@, the @n@-th constructor of its type, with
+--   an equation that puts its size at @n@ plus the size of every field whose
+--   own type is autosized. Also returns the result sort, which
+--   'makeAutoDecrDataCons' turns into the non-negativity invariant.
+--
+--   Every autosized field counts, so the size grows along an edge between two
+--   mutually recursive types. A field of a type that is not autosized has no
+--   @autolen@ of its own and contributes nothing.
 makeSizedDataCons :: S.HashSet TyCon -> [(Id, SpecType)] -> DataCon -> Integer -> (RSort, (Id, SpecType))
 makeSizedDataCons specenv dcts x' n = (toRSort $ ty_res trep, (x, fromRTypeRep trep{ty_res = tres}))
     where
@@ -139,8 +154,6 @@ makeSizedDataCons specenv dcts x' n = (toRSort $ ty_res trep, (x, fromRTypeRep t
       trep   = toRTypeRep st
       tres   = ty_res trep `strengthen` MkUReft (F.Reft (F.vv_, F.PAtom F.Eq (lenOf F.vv_) computelen)) mempty
 
-      -- An argument of an autosized type contributes its own size, so the size
-      -- of a value grows along the edges between mutually recursive types too.
       recarguments = filter (autosized . fst) (zip (ty_args trep) (ty_binds trep))
       autosized (RApp c _ _ _) = S.member (rtc_tc c) specenv
       autosized _              = False

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Init.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Init.hs
@@ -118,7 +118,7 @@ makeAutoDecrDataCons dcts specenv dcs
     tycons      = L.nub $ mapMaybe idTyCon dcs
 
     go tycon
-      | S.member tycon specenv =  zipWith (makeSizedDataCons dcts) (tyConDataCons tycon) [0..]
+      | S.member tycon specenv =  zipWith (makeSizedDataCons specenv dcts) (tyConDataCons tycon) [0..]
     go _
       = []
 
@@ -131,15 +131,19 @@ idTyCon = fmap dataConTyCon . Ghc.isDataConId_maybe
 lenOf :: F.Symbol -> F.Expr
 lenOf x = F.mkEApp lenLocSymbol [F.EVar x]
 
-makeSizedDataCons :: [(Id, SpecType)] -> DataCon -> Integer -> (RSort, (Id, SpecType))
-makeSizedDataCons dcts x' n = (toRSort $ ty_res trep, (x, fromRTypeRep trep{ty_res = tres}))
+makeSizedDataCons :: S.HashSet TyCon -> [(Id, SpecType)] -> DataCon -> Integer -> (RSort, (Id, SpecType))
+makeSizedDataCons specenv dcts x' n = (toRSort $ ty_res trep, (x, fromRTypeRep trep{ty_res = tres}))
     where
       x      = dataConWorkId x'
       st     = fromMaybe (impossible Nothing "makeSizedDataCons: this should never happen") $ L.lookup x dcts
       trep   = toRTypeRep st
       tres   = ty_res trep `strengthen` MkUReft (F.Reft (F.vv_, F.PAtom F.Eq (lenOf F.vv_) computelen)) mempty
 
-      recarguments = filter (\(t,_) -> toRSort t == toRSort tres) (zip (ty_args trep) (ty_binds trep))
+      -- An argument of an autosized type contributes its own size, so the size
+      -- of a value grows along the edges between mutually recursive types too.
+      recarguments = filter (autosized . fst) (zip (ty_args trep) (ty_binds trep))
+      autosized (RApp c _ _ _) = S.member (rtc_tc c) specenv
+      autosized _              = False
       computelen   = foldr (F.EBin F.Plus) (F.ECon $ F.I n) (lenOf .  snd <$> recarguments)
 
 mergeDataConTypes ::  F.TCEmb TyCon -> [(Var, SpecType)] -> [(Var, SpecType)] -> [(Var, SpecType)]

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Termination.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Constraint/Termination.hs
@@ -184,9 +184,15 @@ consCBSizedTys consBind γ xes
        autoenv  <- gets autoSize
        ts       <- forM ts' $ T.mapM refreshArgs
        let vs    = zipWith collectArgs' ts es
-       is       <- mapM makeDecrIndex (zip vars ts) >>= checkSameLens
+       is0      <- mapM makeDecrIndex (zip vars ts) >>= checkSameLens
+       sameTys  <- checkEqTypes =<< mapM checkIndex (zip4 vars vs ts is0)
+       -- The size function of a group is taken from the type of one decreasing
+       -- parameter and applied to all of them, so a group whose parameters have
+       -- different types has no metric to build. Drop it: building one anyway
+       -- produces a refinement the solver cannot sort check, and the error from
+       -- checkEqTypes never gets seen.
+       let is    = if sameTys then is0 else Nothing <$ is0
        let xeets = zipWith (\v i -> [((v,i), x) | x <- zip3 vars is $ map unTemplate ts]) vs is
-       _        <- mapM checkIndex (zip4 vars vs ts is) >>= checkEqTypes
        let rts   = (recType autoenv <$>) <$> xeets
        γ'       <- foldM extender γ (zip vars ts)
        let γs    = zipWith makeRecInvariants [γ' `setTRec` zip vars rts' | rts' <- rts] (filter (not . noMakeRec) <$> vs)
@@ -198,19 +204,26 @@ consCBSizedTys consBind γ xes
        (vars, es)     = unzip xes
        dxs            = F.pprint <$> vars
        collectArgs'   = collectArguments . length . ty_binds . toRTypeRep . unOCons . unTemplate
-       checkEqTypes :: [Maybe SpecType] -> CG [SpecType]
-       checkEqTypes x = checkAllVsHead err1 toRSort (catMaybes x)
+       checkEqTypes :: [Maybe SpecType] -> CG Bool
+       checkEqTypes x =
+         if allEqual (map toRSort $ catMaybes x) then
+           return True
+         else
+           addWarning err1 >> return False
        err1           = ErrTermin loc dxs $ text "The decreasing parameters should be of same type"
        checkSameLens :: [Maybe Int] -> CG [Maybe Int]
-       checkSameLens  = checkAllVsHead err2 length
+       checkSameLens xs =
+         if allEqual (map length xs) then
+           return xs
+         else
+           addWarning err2 >> return []
        err2           = ErrTermin loc dxs $ text "All Recursive functions should have the same number of decreasing parameters"
        loc            = GHC.getSrcSpan (head vars)
 
-       checkAllVsHead :: Eq b => Error -> (a -> b) -> [a] -> CG [a]
-       checkAllVsHead _   _ []          = return []
-       checkAllVsHead err f (x:xs)
-         | all (== f x) (f <$> xs) = return (x:xs)
-         | otherwise               = addWarning err >> return []
+-- All elements of the input are equal to each other
+allEqual :: Eq a => [a] -> Bool
+allEqual []     = True
+allEqual (x:xs) = all (== x) xs
 
 -- See Note [Shape of normalized terms] in
 -- Language.Haskell.Liquid.Transforms.ANF

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/Names.hs
@@ -88,9 +88,13 @@ instance CompatibleBinder (Located Symbol) (Located Symbol)
 instance CompatibleBinder Symbol (Located Symbol) where
   coerceBinder (Loc _ _ s) = s
 
--- RJ: Please add docs
+-- | The size measure applied to values of a type marked @{-@ autosize T @-}@.
+--
+-- It is declared in @GHC.Base_LHAssumptions@, so it must be spelled with that
+-- qualification here: the solver only knows the resolved name, and an
+-- unqualified occurrence is rejected as a free variable.
 lenLocSymbol :: Located Symbol
-lenLocSymbol = dummyLoc $ symbol ("autolen" :: String)
+lenLocSymbol = dummyLoc $ symbol ("GHC.Base_LHAssumptions.autolen" :: String)
 
 anyTypeSymbol :: Symbol
 anyTypeSymbol = symbol (show ''Any)

--- a/tests/errors/T2736.hs
+++ b/tests/errors/T2736.hs
@@ -1,0 +1,25 @@
+{-@ LIQUID "--expect-error-containing=The decreasing parameters should be of same type" @-}
+
+-- sizeTree, sizeForest and sizeTrees recurse on a Tree, a Forest and a list, so
+-- no single size function covers the group.
+module T2736 where
+
+data Tree = Leaf Int | Node Forest
+
+data Forest = Forest
+  { label :: Int
+  , trees :: [Tree] }
+
+{-@ autosize Tree @-}
+{-@ autosize Forest @-}
+
+sizeTree :: Tree -> Int
+sizeTree (Leaf _)   = 1
+sizeTree (Node frs) = 1 + sizeForest frs
+
+sizeForest :: Forest -> Int
+sizeForest (Forest _ ts) = 1 + sizeTrees ts
+
+sizeTrees :: [Tree] -> Int
+sizeTrees []       = 0
+sizeTrees (t : ts) = sizeTree t + sizeTrees ts

--- a/tests/pos/AutoSizeMutual.hs
+++ b/tests/pos/AutoSizeMutual.hs
@@ -1,0 +1,15 @@
+module AutoSizeMutual where
+
+{-@ autosize Tree @-}
+{-@ autosize Forest @-}
+
+data Tree   = Leaf Int | Node Forest
+data Forest = Nil | Cons Tree Forest
+
+-- The size of a Node counts the Forest under it and the size of a Cons counts
+-- both of its fields, so the recursion below decreases on the Tree even where
+-- it steps through the Forest.
+sizeTree :: Tree -> Int
+sizeTree (Leaf _)          = 0
+sizeTree (Node Nil)        = 1
+sizeTree (Node (Cons t f)) = 1 + sizeTree t + sizeTree (Node f)

--- a/tests/pos/T2736.hs
+++ b/tests/pos/T2736.hs
@@ -1,0 +1,14 @@
+-- The autosize measure reaches the solver under the name it is declared with in
+-- GHC.Base_LHAssumptions. The signature below keeps a constraint that mentions
+-- it; with an unqualified name that constraint is rejected as having a free
+-- variable.
+module T2736 where
+
+data List a = N | Cons a (List a)
+
+{-@ autosize List @-}
+
+{-@ sizeList :: List a -> Nat @-}
+sizeList :: List a -> Int
+sizeList N           = 0
+sizeList (Cons _ xs) = 1 + sizeList xs

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -1872,6 +1872,7 @@ executable unit-pos-4
                     , Assume
                     , Automate
                     , AutoSize
+                    , AutoSizeMutual
                     , AutoTerm1
                     , AutoTerm
                     , Avg

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -668,6 +668,7 @@ executable errors
                     , T1498
                     , T2346
                     , T2650
+                    , T2736
                     , T2737
                     , T773
                     , T774

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -1736,6 +1736,7 @@ executable unit-pos-3
                     , T2535
                     , T2579
                     , T2619
+                    , T2736
                     , T385
                     , T531
                     , T595a


### PR DESCRIPTION
Follow-up to #2738, where this was left out on purpose.

`makeSizedDataCons` counted only the fields whose sort equals the type being defined, so in a group of mutually recursive autosized types the size was a constant: `autolen (Node f) = 1` for `Node :: Forest -> Tree`, and nothing that recurses on `Tree` through the `Forest` could be shown to terminate. It now counts the fields whose own type is autosized, so the size grows along the mutual edge:

```haskell
Node :: f:Forest -> {v:Tree | autolen v = 1 + autolen f}
Cons :: t:Tree -> f:Forest -> {v:Forest | autolen v = 1 + autolen t + autolen f}
```

This changes `autolen` for existing code: a constructor with a field of another autosized type gets a larger size than before. The constructor index and the non-negativity invariant are unchanged.

A field whose own type is not autosized, `[Tree]` in the module of #2736, still contributes nothing, so that module stays rejected for the reason given in #2738.

Tests: `tests/pos/AutoSizeMutual.hs`, which fails on `develop` with `autolen ... == 1` for the `Node` case. Docs: the autosize section of `specifications.md`.

The branch sits on top of #2738, so that PR's commits show up here until it merges.
