### PR TITLE
Simplify exception handling

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin.hs
@@ -41,7 +41,8 @@ import           Language.Haskell.Liquid.Transforms.Rewrite (rewriteBinds)
 
 import           Control.Monad
 import qualified Control.Monad.Catch as Ex
-import           Control.Exception (SomeException, displayException)
+import           Control.Exception (SomeException, someExceptionContext)
+import           Control.Exception.Context
 import           Control.Monad.IO.Class (MonadIO)
 
 import           Data.Coerce
@@ -50,11 +51,13 @@ import qualified Data.List                               as L
 import           Data.IORef
 import qualified Data.Map                                as M
 import           Data.Map                                 ( Map )
+import           Data.Maybe                               ( fromMaybe )
 
 
 import qualified Data.HashSet                            as HS
 import qualified Data.HashMap.Strict                     as HM
 
+import           System.IO                                ( hPutStrLn, stderr )
 import           System.IO.Unsafe                         ( unsafePerformIO )
 import           Language.Fixpoint.Types           hiding ( errs
                                                           , panic
@@ -80,12 +83,6 @@ import           Language.Haskell.Liquid.UX.Config
 import           Language.Haskell.Liquid.RefCore.Extract (SrcInfo (..), extractCalculus, writeIlh, writeIlhBin)
 
 
--- | Represents an abnormal but non-fatal state of the plugin. Because it is not
--- meant to escape the plugin, it is not thrown in IO but instead carried around
--- in an `Either`'s `Left` case and handled at the top level of the plugin
--- function.
-newtype LiquidCheckException = ErrorsOccurred [Filter] -- Unmatched expected errors
-  deriving (Eq, Ord, Show)
 
 ---------------------------------------------------------------------------------
 -- | State and configuration management -----------------------------------------
@@ -140,7 +137,10 @@ plugin = GHC.defaultPlugin {
 
     typecheckPlugin :: [CommandLineOption] -> ModSummary -> TcGblEnv -> TcM TcGblEnv
     typecheckPlugin opts summary gblEnv = liquidPlugin opts gblEnv $ \cfg ->
-      typecheckPluginGo cfg summary gblEnv
+      Ex.catch (typecheckPluginGo cfg summary gblEnv) $ \(e :: SomeException) -> do
+        liftIO $ hPutStrLn stderr $ "LiquidHaskell plugin panics:\n" ++
+          displayExceptionContext (someExceptionContext e)
+        Ex.throwM e
 
     typecheckPluginGo cfg summary gblEnv = do
       logger0 <- getLogger
@@ -169,17 +169,8 @@ plugin = GHC.defaultPlugin {
             let warning = mkWarning (mkSrcSpan srcLoc srcLoc) msg
             liftIO $ printWarning logger warning
             pure gblEnv
-          else do
-            newGblEnv <- typecheckHook cfg summary gblEnv
-            case newGblEnv of
-              -- Exit with success if all expected errors were found
-              Left (ErrorsOccurred []) -> pure gblEnv
-              -- Exit with error if there were unmatched expected errors
-              Left (ErrorsOccurred errorFilters) -> do
-                defaultFilterReporter (LH.modSummaryHsFile summary) errorFilters
-                failM
-              Right newGblEnv' ->
-                pure newGblEnv'
+          else
+            fromMaybe gblEnv <$> typecheckHook cfg summary gblEnv
 
     -- We instruct LH to collect timings instead of doing it directly to GHC
     -- This helps work around https://github.com/haskell/cabal/issues/11116
@@ -304,7 +295,10 @@ parsedHook _cfg ms parsedResult = do
 --    grab from desugaring a postprocessed version of the typechecked module, so we are
 --    really independent from the \"normal\" compilation pipeline.
 --
-typecheckHook  :: Config -> ModSummary -> TcGblEnv -> TcM (Either LiquidCheckException TcGblEnv)
+-- The return value is Nothing when the module has failed verification. The actual
+-- errors are reported in the TcM monad.
+--
+typecheckHook  :: Config -> ModSummary -> TcGblEnv -> TcM (Maybe TcGblEnv)
 typecheckHook cfg0 ms tcGblEnv = swapBreadcrumb thisModule Nothing >>= \case
   Just (Parsed specComments) ->
     typecheckHook' cfg0 ms tcGblEnv specComments
@@ -312,26 +306,25 @@ typecheckHook cfg0 ms tcGblEnv = swapBreadcrumb thisModule Nothing >>= \case
     -- The module has been verified by an earlier call to the plugin.
     -- This could happen if multiple @-fplugin=LiquidHaskell@ flags are passed to GHC.
     -- See 'Breadcrumb' for more information.
-    pure $ Right tcGblEnv
+    pure $ Just tcGblEnv
   where
     thisModule = ms_mod ms
 
-typecheckHook' :: Config -> ModSummary -> TcGblEnv -> [SpecComment] -> TcM (Either LiquidCheckException TcGblEnv)
+typecheckHook' :: Config -> ModSummary -> TcGblEnv -> [SpecComment] -> TcM (Maybe TcGblEnv)
 typecheckHook' cfg ms tcGblEnv specComments = do
   debugLog $ "We are in module: " <> show (toStableModule thisModule)
 
   case parseSpecComments (coerce specComments) of
-    Left errors ->
-      LH.filterReportErrors thisFile GHC.failM continue (getFilters cfg) Full errors
+    Left errors -> do
+      LH.filterReportErrors thisFile (getFilters cfg) Full errors
+      pure Nothing
     Right specs ->
       liquidCheckModule cfg ms tcGblEnv specs
   where
     thisModule = ms_mod ms
     thisFile = LH.modSummaryHsFile ms
 
-    continue = pure $ Left (ErrorsOccurred [])
-
-liquidCheckModule :: Config -> ModSummary -> TcGblEnv -> [BPspec] -> TcM (Either LiquidCheckException TcGblEnv)
+liquidCheckModule :: Config -> ModSummary -> TcGblEnv -> [BPspec] -> TcM (Maybe TcGblEnv)
 liquidCheckModule cfg0 ms tcg specs = do
   withPragmas cfg0 pragmas $ \cfg -> do
     pipelineData <- do
@@ -391,7 +384,7 @@ processInputSpec
   -> PipelineData
   -> ModSummary
   -> BareSpecParsed
-  -> TcM (Either LiquidCheckException LiquidLib)
+  -> TcM (Maybe LiquidLib)
 processInputSpec cfg pipelineData modSummary inputSpec = do
   tcg <- getGblEnv
   debugLog $ " Input spec: \n" ++ show (fromBareSpecParsed inputSpec)
@@ -409,11 +402,11 @@ processInputSpec cfg pipelineData modSummary inputSpec = do
 
   -- liftIO $ putStrLn ("liquidHaskellCheck 6: " ++ show isIg)
   if isIgnore inputSpec
-    then pure $ Left (ErrorsOccurred [])
+    then pure Nothing
     else checkLiquidHaskellContext lhContext
 
 liquidHaskellCheckWithConfig
-  :: Config -> PipelineData -> ModSummary -> TcM (Either LiquidCheckException LiquidLib)
+  :: Config -> PipelineData -> ModSummary -> TcM (Maybe LiquidLib)
 liquidHaskellCheckWithConfig cfg pipelineData modSummary = do
   -- Parse the spec comments stored in the pipeline data.
   let inputSpec = snd $
@@ -423,23 +416,15 @@ liquidHaskellCheckWithConfig cfg pipelineData modSummary = do
     `Ex.catch` (\(e :: UserError) -> reportErrs [e])
     `Ex.catch` (\(e :: Error) -> reportErrs [e])
     `Ex.catch` (\(es :: [Error]) -> reportErrs es)
-    `Ex.catch` (\(e :: SomeException) -> do
-                   case Ex.fromException e of
-                     -- Supress the exception thrown by 'failM' when filtering
-                     -- errors
-                     Just GHC.IOEnvFailure -> pure ()
-                     Nothing -> liftIO $ putStrLn $ displayException e
-                   Ex.throwM e)
 
   where
     thisFile = LH.modSummaryHsFile modSummary
     thisModule = ms_mod modSummary
 
-    continue :: TcM (Either LiquidCheckException a)
-    continue = pure $ Left (ErrorsOccurred [])
-
-    reportErrs :: F.PPrint e => [TError e] -> TcM (Either LiquidCheckException a)
-    reportErrs  = LH.filterReportErrors thisFile GHC.failM continue (getFilters cfg) Full
+    reportErrs :: F.PPrint e => [TError e] -> TcM (Maybe LiquidLib)
+    reportErrs xs = do
+      LH.filterReportErrors thisFile (getFilters cfg) Full xs
+      pure Nothing
 
 mkSrcInfo :: LiquidHaskellContext -> TargetInfo -> [CoreBind] -> AnnInfo SpecType -> SrcInfo
 mkSrcInfo lhContext targetInfo cbs infTypes = SrcInfo
@@ -454,12 +439,12 @@ mkSrcInfo lhContext targetInfo cbs infTypes = SrcInfo
 -- | When the @--refcore@ flag is set, extract Calculus declarations and write
 --   the .ilhb binary. With @--refcore-text@ also write the human-readable .ilh
 --   text dump (debug only).
-checkLiquidHaskellContext :: LiquidHaskellContext -> TcM (Either LiquidCheckException LiquidLib)
+checkLiquidHaskellContext :: LiquidHaskellContext -> TcM (Maybe LiquidLib)
 checkLiquidHaskellContext lhContext = do
   pmr <- processModule lhContext
   case pmr of
-    Left e -> pure $ Left e
-    Right ProcessModuleResult{..} -> do
+    Nothing -> pure Nothing
+    Just ProcessModuleResult{..} -> do
       -- Call into the existing Liquid interface
       (out, infTypes) <- liftIO $ LH.checkTargetInfo pmrTargetInfo
 
@@ -482,9 +467,9 @@ checkLiquidHaskellContext lhContext = do
         --
         -- F.Crash is also handled by reportResult and errorLogger
         case o_result out of
-          F.Safe _ -> return $ Right pmrClientLib
+          F.Safe _ -> return $ Just pmrClientLib
           _ | json moduleCfg -> failM
-            | otherwise -> return $ Left $ ErrorsOccurred []
+            | otherwise -> pure Nothing
 
 errorLogger :: FilePath -> [Filter] -> OutputResult -> TcM ()
 errorLogger file filters outputResult = do
@@ -492,8 +477,6 @@ errorLogger file filters outputResult = do
     FilterReportErrorsArgs { errorReporter = \errs ->
                                LH.addTcRnUnknownMessages [(sp, e) | (sp, e) <- errs]
                            , filterReporter = LH.defaultFilterReporter file
-                           , failure = GHC.failM
-                           , continue = pure ()
                            , matchingFilters = LH.reduceFilters (\(src, doc) -> PJ.render doc ++ " at " ++ LH.showPpr src) filters
                            , filters = filters
                            }
@@ -553,7 +536,7 @@ data ProcessModuleResult = ProcessModuleResult {
   --   Empty unless the @--refcore@ flag is set.
   }
 
-processModule :: LiquidHaskellContext -> TcM (Either LiquidCheckException ProcessModuleResult)
+processModule :: LiquidHaskellContext -> TcM (Maybe ProcessModuleResult)
 processModule LiquidHaskellContext{..} = do
   let modGuts0   = lhModuleGuts
       thisModule = mg_module modGuts0
@@ -615,15 +598,17 @@ processModule LiquidHaskellContext{..} = do
               bareSpec
               dependencies
 
-    let continue = pure $ Left (ErrorsOccurred [])
-        reportErrs :: F.PPrint e => [TError e] -> TcRn (Either LiquidCheckException ProcessModuleResult)
-        reportErrs = LH.filterReportErrors file GHC.failM continue (getFilters moduleCfg) Full
+    let reportErrs :: F.PPrint e => [TError e] -> TcRn (Maybe ProcessModuleResult)
+        reportErrs xs = do
+          LH.filterReportErrors file (getFilters moduleCfg) Full xs
+          pure Nothing
 
     (case result of
       -- Print warnings and errors, aborting the compilation.
       Left diagnostics -> do
         liftIO $ mapM_ (printWarning logger)    (allWarnings diagnostics)
         reportErrs $ allErrors diagnostics
+
       Right ((warnings, targetSpec, liftedSpec), bareSpec) -> do
         liftIO $ mapM_ (printWarning logger) warnings
         let targetInfo = TargetInfo targetSrc targetSpec
@@ -639,17 +624,10 @@ processModule LiquidHaskellContext{..} = do
             , pmrRefCoreCbs = refCoreCbs
             }
 
-        pure $ Right result')
+        pure $ Just result')
       `Ex.catch` (\(e :: UserError) -> reportErrs [e])
       `Ex.catch` (\(e :: Error) -> reportErrs [e])
       `Ex.catch` (\(es :: [Error]) -> reportErrs es)
-      `Ex.catch` (\(e :: SomeException) -> do
-                     case Ex.fromException e of
-                       -- Supress the exception thrown by 'failM' when filtering
-                       -- errors
-                       Just GHC.IOEnvFailure -> pure ()
-                       Nothing -> liftIO $ putStrLn $ displayException e
-                     Ex.throwM e)
 
 makeTargetSrc :: Config
               -> FilePath

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/Serialisation.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/GHC/Plugin/Serialisation.hs
@@ -17,10 +17,14 @@ import qualified Data.Binary.Builder                     as Builder
 import qualified Data.Binary.Put                         as B
 import qualified Data.ByteString.Lazy                    as B
 import           Data.Data (Data)
+import           Control.Exception
+import           Control.Exception.Backtrace
+import           Control.Exception.Context
 import           Data.Generics (ext0, gmapAccumT)
 import           Data.HashMap.Strict                     as M
 import           Data.Maybe                               ( listToMaybe )
 import           Data.Word                               (Word8)
+import           GHC.Stack (HasCallStack)
 
 import qualified Liquid.GHC.API as GHC
 import           Language.Haskell.Liquid.GHC.Plugin.Types (LiquidLib)
@@ -95,7 +99,7 @@ deserialiseLiquidLibFromEPS thisModule eps nameCache = do
       _ -> return Nothing
 
 encodeLiquidLib :: LiquidLib -> IO B.ByteString
-encodeLiquidLib lib0 = do
+encodeLiquidLib lib0 = rethrowWithCallStackIO $ do
     let (lib1, ns) = collectLHNames lib0
     bh <- GHC.openBinMem (1024*1024)
     GHC.putWithUserData GHC.QuietBinIFace GHC.SafeExtraCompression bh ns
@@ -103,7 +107,7 @@ encodeLiquidLib lib0 = do
       return $ Builder.toLazyByteString $ B.execPut (B.put lib1) <> Builder.fromByteString bs
 
 decodeLiquidLib :: GHC.NameCache -> B.ByteString -> IO LiquidLib
-decodeLiquidLib nameCache bs0 = do
+decodeLiquidLib nameCache bs0 = rethrowWithCallStackIO $ do
     case B.decodeOrFail bs0 of
       Left (_, _, err) -> error $ "decodeLiquidLib: decodeOrFail: " ++ err
       Right (bs1, _, lib) -> do
@@ -141,3 +145,10 @@ collectLHNames t =
     collectName acc@(sz, m, xs) n = case M.lookup n m of
       Just i -> (acc, LHRIndex i)
       Nothing -> ((sz + 1, M.insert n sz m, n : xs), LHRIndex sz)
+
+-- | Rethrow an exception so we have an indication of where it was thrown in
+-- the stack trace.
+rethrowWithCallStackIO :: HasCallStack => IO a -> IO a
+rethrowWithCallStackIO action = catchNoPropagate action $ \(ExceptionWithContext ctx (e :: SomeException)) -> do
+    btAnn <- collectBacktraces
+    rethrowIO $ ExceptionWithContext (addExceptionAnnotation btAnn ctx) e

--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Types/PrettyPrint.hs
@@ -42,6 +42,7 @@ module Language.Haskell.Liquid.Types.PrettyPrint
 
   ) where
 
+import Control.Monad (unless)
 import qualified Data.HashMap.Strict              as M
 import qualified Data.List                        as L                               -- (sort)
 import qualified Data.Set                         as Set
@@ -456,14 +457,12 @@ instance (IsReft (F.ReftBV b v), Eq v, PPrint (PredicateBV b v), PPrint (F.ReftB
 -- are unexpected errors, or will call @continue@ otherwise.
 --
 -- An error is expected if there is any filter that matches it.
-filterReportErrors :: forall e' a. F.PPrint e' => FilePath -> Ghc.TcRn a -> Ghc.TcRn a -> [Filter] -> F.Tidy -> [TError e'] -> Ghc.TcRn a
-filterReportErrors path failure continue filters k =
+filterReportErrors :: forall e'. F.PPrint e' => FilePath -> [Filter] -> F.Tidy -> [TError e'] -> Ghc.TcRn ()
+filterReportErrors path filters k =
   filterReportErrorsWith
     FilterReportErrorsArgs { errorReporter = \errs ->
                                addTcRnUnknownMessages [(pos err, ppError k empty err) | err <- errs]
                            , filterReporter = defaultFilterReporter path
-                           , failure = failure
-                           , continue = continue
                            , matchingFilters = reduceFilters renderer filters
                            , filters = filters
                            }
@@ -491,7 +490,7 @@ stringMatch :: String -> String -> Bool
 stringMatch filter' str = filter' `L.isInfixOf` str
 
 -- | Used in `filterReportErrorsWith'`
-data FilterReportErrorsArgs m filter msg e a =
+data FilterReportErrorsArgs m filter msg e =
   FilterReportErrorsArgs
   {
     -- | Report the @msgs@ to the monad (usually IO)
@@ -499,12 +498,6 @@ data FilterReportErrorsArgs m filter msg e a =
   ,
     -- | Report unmatched @filters@ to the monad
     filterReporter :: [filter] -> m ()
-  ,
-    -- | Continuation for when there are unmatched filters or unmatched errors
-    failure :: m a
-  ,
-    -- | Continuation for when there are no unmatched errors or filters
-    continue :: m a
   ,
     -- | Yields the filters that map a given error. Must only yield
     -- filters in the @filters@ field.
@@ -516,7 +509,7 @@ data FilterReportErrorsArgs m filter msg e a =
 
 -- | Calls the continuations in FilterReportErrorsArgs depending on whethere there
 -- are unmatched errors, unmatched filters or none.
-filterReportErrorsWith :: (Monad m, Ord filter) => FilterReportErrorsArgs m filter msg e a -> [e] -> m a
+filterReportErrorsWith :: (Monad m, Ord filter) => FilterReportErrorsArgs m filter msg e -> [e] -> m ()
 filterReportErrorsWith FilterReportErrorsArgs {..} errs =
   let
     (unmatchedErrors, matchedFilters) =
@@ -525,14 +518,10 @@ filterReportErrorsWith FilterReportErrorsArgs {..} errs =
       Set.fromList filters `Set.difference` Set.fromList (concatMap snd matchedFilters)
   in
     if null unmatchedErrors then
-      if null unmatchedFilters then
-        continue
-      else do
+      unless (null unmatchedFilters) $
         filterReporter unmatchedFilters
-        failure
-    else do
+    else
       errorReporter $ map fst unmatchedErrors
-      failure
 
 -- | Report errors via GHC's API stating the given `Filter`s did not get
 -- matched. Does nothing if the list of filters is empty.

--- a/tests/tasty/ErrorFilterReportTests.hs
+++ b/tests/tasty/ErrorFilterReportTests.hs
@@ -1,34 +1,31 @@
 module ErrorFilterReportTests(errorFilterReportTests) where
 
+import Control.Monad.State (State, execState, modify)
 import Test.Tasty ( TestTree, testGroup )
 import Test.Tasty.HUnit ( testCase, assertBool )
 import Language.Haskell.Liquid.Types.PrettyPrint (FilterReportErrorsArgs(..))
 import Language.Haskell.Liquid.Types.PrettyPrint (Filter(..), filterReportErrorsWith, reduceFilters)
 import Data.Functor.Identity (Identity(..))
 
-defArgs :: Monad m => FilterReportErrorsArgs m Filter String String Bool
+defArgs :: FilterReportErrorsArgs (State Int) Filter String String
 defArgs = FilterReportErrorsArgs { errorReporter = const (pure ())
-                                 , filterReporter = const (pure ())
-                                 , failure =  pure False
-                                 , continue = pure True
+                                 , filterReporter = \xs -> modify (length xs +)
                                  , matchingFilters = const []
                                  , filters = [] }
 
-defFailingArgs :: Monad m => FilterReportErrorsArgs m Filter String String Bool
-defFailingArgs = defArgs { failure = continue defArgs
-                         , continue = failure defArgs
-                         , matchingFilters = const [] }
+defFailingArgs :: FilterReportErrorsArgs (State Int) Filter String String
+defFailingArgs = defArgs { matchingFilters = const [] }
 
 -- basic success for empty last arg
-emptySuccess :: Monad m => m Bool
+emptySuccess :: State Int ()
 emptySuccess = filterReportErrorsWith defArgs []
 
 -- basic failure for non-empty last arg (prints error)
-nonemptyFailure :: Monad m => m Bool
+nonemptyFailure :: State Int ()
 nonemptyFailure = filterReportErrorsWith defFailingArgs ["expected error!"]
 
 -- prop: always success no matter what last arg is (using filterWithFilters)
-nonemptySuccessWithFiltersAnyFilter :: Monad m => m Bool
+nonemptySuccessWithFiltersAnyFilter :: State Int ()
 nonemptySuccessWithFiltersAnyFilter = filterReportErrorsWith
                                       defArgs { matchingFilters = reduceFilters id filters
                                               , filters = filters }
@@ -36,7 +33,7 @@ nonemptySuccessWithFiltersAnyFilter = filterReportErrorsWith
   where
     filters = [AnyFilter]
 
-nonemptySuccessWithFiltersEmptyString :: Monad m => m Bool
+nonemptySuccessWithFiltersEmptyString :: State Int ()
 nonemptySuccessWithFiltersEmptyString = filterReportErrorsWith
                                         defArgs { matchingFilters = reduceFilters id filters
                                                 , filters = filters }
@@ -45,7 +42,7 @@ nonemptySuccessWithFiltersEmptyString = filterReportErrorsWith
     filters = [StringFilter ""]
 
 -- prop: for singleton final arg, only succeed when element contains StringFilter string
-nonemptyCatchStringFilter :: Monad m => m Bool
+nonemptyCatchStringFilter :: State Int ()
 nonemptyCatchStringFilter = filterReportErrorsWith
                             defArgs { matchingFilters = reduceFilters id filters
                                     , filters = filters}
@@ -54,7 +51,7 @@ nonemptyCatchStringFilter = filterReportErrorsWith
     filters = [StringFilter "error"]
 
 -- prop: for singleton final arg, only fail when element does not contain StringFilter string (prints error)
-nonemptyFailureOnBadStringFilter :: Monad m => m Bool
+nonemptyFailureOnBadStringFilter :: State Int ()
 nonemptyFailureOnBadStringFilter = filterReportErrorsWith
                                    defFailingArgs { matchingFilters = reduceFilters id filters
                                                   , filters = filters}
@@ -62,8 +59,11 @@ nonemptyFailureOnBadStringFilter = filterReportErrorsWith
   where
     filters = [StringFilter "this string does not appear in the error"]
 
-testsInIdentity :: [TestTree]
-testsInIdentity = (\(testName, test) -> testCase testName $ assertBool "" (runIdentity test)) <$> namedTests
+testList :: [TestTree]
+testList =
+    (\(testName, test) ->
+      testCase testName $ assertBool "" (0 == execState test 0)
+    ) <$> namedTests
   where
     namedTests = [ ("emptySuccess", emptySuccess)
                  , ("nonemptyFailure", nonemptyFailure)
@@ -74,4 +74,4 @@ testsInIdentity = (\(testName, test) -> testCase testName $ assertBool "" (runId
                  ]
 
 errorFilterReportTests :: [TestTree]
-errorFilterReportTests = [testGroup "Error Filter in Identity" testsInIdentity]
+errorFilterReportTests = [testGroup "Error Filter" testList]

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2786,6 +2786,7 @@ test-suite tasty
     other-modules:    ErrorFilterReportTests
     hs-source-dirs:   tasty
     build-depends:    base
+                    , mtl
                     , tasty
                     , tasty-hunit
                     , liquidhaskell-boot


### PR DESCRIPTION
This PR includes

* When exceptions are thrown during serialization/deserialization, the stack trace indicates so.
* We print the exception context of uncaught exceptions, which makes error messages more descriptive.
* The code for reporting expected failures has a couple less parameters that were redundant.