### PR TITLE
Fix class methods starting with 'p' being mistaken for superclass bindings

### DIFF
--- a/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
+++ b/liquidhaskell-boot/src/Language/Haskell/Liquid/Bare/Typeclass.hs
@@ -15,6 +15,7 @@ where
 
 import           Control.Monad                 ( forM, guard )
 import           Data.Bifunctor                (second)
+import           Data.Char                     (isDigit)
 import qualified Data.List                     as L
 import qualified Data.HashSet                  as S
 import           Data.Hashable                  ()
@@ -420,13 +421,16 @@ substAuxMethod dfun methods = F.notracepp "substAuxMethod" . go
 
 -- Normalise typeclass names for looking up class selector symbols.
 -- Instance methods are named `$c(method)`. GHC 9 can also expose superclass
--- dictionary bindings named `$cp(n)(Class)`. These correspond to
--- `$p(n)(Class)` selector symbols.
+-- dictionary bindings named `$cp(n)(Class)`, where (n) is the index of the
+-- superclass. These correspond to `$p(n)(Class)` selector symbols.
 -- Since class methods are always identified by variables with the `$c`
 -- prefix, we can ignore other cases.
+-- The digit is what distinguishes a superclass binding from a method whose
+-- name starts with 'p'.
 mkSymbol :: Ghc.Var -> F.Symbol
 mkSymbol x =
   case Ghc.getOccString x of
-    '$' : 'c' : 'p' : rest -> F.symbol ('$' : 'p' : rest)
+    '$' : 'c' : 'p' : rest@(d : _)
+      | isDigit d          -> F.symbol ('$' : 'p' : rest)
     '$' : 'c' : rest       -> F.symbol rest
     occ                    -> impossible Nothing $ "mkSymbol : should only be called with class methods, received " ++ F.showpp occ

--- a/tests/tests.cabal
+++ b/tests/tests.cabal
@@ -2711,6 +2711,7 @@ executable typeclass-pos
                     , SingleMethod
                     , HK1
                     , HK2
+                    , MethodPrefixP
 
     build-depends:    base
                     , liquid-prelude

--- a/tests/typeclasses/pos/MethodPrefixP.hs
+++ b/tests/typeclasses/pos/MethodPrefixP.hs
@@ -1,0 +1,14 @@
+-- Test that a class method whose name starts with 'p' is not mistaken for a
+-- superclass dictionary binding: `$cpnat` must resolve to the method `pnat`,
+-- not to a selector `$pnat`.
+{-@ LIQUID "--reflection" @-}
+{-@ LIQUID "--typeclass" @-}
+module MethodPrefixP where
+
+class PNum a where
+  {-@ pnat :: a -> Nat @-}
+  pnat :: a -> Int
+
+instance PNum Bool where
+  pnat False = 0
+  pnat True  = 1


### PR DESCRIPTION
Under `--typeclass`, using an instance whose method name starts with 'p' failed with an unbound-symbol error:

```
typeclasses/pos/MethodPrefixP.hs:12:10: error:
    Illegal type specification for `MethodPrefixP.$fPNumBool`
    MethodPrefixP.$fPNumBool :: {VV : (MethodPrefixP.PNum GHC.Internal.Types.Bool) | VV == MethodPrefixP.$fPNumBool
                                                                                     && VV == MethodPrefixP.C:PNum $cpnat##a46p}
    Sort Error in Refinement: {VV : (MethodPrefixP.PNum bool) | VV == MethodPrefixP.$fPNumBool
                                                                && VV == MethodPrefixP.C:PNum $cpnat##a46p}
    Unbound symbol $cpnat##a46p --- perhaps you meant: papp4, papp6, Set_cap ?
    Just reflect
   |
12 | instance PNum Bool where
   |          ^^^^^^^^^

typeclasses/pos/MethodPrefixP.hs:13:3: error:
    Illegal type specification for `$cpnat`
    $cpnat :: lq1:GHC.Internal.Types.Bool -> {VV : GHC.Internal.Types.Int | VV == $cpnat##a46p lq1}
    Sort Error in Refinement: {VV : int | VV == $cpnat##a46p lq1}
    Unbound symbol $cpnat##a46p --- perhaps you meant: papp4, papp6, Set_cap ?
    Just assume
   |
13 |   pnat False = 0
   |   ^^^^
```

The reason is that `mkSymbol` in the `Bare.Typeclass` module will identify all names starting with `$cp` as superclass dictionary bindings. This is incorrect when a method's name starts with 'p'. We use a stricter check, using the fact that superclass bindings will include a number after `$cp` indicating the number of levels above the superclass is in.

A test is included.