### PR TITLE
Fix elaboration of specs in classes with higher-kinded parameters

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Elaborate.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Elaborate.hs
@@ -695,7 +695,7 @@ specTypeToLHsType = \case
     REx _ tin tout -> nlHsFunTy (specTypeToLHsType tin) (specTypeToLHsType tout)
     RAppTy _ (RExprArg _) _ ->
       impossible Nothing "RExprArg should not appear here"
-    RAppTy t t' _ -> nlHsFunTy (specTypeToLHsType t) (specTypeToLHsType t')
+    RAppTy t t' _ -> nlHsAppTy (specTypeToLHsType t) (specTypeToLHsType t')
     RRTy _ _ _ t -> specTypeToLHsType t
     RHole _ -> noLocA $ HsWildCardTy Ghc.noAnn
     RExprArg _ ->

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Plugged.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Plugged.hs
@@ -188,6 +188,9 @@ plugHolesOld allowTC tce tyi xx f t0 zz@(Loc l l' st0)
     = Loc l l'
     . mkArrow (zip (updateRTVar <$> αs') rs) ps' []
     . makeCls cs'
+    -- Here `su` maps LH tyvars to GHC tyvars, so goPlug merges two types that
+    -- both use GHC tyvars: binders inserted from the GHC side need no renaming,
+    -- hence [].
     . goPlug tce tyi [] err f (subts su rt)
     . mapExprReft (\_ -> F.applyCoSub coSub)
     . subts su
@@ -289,6 +292,8 @@ goPlug tce tyi su err f = go
     go (RVar _ _)       v@(RVar _ _)       = v
     go (RFun _ _ i o _) (RFun x ii i' o' r)               = RFun x ii    (go i i')   (go o o') r
     go (RAllT _ t _)    (RAllT a t' r)     = RAllT a    (go t t') r
+    -- Binder comes from the GHC type but the body uses LH tyvars. Rename it via
+    -- `su` or it binds nothing (Issue #2727).
     go (RAllT a t r)    t'                 = RAllT (subRTVar su a) (go t t') r
     go t                (RAllP p t')       = RAllP p    (go t t')
     go t                (REx b x t')       = REx b x    (go t t')

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Plugged.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Plugged.hs
@@ -188,7 +188,7 @@ plugHolesOld allowTC tce tyi xx f t0 zz@(Loc l l' st0)
     = Loc l l'
     . mkArrow (zip (updateRTVar <$> αs') rs) ps' []
     . makeCls cs'
-    . goPlug tce tyi err f (subts su rt)
+    . goPlug tce tyi [] err f (subts su rt)
     . mapExprReft (\_ -> F.applyCoSub coSub)
     . subts su
     $ st
@@ -219,7 +219,7 @@ plugHolesNew allowTC@False tce tyi xx f t0 zz@(Loc l l' st0)
     = Loc l l'
     . mkArrow (zip (updateRTVar <$> as'') rs) ps []
     . makeCls cs'
-    . goPlug tce tyi err f rt'
+    . goPlug tce tyi su err f rt'
     $ st
   where
     rt'          = tx rt
@@ -246,7 +246,7 @@ plugHolesNew allowTC@True tce tyi a f t0 zz@(Loc l l' st0)
     = Loc l l'
     . mkArrow (zip (updateRTVar <$> as'') rs) ps (if length cs > length cs' then cs else cs')
     -- . makeCls cs'
-    . goPlug tce tyi err f rt'
+    . goPlug tce tyi su err f rt'
     $ st
   where
     rt'          = tx rt
@@ -272,9 +272,9 @@ plugHolesNew allowTC@True tce tyi a f t0 zz@(Loc l l' st0)
 subRTVar :: [(RTyVar, RTyVar)] -> SpecRTVar -> SpecRTVar
 subRTVar su a@(RTVar v i) = Mb.maybe a (`RTVar` i) (lookup v su)
 
-goPlug :: F.TCEmb Ghc.TyCon -> Bare.TyConMap -> (Doc -> Doc -> Error) -> (SpecType -> RReft -> RReft) -> SpecType -> SpecType
+goPlug :: F.TCEmb Ghc.TyCon -> Bare.TyConMap -> [(RTyVar, RTyVar)] -> (Doc -> Doc -> Error) -> (SpecType -> RReft -> RReft) -> SpecType -> SpecType
        -> SpecType
-goPlug tce tyi err f = go
+goPlug tce tyi su err f = go
   where
     go st (RHole r) = (addHoles t') { rt_reft = f st r }
       where
@@ -289,7 +289,7 @@ goPlug tce tyi err f = go
     go (RVar _ _)       v@(RVar _ _)       = v
     go (RFun _ _ i o _) (RFun x ii i' o' r)               = RFun x ii    (go i i')   (go o o') r
     go (RAllT _ t _)    (RAllT a t' r)     = RAllT a    (go t t') r
-    go (RAllT a t r)    t'                 = RAllT a    (go t t') r
+    go (RAllT a t r)    t'                 = RAllT (subRTVar su a) (go t t') r
     go t                (RAllP p t')       = RAllP p    (go t t')
     go t                (REx b x t')       = REx b x    (go t t')
     go t                (RRTy e r o t')    = RRTy e r o (go t t')

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Transforms/CoreToLogic.hs
@@ -416,7 +416,11 @@ toPredApp p = do
       = PAnd <$> mapM coreToLg [e1, e2]
       | f == symbol ("Language.Haskell.Liquid.Prelude.==>" :: String)
       = PImp <$> coreToLg e1 <*> coreToLg e2
+      | GM.dropModuleUnique f == symbol ("==>" :: String)
+      = PImp <$> coreToLg e1 <*> coreToLg e2
       | f == symbol ("Language.Haskell.Liquid.Prelude.<=>" :: String)
+      = PIff <$> coreToLg e1 <*> coreToLg e2
+      | GM.dropModuleUnique f == symbol ("<=>" :: String)
       = PIff <$> coreToLg e1 <*> coreToLg e2
       | f == symbol (show 'const)
       = coreToLg e1

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2704,6 +2704,8 @@ executable typeclass-pos
                     , SemigroupLib
                     , ConstrainedGADT
                     , SingleMethod
+                    , HK1
+                    -- , HK2
 
     build-depends:    base
                     , liquid-prelude

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2705,7 +2705,7 @@ executable typeclass-pos
                     , ConstrainedGADT
                     , SingleMethod
                     , HK1
-                    -- , HK2
+                    , HK2
 
     build-depends:    base
                     , liquid-prelude

--- a/tests/typeclasses/pos/HK1.hs
+++ b/tests/typeclasses/pos/HK1.hs
@@ -1,3 +1,10 @@
+-- Test for issue #2727:
+-- Specs of classes with higher-kinded parameters used to be elaborated with the
+-- type application `m a` rendered as a function type `m -> a`, throwing a kind
+-- error.
+
+-- Unlike HK2, this test has an implicit higher kinded type.
+
 {-@ LIQUID "--typeclass" @-}
 module HK1 where
 

--- a/tests/typeclasses/pos/HK1.hs
+++ b/tests/typeclasses/pos/HK1.hs
@@ -1,0 +1,11 @@
+{-@ LIQUID "--typeclass" @-}
+module HK1 where
+
+class M m where
+  {-@ ret :: a -> m a @-}
+  ret :: a -> m a
+
+class M m => VM m where
+  {-@ lawRet :: x:a -> y:m a ->
+        { ((y == ret x) ==> (y == ret x)) && ((y == ret x) ==> (y == ret x)) } @-}
+  lawRet :: a -> m a -> ()

--- a/tests/typeclasses/pos/HK2.hs
+++ b/tests/typeclasses/pos/HK2.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE KindSignatures #-}
+{-@ LIQUID "--typeclass" @-}
+module HK2 where
+
+class HK (m :: * -> *) where
+  {-@ lift :: x:a -> {v: (m a) | True } @-}
+  lift :: a -> m a
+

--- a/tests/typeclasses/pos/HK2.hs
+++ b/tests/typeclasses/pos/HK2.hs
@@ -1,8 +1,16 @@
+-- Test for issue #2727:
+-- Specs of classes with higher-kinded parameters used to be elaborated with the
+-- type application `m a` rendered as a function type `m -> a`, throwing a kind
+-- error.
+
+-- Unlike HK1, this test has an explicit kind signature.
+
 {-# LANGUAGE KindSignatures #-}
 {-@ LIQUID "--typeclass" @-}
 module HK2 where
 
-class HK (m :: * -> *) where
+import Data.Kind (Type)
+
+class HK (m :: Type -> Type) where
   {-@ lift :: x:a -> {v: (m a) | True } @-}
   lift :: a -> m a
-


### PR DESCRIPTION
This PR solves issue https://github.com/ucsd-progsys/liquidhaskell/issues/2727. This is a secondary issue found after merging PR https://github.com/ucsd-progsys/liquidhaskell/pull/2716, and is relevant to issue https://github.com/ucsd-progsys/liquidhaskell/issues/2450.

Tests were added too, including the minimal failing example, now passing correctly.

Specs mentioning higher-kinded class parameters (e.g. `y : m a` with `m :: Type -> Type`) failed under `--typeclass` with a GHC kind panic.

There were two bugs contributing to this situation.

## 1. `specTypeToLHsType` rendered type application as a function arrow

To elaborate a refinement, LH converts the spec into a Haskell expression with a type signature and sends it to GHC. `specTypeToLHsType` translated `RAppTy` (type application) using `nlHsFunTy` instead of `nlHsAppTy`.

## 2. `goPlug` inserted wrong binders

`plugHoles` merges the GHC type with the Liquid spec. When the Liquid spec is missing a quantifier that the GHC type has, `goPlug` would insert it using the binder from the GHC type. But since the body produced uses Liquid type variables, the inserted binder binds nothing, and the occurrences it should bind are free. `tyCompat` then rejects the type.

The fix renames the inserted binder to its Liquid counterpart, using a mapping between GHC and LH type variables.