### PR TITLE
Preserve the existing RTVInfo in updateRTVar and ofBRType

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Resolve.hs
@@ -406,9 +406,13 @@ ofBRType env rebindR f l = go []
     go bs (RApp tc ts rs r) = goRApp bs tc ts rs r
     go bs (RFun x i t1 t2 r) = goRFun bs x i t1 t2 r
     go bs (RVar a r)        = RVar (RT.bareRTyVar a) <$> goReft bs r
-    go bs (RAllT a t r)     = RAllT a' <$> go bs t <*> goReft bs r
-      where a' = let RTVar v _s = a
-                  in RTVar (RT.bareRTyVar v) (RTVNoInfo True)
+    go bs (RAllT (RTVar v i) t r)     = RAllT <$> a' <*> go bs t <*> goReft bs r
+      where a' = case i of
+                   RTVInfo{} -> do
+                     k' <- ofBSortE env l (rtv_kind i)
+                     pure $ RTVar (RT.bareRTyVar v) i {rtv_kind = k'}
+                   RTVNoInfo is_pol ->
+                     pure $ RTVar (RT.bareRTyVar v) (RTVNoInfo is_pol)
     go bs (RAllP a t)       = RAllP a' <$> go bs t
       where a'              = ofBPVar env l a
     go bs (REx x t1 t2)     = REx   x  <$> go bs t1    <*> go (x:bs) t2

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/RefType.hs
@@ -397,8 +397,10 @@ rVar   = (`RVar` trueReft) . RTV
 rTyVar :: TyVar -> RTyVar
 rTyVar = RTV
 
-updateRTVar :: RTVar b v c RTyVar -> RTVar Symbol Symbol RTyCon RTyVar
-updateRTVar (RTVar (RTV a) _) = RTVar (RTV a) (rTVarInfo a)
+-- | Compute 'RTVarInfo' for an 'RTVar' if the info is not already present.
+updateRTVar :: SpecRTVar -> SpecRTVar
+updateRTVar (RTVar (RTV a) RTVNoInfo{}) = RTVar (RTV a) (rTVarInfo a)
+updateRTVar v = v
 
 rTVar :: TyVar -> RTVar Symbol Symbol RTyCon RTyVar
 rTVar a = RTVar (RTV a) (rTVarInfo a)

--- a/tests/pos/T1145a.hs
+++ b/tests/pos/T1145a.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+-- | Test that LH can load fine the specification for F,
+-- then test in T1145b that LH can load fine the specification for F from
+-- an imported module.
+module T1145a where
+
+import Data.Kind
+import GHC.TypeNats
+
+{-@ embed Natural as Int @-}
+
+{-@ type BoundedInteger N = { i : Integer | N > 0 && i >= 0 && i < N } @-}
+{-@ data Fin n = F Integer @-}
+{-@ F :: forall (n :: Nat). BoundedInteger n -> Fin n @-}
+type Fin :: Nat -> Type
+data Fin n = F Integer

--- a/tests/pos/T1145b.hs
+++ b/tests/pos/T1145b.hs
@@ -1,0 +1,4 @@
+-- | Tests that LH can load well the specification for F from an imported module
+module T1145b where
+
+import T1145a

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -1602,6 +1602,8 @@ executable unit-pos-2
                     , LooLib
                     , LooLibLib
                     , LNot
+                    , T1145a
+                    , T1145b
 
     build-depends:    base
                     , liquid-finfield


### PR DESCRIPTION
This allows the information about type-level values to survive serialization of the specs and reloading.

Addresses #1145 